### PR TITLE
Automated cherry pick of #14318: Avoid spurious changes with bastion hosts due to user

### DIFF
--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -245,7 +245,7 @@ func (b *BootstrapScriptBuilder) ResourceNodeUp(c *fi.ModelBuilderContext, ig *k
 
 		// Bastions can have AdditionalUserData, but if there isn't any skip this part
 		if len(ig.Spec.AdditionalUserData) == 0 {
-			return fi.NewStringResource(""), nil
+			return nil, nil
 		}
 	}
 

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json
@@ -366,8 +366,7 @@
                 }
               ]
             }
-          ],
-          "UserData": "extracted"
+          ]
         }
       }
     },

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json.extracted.yaml
@@ -1,4 +1,3 @@
-Resources.AWSEC2LaunchTemplatebastionprivatesharedipexamplecom.Properties.LaunchTemplateData.UserData: ""
 Resources.AWSEC2LaunchTemplatemasterustest1amastersprivatesharedipexamplecom.Properties.LaunchTemplateData.UserData: |
   #!/bin/bash
   set -o errexit

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -428,8 +428,7 @@
                 }
               ]
             }
-          ],
-          "UserData": "extracted"
+          ]
         }
       }
     },

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json.extracted.yaml
@@ -1,4 +1,3 @@
-Resources.AWSEC2LaunchTemplatebastionprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: ""
 Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: |
   #!/bin/bash
   set -o errexit

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -400,8 +400,7 @@
                 }
               ]
             }
-          ],
-          "UserData": "extracted"
+          ]
         }
       }
     },

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
@@ -1,4 +1,3 @@
-Resources.AWSEC2LaunchTemplatebastionprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: ""
 Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: |
   #!/bin/bash
   set -o errexit

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -428,8 +428,7 @@
                 }
               ]
             }
-          ],
-          "UserData": "extracted"
+          ]
         }
       }
     },

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
@@ -1,4 +1,3 @@
-Resources.AWSEC2LaunchTemplatebastionprivateciliumadvancedexamplecom.Properties.LaunchTemplateData.UserData: ""
 Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumadvancedexamplecom.Properties.LaunchTemplateData.UserData: |
   #!/bin/bash
   set -o errexit


### PR DESCRIPTION
Cherry pick of #14318 on release-1.25.

#14318: Avoid spurious changes with bastion hosts due to user

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```