### PR TITLE
Automated cherry pick of #14333: Ensure kubelet configuration from IG takes precedence

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3489,7 +3489,9 @@ spec:
                     type: boolean
                 type: object
               kubelet:
-                description: KubeletConfigSpec defines the kubelet configuration
+                description: Kubelet is the kubelet configuration for nodes not belonging
+                  to the control plane. It can be overridden by the kubelet configuration
+                  specified in the instance group.
                 properties:
                   allowPrivileged:
                     description: AllowPrivileged enables containers to request privileged
@@ -3917,7 +3919,9 @@ spec:
                   nodes
                 type: string
               masterKubelet:
-                description: KubeletConfigSpec defines the kubelet configuration
+                description: MasterKubelet is the kubelet configuration for nodes
+                  belonging to the control plane It can be overridden by the kubelet
+                  configuration specified in the instance group.
                 properties:
                   allowPrivileged:
                     description: AllowPrivileged enables containers to request privileged

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -19,6 +19,7 @@ package model
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 
@@ -137,6 +138,8 @@ func TestTaintsApplied(t *testing.T) {
 }
 
 func stringSlicesEqual(exp, other []string) bool {
+	sort.Sort(sort.StringSlice(exp))
+	sort.Sort(sort.StringSlice(other))
 	if exp == nil && other != nil {
 		return false
 	}

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -157,11 +157,15 @@ type ClusterSpec struct {
 	ExternalCloudControllerManager *CloudControllerManagerConfig `json:"cloudControllerManager,omitempty"`
 	KubeScheduler                  *KubeSchedulerConfig          `json:"kubeScheduler,omitempty"`
 	KubeProxy                      *KubeProxyConfig              `json:"kubeProxy,omitempty"`
-	Kubelet                        *KubeletConfigSpec            `json:"kubelet,omitempty"`
-	MasterKubelet                  *KubeletConfigSpec            `json:"masterKubelet,omitempty"`
-	CloudConfig                    *CloudConfiguration           `json:"cloudConfig,omitempty"`
-	ExternalDNS                    *ExternalDNSConfig            `json:"externalDNS,omitempty"`
-	NTP                            *NTPConfig                    `json:"ntp,omitempty"`
+	// Kubelet is the kubelet configuration for nodes not belonging to the control plane.
+	// It can be overridden by the kubelet configuration specified in the instance group.
+	Kubelet *KubeletConfigSpec `json:"kubelet,omitempty"`
+	// MasterKubelet is the kubelet configuration for nodes belonging to the control plane
+	// It can be overridden by the kubelet configuration specified in the instance group.
+	MasterKubelet *KubeletConfigSpec  `json:"masterKubelet,omitempty"`
+	CloudConfig   *CloudConfiguration `json:"cloudConfig,omitempty"`
+	ExternalDNS   *ExternalDNSConfig  `json:"externalDNS,omitempty"`
+	NTP           *NTPConfig          `json:"ntp,omitempty"`
 
 	// NodeTerminationHandler determines the node termination handler configuration.
 	NodeTerminationHandler *NodeTerminationHandlerConfig `json:"nodeTerminationHandler,omitempty"`
@@ -244,20 +248,16 @@ type CloudProviderSpec struct {
 }
 
 // AWSSpec configures the AWS cloud provider.
-type AWSSpec struct {
-}
+type AWSSpec struct{}
 
 // DOSpec configures the Digital Ocean cloud provider.
-type DOSpec struct {
-}
+type DOSpec struct{}
 
 // GCESpec configures the GCE cloud provider.
-type GCESpec struct {
-}
+type GCESpec struct{}
 
 // HetznerSpec configures the Hetzner cloud provider.
-type HetznerSpec struct {
-}
+type HetznerSpec struct{}
 
 type KarpenterConfig struct {
 	Enabled bool `json:"enabled,omitempty"`

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -156,11 +156,15 @@ type ClusterSpec struct {
 	ExternalCloudControllerManager *CloudControllerManagerConfig `json:"cloudControllerManager,omitempty"`
 	KubeScheduler                  *KubeSchedulerConfig          `json:"kubeScheduler,omitempty"`
 	KubeProxy                      *KubeProxyConfig              `json:"kubeProxy,omitempty"`
-	Kubelet                        *KubeletConfigSpec            `json:"kubelet,omitempty"`
-	MasterKubelet                  *KubeletConfigSpec            `json:"masterKubelet,omitempty"`
-	CloudConfig                    *CloudConfiguration           `json:"cloudConfig,omitempty"`
-	ExternalDNS                    *ExternalDNSConfig            `json:"externalDns,omitempty"`
-	NTP                            *NTPConfig                    `json:"ntp,omitempty"`
+	// Kubelet is the kubelet configuration for nodes not belonging to the control plane.
+	// It can be overridden by the kubelet configuration specified in the instance group.
+	Kubelet *KubeletConfigSpec `json:"kubelet,omitempty"`
+	// MasterKubelet is the kubelet configuration for nodes belonging to the control plane
+	// It can be overridden by the kubelet configuration specified in the instance group.
+	MasterKubelet *KubeletConfigSpec  `json:"masterKubelet,omitempty"`
+	CloudConfig   *CloudConfiguration `json:"cloudConfig,omitempty"`
+	ExternalDNS   *ExternalDNSConfig  `json:"externalDns,omitempty"`
+	NTP           *NTPConfig          `json:"ntp,omitempty"`
 
 	// NodeTerminationHandler determines the cluster autoscaler configuration.
 	NodeTerminationHandler *NodeTerminationHandlerConfig `json:"nodeTerminationHandler,omitempty"`

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -155,11 +155,15 @@ type ClusterSpec struct {
 	ExternalCloudControllerManager *CloudControllerManagerConfig `json:"cloudControllerManager,omitempty"`
 	KubeScheduler                  *KubeSchedulerConfig          `json:"kubeScheduler,omitempty"`
 	KubeProxy                      *KubeProxyConfig              `json:"kubeProxy,omitempty"`
-	Kubelet                        *KubeletConfigSpec            `json:"kubelet,omitempty"`
-	MasterKubelet                  *KubeletConfigSpec            `json:"masterKubelet,omitempty"`
-	CloudConfig                    *CloudConfiguration           `json:"cloudConfig,omitempty"`
-	ExternalDNS                    *ExternalDNSConfig            `json:"externalDNS,omitempty"`
-	NTP                            *NTPConfig                    `json:"ntp,omitempty"`
+	// Kubelet is the kubelet configuration for nodes not belonging to the control plane.
+	// It can be overridden by the kubelet configuration specified in the instance group.
+	Kubelet *KubeletConfigSpec `json:"kubelet,omitempty"`
+	// MasterKubelet is the kubelet configuration for nodes belonging to the control plane
+	// It can be overridden by the kubelet configuration specified in the instance group.
+	MasterKubelet *KubeletConfigSpec  `json:"masterKubelet,omitempty"`
+	CloudConfig   *CloudConfiguration `json:"cloudConfig,omitempty"`
+	ExternalDNS   *ExternalDNSConfig  `json:"externalDNS,omitempty"`
+	NTP           *NTPConfig          `json:"ntp,omitempty"`
 
 	// NodeTerminationHandler determines the cluster autoscaler configuration.
 	NodeTerminationHandler *NodeTerminationHandlerConfig `json:"nodeTerminationHandler,omitempty"`
@@ -241,20 +245,16 @@ type CloudProviderSpec struct {
 }
 
 // AWSSpec configures the AWS cloud provider.
-type AWSSpec struct {
-}
+type AWSSpec struct{}
 
 // DOSpec configures the Digital Ocean cloud provider.
-type DOSpec struct {
-}
+type DOSpec struct{}
 
 // GCESpec configures the GCE cloud provider.
-type GCESpec struct {
-}
+type GCESpec struct{}
 
 // HetznerSpec configures the Hetzner cloud provider.
-type HetznerSpec struct {
-}
+type HetznerSpec struct{}
 
 type KarpenterConfig struct {
 	Enabled bool `json:"enabled,omitempty"`

--- a/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
@@ -177,6 +177,28 @@ func TestPopulateCluster_StorageDefault(t *testing.T) {
 	}
 }
 
+func TestPopulateCluster_EvictionHard(t *testing.T) {
+	cloud, c := buildMinimalCluster()
+
+	err := PerformAssignments(c, cloud)
+	if err != nil {
+		t.Fatalf("error from PerformAssignments: %v", err)
+	}
+
+	c.Spec.Kubelet = &kopsapi.KubeletConfigSpec{
+		EvictionHard: fi.String("memory.available<250Mi"),
+	}
+
+	full, err := mockedPopulateClusterSpec(c, cloud)
+	if err != nil {
+		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
+	}
+
+	if fi.StringValue(full.Spec.Kubelet.EvictionHard) != "memory.available<250Mi" {
+		t.Fatalf("Unexpected StorageBackend: %v", *full.Spec.Kubelet.EvictionHard)
+	}
+}
+
 func build(c *kopsapi.Cluster) (*kopsapi.Cluster, error) {
 	cloud, err := BuildCloud(c)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec_test.go
@@ -109,7 +109,6 @@ func TestPopulateInstanceGroup_AddTaintsCollision3(t *testing.T) {
 	}
 
 	channel := &kopsapi.Channel{}
-
 	cloud, err := BuildCloud(cluster)
 	if err != nil {
 		t.Fatalf("error from BuildCloud: %v", err)
@@ -119,7 +118,99 @@ func TestPopulateInstanceGroup_AddTaintsCollision3(t *testing.T) {
 		t.Fatalf("error from PopulateInstanceGroupSpec: %v", err)
 	}
 	if len(output.Spec.Kubelet.Taints) != 2 {
-		t.Errorf("Expected only 2 taints, got %d", len(output.Spec.Kubelet.Taints))
+		t.Errorf("Expected 2 taints, got %d", len(output.Spec.Kubelet.Taints))
+	}
+}
+
+func TestPopulateInstanceGroup_EvictionHard(t *testing.T) {
+	_, cluster := buildMinimalCluster()
+	cluster.Spec.Kubelet = &kopsapi.KubeletConfigSpec{
+		EvictionHard: fi.String("memory.available<350Mi"),
+	}
+	input := buildMinimalNodeInstanceGroup()
+	input.Spec.Kubelet = &kopsapi.KubeletConfigSpec{
+		EvictionHard: fi.String("memory.available<250Mi"),
+	}
+
+	channel := &kopsapi.Channel{}
+
+	cloud, err := BuildCloud(cluster)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+	output, err := PopulateInstanceGroupSpec(cluster, input, cloud, channel)
+	if err != nil {
+		t.Fatalf("error from PopulateInstanceGroupSpec: %v", err)
+	}
+	if fi.StringValue(output.Spec.Kubelet.EvictionHard) != "memory.available<250Mi" {
+		t.Errorf("Unexpected value %v", fi.StringValue(output.Spec.Kubelet.EvictionHard))
+	}
+}
+
+func TestPopulateInstanceGroup_EvictionHard3(t *testing.T) {
+	_, cluster := buildMinimalCluster()
+	cluster.Spec.Kubelet = &kopsapi.KubeletConfigSpec{
+		EvictionHard: fi.String("memory.available<350Mi"),
+	}
+	input := buildMinimalMasterInstanceGroup("us-test-1")
+
+	channel := &kopsapi.Channel{}
+
+	cloud, err := BuildCloud(cluster)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+	output, err := PopulateInstanceGroupSpec(cluster, input, cloud, channel)
+	if err != nil {
+		t.Fatalf("error from PopulateInstanceGroupSpec: %v", err)
+	}
+	// There is no default EvictionHard
+	if fi.StringValue(output.Spec.Kubelet.EvictionHard) != "" {
+		t.Errorf("Unexpected value %v", fi.StringValue(output.Spec.Kubelet.EvictionHard))
+	}
+}
+
+func TestPopulateInstanceGroup_EvictionHard4(t *testing.T) {
+	_, cluster := buildMinimalCluster()
+	cluster.Spec.MasterKubelet = &kopsapi.KubeletConfigSpec{
+		EvictionHard: fi.String("memory.available<350Mi"),
+	}
+	input := buildMinimalMasterInstanceGroup("us-test-1")
+
+	channel := &kopsapi.Channel{}
+
+	cloud, err := BuildCloud(cluster)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+	output, err := PopulateInstanceGroupSpec(cluster, input, cloud, channel)
+	if err != nil {
+		t.Fatalf("error from PopulateInstanceGroupSpec: %v", err)
+	}
+	if fi.StringValue(output.Spec.Kubelet.EvictionHard) != "memory.available<350Mi" {
+		t.Errorf("Unexpected value %v", fi.StringValue(output.Spec.Kubelet.EvictionHard))
+	}
+}
+
+func TestPopulateInstanceGroup_EvictionHard2(t *testing.T) {
+	_, cluster := buildMinimalCluster()
+	input := buildMinimalNodeInstanceGroup()
+	input.Spec.Kubelet = &kopsapi.KubeletConfigSpec{
+		EvictionHard: fi.String("memory.available<250Mi"),
+	}
+
+	channel := &kopsapi.Channel{}
+
+	cloud, err := BuildCloud(cluster)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+	output, err := PopulateInstanceGroupSpec(cluster, input, cloud, channel)
+	if err != nil {
+		t.Fatalf("error from PopulateInstanceGroupSpec: %v", err)
+	}
+	if fi.StringValue(output.Spec.Kubelet.EvictionHard) != "memory.available<250Mi" {
+		t.Errorf("Unexpected value %v", fi.StringValue(output.Spec.Kubelet.EvictionHard))
 	}
 }
 

--- a/util/pkg/reflectutils/walk.go
+++ b/util/pkg/reflectutils/walk.go
@@ -44,6 +44,7 @@ func IsMethodNotFound(err error) bool {
 
 // JSONMergeStruct merges src into dest
 // It uses a JSON marshal & unmarshal, so only fields that are JSON-visible will be copied
+// If both source and destination has a value for a field, source takes presedence
 func JSONMergeStruct(dest, src interface{}) {
 	// Not the most efficient approach, but simple & relatively well defined
 	j, err := json.Marshal(src)

--- a/util/pkg/reflectutils/walk_test.go
+++ b/util/pkg/reflectutils/walk_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reflectutils
+
+import "testing"
+
+type testStruct struct {
+	Value string `json:"value,omitempty"`
+}
+
+func Test_Merge(t *testing.T) {
+	source := testStruct{
+		Value: "foo",
+	}
+
+	destination := testStruct{
+		Value: "bar",
+	}
+
+	JSONMergeStruct(&destination, &source)
+
+	// verify source value overrides destination
+	if destination.Value != "foo" {
+		t.Errorf("unexpected value: %s", destination.Value)
+	}
+}


### PR DESCRIPTION
Cherry pick of #14333 on release-1.25.

#14333: Add test confirming json merge behavior

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```