### PR TITLE
get-keypairs: Tolerate key set items without certificates

### DIFF
--- a/cmd/kops/promote_keypair.go
+++ b/cmd/kops/promote_keypair.go
@@ -162,17 +162,17 @@ func promoteKeypair(out io.Writer, name string, keypairID string, keyStore fi.CA
 	}
 
 	if keypairID == "" {
-		highestTrustedId := big.NewInt(0)
+		highestCandidateId := big.NewInt(0)
 		for id, item := range keyset.Items {
-			if item.PrivateKey != nil && item.DistrustTimestamp == nil {
+			if item.PrivateKey != nil && item.DistrustTimestamp == nil && item.Certificate != nil {
 				itemId, ok := big.NewInt(0).SetString(id, 10)
-				if ok && highestTrustedId.Cmp(itemId) < 0 {
-					highestTrustedId = itemId
+				if ok && highestCandidateId.Cmp(itemId) < 0 {
+					highestCandidateId = itemId
 				}
 			}
 		}
 
-		keypairID = highestTrustedId.String()
+		keypairID = highestCandidateId.String()
 		if keypairID == keyset.Primary.Id {
 			fmt.Fprintf(out, "No %s keypair newer than current primary %s\n", name, keypairID)
 			return nil
@@ -183,6 +183,9 @@ func promoteKeypair(out io.Writer, name string, keypairID string, keyStore fi.CA
 		}
 		if item.PrivateKey == nil {
 			return fmt.Errorf("keypair has no private key")
+		}
+		if item.Certificate == nil {
+			return fmt.Errorf("keypair has no certificate")
 		}
 	} else {
 		return fmt.Errorf("keypair not found")

--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -347,6 +347,9 @@ func (c *VFSCAStore) StoreKeyset(name string, keyset *Keyset) error {
 	if keyset.Items[primaryId].PrivateKey == nil {
 		return fmt.Errorf("keyset's primary id %q must have a private key", primaryId)
 	}
+	if keyset.Items[primaryId].Certificate == nil {
+		return fmt.Errorf("keyset's primary id %q must have a certificate", primaryId)
+	}
 
 	{
 		p := c.buildPrivateKeyPoolPath(name)


### PR DESCRIPTION
Allow the _kops get keypairs_ command to consume key sets with old key pair items that lack an associated X.509 certificate. When the command is invoked without the `--distrusted` flag set to true, omit these old items as if they're distrusted. Conversely, when the command is invoked with the `--distrusted` flag set to true, include these items, but omit their details that would be contingent on the nonexistent certificate.

In order to supply only information that is known to be true, treat the following fields in the output as newly optional:
- _issuer_
- _notAfter_
- _notBefore_
- _subject_

With no certificate present, it's not possible to present concrete values for those fields.

Fixes #14174.