### PR TITLE
Remove usage of cluster kubelet config in nodeup

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -229,8 +229,8 @@ func (b *ContainerdBuilder) buildSystemdService(sv semver.Version) *nodetasks.Se
 
 	manifest.Set("Install", "WantedBy", "multi-user.target")
 
-	if b.Cluster.Spec.Kubelet.CgroupDriver == "systemd" {
-		cgroup := b.Cluster.Spec.Kubelet.RuntimeCgroups
+	if b.NodeupConfig.KubeletConfig.CgroupDriver == "systemd" {
+		cgroup := b.NodeupConfig.KubeletConfig.RuntimeCgroups
 		if cgroup != "" {
 			manifest.Set("Service", "Slice", strings.Trim(cgroup, "/")+".slice")
 		}
@@ -491,8 +491,8 @@ func (b *ContainerdBuilder) buildContainerdConfig() (string, error) {
 
 	config, _ := toml.Load("")
 	config.SetPath([]string{"version"}, int64(2))
-	if cluster.Spec.Kubelet != nil && cluster.Spec.Kubelet.PodInfraContainerImage != "" {
-		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}, cluster.Spec.Kubelet.PodInfraContainerImage)
+	if b.NodeupConfig.KubeletConfig.PodInfraContainerImage != "" {
+		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}, b.NodeupConfig.KubeletConfig.PodInfraContainerImage)
 	}
 	for name, endpoints := range containerd.RegistryMirrors {
 		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "registry", "mirrors", name, "endpoint"}, endpoints)

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -198,13 +198,7 @@ func (c *NodeupModelContext) PathSrvSshproxy() string {
 
 // KubeletBootstrapKubeconfig is the path the bootstrap config file
 func (c *NodeupModelContext) KubeletBootstrapKubeconfig() string {
-	path := c.Cluster.Spec.Kubelet.BootstrapKubeconfig
-
-	if c.IsMaster {
-		if c.Cluster.Spec.MasterKubelet != nil && c.Cluster.Spec.MasterKubelet.BootstrapKubeconfig != "" {
-			path = c.Cluster.Spec.MasterKubelet.BootstrapKubeconfig
-		}
-	}
+	path := c.NodeupConfig.KubeletConfig.BootstrapKubeconfig
 
 	if path != "" {
 		return path
@@ -387,7 +381,7 @@ func (c *NodeupModelContext) UseBootstrapTokens() bool {
 		return fi.BoolValue(c.NodeupConfig.APIServerConfig.KubeAPIServer.EnableBootstrapAuthToken)
 	}
 
-	return c.Cluster.Spec.Kubelet != nil && c.Cluster.Spec.Kubelet.BootstrapKubeconfig != ""
+	return c.NodeupConfig.KubeletConfig.BootstrapKubeconfig != ""
 }
 
 // KubectlPath returns distro based path for kubectl
@@ -545,11 +539,7 @@ func (c *NodeupModelContext) BuildLegacyPrivateKeyTask(ctx *fi.ModelBuilderConte
 // NodeName returns the name of the local Node, as it will be created in k8s
 func (c *NodeupModelContext) NodeName() (string, error) {
 	// This mirrors nodeutil.GetHostName
-	nodeName := c.Cluster.Spec.Kubelet.HostnameOverride
-
-	if c.IsMaster && c.Cluster.Spec.MasterKubelet.HostnameOverride != "" {
-		nodeName = c.Cluster.Spec.MasterKubelet.HostnameOverride
-	}
+	nodeName := c.NodeupConfig.KubeletConfig.HostnameOverride
 
 	if nodeName == "" {
 		hostname, err := os.Hostname()

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -186,7 +186,7 @@ func (b *KubeControllerManagerBuilder) buildPod(kcm *kops.KubeControllerManagerC
 		},
 	}
 
-	volumePluginDir := b.Cluster.Spec.Kubelet.VolumePluginDirectory
+	volumePluginDir := b.NodeupConfig.KubeletConfig.VolumePluginDirectory
 
 	// Ensure the Volume Plugin dir is mounted on the same path as the host machine so DaemonSet deployment is possible
 	if volumePluginDir == "" {

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -387,8 +387,8 @@ func (b *KubeletBuilder) buildSystemdService() *nodetasks.Service {
 
 	manifest.Set("Install", "WantedBy", "multi-user.target")
 
-	if b.Cluster.Spec.Kubelet.CgroupDriver == "systemd" && b.Cluster.Spec.ContainerRuntime == "containerd" {
-		cgroup := b.Cluster.Spec.Kubelet.KubeletCgroups
+	if b.NodeupConfig.KubeletConfig.CgroupDriver == "systemd" && b.Cluster.Spec.ContainerRuntime == "containerd" {
+		cgroup := b.NodeupConfig.KubeletConfig.KubeletCgroups
 		if cgroup != "" {
 			manifest.Set("Service", "Slice", strings.Trim(cgroup, "/")+".slice")
 		}

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -38,43 +38,6 @@ import (
 	"k8s.io/kops/util/pkg/vfs"
 )
 
-func Test_InstanceGroupKubeletMerge(t *testing.T) {
-	cluster := &kops.Cluster{}
-	cluster.Spec.Kubelet = &kops.KubeletConfigSpec{}
-	cluster.Spec.Kubelet.NvidiaGPUs = 0
-	cluster.Spec.KubernetesVersion = "1.6.0"
-
-	instanceGroup := &kops.InstanceGroup{}
-	instanceGroup.Spec.Kubelet = &kops.KubeletConfigSpec{}
-	instanceGroup.Spec.Kubelet.NvidiaGPUs = 1
-	instanceGroup.Spec.Role = kops.InstanceGroupRoleNode
-
-	config, bootConfig := nodeup.NewConfig(cluster, instanceGroup)
-	b := &KubeletBuilder{
-		&NodeupModelContext{
-			Cluster:      cluster,
-			BootConfig:   bootConfig,
-			NodeupConfig: config,
-		},
-	}
-	if err := b.Init(); err != nil {
-		t.Error(err)
-	}
-
-	mergedKubeletSpec, err := b.buildKubeletConfigSpec()
-	if err != nil {
-		t.Error(err)
-	}
-	if mergedKubeletSpec == nil {
-		t.Error("Returned nil kubelet spec")
-		t.FailNow()
-	}
-
-	if mergedKubeletSpec.NvidiaGPUs != instanceGroup.Spec.Kubelet.NvidiaGPUs {
-		t.Errorf("InstanceGroup kubelet value (%d) should be reflected in merged output", instanceGroup.Spec.Kubelet.NvidiaGPUs)
-	}
-}
-
 func TestTaintsApplied(t *testing.T) {
 	tests := []struct {
 		version           string

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -264,8 +264,14 @@ func BuildNodeupModelContext(model *testutils.Model) (*NodeupModelContext, error
 
 	if len(model.InstanceGroups) == 0 {
 		// We tolerate this - not all tests need an instance group
+		// we then use the cluser kubelet config directly
+		nodeupModelContext.NodeupConfig.KubeletConfig = *nodeupModelContext.Cluster.Spec.Kubelet
 	} else if len(model.InstanceGroups) == 1 {
-		nodeupModelContext.NodeupConfig, nodeupModelContext.BootConfig = nodeup.NewConfig(nodeupModelContext.Cluster, model.InstanceGroups[0])
+		ig := model.InstanceGroups[0]
+		nodeupModelContext.NodeupConfig, nodeupModelContext.BootConfig = nodeup.NewConfig(nodeupModelContext.Cluster, ig)
+		if ig.Spec.Kubelet == nil {
+			nodeupModelContext.NodeupConfig.KubeletConfig = *nodeupModelContext.Cluster.Spec.Kubelet
+		}
 	} else {
 		return nil, fmt.Errorf("unexpected number of instance groups: found %d", len(model.InstanceGroups))
 	}

--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--authentication-token-webhook=true --authorization-mode=Webhook --client-ca-file=/srv/kubernetes/ca.crt --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cloud-config=/etc/kubernetes/in-tree-cloud.config --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --tls-cert-file=/srv/kubernetes/kubelet-server.crt --tls-private-key-file=/srv/kubernetes/kubelet-server.key --config=/var/lib/kubelet/kubelet.conf"
+  DAEMON_ARGS="--authentication-token-webhook=true --authorization-mode=Webhook --cgroup-driver=systemd --cgroup-root=/ --client-ca-file=/srv/kubernetes/ca.crt --cloud-provider=external --cluster-dns=100.64.0.10 --cluster-domain=cluster.local --enable-debugging-handlers=true --eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5% --feature-gates=AllowExtTrafficLocalEndpoints=false,CSIMigrationAWS=true,ExperimentalCriticalPodAnnotation=true,InTreePluginAWSUnregister=true --kubeconfig=/var/lib/kubelet/kubeconfig --pod-infra-container-image=registry.k8s.io/pause:3.6 --pod-manifest-path=/etc/kubernetes/manifests --protect-kernel-defaults=true --register-schedulable=true --v=2 --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cloud-config=/etc/kubernetes/in-tree-cloud.config --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --tls-cert-file=/srv/kubernetes/kubelet-server.crt --tls-private-key-file=/srv/kubernetes/kubelet-server.key --config=/var/lib/kubelet/kubelet.conf"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file
@@ -37,8 +37,8 @@ contents: |
   nodeStatusReportFrequency: 0s
   nodeStatusUpdateFrequency: 0s
   runtimeRequestTimeout: 0s
-  shutdownGracePeriod: 0s
-  shutdownGracePeriodCriticalPods: 0s
+  shutdownGracePeriod: 30s
+  shutdownGracePeriodCriticalPods: 10s
   streamingConnectionIdleTimeout: 0s
   syncFrequency: 0s
   volumeStatsAggPeriod: 0s

--- a/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--authentication-token-webhook=true --authorization-mode=Webhook --client-ca-file=/srv/kubernetes/ca.crt --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cloud-config=/etc/kubernetes/in-tree-cloud.config --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --tls-cert-file=/srv/kubernetes/kubelet-server.crt --tls-private-key-file=/srv/kubernetes/kubelet-server.key --config=/var/lib/kubelet/kubelet.conf"
+  DAEMON_ARGS="--authentication-token-webhook=true --authorization-mode=Webhook --cgroup-driver=systemd --cgroup-root=/ --client-ca-file=/srv/kubernetes/ca.crt --cloud-provider=external --cluster-dns=100.64.0.10 --cluster-domain=cluster.local --enable-debugging-handlers=true --eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5% --feature-gates=CSIMigrationAWS=true,InTreePluginAWSUnregister=true --kubeconfig=/var/lib/kubelet/kubeconfig --pod-infra-container-image=registry.k8s.io/pause:3.6 --pod-manifest-path=/etc/kubernetes/manifests --protect-kernel-defaults=true --register-schedulable=true --v=2 --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cloud-config=/etc/kubernetes/in-tree-cloud.config --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --tls-cert-file=/srv/kubernetes/kubelet-server.crt --tls-private-key-file=/srv/kubernetes/kubelet-server.key --config=/var/lib/kubelet/kubelet.conf"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file
@@ -37,8 +37,8 @@ contents: |
   nodeStatusReportFrequency: 0s
   nodeStatusUpdateFrequency: 0s
   runtimeRequestTimeout: 0s
-  shutdownGracePeriod: 0s
-  shutdownGracePeriodCriticalPods: 0s
+  shutdownGracePeriod: 30s
+  shutdownGracePeriodCriticalPods: 10s
   streamingConnectionIdleTimeout: 0s
   syncFrequency: 0s
   volumeStatsAggPeriod: 0s

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -464,9 +464,6 @@ func evaluateSpec(c *NodeUpCommand, nodeupConfig *nodeup.Config, cloudProvider a
 		return err
 	}
 
-	c.cluster.Spec.Kubelet.HostnameOverride = hostnameOverride
-	c.cluster.Spec.MasterKubelet.HostnameOverride = hostnameOverride
-
 	nodeupConfig.KubeletConfig.HostnameOverride = hostnameOverride
 
 	if c.cluster.Spec.KubeProxy == nil {


### PR DESCRIPTION
We should always use the one on the nodeup config.