### PR TITLE
User IG without image should be allowed

### DIFF
--- a/cmd/kops/edit_instancegroup_test.go
+++ b/cmd/kops/edit_instancegroup_test.go
@@ -38,7 +38,6 @@ func TestEditInstanceGroup(t *testing.T) {
 
 	cluster := testutils.BuildMinimalCluster(clusterName)
 	nodes := testutils.BuildMinimalNodeInstanceGroup("nodes", "subnet-us-test-1a")
-	nodes.Spec.Image = "ami-xyz"
 	nodes.Spec.Taints = []string{"e2etest:NoSchedule"}
 
 	testutils.NewIntegrationTestHarness(t).SetupMockAWS()

--- a/cmd/kops/test/edit_instance_group.yaml
+++ b/cmd/kops/test/edit_instance_group.yaml
@@ -7,7 +7,6 @@ metadata:
     kops.k8s.io/cluster: test.k8s.io
   name: nodes
 spec:
-  image: ami-xyz
   maxSize: 10
   role: Node
   subnets:

--- a/pkg/client/simple/vfsclientset/instancegroup.go
+++ b/pkg/client/simple/vfsclientset/instancegroup.go
@@ -54,7 +54,7 @@ func newInstanceGroupVFS(c *VFSClientset, cluster *kopsapi.Cluster) *InstanceGro
 	}
 	r.init(kind, c.basePath.Join(clusterName, "instancegroup"), StoreVersion)
 	r.validate = func(o runtime.Object) error {
-		return validation.ValidateInstanceGroup(o.(*kopsapi.InstanceGroup), nil, true).ToAggregate()
+		return validation.ValidateInstanceGroup(o.(*kopsapi.InstanceGroup), nil, false).ToAggregate()
 	}
 	return r
 }

--- a/pkg/commands/helpers_readwrite.go
+++ b/pkg/commands/helpers_readwrite.go
@@ -84,7 +84,7 @@ func UpdateInstanceGroup(ctx context.Context, clientset simple.Clientset, cluste
 		return err
 	}
 
-	err = validation.CrossValidateInstanceGroup(instanceGroupToUpdate, fullCluster, cloud, true).ToAggregate()
+	err = validation.CrossValidateInstanceGroup(instanceGroupToUpdate, fullCluster, cloud, false).ToAggregate()
 	if err != nil {
 		return err
 	}

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -204,6 +204,15 @@ func (h *IntegrationTestHarness) SetupMockAWS() *awsup.MockAWSCloud {
 	})
 
 	mockEC2.Images = append(mockEC2.Images, &ec2.Image{
+		CreationDate:   aws.String("2019-08-06T00:00:00.000Z"),
+		ImageId:        aws.String("ami-11400001"),
+		Name:           aws.String("k8s-1.14-debian-stretch-amd64-hvm-ebs-2021-02-05"),
+		OwnerId:        aws.String(awsup.WellKnownAccountKopeio),
+		RootDeviceName: aws.String("/dev/xvda"),
+		Architecture:   aws.String("x86_64"),
+	})
+
+	mockEC2.Images = append(mockEC2.Images, &ec2.Image{
 		CreationDate:   aws.String("2022-04-04T00:00:00.000Z"),
 		ImageId:        aws.String("ami-12345678"),
 		Name:           aws.String("ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404"),


### PR DESCRIPTION
This is technically a regression. kOps had the behavior where empty image meant use from channel. But this got removed due to strict validation of user input