### PR TITLE
Automated cherry pick of #14370: get-keypairs: Tolerate items without certificates

### DIFF
--- a/cmd/kops/promote_keypair.go
+++ b/cmd/kops/promote_keypair.go
@@ -162,17 +162,17 @@ func promoteKeypair(out io.Writer, name string, keypairID string, keyStore fi.CA
 	}
 
 	if keypairID == "" {
-		highestTrustedId := big.NewInt(0)
+		highestCandidateId := big.NewInt(0)
 		for id, item := range keyset.Items {
-			if item.PrivateKey != nil && item.DistrustTimestamp == nil {
+			if item.PrivateKey != nil && item.DistrustTimestamp == nil && item.Certificate != nil {
 				itemId, ok := big.NewInt(0).SetString(id, 10)
-				if ok && highestTrustedId.Cmp(itemId) < 0 {
-					highestTrustedId = itemId
+				if ok && highestCandidateId.Cmp(itemId) < 0 {
+					highestCandidateId = itemId
 				}
 			}
 		}
 
-		keypairID = highestTrustedId.String()
+		keypairID = highestCandidateId.String()
 		if keypairID == keyset.Primary.Id {
 			fmt.Fprintf(out, "No %s keypair newer than current primary %s\n", name, keypairID)
 			return nil
@@ -183,6 +183,9 @@ func promoteKeypair(out io.Writer, name string, keypairID string, keyStore fi.CA
 		}
 		if item.PrivateKey == nil {
 			return fmt.Errorf("keypair has no private key")
+		}
+		if item.Certificate == nil {
+			return fmt.Errorf("keypair has no certificate")
 		}
 	} else {
 		return fmt.Errorf("keypair not found")

--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -347,6 +347,9 @@ func (c *VFSCAStore) StoreKeyset(name string, keyset *Keyset) error {
 	if keyset.Items[primaryId].PrivateKey == nil {
 		return fmt.Errorf("keyset's primary id %q must have a private key", primaryId)
 	}
+	if keyset.Items[primaryId].Certificate == nil {
+		return fmt.Errorf("keyset's primary id %q must have a certificate", primaryId)
+	}
 
 	{
 		p := c.buildPrivateKeyPoolPath(name)


### PR DESCRIPTION
Cherry pick of #14370 on release-1.25.

#14370: get-keypairs: Tolerate items without certificates

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```