### PR TITLE
hetzner: Fix metrics-server config to use internal IP

### DIFF
--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -132,7 +132,7 @@ spec:
           - --secure-port=4443
           - --kubelet-use-node-status-port
           - --metric-resolution=15s
-          - --kubelet-preferred-address-types={{ if IsIPv6Only }}InternalIP{{ else }}Hostname{{ end }}
+          - --kubelet-preferred-address-types={{ if or IsIPv6Only (eq GetCloudProvider "hetzner")}}InternalIP{{ else }}Hostname{{ end }}
 {{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
           - --tls-cert-file=/srv/tls.crt
           - --tls-private-key-file=/srv/tls.key


### PR DESCRIPTION
Alternative to https://github.com/kubernetes/kops/pull/14336.

/cc @olemarkus 