### PR TITLE
Automated cherry pick of #14294: Add support for using an existing network for Hetzner

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -92,6 +92,7 @@ func ValidateCluster(c *kops.Cluster, strict bool) field.ErrorList {
 			allErrs = append(allErrs, field.Forbidden(fieldSpec.Child("hetzner"), "only one cloudProvider option permitted"))
 		}
 		optionTaken = true
+		requiresNetworkCIDR = false
 		requiresSubnets = false
 		requiresSubnetCIDR = false
 	}

--- a/pkg/model/hetznermodel/network.go
+++ b/pkg/model/hetznermodel/network.go
@@ -34,16 +34,21 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	network := &hetznertasks.Network{
 		Name:      fi.String(b.ClusterName()),
 		Lifecycle: b.Lifecycle,
-		Region:    b.Region,
-		IPRange:   b.Cluster.Spec.NetworkCIDR,
-		// TODO(hakman): Add support for additional subnets?
-		Subnets: []string{
-			b.Cluster.Spec.NetworkCIDR,
-		},
-		Labels: map[string]string{
-			hetzner.TagKubernetesClusterName: b.ClusterName(),
-		},
 	}
+
+	if b.Cluster.Spec.NetworkID == "" {
+		network.IPRange = b.Cluster.Spec.NetworkCIDR
+		network.Region = b.Region
+		network.Subnets = []string{
+			b.Cluster.Spec.NetworkCIDR,
+		}
+		network.Labels = map[string]string{
+			hetzner.TagKubernetesClusterName: b.ClusterName(),
+		}
+	} else {
+		network.ID = fi.String(b.Cluster.Spec.NetworkID)
+	}
+
 	c.AddTask(network)
 
 	return nil

--- a/upup/models/cloudup/resources/addons/hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml.template
@@ -6,8 +6,8 @@ metadata:
   name: hcloud
   namespace: kube-system
 stringData:
-  token: {{ HCLOUD_TOKEN }}
-  network: {{ ClusterName }}
+  token: "{{ HCLOUD_TOKEN }}"
+  network: "{{ HCLOUD_NETWORK }}"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
@@ -199,6 +199,11 @@ func (_ *LoadBalancer) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes 
 			return fmt.Errorf("failed to find network for loadbalancer %q", fi.StringValue(e.Name))
 		}
 
+		networkID, err := strconv.Atoi(fi.StringValue(e.Network.ID))
+		if err != nil {
+			return fmt.Errorf("failed to convert network ID %q to int: %w", fi.StringValue(e.Network.ID), err)
+		}
+
 		opts := hcloud.LoadBalancerCreateOpts{
 			Name: fi.StringValue(e.Name),
 			LoadBalancerType: &hcloud.LoadBalancerType{
@@ -221,7 +226,7 @@ func (_ *LoadBalancer) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes 
 				},
 			},
 			Network: &hcloud.Network{
-				ID: fi.IntValue(e.Network.ID),
+				ID: networkID,
 			},
 		}
 

--- a/upup/pkg/fi/cloudup/hetznertasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/servergroup.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
@@ -205,6 +206,11 @@ func (_ *ServerGroup) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *
 	}
 	userDataHash := safeBytesHash(userDataBytes)
 
+	networkID, err := strconv.Atoi(fi.StringValue(e.Network.ID))
+	if err != nil {
+		return fmt.Errorf("failed to convert network ID %q to int: %w", fi.StringValue(e.Network.ID), err)
+	}
+
 	for i := 1; i <= expectedCount-actualCount; i++ {
 		// Append a random/unique ID to the node name
 		name := fmt.Sprintf("%s-%x", fi.StringValue(e.Name), rand.Int63())
@@ -214,7 +220,7 @@ func (_ *ServerGroup) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *
 			StartAfterCreate: fi.Bool(true),
 			Networks: []*hcloud.Network{
 				{
-					ID: fi.IntValue(e.Network.ID),
+					ID: networkID,
 				},
 			},
 			Location: &hcloud.Location{

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -173,6 +173,12 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["HCLOUD_TOKEN"] = func() string {
 		return os.Getenv("HCLOUD_TOKEN")
 	}
+	dest["HCLOUD_NETWORK"] = func() string {
+		if cluster.Spec.NetworkID != "" {
+			return cluster.Spec.NetworkID
+		}
+		return cluster.Name
+	}
 
 	if featureflag.Spotinst.Enabled() {
 		if creds, err := spotinst.LoadCredentials(); err == nil {


### PR DESCRIPTION
Cherry pick of #14294 on release-1.25.

#14294: Add support for using an existing network for Hetzner

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```