### PR TITLE
Map kube-apiserver egress-selector-config-file flag

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1669,6 +1669,10 @@ spec:
                   disableBasicAuth:
                     description: DisableBasicAuth removes the --basic-auth-file flag
                     type: boolean
+                  egressSelectorConfigFile:
+                    description: EgressSelectorConfigFile is the file path with api-server
+                      egress selector configuration.
+                    type: string
                   enableAdmissionPlugins:
                     description: EnableAdmissionPlugins is a list of enabled admission
                       plugins

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -321,6 +321,8 @@ type KubeAPIServerConfig struct {
 	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
 	// Passed as --service-node-port-range to kube-apiserver. Expects 'startPort-endPort' format e.g. 30000-33000
 	ServiceNodePortRange string `json:"serviceNodePortRange,omitempty" flag:"service-node-port-range"`
+	// EgressSelectorConfigFile is the file path with api-server egress selector configuration.
+	EgressSelectorConfigFile string `json:"egressSelectorConfigFile,omitempty" flag:"egress-selector-config-file"`
 	// EtcdServers is a list of the etcd service to connect
 	EtcdServers []string `json:"etcdServers,omitempty" flag:"etcd-servers"`
 	// EtcdServersOverrides is per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -321,6 +321,8 @@ type KubeAPIServerConfig struct {
 	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
 	// Passed as --service-node-port-range to kube-apiserver. Expects 'startPort-endPort' format e.g. 30000-33000
 	ServiceNodePortRange string `json:"serviceNodePortRange,omitempty" flag:"service-node-port-range"`
+	// EgressSelectorConfigFile is the file path with api-server egress selector configuration.
+	EgressSelectorConfigFile string `json:"egressSelectorConfigFile,omitempty" flag:"egress-selector-config-file"`
 	// EtcdServers is a list of the etcd service to connect
 	EtcdServers []string `json:"etcdServers,omitempty" flag:"etcd-servers"`
 	// EtcdServersOverrides is per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5037,6 +5037,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.AdmissionControlConfigFile = in.AdmissionControlConfigFile
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
 	out.ServiceNodePortRange = in.ServiceNodePortRange
+	out.EgressSelectorConfigFile = in.EgressSelectorConfigFile
 	out.EtcdServers = in.EtcdServers
 	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.EtcdCAFile = in.EtcdCAFile
@@ -5149,6 +5150,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.AdmissionControlConfigFile = in.AdmissionControlConfigFile
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
 	out.ServiceNodePortRange = in.ServiceNodePortRange
+	out.EgressSelectorConfigFile = in.EgressSelectorConfigFile
 	out.EtcdServers = in.EtcdServers
 	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.EtcdCAFile = in.EtcdCAFile

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -319,6 +319,8 @@ type KubeAPIServerConfig struct {
 	ServiceClusterIPRange string `json:"serviceClusterIPRange,omitempty" flag:"service-cluster-ip-range"`
 	// Passed as --service-node-port-range to kube-apiserver. Expects 'startPort-endPort' format e.g. 30000-33000
 	ServiceNodePortRange string `json:"serviceNodePortRange,omitempty" flag:"service-node-port-range"`
+	// EgressSelectorConfigFile is the file path with api-server egress selector configuration.
+	EgressSelectorConfigFile string `json:"egressSelectorConfigFile,omitempty" flag:"egress-selector-config-file"`
 	// EtcdServers is a list of the etcd service to connect
 	EtcdServers []string `json:"etcdServers,omitempty" flag:"etcd-servers"`
 	// EtcdServersOverrides is per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5204,6 +5204,7 @@ func autoConvert_v1alpha3_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.AdmissionControlConfigFile = in.AdmissionControlConfigFile
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
 	out.ServiceNodePortRange = in.ServiceNodePortRange
+	out.EgressSelectorConfigFile = in.EgressSelectorConfigFile
 	out.EtcdServers = in.EtcdServers
 	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.EtcdCAFile = in.EtcdCAFile
@@ -5316,6 +5317,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha3_KubeAPIServerConfig(in *ko
 	out.AdmissionControlConfigFile = in.AdmissionControlConfigFile
 	out.ServiceClusterIPRange = in.ServiceClusterIPRange
 	out.ServiceNodePortRange = in.ServiceNodePortRange
+	out.EgressSelectorConfigFile = in.EgressSelectorConfigFile
 	out.EtcdServers = in.EtcdServers
 	out.EtcdServersOverrides = in.EtcdServersOverrides
 	out.EtcdCAFile = in.EtcdCAFile


### PR DESCRIPTION
This is needed to support the kube-apiserver-network-proxy

(From my experiments with cloud-control-plane, but useful everywhere for enhanced security)