### PR TITLE
Automated cherry pick of #14423: Ensure kOps doesn't surge on karpenter IGs

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -131,6 +131,11 @@ func (c *RollingUpdateCluster) rollingUpdateInstanceGroup(group *cloudinstances.
 
 	maxConcurrency := maxSurge + settings.MaxUnavailable.IntValue()
 
+	// Karpenter cannot surge
+	if group.InstanceGroup.Spec.Manager == api.InstanceManagerKarpenter {
+		maxSurge = 0
+	}
+
 	if group.InstanceGroup.Spec.Role == api.InstanceGroupRoleMaster && maxSurge != 0 {
 		// Masters are incapable of surging because they rely on registering themselves through
 		// the local apiserver. That apiserver depends on the local etcd, which relies on being


### PR DESCRIPTION
Cherry pick of #14423 on release-1.25.

#14423: Ensure kOps doesn't surge on karpenter IGs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```