### PR TITLE
Add more details to the NTH documentation

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -238,8 +238,10 @@ spec:
   nodeTerminationHandler:
     cpuRequest: 200m
     enabled: true
+    enableRebalanceMonitoring: true
     enableSQSTerminationDraining: true
     managedASGTag: "aws-node-termination-handler/managed"
+    prometheusEnable: true
 ```
 
 ##### Queue Processor Mode

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5331,8 +5331,9 @@ spec:
                       is received Default: false'
                     type: boolean
                   enableSQSTerminationDraining:
-                    description: EnableSQSTerminationDraining enables queue-processor
+                    description: 'EnableSQSTerminationDraining enables queue-processor
                       mode which drains nodes when an SQS termination event is received.
+                      Default: false'
                     type: boolean
                   enableScheduledEventDraining:
                     description: 'EnableScheduledEventDraining makes node termination
@@ -5369,7 +5370,8 @@ spec:
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   prometheusEnable:
-                    description: EnablePrometheusMetrics enables the "/metrics" endpoint.
+                    description: 'EnablePrometheusMetrics enables the "/metrics" endpoint.
+                      Default: false'
                     type: boolean
                   version:
                     description: Version is the container image tag used.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -937,9 +937,11 @@ type NodeTerminationHandlerConfig struct {
 	EnableRebalanceDraining *bool `json:"enableRebalanceDraining,omitempty"`
 
 	// EnablePrometheusMetrics enables the "/metrics" endpoint.
+	// Default: false
 	EnablePrometheusMetrics *bool `json:"prometheusEnable,omitempty"`
 
 	// EnableSQSTerminationDraining enables queue-processor mode which drains nodes when an SQS termination event is received.
+	// Default: false
 	EnableSQSTerminationDraining *bool `json:"enableSQSTerminationDraining,omitempty"`
 
 	// ExcludeFromLoadBalancers makes node termination handler will mark for exclusion from load balancers before node are cordoned.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -963,9 +963,11 @@ type NodeTerminationHandlerConfig struct {
 	EnableRebalanceDraining *bool `json:"enableRebalanceDraining,omitempty"`
 
 	// EnablePrometheusMetrics enables the "/metrics" endpoint.
+	// Default: false
 	EnablePrometheusMetrics *bool `json:"prometheusEnable,omitempty"`
 
 	// EnableSQSTerminationDraining enables queue-processor mode which drains nodes when an SQS termination event is received.
+	// Default: false
 	EnableSQSTerminationDraining *bool `json:"enableSQSTerminationDraining,omitempty"`
 
 	// ExcludeFromLoadBalancers makes node termination handler will mark for exclusion from load balancers before node are cordoned.

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -934,9 +934,11 @@ type NodeTerminationHandlerConfig struct {
 	EnableRebalanceDraining *bool `json:"enableRebalanceDraining,omitempty"`
 
 	// EnablePrometheusMetrics enables the "/metrics" endpoint.
+	// Default: false
 	EnablePrometheusMetrics *bool `json:"prometheusEnable,omitempty"`
 
 	// EnableSQSTerminationDraining enables queue-processor mode which drains nodes when an SQS termination event is received.
+	// Default: false
 	EnableSQSTerminationDraining *bool `json:"enableSQSTerminationDraining,omitempty"`
 
 	// ManagedASGTag is the tag used to determine which nodes NTH can take action on


### PR DESCRIPTION
When trying to enable Prometheus metrics for NTH, I naively set:
```
nodeTerminationHandler:
  enablePrometheusMetrics: true
```

Add `prometheusEnable` to the docs to try to prevent such mistakes in the future. Also add `enableRebalanceMonitoring` for good measure, and a couple missing defaults to the struct field docstrings.

N.B. I almost certainly missed some code generation step or something. Please advise.