### PR TITLE
Automated cherry pick of #14339: Set higher verbosity when logging Gossip DNS info

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -484,7 +484,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 	modelContext.Region = cloud.Region()
 
 	if dns.IsGossipHostname(cluster.ObjectMeta.Name) {
-		klog.Infof("Gossip DNS: skipping DNS validation")
+		klog.V(2).Infof("Gossip DNS: skipping DNS validation")
 	} else {
 		err = validateDNS(cluster, cloud)
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #14339 on release-1.25.

#14339: Set higher verbosity when logging Gossip DNS info

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```