### PR TITLE
Automated cherry pick of #14386: hetzner: Update CCM to v1.13.2

### DIFF
--- a/pkg/model/components/hetznercloudcontrollermanager.go
+++ b/pkg/model/components/hetznercloudcontrollermanager.go
@@ -53,7 +53,7 @@ func (b *HetznerCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}
 	eccm.ConfigureCloudRoutes = fi.Bool(false)
 
 	if eccm.Image == "" {
-		eccm.Image = "hetznercloud/hcloud-cloud-controller-manager:v1.13.1"
+		eccm.Image = "hetznercloud/hcloud-cloud-controller-manager:v1.13.2"
 	}
 
 	return nil

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     cloudProvider: hcloud
     clusterCIDR: 100.64.0.0/10
     configureCloudRoutes: false
-    image: hetznercloud/hcloud-cloud-controller-manager:v1.13.1
+    image: hetznercloud/hcloud-cloud-controller-manager:v1.13.2
     leaderElection:
       leaderElect: false
   cloudProvider: hetzner

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml
-    manifestHash: cc259354c4807a7538689f44b4ab01668da86975ddfad36e0fd2c6f1a7be89d3
+    manifestHash: 950b98db61e752f22afcb7226ca09ca1aad0696b6884325dfaf1b3e75f395594
     name: hcloud-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: hcloud-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
@@ -96,7 +96,7 @@ spec:
             secretKeyRef:
               key: network
               name: hcloud
-        image: hetznercloud/hcloud-cloud-controller-manager:v1.13.1
+        image: hetznercloud/hcloud-cloud-controller-manager:v1.13.2
         name: hcloud-cloud-controller-manager
         resources:
           requests:


### PR DESCRIPTION
Cherry pick of #14386 on release-1.25.

#14386: hetzner: Update CCM to v1.13.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```