### PR TITLE
Karpenter : fallback on ondemand instance by default

### DIFF
--- a/docs/operations/karpenter.md
+++ b/docs/operations/karpenter.md
@@ -66,6 +66,6 @@ As mentioned above, kOps will manage a Provisioner resource per InstanceGroup. I
 ### Other minor limitations
 
 * Control plane nodes must be provisioned with an ASG, not Karpenter.
-* Provisioners will unconditionally use spot instances
+* Provisioners will unconditionally use spot with a fallback on ondemand instances.
 * Provisioners will unconditionally include burstable instance groups such as the T3 instance family.
 * kOps will not allow mixing arm64 and amd64 instances in the same Provider.

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: cdcc6eea95393014d4b1d416a4a8e1b0ca997f2336e7c21a5488ad809b4463c9
+    manifestHash: a6856c8b9223d9ff50fa4f68cc01a44b52163fc5319f4e551f6aa6eda432d56f
     name: karpenter.sh
     selector:
       k8s-addon: karpenter.sh

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -1419,6 +1419,7 @@ spec:
     operator: In
     values:
     - spot
+    - ondemand
   - key: kubernetes.io/arch
     operator: In
     values:
@@ -1455,6 +1456,7 @@ spec:
     operator: In
     values:
     - spot
+    - ondemand
   - key: kubernetes.io/arch
     operator: In
     values:

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -1159,7 +1159,7 @@ spec:
   requirements:
     - key: karpenter.sh/capacity-type
       operator: In
-      values: ["spot"]
+      values: ["spot", "ondemand"]
     - key: kubernetes.io/arch
       operator: In
       values: ["{{ ArchitectureOfAMI $spec.Image }}"]


### PR DESCRIPTION
Hi,

Having ondemand and spot in capacity type can secure the usage of karpenter by always having a solution to spawn a new instance if there is no capacity in spot. 

The karpenter [documentation](https://karpenter.sh/v0.16.3/faq/#what-if-there-is-no-spot-capacity-will-karpenter-use-on-demand) : `If your Karpenter Provisioner specifies flexibility to both Spot and On-Demand capacity, Karpenter will attempt to provision On-Demand capacity if there is no Spot capacity available`

This will not change the basic behavior of karpenter spawning a spot instance if possible first, but it adds a fallback to start an ondemand instance if there is no spot available.

Thanks for your time !