### PR TITLE
Automated cherry pick of #14326: Add --network-id alias for --vpc flag

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -280,8 +280,10 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().Int32Var(&options.MasterVolumeSize, "master-volume-size", options.MasterVolumeSize, "Instance volume size (in GB) for masters")
 	cmd.Flags().Int32Var(&options.NodeVolumeSize, "node-volume-size", options.NodeVolumeSize, "Instance volume size (in GB) for worker nodes")
 
-	cmd.Flags().StringVar(&options.NetworkID, "vpc", options.NetworkID, "Shared VPC to use")
+	cmd.Flags().StringVar(&options.NetworkID, "vpc", options.NetworkID, "Shared Network or VPC to use")
 	cmd.RegisterFlagCompletionFunc("vpc", completeNetworkID)
+	cmd.Flags().StringVar(&options.NetworkID, "network-id", options.NetworkID, "Shared Network or VPC to use")
+	cmd.RegisterFlagCompletionFunc("network-id", completeNetworkID)
 	cmd.Flags().StringSliceVar(&options.SubnetIDs, "subnets", options.SubnetIDs, "Shared subnets to use")
 	cmd.RegisterFlagCompletionFunc("subnets", completeSubnetID(options))
 	cmd.Flags().StringSliceVar(&options.UtilitySubnetIDs, "utility-subnets", options.UtilitySubnetIDs, "Shared utility subnets to use")

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -97,6 +97,7 @@ kops create cluster [CLUSTER] [flags]
       --master-volume-size int32         Instance volume size (in GB) for masters
       --master-zones strings             Zones in which to run masters (must be an odd number)
       --network-cidr string              Network CIDR to use
+      --network-id string                Shared Network or VPC to use
       --networking string                Networking mode.  kubenet, external, weave, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router, amazonvpc, cilium, cilium-etcd, cni. (default "kubenet")
       --node-count int32                 Total number of worker nodes. Defaults to one node per zone
       --node-image string                Machine image for worker nodes. Takes precedence over --image
@@ -121,7 +122,7 @@ kops create cluster [CLUSTER] [flags]
       --target string                    Valid targets: direct, terraform, cloudformation. Set this flag to terraform if you want kOps to generate terraform (default "direct")
   -t, --topology string                  Network topology for the cluster: public or private (default "public")
       --utility-subnets strings          Shared utility subnets to use
-      --vpc string                       Shared VPC to use
+      --vpc string                       Shared Network or VPC to use
   -y, --yes                              Specify --yes to immediately create the cluster
       --zones strings                    Zones in which to run the cluster
 ```


### PR DESCRIPTION
Cherry pick of #14326 on release-1.24.

#14326: Add --network-id alias for --vpc flag

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```