### PR TITLE
Automated cherry pick of #14401: update k8s cloudprovider openstack images

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -764,7 +764,7 @@ func (tf *TemplateFunctions) OpenStackCCMTag() string {
 		if parsed.Minor == 23 {
 			tag = "v1.23.1"
 		} else if parsed.Minor == 24 {
-			tag = "v1.24.4"
+			tag = "v1.24.5"
 		} else if parsed.Minor == 25 {
 			tag = "v1.25.1"
 		} else {
@@ -784,7 +784,7 @@ func (tf *TemplateFunctions) OpenStackCSITag() string {
 		tag = "latest"
 	} else {
 		if parsed.Minor == 24 {
-			tag = "v1.24.4"
+			tag = "v1.24.5"
 		} else if parsed.Minor == 25 {
 			tag = "v1.25.1"
 		} else {

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -761,14 +761,12 @@ func (tf *TemplateFunctions) OpenStackCCMTag() string {
 	if err != nil {
 		tag = "latest"
 	} else {
-		if parsed.Minor == 13 {
-			// The bugfix release
-			tag = "1.13.1"
-		} else if parsed.Minor == 23 {
-			// The bugfix release, see https://github.com/kubernetes/cloud-provider-openstack/releases
+		if parsed.Minor == 23 {
 			tag = "v1.23.1"
 		} else if parsed.Minor == 24 {
-			tag = "v1.24.1"
+			tag = "v1.24.4"
+		} else if parsed.Minor == 25 {
+			tag = "v1.25.1"
 		} else {
 			// otherwise we use always .0 ccm image, if needed that can be overrided using clusterspec
 			tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)
@@ -786,7 +784,9 @@ func (tf *TemplateFunctions) OpenStackCSITag() string {
 		tag = "latest"
 	} else {
 		if parsed.Minor == 24 {
-			tag = "v1.24.1"
+			tag = "v1.24.4"
+		} else if parsed.Minor == 25 {
+			tag = "v1.25.1"
 		} else {
 			// otherwise we use always .0 csi image, if needed that can be overrided using cloud config spec
 			tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)


### PR DESCRIPTION
Cherry pick of #14401 on release-1.24.

#14401: update k8s cloudprovider openstack images

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```