### PR TITLE
Set higher verbosity when logging Gossip DNS info

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -484,7 +484,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 	modelContext.Region = cloud.Region()
 
 	if dns.IsGossipHostname(cluster.ObjectMeta.Name) {
-		klog.Infof("Gossip DNS: skipping DNS validation")
+		klog.V(2).Infof("Gossip DNS: skipping DNS validation")
 	} else {
 		err = validateDNS(cluster, cloud)
 		if err != nil {


### PR DESCRIPTION
Similar to https://github.com/kubernetes/kops/pull/11657:
https://github.com/kubernetes/kops/blob/0be79b25b74e5bec3ddd0907918605b39600e1dd/upup/pkg/fi/cloudup/dns.go#L102