### PR TITLE
Revert "Set metrics-server `--kubelet-preferred-address-types` by k8s version"

### DIFF
--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -132,7 +132,7 @@ spec:
           - --secure-port=4443
           - --kubelet-use-node-status-port
           - --metric-resolution=15s
-          - --kubelet-preferred-address-types={{ if IsKubernetesGTE "1.22" }}InternalIP{{ else }}Hostname{{ end }}
+          - --kubelet-preferred-address-types={{ if IsIPv6Only }}InternalIP{{ else }}Hostname{{ end }}
 {{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
           - --tls-cert-file=/srv/tls.crt
           - --tls-private-key-file=/srv/tls.key

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 7bc0e1bc18e802aaff2c7cc73b766a54f3dfc1b9ce7a31017b3481ffc0d4b170
+    manifestHash: dcc45685fd1de2514d806f6e96f36bfc6fb18af68a8de6a9e5def5af833b1f43
     name: metrics-server.addons.k8s.io
     selector:
       k8s-app: metrics-server

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -170,7 +170,7 @@ spec:
         - --secure-port=4443
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=InternalIP
+        - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
         image: registry.k8s.io/metrics-server/metrics-server:v0.6.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 97f57a040dfc8b8c50ca8e1612c52c5825b4bb033d0e57a7ea0043e7d79ead9e
+    manifestHash: 11c1aee62e84644780c05cd8f7d0bd9a99bc9f0b45a43ab796b51ee335f5ecf6
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -170,7 +170,7 @@ spec:
         - --secure-port=4443
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=InternalIP
+        - --kubelet-preferred-address-types=Hostname
         - --tls-cert-file=/srv/tls.crt
         - --tls-private-key-file=/srv/tls.key
         image: registry.k8s.io/metrics-server/metrics-server:v0.6.1


### PR DESCRIPTION
Reverts kubernetes/kops#14336 in favor of kubernetes/kops#14350.

/cc @olemarkus 