### PR TITLE
Automated cherry pick of #14282: Delete the oldest servers when over the desired count for

### DIFF
--- a/upup/pkg/fi/cloudup/hetznertasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/servergroup.go
@@ -88,9 +88,15 @@ func (v *ServerGroup) Find(c *fi.Context) (*ServerGroup, error) {
 	actual.Count = len(servers)
 
 	// Find servers that need to be updated
-	for _, server := range servers {
+	for i, server := range servers {
 		// Ignore servers that are already labeled as needing update
 		if _, ok := server.Labels[hetzner.TagKubernetesInstanceNeedsUpdate]; ok {
+			continue
+		}
+
+		// Check if server index is higher than desired count
+		if i >= v.Count {
+			actual.NeedUpdate = append(actual.NeedUpdate, server.Name)
 			continue
 		}
 


### PR DESCRIPTION
Cherry pick of #14282 on release-1.25.

#14282: Delete the oldest servers when over the desired count for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```