### PR TITLE
Allow snapshot controller to create volumesnapshotcontent

### DIFF
--- a/upup/models/cloudup/resources/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml.template
+++ b/upup/models/cloudup/resources/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml.template
@@ -1074,6 +1074,7 @@ rules:
   resources:
   - volumesnapshotcontents
   verbs:
+  - create
   - get
   - list
   - watch


### PR DESCRIPTION
For using dynamic provisioning of volumesnapshot the snapshot-controller has to be able to create volumesnapshotcontent objects at the cluster level. When deploying the snapshot-controller as a kops addon the controller is not able to create volumesnapshotcontent object because it lacks the create permission. This PR adds the create permission for the content objects, which should be the default according to https://github.com/kubernetes-csi/external-snapshotter/blob/v6.0.1/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml