### PR TITLE
Disable rp_filter on cilium hosts

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -181,6 +181,8 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"# Depending on systemd version, cloud and distro, rp_filters may be enabled.",
 			"# Cilium requires this to be disabled. See https://github.com/cilium/cilium/issues/10645",
 			"net.ipv4.conf.all.rp_filter=0",
+			"net.ipv4.conf.lxc*.rp_filter=0",
+			"net.ipv4.conf.cilium_*.rp_filter=0",
 			"")
 	}
 


### PR DESCRIPTION
The rp_filter change in https://github.com/kubernetes/kops/pull/14137 was incomplete. This PR should further ensure rp_filter is not enabled when using cilium, and should make cilium work on Jammy.