### PR TITLE
Automated cherry pick of #14265: bump aws-cni to version 1.11.4

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 911607956b82adcb254d8782b70999101b886350741c638ebc6552ab54d8d286
+    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -123,7 +123,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -229,7 +229,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
         livenessProbe:
           exec:
             command:
@@ -279,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 911607956b82adcb254d8782b70999101b886350741c638ebc6552ab54d8d286
+    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -123,7 +123,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -229,7 +229,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
         livenessProbe:
           exec:
             command:
@@ -279,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 911607956b82adcb254d8782b70999101b886350741c638ebc6552ab54d8d286
+    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -123,7 +123,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -229,7 +229,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
         livenessProbe:
           exec:
             command:
@@ -279,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 911607956b82adcb254d8782b70999101b886350741c638ebc6552ab54d8d286
+    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -123,7 +123,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -229,7 +229,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
         livenessProbe:
           exec:
             command:
@@ -279,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 911607956b82adcb254d8782b70999101b886350741c638ebc6552ab54d8d286
+    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -123,7 +123,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -229,7 +229,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
         livenessProbe:
           exec:
             command:
@@ -279,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 911607956b82adcb254d8782b70999101b886350741c638ebc6552ab54d8d286
+    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -123,7 +123,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -229,7 +229,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
         livenessProbe:
           exec:
             command:
@@ -279,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 911607956b82adcb254d8782b70999101b886350741c638ebc6552ab54d8d286
+    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -123,7 +123,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -229,7 +229,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
         livenessProbe:
           exec:
             command:
@@ -279,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.3"
+    app.kubernetes.io/version: "v1.11.4"
 ---
 # Source: aws-vpc-cni/templates/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.3"
+    app.kubernetes.io/version: "v1.11.4"
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.3"
+    app.kubernetes.io/version: "v1.11.4"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -85,7 +85,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.3"
+    app.kubernetes.io/version: "v1.11.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,7 +105,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.3"
+    app.kubernetes.io/version: "v1.11.4"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -126,7 +126,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.3" }}"
+        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4" }}"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -144,7 +144,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.3" }}"
+          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4" }}"
           ports:
             - containerPort: 61678
               name: metrics

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: bba5d626f7d46c57827b1c28c362106e51515ca53b1f8fe6622ab9c1689f4a41
+    manifestHash: 5af8e56dc28de2e5d7d6b89939b253bdd03f40f41ab1d0e20b873f9cf1530fac
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -123,7 +123,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -231,7 +231,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
         livenessProbe:
           exec:
             command:
@@ -281,7 +281,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: bba5d626f7d46c57827b1c28c362106e51515ca53b1f8fe6622ab9c1689f4a41
+    manifestHash: 5af8e56dc28de2e5d7d6b89939b253bdd03f40f41ab1d0e20b873f9cf1530fac
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -123,7 +123,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.3
+    app.kubernetes.io/version: v1.11.4
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -231,7 +231,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
         livenessProbe:
           exec:
             command:
@@ -281,7 +281,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
         name: aws-vpc-cni-init
         securityContext:
           privileged: true


### PR DESCRIPTION
Cherry pick of #14265 on release-1.25.

#14265: bump aws-cni to version 1.11.4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```