### PR TITLE
update node-problem-detector to version 0.8.12

### DIFF
--- a/pkg/model/components/nodeproblemdetector.go
+++ b/pkg/model/components/nodeproblemdetector.go
@@ -62,7 +62,7 @@ func (b *NodeProblemDetectorOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if npd.Image == nil {
-		npd.Image = fi.String("registry.k8s.io/node-problem-detector/node-problem-detector:v0.8.8")
+		npd.Image = fi.String("registry.k8s.io/node-problem-detector/node-problem-detector:v0.8.12")
 	}
 
 	return nil


### PR DESCRIPTION
node-problem-detector has added multi-arch support in 0.8.12
https://github.com/kubernetes/node-problem-detector/releases/tag/v0.8.12

This just updates to that version to avoid CrashLoopBackOff on ARM (etc)