### PR TITLE
Automated cherry pick of #14297: Update Hetzner CCM to v1.13.0

### DIFF
--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml
-    manifestHash: 9f8a6974c1b1b7c32082fbb69866cd122132d3167fa829817588537ddea71c99
+    manifestHash: f599f67d44e0dd315a452e3268daa4b46abe8676dd2b48fe9c88523030b7bf14
     name: hcloud-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: hcloud-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
@@ -91,7 +91,7 @@ spec:
             secretKeyRef:
               key: network
               name: hcloud
-        image: hetznercloud/hcloud-cloud-controller-manager:v1.12.1
+        image: hetznercloud/hcloud-cloud-controller-manager:v1.13.0
         name: hcloud-cloud-controller-manager
         resources:
           requests:
@@ -99,7 +99,7 @@ spec:
             memory: 50Mi
       dnsPolicy: Default
       hostNetwork: true
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
       - effect: NoSchedule

--- a/upup/models/cloudup/resources/addons/hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml.template
@@ -46,7 +46,6 @@ spec:
     spec:
       serviceAccountName: cloud-controller-manager
       dnsPolicy: Default
-      priorityClassName: system-node-critical
       tolerations:
         # this taint is set by all kubelets running `--cloud-provider=external`
         # so we should tolerate it to schedule the cloud controller manager
@@ -66,7 +65,7 @@ spec:
           effect: "NoSchedule"
       hostNetwork: true
       containers:
-        - image: hetznercloud/hcloud-cloud-controller-manager:v1.12.1
+        - image: hetznercloud/hcloud-cloud-controller-manager:v1.13.0
           name: hcloud-cloud-controller-manager
           command:
             - "/bin/hcloud-cloud-controller-manager"
@@ -92,3 +91,4 @@ spec:
                 secretKeyRef:
                   name: hcloud
                   key: network
+      priorityClassName: system-cluster-critical


### PR DESCRIPTION
Cherry pick of #14297 on release-1.25.

#14297: Update Hetzner CCM to v1.13.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```