### PR TITLE
Automated cherry pick of #14417: bump Openstack ccm version

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -775,7 +775,7 @@ func (tf *TemplateFunctions) OpenStackCCMTag() string {
 		} else if parsed.Minor == 24 {
 			tag = "v1.24.5"
 		} else if parsed.Minor == 25 {
-			tag = "v1.25.2"
+			tag = "v1.25.3"
 		} else {
 			// otherwise we use always .0 ccm image, if needed that can be overrided using clusterspec
 			tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)
@@ -795,7 +795,7 @@ func (tf *TemplateFunctions) OpenStackCSITag() string {
 		if parsed.Minor == 24 {
 			tag = "v1.24.5"
 		} else if parsed.Minor == 25 {
-			tag = "v1.25.2"
+			tag = "v1.25.3"
 		} else {
 			// otherwise we use always .0 csi image, if needed that can be overrided using cloud config spec
 			tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)


### PR DESCRIPTION
Cherry pick of #14417 on release-1.25.

#14417: bump Openstack ccm version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```