### PR TITLE
Bump k8s and ubuntu ami version in alpha

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -58,11 +58,11 @@ spec:
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221014
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220924
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20221014
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0"
@@ -88,13 +88,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.25.0"
-    recommendedVersion: 1.25.2
+    recommendedVersion: 1.25.3
     requiredVersion: 1.25.0
   - range: ">=1.24.0"
-    recommendedVersion: 1.24.6
+    recommendedVersion: 1.24.7
     requiredVersion: 1.24.0
   - range: ">=1.23.0"
-    recommendedVersion: 1.23.12
+    recommendedVersion: 1.23.13
     requiredVersion: 1.23.0
   - range: ">=1.22.0"
     recommendedVersion: 1.22.15
@@ -139,15 +139,15 @@ spec:
   - range: ">=1.25.0-alpha.1"
     recommendedVersion: "1.25.0"
     #requiredVersion: 1.25.0
-    kubernetesVersion: 1.25.2
+    kubernetesVersion: 1.25.3
   - range: ">=1.24.0-alpha.1"
     recommendedVersion: "1.24.3"
     #requiredVersion: 1.24.0
-    kubernetesVersion: 1.24.6
+    kubernetesVersion: 1.24.7
   - range: ">=1.23.0-alpha.1"
     recommendedVersion: "1.24.3"
     #requiredVersion: 1.23.0
-    kubernetesVersion: 1.23.12
+    kubernetesVersion: 1.23.13
   - range: ">=1.22.0-alpha.1"
     recommendedVersion: "1.24.3"
     #requiredVersion: 1.22.0


### PR DESCRIPTION
k8s versions for October 2022:
* https://github.com/kubernetes/kubernetes/releases/tag/v1.23.13
* https://github.com/kubernetes/kubernetes/releases/tag/v1.24.7
* https://github.com/kubernetes/kubernetes/releases/tag/v1.25.3
