### PR TITLE
Automated cherry pick of #14436: Log and aggregate errors from rolling update

### DIFF
--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kops/pkg/client/simple"
 
 	"k8s.io/client-go/kubernetes"
@@ -173,9 +174,10 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*cloudinstances.C
 
 		for _, k := range sortGroups(apiServerGroups) {
 			err := c.rollingUpdateInstanceGroup(apiServerGroups[k], c.NodeInterval)
-
 			results[k] = err
-
+			if err != nil {
+				klog.Errorf("failed to roll InstanceGroup %q: %v", k, err)
+			}
 			// TODO: Bail on error?
 		}
 	}
@@ -194,21 +196,23 @@ func (c *RollingUpdateCluster) RollingUpdate(groups map[string]*cloudinstances.C
 
 		for _, k := range sortGroups(nodeGroups) {
 			err := c.rollingUpdateInstanceGroup(nodeGroups[k], c.NodeInterval)
-
 			results[k] = err
-
+			if err != nil {
+				klog.Errorf("failed to roll InstanceGroup %q: %v", k, err)
+			}
 			// TODO: Bail on error?
 		}
 	}
 
+	errs := []error{}
 	for _, err := range results {
 		if err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 
 	klog.Infof("Rolling update completed for cluster %q!", c.ClusterName)
-	return nil
+	return errors.NewAggregate(errs)
 }
 
 func sortGroups(groupMap map[string]*cloudinstances.CloudInstanceGroup) []string {


### PR DESCRIPTION
Cherry pick of #14436 on release-1.25.

#14436: Log and aggregate errors from rolling update

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```