### PR TITLE
Automated cherry pick of #14347: Add create cluster test for arm64

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -63,8 +63,6 @@ type CreateClusterOptions struct {
 	cloudup.NewClusterOptions
 	Yes                  bool
 	Target               string
-	NodeSize             string
-	MasterSize           string
 	MasterVolumeSize     int32
 	NodeVolumeSize       int32
 	ContainerRuntime     string
@@ -543,12 +541,6 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		cluster.Spec.CloudLabels = cloudLabels
 	}
 
-	if c.NodeSize != "" {
-		for _, group := range nodes {
-			group.Spec.MachineType = c.NodeSize
-		}
-	}
-
 	if c.AssociatePublicIP != nil {
 		for _, group := range instanceGroups {
 			group.Spec.AssociatePublicIP = c.AssociatePublicIP
@@ -576,12 +568,6 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 	if len(c.MasterSecurityGroups) > 0 {
 		for _, group := range masters {
 			group.Spec.AdditionalSecurityGroups = c.MasterSecurityGroups
-		}
-	}
-
-	if c.MasterSize != "" {
-		for _, group := range masters {
-			group.Spec.MachineType = c.MasterSize
 		}
 	}
 

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -53,6 +53,7 @@ func TestCreateClusterMinimal(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/minimal-1.24", "v1alpha2")
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/minimal-1.25", "v1alpha2")
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/minimal-1.26", "v1alpha2")
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/minimal-1.26-arm64", "v1alpha2")
 }
 
 // TestCreateClusterHetzner runs kops create cluster minimal.k8s.local --zones fsn1

--- a/tests/integration/create_cluster/minimal-1.26-arm64/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-arm64/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220810
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220810
   instanceMetadata:
     httpPutResponseHopLimit: 3
     httpTokens: required
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220810
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220810
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required

--- a/tests/integration/create_cluster/minimal-1.26-arm64/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-arm64/expected-v1alpha2.yaml
@@ -1,0 +1,97 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  name: minimal.example.com
+spec:
+  api:
+    dns: {}
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/minimal.example.com
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - encryptedVolume: true
+      instanceGroup: master-us-test-1a
+      name: a
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+    - encryptedVolume: true
+      instanceGroup: master-us-test-1a
+      name: a
+    memoryRequest: 100Mi
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubelet:
+    anonymousAuth: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  - ::/0
+  kubernetesVersion: v1.26.0
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    cni: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  - ::/0
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+  name: master-us-test-1a
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220810
+  instanceMetadata:
+    httpPutResponseHopLimit: 3
+    httpTokens: required
+  machineType: m6g.xlarge
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+  name: nodes-us-test-1a
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220810
+  instanceMetadata:
+    httpPutResponseHopLimit: 1
+    httpTokens: required
+  machineType: m6g.xlarge
+  maxSize: 1
+  minSize: 1
+  role: Node
+  subnets:
+  - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.26-arm64/options.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-arm64/options.yaml
@@ -1,0 +1,8 @@
+ClusterName: minimal.example.com
+Zones:
+- us-test-1a
+CloudProvider: aws
+Networking: cni
+KubernetesVersion: v1.26.0
+NodeSize: m6g.xlarge
+MasterSize: m6g.xlarge

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -95,7 +95,7 @@ spec:
   - sg-exampleid3
   - sg-exampleid4
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
-  machineType: n1-standard-1
+  machineType: e2-standard-2
   maxSize: 1
   minSize: 1
   role: Master

--- a/tests/integration/create_cluster/private_gce/options.yaml
+++ b/tests/integration/create_cluster/private_gce/options.yaml
@@ -15,3 +15,4 @@ KubernetesVersion: v1.21.0
 cloudLabels: "Owner=John Doe,dn=\"cn=John Doe: dc=example dc=com\", foo/bar=fib+baz"
 Project: testproject
 GCEServiceAccount: test-account@testproject.iam.gserviceaccount.com
+MasterSize: e2-standard-2

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -358,7 +358,7 @@ func (c *MockAWSCloud) DescribeInstanceType(instanceType string) (*ec2.InstanceT
 				aws.String(ec2.ArchitectureTypeX8664),
 			},
 		}
-	case "a1.large":
+	case "a1.large", "m6g.xlarge":
 		info.ProcessorInfo = &ec2.ProcessorInfo{
 			SupportedArchitectures: []*string{
 				aws.String(ec2.ArchitectureTypeArm64),

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1465,6 +1465,11 @@ func MachineArchitecture(cloud fi.Cloud, machineType string) (architectures.Arch
 		return architectures.ArchitectureAmd64, nil
 	}
 
+	// Some calls only have AWS initialised at this point and in other cases pass in nil as cloud.
+	if cloud == nil {
+		return architectures.ArchitectureAmd64, nil
+	}
+
 	switch cloud.ProviderID() {
 	case kopsapi.CloudProviderAWS:
 		info, err := cloud.(awsup.AWSCloud).DescribeInstanceType(machineType)

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -157,6 +157,8 @@ type NewClusterOptions struct {
 	Image       string
 	NodeImage   string
 	MasterImage string
+	MasterSize  string
+	NodeSize    string
 }
 
 func (o *NewClusterOptions) InitDefaults() {
@@ -856,6 +858,7 @@ func setupMasters(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetMap 
 				}
 			}
 
+			g.Spec.MachineType = opt.MasterSize
 			g.Spec.Image = opt.MasterImage
 
 			masters = append(masters, g)
@@ -983,6 +986,7 @@ func setupNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetMap ma
 			}
 		}
 
+		g.Spec.MachineType = opt.NodeSize
 		g.Spec.Image = opt.NodeImage
 
 		nodes = append(nodes, g)
@@ -1465,7 +1469,7 @@ func MachineArchitecture(cloud fi.Cloud, machineType string) (architectures.Arch
 	case kopsapi.CloudProviderAWS:
 		info, err := cloud.(awsup.AWSCloud).DescribeInstanceType(machineType)
 		if err != nil {
-			return "", fmt.Errorf("error finding instance info for instance type %q: %v", machineType, err)
+			return "", fmt.Errorf("error finding instance info for instance type %q: %w", machineType, err)
 		}
 		if info.ProcessorInfo == nil || len(info.ProcessorInfo.SupportedArchitectures) == 0 {
 			return "", fmt.Errorf("error finding architecture info for instance type %q", machineType)


### PR DESCRIPTION
Cherry pick of #14347 on release-1.25.

#14347: Add create cluster test for arm64

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```