### PR TITLE
Fix typo in doc for enabling cert-manager dns-01 challenges

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -158,7 +158,7 @@ spec:
     hostedZoneIDs:
     - ZONEID
   iam:
-    useServiceAccountsExternalPermissions: true
+    useServiceAccountExternalPermissions: true
 ```
 
 Read more about cert-manager in the [official documentation](https://cert-manager.io/docs/)


### PR DESCRIPTION
Following the doc resulted in an error from kOps CLI

```
Error: error creating cluster: spec.certManager: Forbidden: Cert Manager requires that service accounts use external permissions in order to do dns-01 validation
```

because there is a typo in the doc