### PR TITLE
gce: memberlist needs TCP also

### DIFF
--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -115,7 +115,9 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 		if b.IsGossip() {
 			t.Allowed = append(t.Allowed, fmt.Sprintf("udp:%d", wellknownports.DNSControllerGossipMemberlist))
+			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.DNSControllerGossipMemberlist))
 			t.Allowed = append(t.Allowed, fmt.Sprintf("udp:%d", wellknownports.ProtokubeGossipMemberlist))
+			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.ProtokubeGossipMemberlist))
 		}
 		if b.NetworkingIsCalico() {
 			t.Allowed = append(t.Allowed, "ipip")


### PR DESCRIPTION
The memberlist gossip protocol exchange happens over TCP and UDP, so
we need to open both protocols.
