### PR TITLE
Automated cherry pick of #14369: Disable rp_filter on cilium hosts

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -181,6 +181,8 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"# Depending on systemd version, cloud and distro, rp_filters may be enabled.",
 			"# Cilium requires this to be disabled. See https://github.com/cilium/cilium/issues/10645",
 			"net.ipv4.conf.all.rp_filter=0",
+			"net.ipv4.conf.lxc*.rp_filter=0",
+			"net.ipv4.conf.cilium_*.rp_filter=0",
 			"")
 	}
 


### PR DESCRIPTION
Cherry pick of #14369 on release-1.25.

#14369: Disable rp_filter on cilium hosts

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```