### PR TITLE
Automated cherry pick of #14291: Bump tests to supported k8s version

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -499,7 +499,7 @@ func (b *ContainerdBuilder) buildContainerdConfig() (string, error) {
 	}
 	config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc", "runtime_type"}, "io.containerd.runc.v2")
 	// only enable systemd cgroups for kubernetes >= 1.20
-	config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc", "options", "SystemdCgroup"}, cluster.IsKubernetesGTE("1.20"))
+	config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc", "options", "SystemdCgroup"}, true)
 	if components.UsesKubenet(cluster.Spec.Networking) {
 		// Using containerd with Kubenet requires special configuration.
 		// This is a temporary backwards-compatible solution for kubenet users and will be deprecated when Kubenet is deprecated:

--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/cluster.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/cluster.yaml
@@ -22,7 +22,7 @@ spec:
       name: events
   iam:
     legacy: false
-  kubernetesVersion: v1.19.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
@@ -39,7 +39,7 @@ contents: |
             runtime_type = "io.containerd.runc.v2"
 
             [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-              SystemdCgroup = false
+              SystemdCgroup = true
 path: /etc/containerd/config-kops.toml
 type: file
 ---

--- a/nodeup/pkg/model/tests/containerdbuilder/from_docker_19.03.11/cluster.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/from_docker_19.03.11/cluster.yaml
@@ -22,7 +22,7 @@ spec:
       name: events
   iam:
     legacy: false
-  kubernetesVersion: v1.19.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/containerdbuilder/from_docker_19.03.14/cluster.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/from_docker_19.03.14/cluster.yaml
@@ -22,7 +22,7 @@ spec:
       name: events
   iam:
     legacy: false
-  kubernetesVersion: v1.19.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/cluster.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/cluster.yaml
@@ -22,7 +22,7 @@ spec:
       name: events
   iam:
     legacy: false
-  kubernetesVersion: v1.19.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -39,7 +39,7 @@ contents: |
             runtime_type = "io.containerd.runc.v2"
 
             [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-              SystemdCgroup = false
+              SystemdCgroup = true
 path: /etc/containerd/config-kops.toml
 type: file
 ---

--- a/nodeup/pkg/model/tests/containerdbuilder/skipinstall/cluster.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/skipinstall/cluster.yaml
@@ -22,7 +22,7 @@ spec:
       name: events
   iam:
     legacy: false
-  kubernetesVersion: v1.16.3
+  kubernetesVersion: v1.20.3
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/dockerbuilder/docker_19.03.11/cluster.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/docker_19.03.11/cluster.yaml
@@ -23,7 +23,7 @@ spec:
     name: events
   iam:
     legacy: false
-  kubernetesVersion: v1.19.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/dockerbuilder/docker_19.03.11/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/docker_19.03.11/tasks.yaml
@@ -1,5 +1,5 @@
 contents: |-
-  DOCKER_OPTS=--ip-masq=false --iptables=false --log-driver=json-file --log-level=info --log-opt=max-file=5 --log-opt=max-size=10m --storage-driver=overlay2,overlay,aufs
+  DOCKER_OPTS=--exec-opt=native.cgroupdriver=systemd --ip-masq=false --iptables=false --log-driver=json-file --log-level=info --log-opt=max-file=5 --log-opt=max-size=10m --storage-driver=overlay2,overlay,aufs
   DOCKER_NOFILE=1000000
 path: /etc/sysconfig/docker
 type: file

--- a/nodeup/pkg/model/tests/dockerbuilder/healthcheck/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/healthcheck/tasks.yaml
@@ -2,7 +2,7 @@ file: /usr/bin/docker-runc
 mode: +i
 ---
 contents: |-
-  DOCKER_OPTS=--ip-masq=false --iptables=false --log-driver=json-file --log-level=info --log-opt=max-file=5 --log-opt=max-size=10m --storage-driver=overlay2,overlay,aufs
+  DOCKER_OPTS=--exec-opt=native.cgroupdriver=systemd --ip-masq=false --iptables=false --log-driver=json-file --log-level=info --log-opt=max-file=5 --log-opt=max-size=10m --storage-driver=overlay2,overlay,aufs
   DOCKER_NOFILE=1000000
 path: /etc/sysconfig/docker
 type: file

--- a/nodeup/pkg/model/tests/dockerbuilder/logflags/cluster.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/logflags/cluster.yaml
@@ -22,7 +22,7 @@ spec:
     name: events
   iam:
     legacy: false
-  kubernetesVersion: v1.18.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.logflags.example.com
   masterPublicName: api.logflags.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/dockerbuilder/logflags/tasks.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/logflags/tasks.yaml
@@ -1,5 +1,5 @@
 contents: |-
-  DOCKER_OPTS=--ip-masq=false --iptables=false --log-driver=json-file --log-level=info --log-opt=max-file=5 --log-opt=max-size=10m --storage-driver=overlay2,overlay,aufs
+  DOCKER_OPTS=--exec-opt=native.cgroupdriver=systemd --ip-masq=false --iptables=false --log-driver=json-file --log-level=info --log-opt=max-file=5 --log-opt=max-size=10m --storage-driver=overlay2,overlay,aufs
   DOCKER_NOFILE=1000000
 path: /etc/sysconfig/docker
 type: file

--- a/nodeup/pkg/model/tests/dockerbuilder/skipinstall/cluster.yaml
+++ b/nodeup/pkg/model/tests/dockerbuilder/skipinstall/cluster.yaml
@@ -22,7 +22,7 @@ spec:
     name: events
   iam:
     legacy: false
-  kubernetesVersion: v1.14.6
+  kubernetesVersion: v1.20.6
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/golden/awsiam/cluster.yaml
+++ b/nodeup/pkg/model/tests/golden/awsiam/cluster.yaml
@@ -32,7 +32,7 @@ spec:
   iam: {}
   kubelet:
     anonymousAuth: false
-  kubernetesVersion: v1.18.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
@@ -51,7 +51,6 @@ contents: |
       - --etcd-keyfile=/srv/kubernetes/kube-apiserver/etcd-client.key
       - --etcd-servers-overrides=/events#https://127.0.0.1:4002
       - --etcd-servers=https://127.0.0.1:4001
-      - --insecure-port=0
       - --kubelet-client-certificate=/srv/kubernetes/kube-apiserver/kubelet-api.crt
       - --kubelet-client-key=/srv/kubernetes/kube-apiserver/kubelet-api.key
       - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
@@ -77,7 +76,7 @@ contents: |
       - --log-file=/var/log/kube-apiserver.log
       command:
       - /usr/local/bin/kube-apiserver
-      image: registry.k8s.io/kube-apiserver:v1.18.0
+      image: registry.k8s.io/kube-apiserver:v1.20.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/nodeup/pkg/model/tests/golden/dedicated-apiserver/cluster.yaml
+++ b/nodeup/pkg/model/tests/golden/dedicated-apiserver/cluster.yaml
@@ -30,7 +30,7 @@ spec:
   iam: {}
   kubelet:
     anonymousAuth: false
-  kubernetesVersion: v1.18.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
@@ -29,7 +29,6 @@ contents: |
       - --etcd-keyfile=/srv/kubernetes/kube-apiserver/etcd-client.key
       - --etcd-servers-overrides=/events#https://events.etcd.minimal.example.com:4002
       - --etcd-servers=https://main.etcd.minimal.example.com:4001
-      - --insecure-port=0
       - --kubelet-client-certificate=/srv/kubernetes/kube-apiserver/kubelet-api.crt
       - --kubelet-client-key=/srv/kubernetes/kube-apiserver/kubelet-api.key
       - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
@@ -55,7 +54,7 @@ contents: |
       - --log-file=/var/log/kube-apiserver.log
       command:
       - /usr/local/bin/kube-apiserver
-      image: registry.k8s.io/kube-apiserver:v1.18.0
+      image: registry.k8s.io/kube-apiserver:v1.20.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/nodeup/pkg/model/tests/golden/without-etcd-events/cluster.yaml
+++ b/nodeup/pkg/model/tests/golden/without-etcd-events/cluster.yaml
@@ -21,7 +21,7 @@ spec:
   iam: {}
   kubelet:
     anonymousAuth: false
-  kubernetesVersion: v1.18.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/golden/without-etcd-events/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/without-etcd-events/tasks-kube-apiserver.yaml
@@ -28,7 +28,6 @@ contents: |
       - --etcd-certfile=/srv/kubernetes/kube-apiserver/etcd-client.crt
       - --etcd-keyfile=/srv/kubernetes/kube-apiserver/etcd-client.key
       - --etcd-servers=https://127.0.0.1:4001
-      - --insecure-port=0
       - --kubelet-client-certificate=/srv/kubernetes/kube-apiserver/kubelet-api.crt
       - --kubelet-client-key=/srv/kubernetes/kube-apiserver/kubelet-api.key
       - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
@@ -54,7 +53,7 @@ contents: |
       - --log-file=/var/log/kube-apiserver.log
       command:
       - /usr/local/bin/kube-apiserver
-      image: registry.k8s.io/kube-apiserver:v1.18.0
+      image: registry.k8s.io/kube-apiserver:v1.20.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/nodeup/pkg/model/tests/protokube/cluster.yaml
+++ b/nodeup/pkg/model/tests/protokube/cluster.yaml
@@ -26,7 +26,7 @@ spec:
   iam: {}
   kubelet:
     hostnameOverride: master.hostname.invalid
-  kubernetesVersion: v1.18.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/updateservicebuilder/automatic/cluster.yaml
+++ b/nodeup/pkg/model/tests/updateservicebuilder/automatic/cluster.yaml
@@ -26,7 +26,7 @@ spec:
   iam: {}
   kubelet:
     hostnameOverride: master.hostname.invalid
-  kubernetesVersion: v1.17.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/updateservicebuilder/external/cluster.yaml
+++ b/nodeup/pkg/model/tests/updateservicebuilder/external/cluster.yaml
@@ -26,7 +26,7 @@ spec:
   iam: {}
   kubelet:
     hostnameOverride: master.hostname.invalid
-  kubernetesVersion: v1.17.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -663,11 +663,10 @@ func validateKubeAPIServer(v *kops.KubeAPIServerConfig, c *kops.Cluster, fldPath
 
 	if v.InsecurePort != nil {
 		insecurePort := *v.InsecurePort
-		if c.IsKubernetesGTE("1.20") && insecurePort != 0 {
-			field.Forbidden(fldPath.Child("insecurePort"), "insecurePort can only be 0 as of Kubernetes 1.20")
-		}
 		if c.IsKubernetesGTE("1.24") {
 			field.Forbidden(fldPath.Child("insecurePort"), "insecurePort must not be set as of Kubernetes 1.24")
+		} else if insecurePort != 0 {
+			field.Forbidden(fldPath.Child("insecurePort"), "insecurePort can only be 0 or nil")
 		}
 	}
 
@@ -751,9 +750,7 @@ func validateKubelet(k *kops.KubeletConfigSpec, c *kops.Cluster, kubeletPath *fi
 		}
 
 		if k.CPUCFSQuotaPeriod != nil {
-			if c.IsKubernetesGTE("1.20") {
-				allErrs = append(allErrs, field.Forbidden(kubeletPath.Child("cpuCFSQuotaPeriod"), "cpuCFSQuotaPeriod has been removed on Kubernetes >=1.20"))
-			}
+			allErrs = append(allErrs, field.Forbidden(kubeletPath.Child("cpuCFSQuotaPeriod"), "cpuCFSQuotaPeriod has been removed on Kubernetes >=1.20"))
 		}
 
 		if c.IsKubernetesGTE("1.24") {
@@ -1686,9 +1683,6 @@ func validateWarmPool(warmPool *kops.WarmPoolSpec, fldPath *field.Path) (allErrs
 
 func validateSnapshotController(cluster *kops.Cluster, spec *kops.SnapshotControllerConfig, fldPath *field.Path) (allErrs field.ErrorList) {
 	if spec != nil && fi.BoolValue(spec.Enabled) {
-		if !cluster.IsKubernetesGTE("1.20") {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("enabled"), "Snapshot controller requires kubernetes 1.20+"))
-		}
 		if !components.IsCertManagerEnabled(cluster) {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("enabled"), "Snapshot controller requires that cert manager is enabled"))
 		}

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -165,11 +165,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 
 	// We query via the kube-apiserver-healthcheck proxy, which listens on port 3990
 	c.InsecureBindAddress = ""
-	if b.IsKubernetesGTE("1.20") {
-		c.InsecurePort = nil
-	} else {
-		c.InsecurePort = fi.Int32(0)
-	}
+	c.InsecurePort = nil
 
 	// If metrics-server is enabled, we want aggregator routing enabled so that requests are load balanced.
 	metricsServer := clusterSpec.MetricsServer

--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -72,7 +72,7 @@ func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
 	docker.Storage = fi.String("overlay2,overlay,aufs")
 
 	// Set systemd as the default cgroup driver in docker from k8s 1.20.
-	if b.IsKubernetesGTE("1.20") && getDockerCgroupDriver(docker.ExecOpt) == "" {
+	if getDockerCgroupDriver(docker.ExecOpt) == "" {
 		docker.ExecOpt = append(docker.ExecOpt, "native.cgroupdriver=systemd")
 	}
 

--- a/pkg/model/components/etcdmanager/tests/interval/cluster.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/cluster.yaml
@@ -33,7 +33,7 @@ spec:
     provider: Manager
     backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-  kubernetesVersion: v1.17.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/pkg/model/components/etcdmanager/tests/minimal/cluster.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/cluster.yaml
@@ -28,7 +28,7 @@ spec:
     provider: Manager
     backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-  kubernetesVersion: v1.17.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/cluster.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/cluster.yaml
@@ -38,7 +38,7 @@ spec:
     provider: Manager
     backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-  kubernetesVersion: v1.17.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/pkg/model/components/etcdmanager/tests/proxy/cluster.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/cluster.yaml
@@ -32,7 +32,7 @@ spec:
     provider: Manager
     backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
-  kubernetesVersion: v1.17.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/pkg/model/components/kubeapiserver/tests/minimal/cluster.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/cluster.yaml
@@ -9,7 +9,7 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://clusters.example.com/minimal.example.com
-  kubernetesVersion: v1.18.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -204,8 +204,8 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 	}
 
-	// Set systemd as the default cgroup driver for kubelet from k8s 1.20
-	if b.IsKubernetesGTE("1.20") && clusterSpec.Kubelet.CgroupDriver == "" {
+	// Set systemd as the default cgroup driver for kubelet
+	if clusterSpec.Kubelet.CgroupDriver == "" {
 		clusterSpec.Kubelet.CgroupDriver = "systemd"
 	}
 

--- a/tests/integration/conversion/aws/v1alpha2.yaml
+++ b/tests/integration/conversion/aws/v1alpha2.yaml
@@ -41,7 +41,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/aws/v1alpha3.yaml
+++ b/tests/integration/conversion/aws/v1alpha3.yaml
@@ -40,7 +40,7 @@ spec:
   iam: {}
   kubernetesAPIAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/azure/v1alpha2.yaml
+++ b/tests/integration/conversion/azure/v1alpha2.yaml
@@ -38,7 +38,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/azure/v1alpha3.yaml
+++ b/tests/integration/conversion/azure/v1alpha3.yaml
@@ -36,7 +36,7 @@ spec:
   iam: {}
   kubernetesAPIAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/canal/v1alpha2.yaml
+++ b/tests/integration/conversion/canal/v1alpha2.yaml
@@ -32,7 +32,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/canal/v1alpha3.yaml
+++ b/tests/integration/conversion/canal/v1alpha3.yaml
@@ -32,7 +32,7 @@ spec:
   iam: {}
   kubernetesAPIAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/cilium/v1alpha2.yaml
+++ b/tests/integration/conversion/cilium/v1alpha2.yaml
@@ -32,7 +32,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/cilium/v1alpha3.yaml
+++ b/tests/integration/conversion/cilium/v1alpha3.yaml
@@ -32,7 +32,7 @@ spec:
   iam: {}
   kubernetesAPIAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/do/v1alpha2.yaml
+++ b/tests/integration/conversion/do/v1alpha2.yaml
@@ -31,7 +31,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/do/v1alpha3.yaml
+++ b/tests/integration/conversion/do/v1alpha3.yaml
@@ -30,7 +30,7 @@ spec:
   iam: {}
   kubernetesAPIAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/gce/v1alpha2.yaml
+++ b/tests/integration/conversion/gce/v1alpha2.yaml
@@ -31,7 +31,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/gce/v1alpha3.yaml
+++ b/tests/integration/conversion/gce/v1alpha3.yaml
@@ -30,7 +30,7 @@ spec:
   iam: {}
   kubernetesAPIAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/minimal/legacy-v1alpha2.yaml
+++ b/tests/integration/conversion/minimal/legacy-v1alpha2.yaml
@@ -32,7 +32,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/minimal/v1alpha2.yaml
+++ b/tests/integration/conversion/minimal/v1alpha2.yaml
@@ -32,7 +32,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/minimal/v1alpha3.yaml
+++ b/tests/integration/conversion/minimal/v1alpha3.yaml
@@ -32,7 +32,7 @@ spec:
   iam: {}
   kubernetesAPIAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/openstack/v1alpha2.yaml
+++ b/tests/integration/conversion/openstack/v1alpha2.yaml
@@ -47,7 +47,7 @@ spec:
     legacy: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/tests/integration/conversion/openstack/v1alpha3.yaml
+++ b/tests/integration/conversion/openstack/v1alpha3.yaml
@@ -45,7 +45,7 @@ spec:
   iam: {}
   kubernetesAPIAccess:
   - 0.0.0.0/0
-  kubernetesVersion: v1.14.0
+  kubernetesVersion: v1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -1166,7 +1166,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*Addon
 		}
 	}
 
-	if b.IsKubernetesGTE("1.20") && b.Cluster.Spec.SnapshotController != nil && fi.BoolValue(b.Cluster.Spec.SnapshotController.Enabled) {
+	if b.Cluster.Spec.SnapshotController != nil && fi.BoolValue(b.Cluster.Spec.SnapshotController.Enabled) {
 		key := "snapshot-controller.addons.k8s.io"
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/cluster.yaml
@@ -23,7 +23,7 @@ spec:
     version: 3.1.12
     name: events
   iam: {}
-  kubernetesVersion: 1.19.0
+  kubernetesVersion: 1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   metricsServer:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/cluster.yaml
@@ -25,7 +25,7 @@ spec:
     version: 3.1.12
     name: events
   iam: {}
-  kubernetesVersion: 1.19.0
+  kubernetesVersion: 1.20.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   metricsServer:


### PR DESCRIPTION
Cherry pick of #14291 on release-1.25.

#14291: Bump tests to supported k8s version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```