### PR TITLE
Refactor Context into separate cloudup and nodeup types

### DIFF
--- a/cmd/kops/lifecycle_integration_test.go
+++ b/cmd/kops/lifecycle_integration_test.go
@@ -545,7 +545,7 @@ func updateEnsureNoChanges(ctx context.Context, t *testing.T, factory *util.Fact
 		t.Fatalf("error running update cluster %q: %v", clusterName, err)
 	}
 
-	target := results.Target.(*fi.DryRunTarget)
+	target := results.Target.(*fi.CloudupDryRunTarget)
 	if target.HasChanges() {
 		var b bytes.Buffer
 		if err := target.PrintReport(results.TaskMap, &b); err != nil {

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -138,11 +138,11 @@ func NewCmdUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 type UpdateClusterResults struct {
-	// Target is the fi.Target we will operated against.  This can be used to get dryrun results (primarily for tests)
-	Target fi.Target
+	// Target is the fi.Target we will operate against.  This can be used to get dryrun results (primarily for tests)
+	Target fi.CloudupTarget
 
 	// TaskMap is the map of tasks that we built (output)
-	TaskMap map[string]fi.Task
+	TaskMap map[string]fi.CloudupTask
 
 	// ImageAssets are the image assets we use (output).
 	ImageAssets []*assets.ImageAsset
@@ -301,7 +301,7 @@ func RunUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Up
 	results.Cluster = cluster
 
 	if isDryrun && !c.GetAssets {
-		target := applyCmd.Target.(*fi.DryRunTarget)
+		target := applyCmd.Target.(*fi.CloudupDryRunTarget)
 		if target.HasChanges() {
 			fmt.Fprintf(out, "Must specify --yes to apply changes\n")
 		} else {

--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -45,9 +45,9 @@ func (i *Installation) Run() error {
 		return fmt.Errorf("error determining OS distribution: %v", err)
 	}
 
-	tasks := make(map[string]fi.Task)
+	tasks := make(map[string]fi.NodeupTask)
 
-	buildContext := &fi.ModelBuilderContext{
+	buildContext := &fi.NodeupModelBuilderContext{
 		Tasks: tasks,
 	}
 	i.Build(buildContext)
@@ -75,7 +75,7 @@ func (i *Installation) Run() error {
 	}
 
 	checkExisting := true
-	context, err := fi.NewContext(ctx, target, nil, cloud, keyStore, secretStore, configBase, checkExisting, tasks)
+	context, err := fi.NewNodeupContext(ctx, target, nil, cloud, keyStore, secretStore, configBase, checkExisting, tasks)
 	if err != nil {
 		return fmt.Errorf("error building context: %v", err)
 	}
@@ -94,7 +94,7 @@ func (i *Installation) Run() error {
 	return nil
 }
 
-func (i *Installation) Build(c *fi.ModelBuilderContext) {
+func (i *Installation) Build(c *fi.NodeupModelBuilderContext) {
 	c.AddTask(i.buildEnvFile())
 	c.AddTask(i.buildSystemdJob())
 }

--- a/nodeup/pkg/bootstrap/install_test.go
+++ b/nodeup/pkg/bootstrap/install_test.go
@@ -34,8 +34,8 @@ func runInstallBuilderTest(t *testing.T, basedir string) {
 	installation := Installation{
 		Command: []string{"/opt/kops/bin/nodeup", "--conf=/opt/kops/conf/kube_env.yaml", "--v=8"},
 	}
-	tasks := make(map[string]fi.Task)
-	buildContext := &fi.ModelBuilderContext{
+	tasks := make(map[string]fi.NodeupTask)
+	buildContext := &fi.NodeupModelBuilderContext{
 		Tasks: tasks,
 	}
 	installation.Build(buildContext)

--- a/nodeup/pkg/model/bootstrap_client.go
+++ b/nodeup/pkg/model/bootstrap_client.go
@@ -37,7 +37,7 @@ type BootstrapClientBuilder struct {
 	*NodeupModelContext
 }
 
-func (b BootstrapClientBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b BootstrapClientBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if b.IsMaster || !b.UseKopsControllerForNodeBootstrap() {
 		return nil
 	}
@@ -89,4 +89,4 @@ func (b BootstrapClientBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-var _ fi.ModelBuilder = &BootstrapClientBuilder{}
+var _ fi.NodeupModelBuilder = &BootstrapClientBuilder{}

--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -70,9 +70,9 @@ type CloudConfigBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &CloudConfigBuilder{}
+var _ fi.NodeupModelBuilder = &CloudConfigBuilder{}
 
-func (b *CloudConfigBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *CloudConfigBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if err := b.build(c, true); err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (b *CloudConfigBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *CloudConfigBuilder) build(c *fi.ModelBuilderContext, inTree bool) error {
+func (b *CloudConfigBuilder) build(c *fi.NodeupModelBuilderContext, inTree bool) error {
 	// Add cloud config file if needed
 	var lines []string
 

--- a/nodeup/pkg/model/cloudconfig_test.go
+++ b/nodeup/pkg/model/cloudconfig_test.go
@@ -68,8 +68,8 @@ func TestBuildAzure(t *testing.T) {
 			Cluster:       cluster,
 		},
 	}
-	ctx := &fi.ModelBuilderContext{
-		Tasks: map[string]fi.Task{},
+	ctx := &fi.NodeupModelBuilderContext{
+		Tasks: map[string]fi.NodeupTask{},
 	}
 	if err := b.Build(ctx); err != nil {
 		t.Fatalf("unexpected error from Build(): %v", err)
@@ -141,8 +141,8 @@ func TestBuildAWSCustomNodeIPFamilies(t *testing.T) {
 			Cluster:       cluster,
 		},
 	}
-	ctx := &fi.ModelBuilderContext{
-		Tasks: map[string]fi.Task{},
+	ctx := &fi.NodeupModelBuilderContext{
+		Tasks: map[string]fi.NodeupTask{},
 	}
 	if err := b.Build(ctx); err != nil {
 		t.Fatalf("unexpected error from Build(): %v", err)

--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -41,10 +41,10 @@ type ContainerdBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &ContainerdBuilder{}
+var _ fi.NodeupModelBuilder = &ContainerdBuilder{}
 
 // Build is responsible for configuring the containerd daemon
-func (b *ContainerdBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *ContainerdBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if b.skipInstall() {
 		klog.Infof("SkipInstall is set to true; won't install containerd")
 		return nil
@@ -94,7 +94,7 @@ func (b *ContainerdBuilder) Build(c *fi.ModelBuilderContext) error {
 
 // installContainerd installs the binaries and services to run containerd.
 // We break it out because on immutable OSes we only configure containerd, we don't install it.
-func (b *ContainerdBuilder) installContainerd(c *fi.ModelBuilderContext) error {
+func (b *ContainerdBuilder) installContainerd(c *fi.NodeupModelBuilderContext) error {
 	// Add Apache2 license
 	{
 		t := &nodetasks.File{
@@ -262,7 +262,7 @@ func (b *ContainerdBuilder) containerdConfigFilePath() string {
 }
 
 // buildSystemdServiceOverrideContainerOS is responsible for overriding the containerd service for ContainerOS
-func (b *ContainerdBuilder) buildSystemdServiceOverrideContainerOS(c *fi.ModelBuilderContext) {
+func (b *ContainerdBuilder) buildSystemdServiceOverrideContainerOS(c *fi.NodeupModelBuilderContext) {
 	lines := []string{
 		"[Service]",
 		"EnvironmentFile=/etc/environment",
@@ -288,7 +288,7 @@ func (b *ContainerdBuilder) buildSystemdServiceOverrideContainerOS(c *fi.ModelBu
 }
 
 // buildSystemdServiceOverrideFlatcar is responsible for overriding the containerd service for Flatcar
-func (b *ContainerdBuilder) buildSystemdServiceOverrideFlatcar(c *fi.ModelBuilderContext) {
+func (b *ContainerdBuilder) buildSystemdServiceOverrideFlatcar(c *fi.NodeupModelBuilderContext) {
 	lines := []string{
 		"[Service]",
 		"EnvironmentFile=/etc/environment",
@@ -315,7 +315,7 @@ func (b *ContainerdBuilder) buildSystemdServiceOverrideFlatcar(c *fi.ModelBuilde
 }
 
 // buildSysconfigFile is responsible for creating the containerd sysconfig file
-func (b *ContainerdBuilder) buildSysconfigFile(c *fi.ModelBuilderContext) error {
+func (b *ContainerdBuilder) buildSysconfigFile(c *fi.NodeupModelBuilderContext) error {
 	var containerd kops.ContainerdConfig
 	if b.NodeupConfig.ContainerdConfig != nil {
 		containerd = *b.NodeupConfig.ContainerdConfig
@@ -341,7 +341,7 @@ func (b *ContainerdBuilder) buildSysconfigFile(c *fi.ModelBuilderContext) error 
 }
 
 // buildConfigFile is responsible for creating the containerd configuration file
-func (b *ContainerdBuilder) buildConfigFile(c *fi.ModelBuilderContext) error {
+func (b *ContainerdBuilder) buildConfigFile(c *fi.NodeupModelBuilderContext) error {
 	var config string
 
 	if b.NodeupConfig.ContainerdConfig != nil && b.NodeupConfig.ContainerdConfig.ConfigOverride != nil {
@@ -374,7 +374,7 @@ func (b *ContainerdBuilder) skipInstall() bool {
 }
 
 // addCritctlConfig creates /etc/crictl.yaml, which lets crictl work out-of-the-box.
-func (b *ContainerdBuilder) addCrictlConfig(c *fi.ModelBuilderContext) {
+func (b *ContainerdBuilder) addCrictlConfig(c *fi.NodeupModelBuilderContext) {
 	conf := `
 runtime-endpoint: unix:///run/containerd/containerd.sock
 `
@@ -388,7 +388,7 @@ runtime-endpoint: unix:///run/containerd/containerd.sock
 
 // buildIPMasqueradeRules creates the DNAT rules.
 // Network modes where pods don't have "real network" IPs, use NAT so that they assume the IP of the node.
-func (b *ContainerdBuilder) buildIPMasqueradeRules(c *fi.ModelBuilderContext) error {
+func (b *ContainerdBuilder) buildIPMasqueradeRules(c *fi.NodeupModelBuilderContext) error {
 	// TODO: Should we just rely on running nodeup on every boot, instead of setting up a systemd unit?
 
 	// This is based on rules from gce/cos/configure-helper.sh and the old logic in kubenet_linux.go
@@ -444,7 +444,7 @@ iptables -w -t nat -A IP-MASQ -m comment --comment "ip-masq: outbound traffic is
 }
 
 // buildCNIConfigTemplateFile is responsible for creating a special template for setups using Kubenet
-func (b *ContainerdBuilder) buildCNIConfigTemplateFile(c *fi.ModelBuilderContext) {
+func (b *ContainerdBuilder) buildCNIConfigTemplateFile(c *fi.NodeupModelBuilderContext) {
 	// Based on https://github.com/kubernetes/kubernetes/blob/15a8a8ec4a3275a33b7f8eb3d4d98db2abad55b7/cluster/gce/gci/configure-helper.sh#L2911-L2937
 
 	contents := `{

--- a/nodeup/pkg/model/containerd_test.go
+++ b/nodeup/pkg/model/containerd_test.go
@@ -166,8 +166,8 @@ func runContainerdBuilderTest(t *testing.T, key string, distro distributions.Dis
 		t.Fatalf("error from nodeupModelContext.Init(): %v", err)
 		return
 	}
-	context := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	context := &fi.NodeupModelBuilderContext{
+		Tasks: make(map[string]fi.NodeupTask),
 	}
 
 	builder := ContainerdBuilder{NodeupModelContext: nodeUpModelContext}

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -213,7 +213,7 @@ func (c *NodeupModelContext) KubeletKubeConfig() string {
 }
 
 // BuildIssuedKubeconfig generates a kubeconfig with a locally issued client certificate.
-func (c *NodeupModelContext) BuildIssuedKubeconfig(name string, subject nodetasks.PKIXName, ctx *fi.ModelBuilderContext) *fi.TaskDependentResource {
+func (c *NodeupModelContext) BuildIssuedKubeconfig(name string, subject nodetasks.PKIXName, ctx *fi.NodeupModelBuilderContext) *fi.NodeupTaskDependentResource {
 	issueCert := &nodetasks.IssueCert{
 		Name:      name,
 		Signer:    fi.CertificateIDCA,
@@ -248,8 +248,8 @@ func (c *NodeupModelContext) GetBootstrapCert(name string, signer string) (cert,
 	b, ok := c.bootstrapCerts[name]
 	if !ok {
 		b = &nodetasks.BootstrapCert{
-			Cert: &fi.TaskDependentResource{},
-			Key:  &fi.TaskDependentResource{},
+			Cert: &fi.NodeupTaskDependentResource{},
+			Key:  &fi.NodeupTaskDependentResource{},
 		}
 		c.bootstrapCerts[name] = b
 	}
@@ -261,7 +261,7 @@ func (c *NodeupModelContext) GetBootstrapCert(name string, signer string) (cert,
 }
 
 // BuildBootstrapKubeconfig generates a kubeconfig with a client certificate from either kops-controller or the state store.
-func (c *NodeupModelContext) BuildBootstrapKubeconfig(name string, ctx *fi.ModelBuilderContext) (fi.Resource, error) {
+func (c *NodeupModelContext) BuildBootstrapKubeconfig(name string, ctx *fi.NodeupModelBuilderContext) (fi.Resource, error) {
 	if c.UseKopsControllerForNodeBootstrap() {
 		cert, key, err := c.GetBootstrapCert(name, fi.CertificateIDCA)
 		if err != nil {
@@ -397,16 +397,16 @@ func (c *NodeupModelContext) KubectlPath() string {
 }
 
 // BuildCertificatePairTask creates the tasks to create the certificate and private key files.
-func (c *NodeupModelContext) BuildCertificatePairTask(ctx *fi.ModelBuilderContext, name, path, filename string, owner *string, beforeServices []string) error {
+func (c *NodeupModelContext) BuildCertificatePairTask(ctx *fi.NodeupModelBuilderContext, name, path, filename string, owner *string, beforeServices []string) error {
 	return c.buildCertificatePairTask(ctx, name, path, filename, owner, beforeServices, true)
 }
 
 // BuildPrivateKeyTask builds a task to create the private key file.
-func (c *NodeupModelContext) BuildPrivateKeyTask(ctx *fi.ModelBuilderContext, name, path, filename string, owner *string, beforeServices []string) error {
+func (c *NodeupModelContext) BuildPrivateKeyTask(ctx *fi.NodeupModelBuilderContext, name, path, filename string, owner *string, beforeServices []string) error {
 	return c.buildCertificatePairTask(ctx, name, path, filename, owner, beforeServices, false)
 }
 
-func (c *NodeupModelContext) buildCertificatePairTask(ctx *fi.ModelBuilderContext, name, path, filename string, owner *string, beforeServices []string, includeCert bool) error {
+func (c *NodeupModelContext) buildCertificatePairTask(ctx *fi.NodeupModelBuilderContext, name, path, filename string, owner *string, beforeServices []string, includeCert bool) error {
 	p := filepath.Join(path, filename)
 	if !filepath.IsAbs(p) {
 		p = filepath.Join(c.PathSrvKubernetes(), p)
@@ -474,7 +474,7 @@ func (c *NodeupModelContext) buildCertificatePairTask(ctx *fi.ModelBuilderContex
 }
 
 // BuildCertificateTask builds a task to create a certificate file.
-func (c *NodeupModelContext) BuildCertificateTask(ctx *fi.ModelBuilderContext, name, filename string, owner *string) error {
+func (c *NodeupModelContext) BuildCertificateTask(ctx *fi.NodeupModelBuilderContext, name, filename string, owner *string) error {
 	keyset, err := c.KeyStore.FindKeyset(name)
 	if err != nil {
 		return err
@@ -505,7 +505,7 @@ func (c *NodeupModelContext) BuildCertificateTask(ctx *fi.ModelBuilderContext, n
 }
 
 // BuildLegacyPrivateKeyTask builds a task to create a private key file.
-func (c *NodeupModelContext) BuildLegacyPrivateKeyTask(ctx *fi.ModelBuilderContext, name, filename string, owner *string) error {
+func (c *NodeupModelContext) BuildLegacyPrivateKeyTask(ctx *fi.NodeupModelBuilderContext, name, filename string, owner *string) error {
 	keyset, err := c.KeyStore.FindKeyset(name)
 	if err != nil {
 		return err
@@ -552,7 +552,7 @@ func (c *NodeupModelContext) NodeName() (string, error) {
 	return strings.ToLower(strings.TrimSpace(nodeName)), nil
 }
 
-func (b *NodeupModelContext) AddCNIBinAssets(c *fi.ModelBuilderContext, assetNames []string) error {
+func (b *NodeupModelContext) AddCNIBinAssets(c *fi.NodeupModelBuilderContext, assetNames []string) error {
 	for _, assetName := range assetNames {
 		re, err := regexp.Compile(fmt.Sprintf("^%s$", regexp.QuoteMeta(assetName)))
 		if err != nil {
@@ -565,7 +565,7 @@ func (b *NodeupModelContext) AddCNIBinAssets(c *fi.ModelBuilderContext, assetNam
 	return nil
 }
 
-func (b *NodeupModelContext) addCNIBinAsset(c *fi.ModelBuilderContext, assetPath *regexp.Regexp) error {
+func (b *NodeupModelContext) addCNIBinAsset(c *fi.NodeupModelBuilderContext, assetPath *regexp.Regexp) error {
 	name, res, err := b.Assets.FindMatch(assetPath)
 	if err != nil {
 		return err

--- a/nodeup/pkg/model/directories.go
+++ b/nodeup/pkg/model/directories.go
@@ -29,10 +29,10 @@ type DirectoryBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &DirectoryBuilder{}
+var _ fi.NodeupModelBuilder = &DirectoryBuilder{}
 
 // Build is responsible for specific directories are created - os dependent
-func (b *DirectoryBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *DirectoryBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if b.Distribution == distributions.DistributionContainerOS {
 		dirname := "/home/kubernetes/bin"
 

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -41,7 +41,7 @@ type DockerBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &DockerBuilder{}
+var _ fi.NodeupModelBuilder = &DockerBuilder{}
 
 func (b *DockerBuilder) dockerVersion() (string, error) {
 	dockerVersion := ""
@@ -55,7 +55,7 @@ func (b *DockerBuilder) dockerVersion() (string, error) {
 }
 
 // Build is responsible for configuring the docker daemon
-func (b *DockerBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *DockerBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if b.Cluster.Spec.ContainerRuntime != "docker" {
 		return nil
 	}
@@ -114,7 +114,7 @@ func (b *DockerBuilder) Build(c *fi.ModelBuilderContext) error {
 				c.AddTask(&nodetasks.Chattr{
 					File: filepath.Join("/usr/bin", k),
 					Mode: "+i",
-					Deps: []fi.Task{fileTask},
+					Deps: []fi.NodeupTask{fileTask},
 				})
 			}
 		}
@@ -309,7 +309,7 @@ func (b *DockerBuilder) buildSystemdHealthCheckTimer() *nodetasks.Service {
 }
 
 // buildContainerOSConfigurationDropIn is responsible for configuring the docker daemon options
-func (b *DockerBuilder) buildContainerOSConfigurationDropIn(c *fi.ModelBuilderContext) error {
+func (b *DockerBuilder) buildContainerOSConfigurationDropIn(c *fi.NodeupModelBuilderContext) error {
 	lines := []string{
 		"[Service]",
 		"EnvironmentFile=/etc/sysconfig/docker",
@@ -345,7 +345,7 @@ func (b *DockerBuilder) buildContainerOSConfigurationDropIn(c *fi.ModelBuilderCo
 }
 
 // buildSysconfig is responsible for extracting the docker configuration and writing the sysconfig file
-func (b *DockerBuilder) buildSysconfig(c *fi.ModelBuilderContext) error {
+func (b *DockerBuilder) buildSysconfig(c *fi.NodeupModelBuilderContext) error {
 	var docker kops.DockerConfig
 	if b.Cluster.Spec.Docker != nil {
 		docker = *b.Cluster.Spec.Docker

--- a/nodeup/pkg/model/docker_test.go
+++ b/nodeup/pkg/model/docker_test.go
@@ -181,8 +181,8 @@ func runDockerBuilderTest(t *testing.T, key string) {
 	if err := nodeUpModelContext.Init(); err != nil {
 		t.Fatalf("error from nodeUpModelContext.Init(): %v", err)
 	}
-	context := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	context := &fi.NodeupModelBuilderContext{
+		Tasks: make(map[string]fi.NodeupTask),
 	}
 
 	builder := DockerBuilder{NodeupModelContext: nodeUpModelContext}

--- a/nodeup/pkg/model/etc_hosts.go
+++ b/nodeup/pkg/model/etc_hosts.go
@@ -26,10 +26,10 @@ type EtcHostsBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &EtcHostsBuilder{}
+var _ fi.NodeupModelBuilder = &EtcHostsBuilder{}
 
 // Build is responsible for configuring the gossip DNS tasks.
-func (b *EtcHostsBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *EtcHostsBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 
 	task := &nodetasks.UpdateEtcHostsTask{
 		Name: "control-plane-address",

--- a/nodeup/pkg/model/etcd_manager_tls.go
+++ b/nodeup/pkg/model/etcd_manager_tls.go
@@ -28,10 +28,10 @@ type EtcdManagerTLSBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &EtcdManagerTLSBuilder{}
+var _ fi.NodeupModelBuilder = &EtcdManagerTLSBuilder{}
 
 // Build is responsible for TLS configuration for etcd-manager
-func (b *EtcdManagerTLSBuilder) Build(ctx *fi.ModelBuilderContext) error {
+func (b *EtcdManagerTLSBuilder) Build(ctx *fi.NodeupModelBuilderContext) error {
 	if !b.IsMaster {
 		return nil
 	}

--- a/nodeup/pkg/model/file_assets.go
+++ b/nodeup/pkg/model/file_assets.go
@@ -31,10 +31,10 @@ type FileAssetsBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &FileAssetsBuilder{}
+var _ fi.NodeupModelBuilder = &FileAssetsBuilder{}
 
 // Build is responsible for writing out the file assets from cluster and instanceGroup
-func (f *FileAssetsBuilder) Build(c *fi.ModelBuilderContext) error {
+func (f *FileAssetsBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	// used to keep track of previous file, so a instanceGroup can override a cluster wide one
 	tracker := make(map[string]bool)
 
@@ -49,7 +49,7 @@ func (f *FileAssetsBuilder) Build(c *fi.ModelBuilderContext) error {
 }
 
 // buildFileAssets is responsible for rendering the file assets to disk
-func (f *FileAssetsBuilder) buildFileAssets(c *fi.ModelBuilderContext, assets []kops.FileAssetSpec, tracker map[string]bool) error {
+func (f *FileAssetsBuilder) buildFileAssets(c *fi.NodeupModelBuilderContext, assets []kops.FileAssetSpec, tracker map[string]bool) error {
 	for _, asset := range assets {
 		// @check if e have a path and if not use the default path
 		assetPath := asset.Path

--- a/nodeup/pkg/model/firewall.go
+++ b/nodeup/pkg/model/firewall.go
@@ -28,10 +28,10 @@ type FirewallBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &FirewallBuilder{}
+var _ fi.NodeupModelBuilder = &FirewallBuilder{}
 
 // Build is responsible for generating any node firewall rules
-func (b *FirewallBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *FirewallBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	// We need forwarding enabled (https://github.com/kubernetes/kubernetes/issues/40182)
 	c.AddTask(b.buildFirewallScript())
 	c.AddTask(b.buildSystemdService())

--- a/nodeup/pkg/model/hooks.go
+++ b/nodeup/pkg/model/hooks.go
@@ -34,10 +34,10 @@ type HookBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &HookBuilder{}
+var _ fi.NodeupModelBuilder = &HookBuilder{}
 
 // Build is responsible for implementing the cluster hook
-func (h *HookBuilder) Build(c *fi.ModelBuilderContext) error {
+func (h *HookBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	// we keep a list of hooks name so we can allow local instanceGroup hooks override the cluster ones
 	hookNames := make(map[string]bool)
 	for i, spec := range h.NodeupConfig.Hooks {

--- a/nodeup/pkg/model/hooks_test.go
+++ b/nodeup/pkg/model/hooks_test.go
@@ -23,14 +23,14 @@ import (
 )
 
 func TestContainerdHooksBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/hooks-containerd-exec", "hooks", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/hooks-containerd-exec", "hooks", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := HookBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestDockerHooksBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/hooks-docker-exec", "hooks", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/hooks-docker-exec", "hooks", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := HookBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})

--- a/nodeup/pkg/model/kops_controller.go
+++ b/nodeup/pkg/model/kops_controller.go
@@ -31,10 +31,10 @@ type KopsControllerBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &KopsControllerBuilder{}
+var _ fi.NodeupModelBuilder = &KopsControllerBuilder{}
 
 // Build is responsible for configuring keys that will be used by kops-controller (via hostPath)
-func (b *KopsControllerBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *KopsControllerBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if !b.IsMaster {
 		return nil
 	}

--- a/nodeup/pkg/model/kops_controller_test.go
+++ b/nodeup/pkg/model/kops_controller_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestKopsControllerBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/minimal", "kops-controller", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/minimal", "kops-controller", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KopsControllerBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -49,10 +49,10 @@ type KubeAPIServerBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &KubeAPIServerBuilder{}
+var _ fi.NodeupModelBuilder = &KubeAPIServerBuilder{}
 
 // Build is responsible for generating the configuration for the kube-apiserver.
-func (b *KubeAPIServerBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *KubeAPIServerBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if !b.HasAPIServer {
 		return nil
 	}
@@ -216,7 +216,7 @@ func (b *KubeAPIServerBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderContext, kubeAPIServer *kops.KubeAPIServerConfig) error {
+func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.NodeupModelBuilderContext, kubeAPIServer *kops.KubeAPIServerConfig) error {
 	if b.Cluster.Spec.Authentication == nil || b.Cluster.Spec.Authentication.IsEmpty() {
 		return nil
 	}
@@ -354,7 +354,7 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 	return fmt.Errorf("unrecognized authentication config %v", b.Cluster.Spec.Authentication)
 }
 
-func (b *KubeAPIServerBuilder) writeServerCertificate(c *fi.ModelBuilderContext, kubeAPIServer *kops.KubeAPIServerConfig) error {
+func (b *KubeAPIServerBuilder) writeServerCertificate(c *fi.NodeupModelBuilderContext, kubeAPIServer *kops.KubeAPIServerConfig) error {
 	pathSrvKAPI := filepath.Join(b.PathSrvKubernetes(), "kube-apiserver")
 
 	{
@@ -436,7 +436,7 @@ func (b *KubeAPIServerBuilder) writeServerCertificate(c *fi.ModelBuilderContext,
 	return nil
 }
 
-func (b *KubeAPIServerBuilder) writeKubeletAPICertificate(c *fi.ModelBuilderContext, kubeAPIServer *kops.KubeAPIServerConfig) error {
+func (b *KubeAPIServerBuilder) writeKubeletAPICertificate(c *fi.NodeupModelBuilderContext, kubeAPIServer *kops.KubeAPIServerConfig) error {
 	pathSrvKAPI := filepath.Join(b.PathSrvKubernetes(), "kube-apiserver")
 
 	issueCert := &nodetasks.IssueCert{
@@ -459,7 +459,7 @@ func (b *KubeAPIServerBuilder) writeKubeletAPICertificate(c *fi.ModelBuilderCont
 	return nil
 }
 
-func (b *KubeAPIServerBuilder) writeStaticCredentials(c *fi.ModelBuilderContext, kubeAPIServer *kops.KubeAPIServerConfig) error {
+func (b *KubeAPIServerBuilder) writeStaticCredentials(c *fi.NodeupModelBuilderContext, kubeAPIServer *kops.KubeAPIServerConfig) error {
 	pathSrvKAPI := filepath.Join(b.PathSrvKubernetes(), "kube-apiserver")
 
 	if b.SecretStore != nil {

--- a/nodeup/pkg/model/kube_apiserver_healthcheck.go
+++ b/nodeup/pkg/model/kube_apiserver_healthcheck.go
@@ -56,7 +56,7 @@ func (b *KubeAPIServerBuilder) addHealthcheckSidecar(pod *corev1.Pod) error {
 	return nil
 }
 
-func (b *KubeAPIServerBuilder) addHealthcheckSidecarTasks(c *fi.ModelBuilderContext) error {
+func (b *KubeAPIServerBuilder) addHealthcheckSidecarTasks(c *fi.NodeupModelBuilderContext) error {
 	id := "kube-apiserver-healthcheck"
 	secretsDir := "/etc/kubernetes/" + id + "/secrets"
 	userID := wellknownusers.KubeApiserverHealthcheckID

--- a/nodeup/pkg/model/kube_apiserver_test.go
+++ b/nodeup/pkg/model/kube_apiserver_test.go
@@ -142,42 +142,42 @@ func Test_KubeAPIServer_BuildFlags(t *testing.T) {
 }
 
 func TestKubeAPIServerBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/minimal", "kube-apiserver", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/minimal", "kube-apiserver", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeAPIServerBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestDeddicatedAPIServerBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/dedicated-apiserver", "kube-apiserver", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/dedicated-apiserver", "kube-apiserver", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeAPIServerBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestWithoutEtcdEventsAPIServerBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/without-etcd-events", "kube-apiserver", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/without-etcd-events", "kube-apiserver", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeAPIServerBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestAwsIamAuthenticator(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/awsiam", "kube-apiserver", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/awsiam", "kube-apiserver", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeAPIServerBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestKubeAPIServerBuilderAMD64(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/side-loading", "kube-apiserver-amd64", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/side-loading", "kube-apiserver-amd64", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeAPIServerBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestKubeAPIServerBuilderARM64(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/side-loading", "kube-apiserver-arm64", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/side-loading", "kube-apiserver-arm64", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeAPIServerBuilder{NodeupModelContext: nodeupModelContext}
 		builder.Architecture = architectures.ArchitectureArm64
 		return builder.Build(target)

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -44,10 +44,10 @@ type KubeControllerManagerBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &KubeControllerManagerBuilder{}
+var _ fi.NodeupModelBuilder = &KubeControllerManagerBuilder{}
 
 // Build is responsible for configuring the kube-controller-manager
-func (b *KubeControllerManagerBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *KubeControllerManagerBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if !b.IsMaster {
 		return nil
 	}
@@ -114,7 +114,7 @@ func (b *KubeControllerManagerBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *KubeControllerManagerBuilder) writeServerCertificate(c *fi.ModelBuilderContext, kcm *kops.KubeControllerManagerConfig) error {
+func (b *KubeControllerManagerBuilder) writeServerCertificate(c *fi.NodeupModelBuilderContext, kcm *kops.KubeControllerManagerConfig) error {
 	pathSrvKCM := filepath.Join(b.PathSrvKubernetes(), "kube-controller-manager")
 
 	if kcm.TLSCertFile == nil {

--- a/nodeup/pkg/model/kube_controller_manager_test.go
+++ b/nodeup/pkg/model/kube_controller_manager_test.go
@@ -24,21 +24,21 @@ import (
 )
 
 func TestKubeControllerManagerBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/minimal", "kube-controller-manager", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/minimal", "kube-controller-manager", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeControllerManagerBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestKubeControllerManagerBuilderAMD64(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/side-loading", "kube-controller-manager-amd64", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/side-loading", "kube-controller-manager-amd64", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeControllerManagerBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestKubeControllerManagerBuilderARM64(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/side-loading", "kube-controller-manager-arm64", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/side-loading", "kube-controller-manager-arm64", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeControllerManagerBuilder{NodeupModelContext: nodeupModelContext}
 		builder.Architecture = architectures.ArchitectureArm64
 		return builder.Build(target)

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -38,11 +38,11 @@ type KubeProxyBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &KubeProxyBuilder{}
+var _ fi.NodeupModelBuilder = &KubeProxyBuilder{}
 
 // Build is responsible for building the kube-proxy manifest
 // @TODO we should probably change this to a daemonset in the future and follow the kubeadm path
-func (b *KubeProxyBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *KubeProxyBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if b.Cluster.Spec.KubeProxy.Enabled != nil && !*b.Cluster.Spec.KubeProxy.Enabled {
 		klog.V(2).Infof("Kube-proxy is disabled, will not create configuration for it.")
 		return nil

--- a/nodeup/pkg/model/kube_proxy_test.go
+++ b/nodeup/pkg/model/kube_proxy_test.go
@@ -148,21 +148,21 @@ func TestKubeProxyBuilder_buildPod(t *testing.T) {
 }
 
 func TestKubeProxyBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/minimal", "kube-proxy", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/minimal", "kube-proxy", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeProxyBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestKubeProxyBuilderAMD64(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/side-loading", "kube-proxy-amd64", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/side-loading", "kube-proxy-amd64", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeProxyBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestKubeProxyBuilderARM64(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/side-loading", "kube-proxy-arm64", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/side-loading", "kube-proxy-arm64", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeProxyBuilder{NodeupModelContext: nodeupModelContext}
 		builder.Architecture = architectures.ArchitectureArm64
 		return builder.Build(target)

--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -61,10 +61,10 @@ type KubeSchedulerBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &KubeSchedulerBuilder{}
+var _ fi.NodeupModelBuilder = &KubeSchedulerBuilder{}
 
 // Build is responsible for building the manifest for the kube-scheduler
-func (b *KubeSchedulerBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *KubeSchedulerBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if !b.IsMaster {
 		return nil
 	}
@@ -155,7 +155,7 @@ func NewSchedulerConfig(apiVersion string) *SchedulerConfig {
 	return schedConfig
 }
 
-func (b *KubeSchedulerBuilder) writeServerCertificate(c *fi.ModelBuilderContext, kubeScheduler *kops.KubeSchedulerConfig) error {
+func (b *KubeSchedulerBuilder) writeServerCertificate(c *fi.NodeupModelBuilderContext, kubeScheduler *kops.KubeSchedulerConfig) error {
 	pathSrvScheduler := filepath.Join(b.PathSrvKubernetes(), "kube-scheduler")
 
 	if kubeScheduler.TLSCertFile == nil {

--- a/nodeup/pkg/model/kube_scheduler_test.go
+++ b/nodeup/pkg/model/kube_scheduler_test.go
@@ -71,21 +71,21 @@ kind: KubeSchedulerConfiguration
 }
 
 func TestKubeSchedulerBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/minimal", "kube-scheduler", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/minimal", "kube-scheduler", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeSchedulerBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestKubeSchedulerBuilderAMD64(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/side-loading", "kube-scheduler-amd64", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/side-loading", "kube-scheduler-amd64", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeSchedulerBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestKubeSchedulerBuilderARM64(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/side-loading", "kube-scheduler-arm64", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/side-loading", "kube-scheduler-arm64", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := KubeSchedulerBuilder{NodeupModelContext: nodeupModelContext}
 		builder.Architecture = architectures.ArchitectureArm64
 		return builder.Build(target)

--- a/nodeup/pkg/model/kubectl.go
+++ b/nodeup/pkg/model/kubectl.go
@@ -31,10 +31,10 @@ type KubectlBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &KubectlBuilder{}
+var _ fi.NodeupModelBuilder = &KubectlBuilder{}
 
 // Build is responsible for managing the kubectl on the nodes
-func (b *KubectlBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *KubectlBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if !b.HasAPIServer {
 		return nil
 	}

--- a/nodeup/pkg/model/kubectl_test.go
+++ b/nodeup/pkg/model/kubectl_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestKubectlBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/minimal", "kubectl", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/minimal", "kubectl", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		nodeupModelContext.Assets = fi.NewAssetStore("")
 		nodeupModelContext.Assets.AddForTest("kubectl", "/path/to/kubectl/asset", "testing kubectl content")
 		// NodeUp looks for the default user and group on the machine running the tests.

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -58,10 +58,10 @@ type KubeletBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &KubeletBuilder{}
+var _ fi.NodeupModelBuilder = &KubeletBuilder{}
 
 // Build is responsible for building the kubelet configuration
-func (b *KubeletBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *KubeletBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	err := b.buildKubeletServingCertificate(c)
 	if err != nil {
 		return fmt.Errorf("error building kubelet server cert: %v", err)
@@ -421,7 +421,7 @@ func (b *KubeletBuilder) usesContainerizedMounter() bool {
 }
 
 // addContainerizedMounter downloads and installs the containerized mounter, that we need on ContainerOS
-func (b *KubeletBuilder) addContainerizedMounter(c *fi.ModelBuilderContext) error {
+func (b *KubeletBuilder) addContainerizedMounter(c *fi.NodeupModelBuilderContext) error {
 	if !b.usesContainerizedMounter() {
 		return nil
 	}
@@ -609,7 +609,7 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 }
 
 // buildControlPlaneKubeletKubeconfig builds a kubeconfig for the master kubelet, self-signing the kubelet cert
-func (b *KubeletBuilder) buildControlPlaneKubeletKubeconfig(c *fi.ModelBuilderContext) (fi.Resource, error) {
+func (b *KubeletBuilder) buildControlPlaneKubeletKubeconfig(c *fi.NodeupModelBuilderContext) (fi.Resource, error) {
 	nodeName, err := b.NodeName()
 	if err != nil {
 		return nil, fmt.Errorf("error getting NodeName: %v", err)
@@ -622,7 +622,7 @@ func (b *KubeletBuilder) buildControlPlaneKubeletKubeconfig(c *fi.ModelBuilderCo
 	return b.BuildIssuedKubeconfig("kubelet", certName, c), nil
 }
 
-func (b *KubeletBuilder) buildKubeletServingCertificate(c *fi.ModelBuilderContext) error {
+func (b *KubeletBuilder) buildKubeletServingCertificate(c *fi.NodeupModelBuilderContext) error {
 	if b.UseKopsControllerForNodeBootstrap() {
 		name := "kubelet-server"
 		dir := b.PathSrvKubernetes()

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -127,8 +127,8 @@ func Test_RunKubeletBuilder(t *testing.T) {
 
 	basedir := "tests/kubelet/featuregates"
 
-	context := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	context := &fi.NodeupModelBuilderContext{
+		Tasks: make(map[string]fi.NodeupTask),
 	}
 
 	model, err := testutils.LoadModel(basedir)
@@ -155,8 +155,8 @@ func Test_RunKubeletBuilderWarmPool(t *testing.T) {
 
 	basedir := "tests/kubelet/warmpool"
 
-	context := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	context := &fi.NodeupModelBuilderContext{
+		Tasks: make(map[string]fi.NodeupTask),
 	}
 
 	model, err := testutils.LoadModel(basedir)
@@ -177,7 +177,7 @@ func Test_RunKubeletBuilderWarmPool(t *testing.T) {
 	testutils.ValidateTasks(t, filepath.Join(basedir, "tasks.yaml"), context)
 }
 
-func runKubeletBuilder(t *testing.T, context *fi.ModelBuilderContext, nodeupModelContext *NodeupModelContext) {
+func runKubeletBuilder(t *testing.T, context *fi.NodeupModelBuilderContext, nodeupModelContext *NodeupModelContext) {
 	if err := nodeupModelContext.Init(); err != nil {
 		t.Fatalf("error from nodeupModelContext.Init(): %v", err)
 	}
@@ -354,15 +354,15 @@ func mustParseKey(s string) *pki.PrivateKey {
 	return k
 }
 
-func RunGoldenTest(t *testing.T, basedir string, key string, builder func(*NodeupModelContext, *fi.ModelBuilderContext) error) {
+func RunGoldenTest(t *testing.T, basedir string, key string, builder func(*NodeupModelContext, *fi.NodeupModelBuilderContext) error) {
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
 	h.MockKopsVersion("1.18.0")
 	h.SetupMockAWS()
 
-	context := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	context := &fi.NodeupModelBuilderContext{
+		Tasks: make(map[string]fi.NodeupTask),
 	}
 
 	model, err := testutils.LoadModel(basedir)

--- a/nodeup/pkg/model/logrotate.go
+++ b/nodeup/pkg/model/logrotate.go
@@ -33,10 +33,10 @@ type LogrotateBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &LogrotateBuilder{}
+var _ fi.NodeupModelBuilder = &LogrotateBuilder{}
 
 // Build is responsible for configuring logrotate
-func (b *LogrotateBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *LogrotateBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	switch b.Distribution {
 	case distributions.DistributionContainerOS:
 		klog.Infof("Detected ContainerOS; won't install logrotate")
@@ -84,7 +84,7 @@ func (b *LogrotateBuilder) Build(c *fi.ModelBuilderContext) error {
 }
 
 // addLogrotateService creates a logrotate systemd task to act as target for the timer, if one is needed
-func (b *LogrotateBuilder) addLogrotateService(c *fi.ModelBuilderContext) error {
+func (b *LogrotateBuilder) addLogrotateService(c *fi.NodeupModelBuilderContext) error {
 	switch b.Distribution {
 	case distributions.DistributionFlatcar, distributions.DistributionContainerOS:
 		// logrotate service already exists
@@ -110,7 +110,7 @@ type logRotateOptions struct {
 	DateFormat string
 }
 
-func (b *LogrotateBuilder) addLogRotate(c *fi.ModelBuilderContext, name, path string, options logRotateOptions) {
+func (b *LogrotateBuilder) addLogRotate(c *fi.NodeupModelBuilderContext, name, path string, options logRotateOptions) {
 	if options.MaxSize == "" {
 		options.MaxSize = "100M"
 	}

--- a/nodeup/pkg/model/manifests.go
+++ b/nodeup/pkg/model/manifests.go
@@ -31,10 +31,10 @@ type ManifestsBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &ManifestsBuilder{}
+var _ fi.NodeupModelBuilder = &ManifestsBuilder{}
 
 // Build creates tasks for copying the manifests
-func (b *ManifestsBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *ManifestsBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	// Write etcd manifests (currently etcd <=> master)
 	if b.IsMaster {
 		for _, manifest := range b.NodeupConfig.EtcdManifests {

--- a/nodeup/pkg/model/miscutils.go
+++ b/nodeup/pkg/model/miscutils.go
@@ -29,10 +29,10 @@ type MiscUtilsBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &MiscUtilsBuilder{}
+var _ fi.NodeupModelBuilder = &MiscUtilsBuilder{}
 
 // Build is responsible for configuring the miscellaneous packages we want installed
-func (b *MiscUtilsBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *MiscUtilsBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	switch b.Distribution {
 	case distributions.DistributionContainerOS:
 		klog.V(2).Infof("Detected ContainerOS; won't install misc. utils")

--- a/nodeup/pkg/model/networking/calico.go
+++ b/nodeup/pkg/model/networking/calico.go
@@ -27,10 +27,10 @@ type CalicoBuilder struct {
 	*model.NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &CalicoBuilder{}
+var _ fi.NodeupModelBuilder = &CalicoBuilder{}
 
 // Build is responsible for performing setup for CNIs that need etcd TLS support
-func (b *CalicoBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *CalicoBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	networking := b.Cluster.Spec.Networking
 
 	if networking.Calico == nil {

--- a/nodeup/pkg/model/networking/cilium.go
+++ b/nodeup/pkg/model/networking/cilium.go
@@ -35,10 +35,10 @@ type CiliumBuilder struct {
 	*model.NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &CiliumBuilder{}
+var _ fi.NodeupModelBuilder = &CiliumBuilder{}
 
 // Build is responsible for configuring the network cni
-func (b *CiliumBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *CiliumBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	cilium := b.Cluster.Spec.Networking.Cilium
 
 	// As long as the Cilium Etcd cluster exists, we should do this
@@ -63,7 +63,7 @@ func (b *CiliumBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *CiliumBuilder) buildBPFMount(c *fi.ModelBuilderContext) error {
+func (b *CiliumBuilder) buildBPFMount(c *fi.NodeupModelBuilderContext) error {
 	var fsdata unix.Statfs_t
 	err := unix.Statfs("/sys/fs/bpf", &fsdata)
 	if err != nil {
@@ -104,7 +104,7 @@ WantedBy=multi-user.target
 	return nil
 }
 
-func (b *CiliumBuilder) buildCgroup2Mount(c *fi.ModelBuilderContext) error {
+func (b *CiliumBuilder) buildCgroup2Mount(c *fi.NodeupModelBuilderContext) error {
 	cgroupPath := "/run/cilium/cgroupv2"
 
 	var fsdata unix.Statfs_t
@@ -148,7 +148,7 @@ WantedBy=multi-user.target
 	return nil
 }
 
-func (b *CiliumBuilder) buildCiliumEtcdSecrets(c *fi.ModelBuilderContext) error {
+func (b *CiliumBuilder) buildCiliumEtcdSecrets(c *fi.NodeupModelBuilderContext) error {
 	name := "etcd-client-cilium"
 	dir := "/etc/kubernetes/pki/cilium"
 	signer := "etcd-clients-ca-cilium"

--- a/nodeup/pkg/model/networking/common.go
+++ b/nodeup/pkg/model/networking/common.go
@@ -26,10 +26,10 @@ type CommonBuilder struct {
 	*model.NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &CommonBuilder{}
+var _ fi.NodeupModelBuilder = &CommonBuilder{}
 
 // Build is responsible for copying the common CNI binaries
-func (b *CommonBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *CommonBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	// Based on https://github.com/containernetworking/plugins/releases/tag/v0.7.5
 	assets := []string{
 		"bridge",

--- a/nodeup/pkg/model/networking/kube_router.go
+++ b/nodeup/pkg/model/networking/kube_router.go
@@ -28,10 +28,10 @@ type KuberouterBuilder struct {
 	*model.NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &KuberouterBuilder{}
+var _ fi.NodeupModelBuilder = &KuberouterBuilder{}
 
 // Build is responsible for configuring the kube-router
-func (b *KuberouterBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *KuberouterBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	networking := b.Cluster.Spec.Networking
 
 	if networking.KubeRouter == nil {

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -31,10 +31,10 @@ type NTPBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &NTPBuilder{}
+var _ fi.NodeupModelBuilder = &NTPBuilder{}
 
 // Build is responsible for configuring NTP
-func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *NTPBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if !b.managed() {
 		klog.Infof("Managed is set to false; won't install NTP")
 		return nil

--- a/nodeup/pkg/model/nvidia.go
+++ b/nodeup/pkg/model/nvidia.go
@@ -28,10 +28,10 @@ type NvidiaBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &NvidiaBuilder{}
+var _ fi.NodeupModelBuilder = &NvidiaBuilder{}
 
 // Build is responsible for installing packages.
-func (b *NvidiaBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *NvidiaBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if b.InstallNvidiaRuntime() && b.Distribution.IsUbuntu() {
 		version := ""
 		if b.Distribution.Version() >= 22.04 {

--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -29,10 +29,10 @@ type PackagesBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &DockerBuilder{}
+var _ fi.NodeupModelBuilder = &PackagesBuilder{}
 
 // Build is responsible for installing packages
-func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	// kubelet needs:
 	//   conntrack  - kops #5671
 	//   ebtables - kops #1711

--- a/nodeup/pkg/model/prefix.go
+++ b/nodeup/pkg/model/prefix.go
@@ -25,9 +25,9 @@ type PrefixBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &PrefixBuilder{}
+var _ fi.NodeupModelBuilder = &PrefixBuilder{}
 
-func (b *PrefixBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *PrefixBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if !b.Cluster.Spec.IsKopsControllerIPAM() {
 		return nil
 	}

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -41,10 +41,10 @@ type ProtokubeBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &ProtokubeBuilder{}
+var _ fi.NodeupModelBuilder = &ProtokubeBuilder{}
 
 // Build is responsible for generating the options for protokube
-func (t *ProtokubeBuilder) Build(c *fi.ModelBuilderContext) error {
+func (t *ProtokubeBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	useGossip := t.Cluster.IsGossip()
 
 	// check is not a master and we are not using gossip (https://github.com/kubernetes/kops/pull/3091)

--- a/nodeup/pkg/model/protokube_test.go
+++ b/nodeup/pkg/model/protokube_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestProtokubeBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/protokube/", "protokube", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/protokube/", "protokube", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := ProtokubeBuilder{NodeupModelContext: nodeupModelContext}
 		populateAssets(nodeupModelContext)
 		return builder.Build(target)

--- a/nodeup/pkg/model/secrets.go
+++ b/nodeup/pkg/model/secrets.go
@@ -29,7 +29,7 @@ type SecretBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &SecretBuilder{}
+var _ fi.NodeupModelBuilder = &SecretBuilder{}
 
 const (
 	adminUser  = "admin"
@@ -37,7 +37,7 @@ const (
 )
 
 // Build is responsible for pulling down the secrets
-func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *SecretBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	// @step: write out the platform ca
 	c.AddTask(&nodetasks.File{
 		Path:     filepath.Join(b.PathSrvKubernetes(), "ca.crt"),

--- a/nodeup/pkg/model/secrets_test.go
+++ b/nodeup/pkg/model/secrets_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestSecretBuilder(t *testing.T) {
-	RunGoldenTest(t, "tests/golden/minimal", "secret", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/golden/minimal", "secret", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := SecretBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})

--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -32,10 +32,10 @@ type SysctlBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &SysctlBuilder{}
+var _ fi.NodeupModelBuilder = &SysctlBuilder{}
 
 // Build is responsible for configuring sysctl settings
-func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *SysctlBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	var sysctls []string
 
 	// Common settings

--- a/nodeup/pkg/model/update_service.go
+++ b/nodeup/pkg/model/update_service.go
@@ -36,10 +36,10 @@ const (
 	debianPackageName  = "unattended-upgrades"
 )
 
-var _ fi.ModelBuilder = &UpdateServiceBuilder{}
+var _ fi.NodeupModelBuilder = &UpdateServiceBuilder{}
 
 // Build is responsible for configuring automatic updates based on the OS.
-func (b *UpdateServiceBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *UpdateServiceBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if b.Distribution == distributions.DistributionFlatcar {
 		b.buildFlatcarSystemdService(c)
 	} else if b.Distribution.IsDebianFamily() {
@@ -49,7 +49,7 @@ func (b *UpdateServiceBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *UpdateServiceBuilder) buildFlatcarSystemdService(c *fi.ModelBuilderContext) {
+func (b *UpdateServiceBuilder) buildFlatcarSystemdService(c *fi.NodeupModelBuilderContext) {
 	if b.NodeupConfig.UpdatePolicy != kops.UpdatePolicyExternal {
 		klog.Infof("UpdatePolicy requests automatic updates; skipping creation of systemd unit %q", flatcarServiceName)
 		return
@@ -85,7 +85,7 @@ func (b *UpdateServiceBuilder) buildFlatcarSystemdService(c *fi.ModelBuilderCont
 	c.AddTask(service)
 }
 
-func (b *UpdateServiceBuilder) buildDebianPackage(c *fi.ModelBuilderContext) {
+func (b *UpdateServiceBuilder) buildDebianPackage(c *fi.NodeupModelBuilderContext) {
 	contents := ""
 	if b.NodeupConfig.UpdatePolicy == kops.UpdatePolicyExternal {
 		klog.Infof("UpdatePolicy requests automatic updates; skipping installation of package %q", debianPackageName)

--- a/nodeup/pkg/model/update_service_test.go
+++ b/nodeup/pkg/model/update_service_test.go
@@ -23,14 +23,14 @@ import (
 )
 
 func TestUpdateServiceBuilderAutomaticUpgrade(t *testing.T) {
-	RunGoldenTest(t, "tests/updateservicebuilder/automatic", "updateservice", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/updateservicebuilder/automatic", "updateservice", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := UpdateServiceBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})
 }
 
 func TestUpdateServiceBuilderExternal(t *testing.T) {
-	RunGoldenTest(t, "tests/updateservicebuilder/external", "updateservice", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+	RunGoldenTest(t, "tests/updateservicebuilder/external", "updateservice", func(nodeupModelContext *NodeupModelContext, target *fi.NodeupModelBuilderContext) error {
 		builder := UpdateServiceBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})

--- a/nodeup/pkg/model/volumes.go
+++ b/nodeup/pkg/model/volumes.go
@@ -31,10 +31,10 @@ type VolumesBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &VolumesBuilder{}
+var _ fi.NodeupModelBuilder = &VolumesBuilder{}
 
 // Build is responsible for handling the mounting additional volumes onto the instance
-func (b *VolumesBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *VolumesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	// @step: check if the instancegroup has any volumes to mount
 	if !b.UseVolumeMounts() {
 		klog.V(1).Info("Skipping the volume builder, no volumes defined for this instancegroup")

--- a/nodeup/pkg/model/warm_pool.go
+++ b/nodeup/pkg/model/warm_pool.go
@@ -26,9 +26,9 @@ type WarmPoolBuilder struct {
 	*NodeupModelContext
 }
 
-var _ fi.ModelBuilder = &WarmPoolBuilder{}
+var _ fi.NodeupModelBuilder = &WarmPoolBuilder{}
 
-func (b *WarmPoolBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *WarmPoolBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	// Check if the cloud provider is AWS
 	if b.CloudProvider != kops.CloudProviderAWS {
 		return nil

--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -42,10 +42,10 @@ type APILoadBalancerBuilder struct {
 	SecurityLifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &APILoadBalancerBuilder{}
+var _ fi.CloudupModelBuilder = &APILoadBalancerBuilder{}
 
 // Build is responsible for building the KubeAPI tasks for the aws model
-func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	// Configuration where an ELB fronts the API
 	if !b.UseLoadBalancerForAPI() {
 		return nil

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -60,10 +60,10 @@ type AutoscalingGroupModelBuilder struct {
 	Cluster                *kops.Cluster
 }
 
-var _ fi.ModelBuilder = &AutoscalingGroupModelBuilder{}
+var _ fi.CloudupModelBuilder = &AutoscalingGroupModelBuilder{}
 
 // Build is responsible for constructing the aws autoscaling group from the kops spec
-func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	for _, ig := range b.InstanceGroups {
 		name := b.AutoscalingGroupName(ig)
 
@@ -131,7 +131,7 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 }
 
 // buildLaunchTemplateTask is responsible for creating the template task into the aws model
-func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilderContext, name string, ig *kops.InstanceGroup) (*awstasks.LaunchTemplate, error) {
+func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.CloudupModelBuilderContext, name string, ig *kops.InstanceGroup) (*awstasks.LaunchTemplate, error) {
 	// @step: add the iam instance profile
 	link, err := b.LinkToIAMInstanceProfile(ig)
 	if err != nil {
@@ -331,7 +331,7 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 }
 
 // buildSecurityGroups is responsible for building security groups for a launch template.
-func (b *AutoscalingGroupModelBuilder) buildSecurityGroups(c *fi.ModelBuilderContext, ig *kops.InstanceGroup) ([]*awstasks.SecurityGroup, error) {
+func (b *AutoscalingGroupModelBuilder) buildSecurityGroups(c *fi.CloudupModelBuilderContext, ig *kops.InstanceGroup) ([]*awstasks.SecurityGroup, error) {
 	// @step: if required we add the override for the security group for this instancegroup
 	sgLink := b.LinkToSecurityGroup(ig.Spec.Role)
 	if ig.Spec.SecurityGroupOverride != nil {
@@ -379,7 +379,7 @@ func (b *AutoscalingGroupModelBuilder) buildSecurityGroups(c *fi.ModelBuilderCon
 }
 
 // buildAutoscalingGroupTask is responsible for building the autoscaling task into the model
-func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuilderContext, name string, ig *kops.InstanceGroup) (*awstasks.AutoscalingGroup, error) {
+func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.CloudupModelBuilderContext, name string, ig *kops.InstanceGroup) (*awstasks.AutoscalingGroup, error) {
 	t := &awstasks.AutoscalingGroup{
 		Name:      fi.PtrTo(name),
 		Lifecycle: b.Lifecycle,

--- a/pkg/model/awsmodel/autoscalinggroup_test.go
+++ b/pkg/model/awsmodel/autoscalinggroup_test.go
@@ -82,8 +82,8 @@ func TestRootVolumeOptimizationFlag(t *testing.T) {
 		Cluster: cluster,
 	}
 
-	c := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	c := &fi.CloudupModelBuilderContext{
+		Tasks: make(map[string]fi.CloudupTask),
 	}
 
 	// We need the CA for the bootstrap script
@@ -186,8 +186,8 @@ func TestAPIServerAdditionalSecurityGroupsWithNLB(t *testing.T) {
 		Cluster: cluster,
 	}
 
-	c := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	c := &fi.CloudupModelBuilderContext{
+		Tasks: make(map[string]fi.CloudupTask),
 	}
 
 	// We need the CA for the bootstrap script

--- a/pkg/model/awsmodel/bastion.go
+++ b/pkg/model/awsmodel/bastion.go
@@ -41,9 +41,9 @@ type BastionModelBuilder struct {
 	SecurityLifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &BastionModelBuilder{}
+var _ fi.CloudupModelBuilder = &BastionModelBuilder{}
 
-func (b *BastionModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *BastionModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	var bastionInstanceGroups []*kops.InstanceGroup
 	for _, ig := range b.InstanceGroups {
 		if ig.Spec.Role == kops.InstanceGroupRoleBastion {

--- a/pkg/model/awsmodel/dns.go
+++ b/pkg/model/awsmodel/dns.go
@@ -31,9 +31,9 @@ type DNSModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &DNSModelBuilder{}
+var _ fi.CloudupModelBuilder = &DNSModelBuilder{}
 
-func (b *DNSModelBuilder) ensureDNSZone(c *fi.ModelBuilderContext) error {
+func (b *DNSModelBuilder) ensureDNSZone(c *fi.CloudupModelBuilderContext) error {
 	if b.Cluster.IsGossip() || b.Cluster.UsesNoneDNS() {
 		return nil
 	}
@@ -70,7 +70,7 @@ func (b *DNSModelBuilder) ensureDNSZone(c *fi.ModelBuilderContext) error {
 	return c.EnsureTask(dnsZone)
 }
 
-func (b *DNSModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *DNSModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	// Add a HostedZone if we are going to publish a dns record that depends on it
 	if !b.Cluster.IsGossip() && !b.Cluster.UsesNoneDNS() {
 		if err := b.ensureDNSZone(c); err != nil {

--- a/pkg/model/awsmodel/external_access.go
+++ b/pkg/model/awsmodel/external_access.go
@@ -32,9 +32,9 @@ type ExternalAccessModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &ExternalAccessModelBuilder{}
+var _ fi.CloudupModelBuilder = &ExternalAccessModelBuilder{}
 
-func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *ExternalAccessModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	if len(b.Cluster.Spec.API.Access) == 0 {
 		klog.Warningf("KubernetesAPIAccess is empty")
 	}

--- a/pkg/model/awsmodel/firewall.go
+++ b/pkg/model/awsmodel/firewall.go
@@ -39,9 +39,9 @@ type FirewallModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &FirewallModelBuilder{}
+var _ fi.CloudupModelBuilder = &FirewallModelBuilder{}
 
-func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	nodeGroups, err := b.buildNodeRules(c)
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *FirewallModelBuilder) buildNodeRules(c *fi.ModelBuilderContext) ([]SecurityGroupInfo, error) {
+func (b *FirewallModelBuilder) buildNodeRules(c *fi.CloudupModelBuilderContext) ([]SecurityGroupInfo, error) {
 	nodeGroups, err := b.GetSecurityGroups(kops.InstanceGroupRoleNode)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func (b *FirewallModelBuilder) buildNodeRules(c *fi.ModelBuilderContext) ([]Secu
 	return nodeGroups, nil
 }
 
-func (b *FirewallModelBuilder) applyNodeToMasterBlockSpecificPorts(c *fi.ModelBuilderContext, nodeGroups []SecurityGroupInfo, masterGroups []SecurityGroupInfo) {
+func (b *FirewallModelBuilder) applyNodeToMasterBlockSpecificPorts(c *fi.CloudupModelBuilderContext, nodeGroups []SecurityGroupInfo, masterGroups []SecurityGroupInfo) {
 	type portRange struct {
 		From int
 		To   int
@@ -231,7 +231,7 @@ func (b *FirewallModelBuilder) applyNodeToMasterBlockSpecificPorts(c *fi.ModelBu
 	}
 }
 
-func (b *FirewallModelBuilder) buildMasterRules(c *fi.ModelBuilderContext, nodeGroups []SecurityGroupInfo) ([]SecurityGroupInfo, error) {
+func (b *FirewallModelBuilder) buildMasterRules(c *fi.CloudupModelBuilderContext, nodeGroups []SecurityGroupInfo) ([]SecurityGroupInfo, error) {
 	masterGroups, err := b.GetSecurityGroups(kops.InstanceGroupRoleControlPlane)
 	if err != nil {
 		return nil, err
@@ -423,7 +423,7 @@ func JoinSuffixes(src SecurityGroupInfo, dest SecurityGroupInfo) string {
 	return s + d
 }
 
-func AddDirectionalGroupRule(c *fi.ModelBuilderContext, t *awstasks.SecurityGroupRule) {
+func AddDirectionalGroupRule(c *fi.CloudupModelBuilderContext, t *awstasks.SecurityGroupRule) {
 	name := generateName(t)
 	t.Name = fi.PtrTo(name)
 	tags := make(map[string]string)

--- a/pkg/model/awsmodel/iam.go
+++ b/pkg/model/awsmodel/iam.go
@@ -42,8 +42,8 @@ type IAMModelBuilder struct {
 }
 
 var (
-	_ fi.ModelBuilder = &IAMModelBuilder{}
-	_ fi.HasDeletions = &IAMModelBuilder{}
+	_ fi.CloudupModelBuilder = &IAMModelBuilder{}
+	_ fi.HasDeletions        = &IAMModelBuilder{}
 )
 
 const NodeRolePolicyTemplate = `{
@@ -57,7 +57,7 @@ const NodeRolePolicyTemplate = `{
   ]
 }`
 
-func (b *IAMModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *IAMModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	// Collect managed Instance Group roles
 	managedRoles := make(map[kops.InstanceGroupRole]bool)
 
@@ -170,7 +170,7 @@ func (b *IAMModelBuilder) Build(c *fi.ModelBuilderContext) error {
 }
 
 // BuildServiceAccountRoleTasks build tasks specifically for the ServiceAccount role.
-func (b *IAMModelBuilder) BuildServiceAccountRoleTasks(role iam.Subject, c *fi.ModelBuilderContext) (*awstasks.IAMRole, error) {
+func (b *IAMModelBuilder) BuildServiceAccountRoleTasks(role iam.Subject, c *fi.CloudupModelBuilderContext) (*awstasks.IAMRole, error) {
 	iamName, err := b.IAMNameForServiceAccountRole(role)
 	if err != nil {
 		return nil, err
@@ -188,7 +188,7 @@ func (b *IAMModelBuilder) BuildServiceAccountRoleTasks(role iam.Subject, c *fi.M
 	return iamRole, nil
 }
 
-func (b *IAMModelBuilder) buildIAMRole(role iam.Subject, iamName string, c *fi.ModelBuilderContext) (*awstasks.IAMRole, error) {
+func (b *IAMModelBuilder) buildIAMRole(role iam.Subject, iamName string, c *fi.CloudupModelBuilderContext) (*awstasks.IAMRole, error) {
 	roleKey, isServiceAccount := b.roleKey(role)
 
 	rolePolicy, err := b.buildAWSIAMRolePolicy(role)
@@ -225,7 +225,7 @@ func (b *IAMModelBuilder) buildIAMRole(role iam.Subject, iamName string, c *fi.M
 	return iamRole, nil
 }
 
-func (b *IAMModelBuilder) buildIAMRolePolicy(role iam.Subject, iamName string, iamRole *awstasks.IAMRole, c *fi.ModelBuilderContext) error {
+func (b *IAMModelBuilder) buildIAMRolePolicy(role iam.Subject, iamName string, iamRole *awstasks.IAMRole, c *fi.CloudupModelBuilderContext) error {
 	iamPolicy := &iam.PolicyResource{
 		Builder: &iam.PolicyBuilder{
 			Cluster:                               b.Cluster,
@@ -281,7 +281,7 @@ func (b *IAMModelBuilder) roleKey(role iam.Subject) (string, bool) {
 	}
 }
 
-func (b *IAMModelBuilder) buildIAMTasks(role iam.Subject, iamName string, c *fi.ModelBuilderContext, shared bool) error {
+func (b *IAMModelBuilder) buildIAMTasks(role iam.Subject, iamName string, c *fi.CloudupModelBuilderContext, shared bool) error {
 	roleKey, _ := b.roleKey(role)
 
 	{
@@ -471,7 +471,7 @@ func (b *IAMModelBuilder) buildAWSIAMRolePolicy(role iam.Subject) (fi.Resource, 
 	return fi.NewStringResource(policy), nil
 }
 
-func (b *IAMModelBuilder) FindDeletions(context *fi.ModelBuilderContext, cloud fi.Cloud) error {
+func (b *IAMModelBuilder) FindDeletions(context *fi.CloudupModelBuilderContext, cloud fi.Cloud) error {
 	iamapi := cloud.(awsup.AWSCloud).IAM()
 	ownershipTag := "kubernetes.io/cluster/" + b.Cluster.ObjectMeta.Name
 	request := &awsIam.ListRolesInput{}

--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -35,7 +35,7 @@ type NetworkModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &NetworkModelBuilder{}
+var _ fi.CloudupModelBuilder = &NetworkModelBuilder{}
 
 type zoneInfo struct {
 	NATSubnets           []*kops.ClusterSubnetSpec
@@ -47,7 +47,7 @@ func isUnmanaged(subnet *kops.ClusterSubnetSpec) bool {
 	return subnet.Egress == kops.EgressExternal
 }
 
-func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	sharedVPC := b.Cluster.SharedVPC()
 	vpcName := b.ClusterName()
 	tags := b.CloudTags(vpcName, sharedVPC)
@@ -641,7 +641,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func addAdditionalRoutes(routes []kops.RouteSpec, sbName string, rt *awstasks.RouteTable, lf fi.Lifecycle, c *fi.ModelBuilderContext) error {
+func addAdditionalRoutes(routes []kops.RouteSpec, sbName string, rt *awstasks.RouteTable, lf fi.Lifecycle, c *fi.CloudupModelBuilderContext) error {
 	for _, r := range routes {
 		t := &awstasks.Route{
 			Name:       fi.PtrTo(sbName + "." + r.CIDR),

--- a/pkg/model/awsmodel/nodeterminationhandler.go
+++ b/pkg/model/awsmodel/nodeterminationhandler.go
@@ -50,8 +50,8 @@ type event struct {
 }
 
 var (
-	_ fi.ModelBuilder = &NodeTerminationHandlerBuilder{}
-	_ fi.HasDeletions = &NodeTerminationHandlerBuilder{}
+	_ fi.CloudupModelBuilder = &NodeTerminationHandlerBuilder{}
+	_ fi.HasDeletions        = &NodeTerminationHandlerBuilder{}
 
 	fixedEvents = []event{
 		{
@@ -84,7 +84,7 @@ type NodeTerminationHandlerBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-func (b *NodeTerminationHandlerBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *NodeTerminationHandlerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	for _, ig := range b.InstanceGroups {
 		if ig.Spec.Manager == kops.InstanceManagerCloudGroup {
 			err := b.configureASG(c, ig)
@@ -102,7 +102,7 @@ func (b *NodeTerminationHandlerBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *NodeTerminationHandlerBuilder) configureASG(c *fi.ModelBuilderContext, ig *kops.InstanceGroup) error {
+func (b *NodeTerminationHandlerBuilder) configureASG(c *fi.CloudupModelBuilderContext, ig *kops.InstanceGroup) error {
 	name := ig.Name + "-NTHLifecycleHook"
 
 	lifecyleTask := &awstasks.AutoscalingLifecycleHook{
@@ -121,7 +121,7 @@ func (b *NodeTerminationHandlerBuilder) configureASG(c *fi.ModelBuilderContext, 
 	return nil
 }
 
-func (b *NodeTerminationHandlerBuilder) build(c *fi.ModelBuilderContext) error {
+func (b *NodeTerminationHandlerBuilder) build(c *fi.CloudupModelBuilderContext) error {
 	queueName := model.QueueNamePrefix(b.ClusterName()) + "-nth"
 	policy := strings.ReplaceAll(NTHTemplate, "{{ AWS_REGION }}", b.Region)
 	policy = strings.ReplaceAll(policy, "{{ AWS_PARTITION }}", b.AWSPartition)
@@ -178,7 +178,7 @@ func (b *NodeTerminationHandlerBuilder) build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *NodeTerminationHandlerBuilder) FindDeletions(c *fi.ModelBuilderContext, cloud fi.Cloud) error {
+func (b *NodeTerminationHandlerBuilder) FindDeletions(c *fi.CloudupModelBuilderContext, cloud fi.Cloud) error {
 	if b.Cluster.Spec.NodeTerminationHandler != nil && fi.ValueOf(b.Cluster.Spec.NodeTerminationHandler.EnableRebalanceDraining) {
 		return nil
 	}

--- a/pkg/model/awsmodel/oidc_provider.go
+++ b/pkg/model/awsmodel/oidc_provider.go
@@ -28,13 +28,13 @@ type OIDCProviderBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &OIDCProviderBuilder{}
+var _ fi.CloudupModelBuilder = &OIDCProviderBuilder{}
 
 const (
 	defaultAudience = "amazonaws.com"
 )
 
-func (b *OIDCProviderBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *OIDCProviderBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	if b.Cluster.Spec.ServiceAccountIssuerDiscovery == nil ||
 		!b.Cluster.Spec.ServiceAccountIssuerDiscovery.EnableAWSOIDCProvider {
 		return nil

--- a/pkg/model/awsmodel/spotinst.go
+++ b/pkg/model/awsmodel/spotinst.go
@@ -137,9 +137,9 @@ type SpotInstanceGroupModelBuilder struct {
 	SecurityLifecycle      fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &SpotInstanceGroupModelBuilder{}
+var _ fi.CloudupModelBuilder = &SpotInstanceGroupModelBuilder{}
 
-func (b *SpotInstanceGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *SpotInstanceGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	var nodeSpotInstanceGroups []*kops.InstanceGroup
 	var err error
 
@@ -187,7 +187,7 @@ func (b *SpotInstanceGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *SpotInstanceGroupModelBuilder) buildElastigroup(c *fi.ModelBuilderContext, ig *kops.InstanceGroup) (err error) {
+func (b *SpotInstanceGroupModelBuilder) buildElastigroup(c *fi.CloudupModelBuilderContext, ig *kops.InstanceGroup) (err error) {
 	klog.V(4).Infof("Building instance group as Elastigroup: %q", b.AutoscalingGroupName(ig))
 	group := &spotinsttasks.Elastigroup{
 		Lifecycle:            b.Lifecycle,
@@ -330,7 +330,7 @@ func (b *SpotInstanceGroupModelBuilder) buildElastigroup(c *fi.ModelBuilderConte
 	return nil
 }
 
-func (b *SpotInstanceGroupModelBuilder) buildOcean(c *fi.ModelBuilderContext, igs ...*kops.InstanceGroup) (err error) {
+func (b *SpotInstanceGroupModelBuilder) buildOcean(c *fi.CloudupModelBuilderContext, igs ...*kops.InstanceGroup) (err error) {
 	klog.V(4).Infof("Building instance group as Ocean: %q", "nodes."+b.ClusterName())
 	ocean := &spotinsttasks.Ocean{
 		Lifecycle: b.Lifecycle,
@@ -505,7 +505,7 @@ func (b *SpotInstanceGroupModelBuilder) buildOcean(c *fi.ModelBuilderContext, ig
 	return nil
 }
 
-func (b *SpotInstanceGroupModelBuilder) buildLaunchSpec(c *fi.ModelBuilderContext,
+func (b *SpotInstanceGroupModelBuilder) buildLaunchSpec(c *fi.CloudupModelBuilderContext,
 	ig, igOcean *kops.InstanceGroup, ocean *spotinsttasks.Ocean) (err error) {
 	klog.V(4).Infof("Building instance group as LaunchSpec: %q", b.AutoscalingGroupName(ig))
 	launchSpec := &spotinsttasks.LaunchSpec{
@@ -627,7 +627,7 @@ func (b *SpotInstanceGroupModelBuilder) buildLaunchSpec(c *fi.ModelBuilderContex
 	return nil
 }
 
-func (b *SpotInstanceGroupModelBuilder) buildSecurityGroups(c *fi.ModelBuilderContext,
+func (b *SpotInstanceGroupModelBuilder) buildSecurityGroups(c *fi.CloudupModelBuilderContext,
 	ig *kops.InstanceGroup) ([]*awstasks.SecurityGroup, error) {
 	securityGroups := []*awstasks.SecurityGroup{
 		b.LinkToSecurityGroup(ig.Spec.Role),
@@ -782,7 +782,7 @@ func (b *SpotInstanceGroupModelBuilder) buildCapacity(ig *kops.InstanceGroup) (*
 	return fi.PtrTo(int64(minSize)), fi.PtrTo(int64(maxSize))
 }
 
-func (b *SpotInstanceGroupModelBuilder) buildLoadBalancers(c *fi.ModelBuilderContext,
+func (b *SpotInstanceGroupModelBuilder) buildLoadBalancers(c *fi.CloudupModelBuilderContext,
 	ig *kops.InstanceGroup) ([]*awstasks.ClassicLoadBalancer, []*awstasks.TargetGroup, error) {
 	var loadBalancers []*awstasks.ClassicLoadBalancer
 	var targetGroups []*awstasks.TargetGroup

--- a/pkg/model/awsmodel/sshkey.go
+++ b/pkg/model/awsmodel/sshkey.go
@@ -27,9 +27,9 @@ type SSHKeyModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &SSHKeyModelBuilder{}
+var _ fi.CloudupModelBuilder = &SSHKeyModelBuilder{}
 
-func (b *SSHKeyModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *SSHKeyModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	if !b.UseSSHKey() {
 		return nil
 	}

--- a/pkg/model/azuremodel/api_loadbalancer.go
+++ b/pkg/model/azuremodel/api_loadbalancer.go
@@ -33,10 +33,10 @@ type APILoadBalancerModelBuilder struct {
 	SecurityLifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &APILoadBalancerModelBuilder{}
+var _ fi.CloudupModelBuilder = &APILoadBalancerModelBuilder{}
 
 // Build builds tasks for creating a K8s API server for Azure.
-func (b *APILoadBalancerModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *APILoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	if !b.UseLoadBalancerForAPI() {
 		return nil
 	}

--- a/pkg/model/azuremodel/api_loadbalancer_test.go
+++ b/pkg/model/azuremodel/api_loadbalancer_test.go
@@ -29,8 +29,8 @@ func TestAPILoadBalancerModelBuilder_Build(t *testing.T) {
 		AzureModelContext: newTestAzureModelContext(),
 	}
 	b.InstanceGroups[0].Spec.Role = kops.InstanceGroupRoleControlPlane
-	c := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	c := &fi.CloudupModelBuilderContext{
+		Tasks: make(map[string]fi.CloudupTask),
 	}
 	err := b.Build(c)
 	if err != nil {

--- a/pkg/model/azuremodel/network.go
+++ b/pkg/model/azuremodel/network.go
@@ -27,10 +27,10 @@ type NetworkModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &NetworkModelBuilder{}
+var _ fi.CloudupModelBuilder = &NetworkModelBuilder{}
 
 // Build builds tasks for creating a virtual network and subnets.
-func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	networkTask := &azuretasks.VirtualNetwork{
 		Name:          fi.PtrTo(b.NameForVirtualNetwork()),
 		Lifecycle:     b.Lifecycle,

--- a/pkg/model/azuremodel/network_test.go
+++ b/pkg/model/azuremodel/network_test.go
@@ -26,8 +26,8 @@ func TestNetworkModelBuilder_Build(t *testing.T) {
 	b := NetworkModelBuilder{
 		AzureModelContext: newTestAzureModelContext(),
 	}
-	c := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	c := &fi.CloudupModelBuilderContext{
+		Tasks: make(map[string]fi.CloudupTask),
 	}
 	err := b.Build(c)
 	if err != nil {

--- a/pkg/model/azuremodel/resourcegroup.go
+++ b/pkg/model/azuremodel/resourcegroup.go
@@ -27,10 +27,10 @@ type ResourceGroupModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &ResourceGroupModelBuilder{}
+var _ fi.CloudupModelBuilder = &ResourceGroupModelBuilder{}
 
 // Build builds a task for creating a Resource Group.
-func (b *ResourceGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *ResourceGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	t := &azuretasks.ResourceGroup{
 		Name:      fi.PtrTo(b.NameForResourceGroup()),
 		Lifecycle: b.Lifecycle,

--- a/pkg/model/azuremodel/resourcegroup_test.go
+++ b/pkg/model/azuremodel/resourcegroup_test.go
@@ -27,8 +27,8 @@ func TestResourceGroupModelBuilder_Build(t *testing.T) {
 	b := ResourceGroupModelBuilder{
 		AzureModelContext: newTestAzureModelContext(),
 	}
-	c := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	c := &fi.CloudupModelBuilderContext{
+		Tasks: make(map[string]fi.CloudupTask),
 	}
 	err := b.Build(c)
 	if err != nil {
@@ -37,7 +37,7 @@ func TestResourceGroupModelBuilder_Build(t *testing.T) {
 	if len(c.Tasks) != 1 {
 		t.Errorf("unexpected number of tasks: %s", c.Tasks)
 	}
-	var task fi.Task
+	var task fi.CloudupTask
 	for _, t := range c.Tasks {
 		task = t
 		break

--- a/pkg/model/azuremodel/vmscaleset.go
+++ b/pkg/model/azuremodel/vmscaleset.go
@@ -37,10 +37,10 @@ type VMScaleSetModelBuilder struct {
 	Lifecycle              fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &VMScaleSetModelBuilder{}
+var _ fi.CloudupModelBuilder = &VMScaleSetModelBuilder{}
 
 // Build is responsible for constructing the VM ScaleSet from the kops spec.
-func (b *VMScaleSetModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *VMScaleSetModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	for _, ig := range b.InstanceGroups {
 		name := b.AutoscalingGroupName(ig)
 		vmss, err := b.buildVMScaleSetTask(c, name, ig)
@@ -67,7 +67,7 @@ func (b *VMScaleSetModelBuilder) Build(c *fi.ModelBuilderContext) error {
 }
 
 func (b *VMScaleSetModelBuilder) buildVMScaleSetTask(
-	c *fi.ModelBuilderContext,
+	c *fi.CloudupModelBuilderContext,
 	name string,
 	ig *kops.InstanceGroup,
 ) (*azuretasks.VMScaleSet, error) {

--- a/pkg/model/azuremodel/vmscaleset_test.go
+++ b/pkg/model/azuremodel/vmscaleset_test.go
@@ -42,8 +42,8 @@ func TestVMScaleSetModelBuilder_Build(t *testing.T) {
 			},
 		},
 	}
-	c := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	c := &fi.CloudupModelBuilderContext{
+		Tasks: make(map[string]fi.CloudupTask),
 	}
 
 	caTask := &fitasks.Keypair{

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -61,7 +61,7 @@ type BootstrapScript struct {
 	Lifecycle fi.Lifecycle
 	ig        *kops.InstanceGroup
 	builder   *BootstrapScriptBuilder
-	resource  fi.TaskDependentResource
+	resource  fi.CloudupTaskDependentResource
 	// alternateNameTasks are tasks that contribute api-server IP addresses.
 	alternateNameTasks []fi.HasAddress
 
@@ -69,17 +69,17 @@ type BootstrapScript struct {
 	caTasks map[string]*fitasks.Keypair
 
 	// nodeupConfig contains the nodeup config.
-	nodeupConfig fi.TaskDependentResource
+	nodeupConfig fi.CloudupTaskDependentResource
 }
 
 var (
-	_ fi.Task            = &BootstrapScript{}
-	_ fi.HasName         = &BootstrapScript{}
-	_ fi.HasDependencies = &BootstrapScript{}
+	_ fi.CloudupTask            = &BootstrapScript{}
+	_ fi.HasName                = &BootstrapScript{}
+	_ fi.CloudupHasDependencies = &BootstrapScript{}
 )
 
 // kubeEnv returns the boot config for the instance group
-func (b *BootstrapScript) kubeEnv(ig *kops.InstanceGroup, c *fi.Context) (*nodeup.BootConfig, error) {
+func (b *BootstrapScript) kubeEnv(ig *kops.InstanceGroup, c *fi.CloudupContext) (*nodeup.BootConfig, error) {
 	var alternateNames []string
 
 	for _, hasAddress := range b.alternateNameTasks {
@@ -253,7 +253,7 @@ func (b *BootstrapScript) buildEnvironmentVariables(cluster *kops.Cluster) (map[
 
 // ResourceNodeUp generates and returns a nodeup (bootstrap) script from a
 // template file, substituting in specific env vars & cluster spec configuration
-func (b *BootstrapScriptBuilder) ResourceNodeUp(c *fi.ModelBuilderContext, ig *kops.InstanceGroup) (fi.Resource, error) {
+func (b *BootstrapScriptBuilder) ResourceNodeUp(c *fi.CloudupModelBuilderContext, ig *kops.InstanceGroup) (fi.Resource, error) {
 	keypairs := []string{"kubernetes-ca", "etcd-clients-ca"}
 	for _, etcdCluster := range b.Cluster.Spec.EtcdClusters {
 		k := etcdCluster.Name
@@ -317,8 +317,8 @@ func (b *BootstrapScript) GetName() *string {
 	return &b.Name
 }
 
-func (b *BootstrapScript) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (b *BootstrapScript) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 
 	for _, task := range tasks {
 		if hasAddress, ok := task.(fi.HasAddress); ok && hasAddress.IsForAPIServer() {
@@ -334,7 +334,7 @@ func (b *BootstrapScript) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 	return deps
 }
 
-func (b *BootstrapScript) Run(c *fi.Context) error {
+func (b *BootstrapScript) Run(c *fi.CloudupContext) error {
 	if b.Lifecycle == fi.LifecycleIgnore {
 		return nil
 	}

--- a/pkg/model/bootstrapscript_test.go
+++ b/pkg/model/bootstrapscript_test.go
@@ -137,8 +137,8 @@ func TestBootstrapUserData(t *testing.T) {
 	for i, x := range cs {
 		cluster := makeTestCluster(x.HookSpecRoles, x.FileAssetSpecRoles)
 		group := makeTestInstanceGroup(x.Role, x.HookSpecRoles, x.FileAssetSpecRoles)
-		c := &fi.ModelBuilderContext{
-			Tasks: make(map[string]fi.Task),
+		c := &fi.CloudupModelBuilderContext{
+			Tasks: make(map[string]fi.CloudupTask),
 		}
 
 		caTask := &fitasks.Keypair{
@@ -190,7 +190,7 @@ func TestBootstrapUserData(t *testing.T) {
 		}
 
 		require.Contains(t, c.Tasks, "BootstrapScript/testIG")
-		err = c.Tasks["BootstrapScript/testIG"].Run(&fi.Context{Cluster: cluster})
+		err = c.Tasks["BootstrapScript/testIG"].Run(&fi.CloudupContext{Cluster: cluster})
 		require.NoError(t, err, "running task")
 
 		actual, err := fi.ResourceAsString(res)

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -52,10 +52,10 @@ type EtcdManagerBuilder struct {
 	AssetBuilder *assets.AssetBuilder
 }
 
-var _ fi.ModelBuilder = &EtcdManagerBuilder{}
+var _ fi.CloudupModelBuilder = &EtcdManagerBuilder{}
 
 // Build creates the tasks
-func (b *EtcdManagerBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *EtcdManagerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	for _, etcdCluster := range b.Cluster.Spec.EtcdClusters {
 		backupStore := ""
 		if etcdCluster.Backups != nil {

--- a/pkg/model/components/etcdmanager/model_test.go
+++ b/pkg/model/components/etcdmanager/model_test.go
@@ -41,8 +41,8 @@ func Test_RunEtcdManagerBuilder(t *testing.T) {
 		basedir := basedir
 
 		t.Run(fmt.Sprintf("basedir=%s", basedir), func(t *testing.T) {
-			context := &fi.ModelBuilderContext{
-				Tasks: make(map[string]fi.Task),
+			context := &fi.CloudupModelBuilderContext{
+				Tasks: make(map[string]fi.CloudupTask),
 			}
 			kopsModelContext, err := LoadKopsModelContext(basedir)
 			if err != nil {

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -36,11 +36,11 @@ type KubeApiserverBuilder struct {
 	AssetBuilder *assets.AssetBuilder
 }
 
-var _ fi.ModelBuilder = &KubeApiserverBuilder{}
+var _ fi.CloudupModelBuilder = &KubeApiserverBuilder{}
 
 // Build creates the tasks relating to kube-apiserver
 // Currently we only build the kube-apiserver-healthcheck sidecar
-func (b *KubeApiserverBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *KubeApiserverBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	manifest, err := b.buildManifest()
 	if err != nil {
 		return err

--- a/pkg/model/components/kubeapiserver/model_test.go
+++ b/pkg/model/components/kubeapiserver/model_test.go
@@ -38,8 +38,8 @@ func Test_RunKubeApiserverBuilder(t *testing.T) {
 		basedir := basedir
 
 		t.Run(fmt.Sprintf("basedir=%s", basedir), func(t *testing.T) {
-			context := &fi.ModelBuilderContext{
-				Tasks: make(map[string]fi.Task),
+			context := &fi.CloudupModelBuilderContext{
+				Tasks: make(map[string]fi.CloudupTask),
 			}
 			kopsModelContext, err := LoadKopsModelContext(basedir)
 			if err != nil {

--- a/pkg/model/components/kubescheduler/model.go
+++ b/pkg/model/components/kubescheduler/model.go
@@ -47,10 +47,10 @@ type KubeSchedulerBuilder struct {
 	AssetBuilder *assets.AssetBuilder
 }
 
-var _ fi.ModelBuilder = &KubeSchedulerBuilder{}
+var _ fi.CloudupModelBuilder = &KubeSchedulerBuilder{}
 
 // Build creates the tasks relating to kube-scheduler
-func (b *KubeSchedulerBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *KubeSchedulerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	configYAML, err := b.buildSchedulerConfig()
 	if err != nil {
 		return err

--- a/pkg/model/components/kubescheduler/model_test.go
+++ b/pkg/model/components/kubescheduler/model_test.go
@@ -39,8 +39,8 @@ func Test_RunKubeSchedulerBuilder(t *testing.T) {
 		basedir := basedir
 
 		t.Run(fmt.Sprintf("basedir=%s", basedir), func(t *testing.T) {
-			context := &fi.ModelBuilderContext{
-				Tasks: make(map[string]fi.Task),
+			context := &fi.CloudupModelBuilderContext{
+				Tasks: make(map[string]fi.CloudupTask),
 			}
 			kopsModelContext, err := LoadKopsModelContext(basedir)
 			if err != nil {

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -34,7 +34,7 @@ type ConfigBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-func (b *ConfigBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *ConfigBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	c.AddTask(&fitasks.ManagedFile{
 		Name:      fi.PtrTo(registry.PathKopsVersionUpdated),
 		Lifecycle: b.Lifecycle,

--- a/pkg/model/domodel/api_loadbalancer.go
+++ b/pkg/model/domodel/api_loadbalancer.go
@@ -31,9 +31,9 @@ type APILoadBalancerModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &APILoadBalancerModelBuilder{}
+var _ fi.CloudupModelBuilder = &APILoadBalancerModelBuilder{}
 
-func (b *APILoadBalancerModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *APILoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	// Configuration where a load balancer fronts the API
 	if !b.UseLoadBalancerForAPI() {
 		return nil

--- a/pkg/model/domodel/droplets.go
+++ b/pkg/model/domodel/droplets.go
@@ -34,9 +34,9 @@ type DropletBuilder struct {
 	Lifecycle              fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &DropletBuilder{}
+var _ fi.CloudupModelBuilder = &DropletBuilder{}
 
-func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
+func (d *DropletBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	sshKeyName, err := d.SSHKeyName()
 	if err != nil {
 		return err

--- a/pkg/model/domodel/network.go
+++ b/pkg/model/domodel/network.go
@@ -29,9 +29,9 @@ type NetworkModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &NetworkModelBuilder{}
+var _ fi.CloudupModelBuilder = &NetworkModelBuilder{}
 
-func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 
 	ipRange := b.Cluster.Spec.Networking.NetworkCIDR
 	if ipRange == "" {

--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -33,11 +33,11 @@ type APILoadBalancerBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &APILoadBalancerBuilder{}
+var _ fi.CloudupModelBuilder = &APILoadBalancerBuilder{}
 
 // createPublicLB validates the existence of a target pool with the given name,
 // and creates an IP address and forwarding rule pointing to that target pool.
-func createPublicLB(b *APILoadBalancerBuilder, c *fi.ModelBuilderContext) error {
+func createPublicLB(b *APILoadBalancerBuilder, c *fi.CloudupModelBuilderContext) error {
 	// TODO: point target pool to instance group managers, as done in internal LB.
 	targetPool := &gcetasks.TargetPool{
 		Name:      s(b.NameForTargetPool("api")),
@@ -116,7 +116,7 @@ func createPublicLB(b *APILoadBalancerBuilder, c *fi.ModelBuilderContext) error 
 // createInternalLB creates an internal load balancer for the cluster.  In
 // GCP this entails creating a health check, backend service, and one forwarding rule
 // per specified subnet pointing to that backend service.
-func createInternalLB(b *APILoadBalancerBuilder, c *fi.ModelBuilderContext) error {
+func createInternalLB(b *APILoadBalancerBuilder, c *fi.CloudupModelBuilderContext) error {
 	lbSpec := b.Cluster.Spec.API.LoadBalancer
 	hc := &gcetasks.HealthCheck{
 		Name:      s(b.NameForHealthCheck("api")),
@@ -194,7 +194,7 @@ func createInternalLB(b *APILoadBalancerBuilder, c *fi.ModelBuilderContext) erro
 	return nil
 }
 
-func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	if !b.UseLoadBalancerForAPI() {
 		return nil
 	}

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -45,11 +45,11 @@ type AutoscalingGroupModelBuilder struct {
 	Lifecycle              fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &AutoscalingGroupModelBuilder{}
+var _ fi.CloudupModelBuilder = &AutoscalingGroupModelBuilder{}
 
 // Build the GCE instance template object for an InstanceGroup
 // We are then able to extract out the fields when running with the clusterapi.
-func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.ModelBuilderContext, ig *kops.InstanceGroup, subnet *kops.ClusterSubnetSpec) (*gcetasks.InstanceTemplate, error) {
+func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelBuilderContext, ig *kops.InstanceGroup, subnet *kops.ClusterSubnetSpec) (*gcetasks.InstanceTemplate, error) {
 	// Indented to keep diff manageable
 	// TODO: Remove spurious indent
 	{
@@ -245,7 +245,7 @@ func (b *AutoscalingGroupModelBuilder) splitToZones(ig *kops.InstanceGroup) (map
 	}
 }
 
-func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	for _, ig := range b.InstanceGroups {
 		subnets, err := b.GatherSubnets(ig)
 		if err != nil {

--- a/pkg/model/gcemodel/external_access.go
+++ b/pkg/model/gcemodel/external_access.go
@@ -30,9 +30,9 @@ type ExternalAccessModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &ExternalAccessModelBuilder{}
+var _ fi.CloudupModelBuilder = &ExternalAccessModelBuilder{}
 
-func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *ExternalAccessModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	klog.Warningf("TODO: Harmonize gcemodel ExternalAccessModelBuilder with awsmodel")
 	if len(b.Cluster.Spec.API.Access) == 0 {
 		klog.Warningf("KubernetesAPIAccess is empty")

--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -35,9 +35,9 @@ type FirewallModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &FirewallModelBuilder{}
+var _ fi.CloudupModelBuilder = &FirewallModelBuilder{}
 
-func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	klog.Warningf("TODO: Harmonize gcemodel with awsmodel for firewall - GCE model is way too open")
 
 	allProtocols := []string{"tcp", "udp", "icmp", "esp", "ah", "sctp"}
@@ -161,7 +161,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 // GCE does not allow us to mix ipv4 and ipv6 in the same firewall rule, so we must create separate rules.
 // Furthermore, an empty SourceRange with empty SourceTags is interpreted as allow-everything,
 // but we intend for it to block everything; so we can Disabled to achieve the desired blocking.
-func (b *GCEModelContext) AddFirewallRulesTasks(c *fi.ModelBuilderContext, name string, rule *gcetasks.FirewallRule) {
+func (b *GCEModelContext) AddFirewallRulesTasks(c *fi.CloudupModelBuilderContext, name string, rule *gcetasks.FirewallRule) {
 	var ipv4SourceRanges []string
 	var ipv6SourceRanges []string
 	for _, sourceRange := range rule.SourceRanges {

--- a/pkg/model/gcemodel/network.go
+++ b/pkg/model/gcemodel/network.go
@@ -31,9 +31,9 @@ type NetworkModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &NetworkModelBuilder{}
+var _ fi.CloudupModelBuilder = &NetworkModelBuilder{}
 
-func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	sharedNetwork := b.Cluster.Spec.Networking.NetworkID != ""
 
 	network, err := b.LinkToNetwork()

--- a/pkg/model/gcemodel/service_accounts.go
+++ b/pkg/model/gcemodel/service_accounts.go
@@ -30,9 +30,9 @@ type ServiceAccountsBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &ServiceAccountsBuilder{}
+var _ fi.CloudupModelBuilder = &ServiceAccountsBuilder{}
 
-func (b *ServiceAccountsBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *ServiceAccountsBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	if b.Cluster.Spec.CloudConfig.GCEServiceAccount != "" {
 		serviceAccount := &gcetasks.ServiceAccount{
 			Name:      s("shared"),
@@ -90,7 +90,7 @@ func (b *ServiceAccountsBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *ServiceAccountsBuilder) addInstanceGroupServiceAccountPermissions(c *fi.ModelBuilderContext, serviceAccountEmail string, role kops.InstanceGroupRole) error {
+func (b *ServiceAccountsBuilder) addInstanceGroupServiceAccountPermissions(c *fi.CloudupModelBuilderContext, serviceAccountEmail string, role kops.InstanceGroupRole) error {
 	member := "serviceAccount:" + serviceAccountEmail
 
 	// Ideally we would use a custom role here, but the deletion of a custom role takes 7 days,

--- a/pkg/model/gcemodel/storageacl.go
+++ b/pkg/model/gcemodel/storageacl.go
@@ -38,11 +38,11 @@ type StorageAclBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &NetworkModelBuilder{}
+var _ fi.CloudupModelBuilder = &NetworkModelBuilder{}
 
 // Build creates the tasks that set up storage acls
 
-func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *StorageAclBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	if featureflag.GoogleCloudBucketACL.Enabled() {
 		if b.Cluster.Spec.CloudConfig.GCEServiceAccount == "" {
 			return fmt.Errorf("featureflag GoogleCloudBucketACL not supported with per-instancegroup GCEServiceAccount")

--- a/pkg/model/hetznermodel/firewall.go
+++ b/pkg/model/hetznermodel/firewall.go
@@ -34,9 +34,9 @@ type ExternalAccessModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &ExternalAccessModelBuilder{}
+var _ fi.CloudupModelBuilder = &ExternalAccessModelBuilder{}
 
-func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *ExternalAccessModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	var sshAccess []net.IPNet
 	for _, cidr := range b.Cluster.Spec.SSHAccess {
 		_, ipNet, err := net.ParseCIDR(cidr)

--- a/pkg/model/hetznermodel/loadbalancer.go
+++ b/pkg/model/hetznermodel/loadbalancer.go
@@ -34,9 +34,9 @@ type LoadBalancerModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &LoadBalancerModelBuilder{}
+var _ fi.CloudupModelBuilder = &LoadBalancerModelBuilder{}
 
-func (b *LoadBalancerModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *LoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	controlPlaneLabelSelector := []string{
 		fmt.Sprintf("%s=%s", hetzner.TagKubernetesClusterName, b.ClusterName()),
 		fmt.Sprintf("%s=%s", hetzner.TagKubernetesInstanceRole, string(kops.InstanceGroupRoleControlPlane)),

--- a/pkg/model/hetznermodel/network.go
+++ b/pkg/model/hetznermodel/network.go
@@ -28,9 +28,9 @@ type NetworkModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &NetworkModelBuilder{}
+var _ fi.CloudupModelBuilder = &NetworkModelBuilder{}
 
-func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	network := &hetznertasks.Network{
 		Name:      fi.PtrTo(b.ClusterName()),
 		Lifecycle: b.Lifecycle,

--- a/pkg/model/hetznermodel/servers.go
+++ b/pkg/model/hetznermodel/servers.go
@@ -31,9 +31,9 @@ type ServerGroupModelBuilder struct {
 	BootstrapScriptBuilder *model.BootstrapScriptBuilder
 }
 
-var _ fi.ModelBuilder = &ServerGroupModelBuilder{}
+var _ fi.CloudupModelBuilder = &ServerGroupModelBuilder{}
 
-func (b *ServerGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *ServerGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	var sshkeyTasks []*hetznertasks.SSHKey
 	for _, sshkey := range b.SSHPublicKeys {
 		fingerprint, err := pki.ComputeOpenSSHKeyFingerprint(string(sshkey))

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -737,13 +737,13 @@ type PolicyResource struct {
 }
 
 var (
-	_ fi.Resource        = &PolicyResource{}
-	_ fi.HasDependencies = &PolicyResource{}
+	_ fi.Resource               = &PolicyResource{}
+	_ fi.CloudupHasDependencies = &PolicyResource{}
 )
 
 // GetDependencies adds the DNSZone task to the list of dependencies if set
-func (b *PolicyResource) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (b *PolicyResource) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	if b.DNSZone != nil {
 		deps = append(deps, b.DNSZone)
 	}

--- a/pkg/model/issuerdiscovery.go
+++ b/pkg/model/issuerdiscovery.go
@@ -53,7 +53,7 @@ type oidcDiscovery struct {
 	ClaimsSupported       []string `json:"claims_supported"`
 }
 
-func (b *IssuerDiscoveryModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *IssuerDiscoveryModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	ctx := context.TODO()
 
 	said := b.Cluster.Spec.ServiceAccountIssuerDiscovery
@@ -148,8 +148,8 @@ type OIDCKeys struct {
 }
 
 // GetDependencies adds CA to the list of dependencies
-func (o *OIDCKeys) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	return []fi.Task{
+func (o *OIDCKeys) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	return []fi.CloudupTask{
 		o.SigningKey,
 	}
 }

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -57,12 +57,12 @@ type MasterVolumeBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &MasterVolumeBuilder{}
+var _ fi.CloudupModelBuilder = &MasterVolumeBuilder{}
 
-func (b *MasterVolumeBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *MasterVolumeBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	for _, etcd := range b.Cluster.Spec.EtcdClusters {
 		for _, m := range etcd.Members {
-			// EBS volume for each member of the each etcd cluster
+			// EBS volume for each member of each etcd cluster
 			prefix := m.Name + ".etcd-" + etcd.Name
 			name := prefix + "." + b.ClusterName()
 
@@ -130,7 +130,7 @@ func (b *MasterVolumeBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) error {
+func (b *MasterVolumeBuilder) addAWSVolume(c *fi.CloudupModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) error {
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html
 	volumeType := fi.ValueOf(m.VolumeType)
 	if volumeType == "" {
@@ -223,7 +223,7 @@ func validateAWSVolume(name, volumeType string, volumeSize, volumeIops, volumeTh
 	return nil
 }
 
-func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
+func (b *MasterVolumeBuilder) addDOVolume(c *fi.CloudupModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
 	// required that names start with a lower case and only contains letters, numbers and hyphens
 	name = "kops-" + do.SafeClusterName(name)
 
@@ -250,7 +250,7 @@ func (b *MasterVolumeBuilder) addDOVolume(c *fi.ModelBuilderContext, name string
 	c.AddTask(t)
 }
 
-func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, prefix string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
+func (b *MasterVolumeBuilder) addGCEVolume(c *fi.CloudupModelBuilderContext, prefix string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
 	volumeType := fi.ValueOf(m.VolumeType)
 	if volumeType == "" {
 		volumeType = DefaultGCEEtcdVolumeType
@@ -298,7 +298,7 @@ func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, prefix str
 	c.AddTask(t)
 }
 
-func (b *MasterVolumeBuilder) addHetznerVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
+func (b *MasterVolumeBuilder) addHetznerVolume(c *fi.CloudupModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
 	tags := make(map[string]string)
 	tags[hetzner.TagKubernetesClusterName] = b.Cluster.ObjectMeta.Name
 	tags[hetzner.TagKubernetesInstanceGroup] = fi.ValueOf(m.InstanceGroup)
@@ -316,7 +316,7 @@ func (b *MasterVolumeBuilder) addHetznerVolume(c *fi.ModelBuilderContext, name s
 	return
 }
 
-func (b *MasterVolumeBuilder) addOpenstackVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) error {
+func (b *MasterVolumeBuilder) addOpenstackVolume(c *fi.CloudupModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) error {
 	volumeType := fi.ValueOf(m.VolumeType)
 
 	// The tags are how protokube knows to mount the volume and use it for etcd
@@ -349,7 +349,7 @@ func (b *MasterVolumeBuilder) addOpenstackVolume(c *fi.ModelBuilderContext, name
 }
 
 func (b *MasterVolumeBuilder) addAzureVolume(
-	c *fi.ModelBuilderContext,
+	c *fi.CloudupModelBuilderContext,
 	name string,
 	volumeSize int32,
 	zone string,
@@ -397,7 +397,7 @@ func (b *MasterVolumeBuilder) addAzureVolume(
 	return nil
 }
 
-func (b *MasterVolumeBuilder) addScalewayVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
+func (b *MasterVolumeBuilder) addScalewayVolume(c *fi.CloudupModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
 	tags := []string{
 		fmt.Sprintf("%s=%s", scaleway.TagClusterName, b.Cluster.ObjectMeta.Name),
 		fmt.Sprintf("%s=%s", scaleway.TagNameEtcdClusterPrefix, etcd.Name),

--- a/pkg/model/openstackmodel/firewall.go
+++ b/pkg/model/openstackmodel/firewall.go
@@ -46,7 +46,7 @@ type FirewallModelBuilder struct {
 	Rules     map[string]*openstacktasks.SecurityGroupRule
 }
 
-var _ fi.ModelBuilder = &FirewallModelBuilder{}
+var _ fi.CloudupModelBuilder = &FirewallModelBuilder{}
 
 func (b *FirewallModelBuilder) usesOctavia() bool {
 	if b.Cluster.Spec.CloudProvider.Openstack.Loadbalancer != nil {
@@ -67,7 +67,7 @@ func (b *FirewallModelBuilder) getOctaviaProvider() string {
 //	Example
 //	Create an Ingress rule on source allowing traffic from dest with the options in the SecurityGroupRule
 //	Create an Egress rule on source allowing traffic to dest with the options in the SecurityGroupRule
-func (b *FirewallModelBuilder) addDirectionalGroupRule(c *fi.ModelBuilderContext, source, dest *openstacktasks.SecurityGroup, sgr *openstacktasks.SecurityGroupRule) {
+func (b *FirewallModelBuilder) addDirectionalGroupRule(c *fi.CloudupModelBuilderContext, source, dest *openstacktasks.SecurityGroup, sgr *openstacktasks.SecurityGroupRule) {
 	t := &openstacktasks.SecurityGroupRule{
 		Direction:      sgr.Direction,
 		EtherType:      sgr.EtherType,
@@ -86,7 +86,7 @@ func (b *FirewallModelBuilder) addDirectionalGroupRule(c *fi.ModelBuilderContext
 }
 
 // addSSHRules - sets the ssh rules based on the presence of a bastion
-func (b *FirewallModelBuilder) addSSHRules(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
+func (b *FirewallModelBuilder) addSSHRules(c *fi.CloudupModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
 	masterName := b.SecurityGroupName(kops.InstanceGroupRoleControlPlane)
 	nodeName := b.SecurityGroupName(kops.InstanceGroupRoleNode)
 	bastionName := b.SecurityGroupName(kops.InstanceGroupRoleBastion)
@@ -146,7 +146,7 @@ func (b *FirewallModelBuilder) addSSHRules(c *fi.ModelBuilderContext, sgMap map[
 }
 
 // addETCDRules - Add ETCD access rules based on which CNI might need to access __ETCD_ENDPOINTS__
-func (b *FirewallModelBuilder) addETCDRules(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
+func (b *FirewallModelBuilder) addETCDRules(c *fi.CloudupModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
 	masterName := b.SecurityGroupName(kops.InstanceGroupRoleControlPlane)
 	nodeName := b.SecurityGroupName(kops.InstanceGroupRoleNode)
 	masterSG := sgMap[masterName]
@@ -202,7 +202,7 @@ func (b *FirewallModelBuilder) addETCDRules(c *fi.ModelBuilderContext, sgMap map
 }
 
 // addNodePortRules - Add node port rules to nodes give the NodePortRange
-func (b *FirewallModelBuilder) addNodePortRules(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
+func (b *FirewallModelBuilder) addNodePortRules(c *fi.CloudupModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
 	nodeName := b.SecurityGroupName(kops.InstanceGroupRoleNode)
 	nodeSG := sgMap[nodeName]
 
@@ -230,7 +230,7 @@ func (b *FirewallModelBuilder) addNodePortRules(c *fi.ModelBuilderContext, sgMap
 }
 
 // addHTTPSRules - Add rules to 443 access given the presence of a loadbalancer or not
-func (b *FirewallModelBuilder) addHTTPSRules(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup, useVIPACL bool) error {
+func (b *FirewallModelBuilder) addHTTPSRules(c *fi.CloudupModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup, useVIPACL bool) error {
 	masterName := b.SecurityGroupName(kops.InstanceGroupRoleControlPlane)
 	nodeName := b.SecurityGroupName(kops.InstanceGroupRoleNode)
 	lbSGName := b.Cluster.Spec.API.PublicName
@@ -327,7 +327,7 @@ func (b *FirewallModelBuilder) addHTTPSRules(c *fi.ModelBuilderContext, sgMap ma
 }
 
 // addKubeletRules - Add rules to 10250 port
-func (b *FirewallModelBuilder) addKubeletRules(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
+func (b *FirewallModelBuilder) addKubeletRules(c *fi.CloudupModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
 	// TODO: This is the default port for kubelet and may be overridden
 	masterName := b.SecurityGroupName(kops.InstanceGroupRoleControlPlane)
 	nodeName := b.SecurityGroupName(kops.InstanceGroupRoleNode)
@@ -352,7 +352,7 @@ func (b *FirewallModelBuilder) addKubeletRules(c *fi.ModelBuilderContext, sgMap 
 }
 
 // addNodeExporterAndOccmRules - Allow 9100 TCP port from nodesg, allow 10258 from nodes to master - expose occm metrics
-func (b *FirewallModelBuilder) addNodeExporterAndOccmRules(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
+func (b *FirewallModelBuilder) addNodeExporterAndOccmRules(c *fi.CloudupModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
 	masterName := b.SecurityGroupName(kops.InstanceGroupRoleControlPlane)
 	nodeName := b.SecurityGroupName(kops.InstanceGroupRoleNode)
 	masterSG := sgMap[masterName]
@@ -382,7 +382,7 @@ func (b *FirewallModelBuilder) addNodeExporterAndOccmRules(c *fi.ModelBuilderCon
 }
 
 // addDNSRules - Add DNS rules for internal DNS queries
-func (b *FirewallModelBuilder) addDNSRules(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
+func (b *FirewallModelBuilder) addDNSRules(c *fi.CloudupModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
 	masterName := b.SecurityGroupName(kops.InstanceGroupRoleControlPlane)
 	nodeName := b.SecurityGroupName(kops.InstanceGroupRoleNode)
 	masterSG := sgMap[masterName]
@@ -404,7 +404,7 @@ func (b *FirewallModelBuilder) addDNSRules(c *fi.ModelBuilderContext, sgMap map[
 }
 
 // addCNIRules - Add ports required for different CNI implementations
-func (b *FirewallModelBuilder) addCNIRules(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
+func (b *FirewallModelBuilder) addCNIRules(c *fi.CloudupModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
 	udpPorts := []int{}
 	tcpPorts := []int{}
 	protocols := []string{}
@@ -498,7 +498,7 @@ func (b *FirewallModelBuilder) addCNIRules(c *fi.ModelBuilderContext, sgMap map[
 }
 
 // addProtokubeRules - Add rules for protokube if gossip DNS is enabled
-func (b *FirewallModelBuilder) addProtokubeRules(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
+func (b *FirewallModelBuilder) addProtokubeRules(c *fi.CloudupModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup) error {
 	if b.Cluster.IsGossip() {
 		masterName := b.SecurityGroupName(kops.InstanceGroupRoleControlPlane)
 		nodeName := b.SecurityGroupName(kops.InstanceGroupRoleNode)
@@ -577,7 +577,7 @@ func (b *FirewallModelBuilder) getExistingRules(sgMap map[string]*openstacktasks
 	return nil
 }
 
-func (b *FirewallModelBuilder) addDefaultEgress(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup, useVIPACL bool) {
+func (b *FirewallModelBuilder) addDefaultEgress(c *fi.CloudupModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup, useVIPACL bool) {
 	for name, sg := range sgMap {
 		if useVIPACL && name == b.Cluster.Spec.API.PublicName {
 			continue
@@ -603,7 +603,7 @@ func (b *FirewallModelBuilder) addDefaultEgress(c *fi.ModelBuilderContext, sgMap
 }
 
 // Build - schedule security groups and security group rule tasks for Openstack
-func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	roles := []kops.InstanceGroupRole{kops.InstanceGroupRoleControlPlane, kops.InstanceGroupRoleNode}
 	if b.UsesSSHBastion() {
 		roles = append(roles, kops.InstanceGroupRoleBastion)

--- a/pkg/model/openstackmodel/network.go
+++ b/pkg/model/openstackmodel/network.go
@@ -29,9 +29,9 @@ type NetworkModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &NetworkModelBuilder{}
+var _ fi.CloudupModelBuilder = &NetworkModelBuilder{}
 
-func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	clusterName := b.ClusterName()
 
 	osSpec := b.Cluster.Spec.CloudProvider.Openstack

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -39,7 +39,7 @@ type ServerGroupModelBuilder struct {
 	Lifecycle              fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &ServerGroupModelBuilder{}
+var _ fi.CloudupModelBuilder = &ServerGroupModelBuilder{}
 
 // See https://specs.openstack.org/openstack/nova-specs/specs/newton/approved/lowercase-metadata-keys.html for details
 var instanceMetadataNotAllowedCharacters = regexp.MustCompile("[^a-zA-Z0-9-_:. ]")
@@ -53,7 +53,7 @@ var TRUNCATE_OPT = truncate.TruncateStringOptions{
 	HashLength:    6,
 }
 
-func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *openstacktasks.ServerGroup, ig *kops.InstanceGroup) error {
+func (b *ServerGroupModelBuilder) buildInstances(c *fi.CloudupModelBuilderContext, sg *openstacktasks.ServerGroup, ig *kops.InstanceGroup) error {
 	sshKeyNameFull, err := b.SSHKeyName()
 	if err != nil {
 		return err
@@ -237,7 +237,7 @@ func (b *ServerGroupModelBuilder) associateFIPToKeypair(fipTask *openstacktasks.
 	fipTask.ForAPIServer = true
 }
 
-func (b *ServerGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *ServerGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	clusterName := b.ClusterName()
 
 	var masters []*openstacktasks.ServerGroup

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -1232,8 +1232,8 @@ func RunGoldenTest(t *testing.T, basedir string, testCase serverGroupModelBuilde
 
 	builder := createBuilderForCluster(testCase.cluster, testCase.instanceGroups, clusterLifecycle, bootstrapScriptBuilder)
 
-	context := &fi.ModelBuilderContext{
-		Tasks:              make(map[string]fi.Task),
+	context := &fi.CloudupModelBuilderContext{
+		Tasks:              make(map[string]fi.CloudupTask),
 		LifecycleOverrides: map[string]fi.Lifecycle{},
 	}
 

--- a/pkg/model/openstackmodel/sshkey.go
+++ b/pkg/model/openstackmodel/sshkey.go
@@ -27,9 +27,9 @@ type SSHKeyModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &SSHKeyModelBuilder{}
+var _ fi.CloudupModelBuilder = &SSHKeyModelBuilder{}
 
-func (b *SSHKeyModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *SSHKeyModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	name, err := b.SSHKeyName()
 	if err != nil {
 		return err

--- a/pkg/model/pki.go
+++ b/pkg/model/pki.go
@@ -32,10 +32,10 @@ type PKIModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &PKIModelBuilder{}
+var _ fi.CloudupModelBuilder = &PKIModelBuilder{}
 
 // Build is responsible for generating the various pki assets.
-func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *PKIModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	// TODO: Only create the CA via this task
 	defaultCA := &fitasks.Keypair{
 		Name:      fi.PtrTo(fi.CertificateIDCA),

--- a/pkg/model/scalewaymodel/instances.go
+++ b/pkg/model/scalewaymodel/instances.go
@@ -34,9 +34,9 @@ type InstanceModelBuilder struct {
 	Lifecycle              fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &InstanceModelBuilder{}
+var _ fi.CloudupModelBuilder = &InstanceModelBuilder{}
 
-func (d *InstanceModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (d *InstanceModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	for _, ig := range d.InstanceGroups {
 		name := d.AutoscalingGroupName(ig)
 		zone, err := scw.ParseZone(ig.Spec.Subnets[0])

--- a/pkg/model/scalewaymodel/sshkey.go
+++ b/pkg/model/scalewaymodel/sshkey.go
@@ -29,9 +29,9 @@ type SSHKeyModelBuilder struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.ModelBuilder = &SSHKeyModelBuilder{}
+var _ fi.CloudupModelBuilder = &SSHKeyModelBuilder{}
 
-func (b *SSHKeyModelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *SSHKeyModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	name, err := b.SSHKeyName()
 	if err != nil {
 		return fmt.Errorf("error building ssh key task: %w", err)

--- a/pkg/testutils/modelharness.go
+++ b/pkg/testutils/modelharness.go
@@ -85,7 +85,7 @@ func LoadModel(basedir string) (*Model, error) {
 	return spec, nil
 }
 
-func ValidateTasks(t *testing.T, expectedFile string, context *fi.ModelBuilderContext) {
+func ValidateTasks[T fi.SubContext](t *testing.T, expectedFile string, context *fi.ModelBuilderContext[T]) {
 	var keys []string
 	for key := range context.Tasks {
 		keys = append(keys, key)

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -107,7 +107,7 @@ type ApplyClusterCmd struct {
 	TargetName string
 
 	// Target is the fi.Target we will operate against
-	Target fi.Target
+	Target fi.CloudupTarget
 
 	// OutDir is a local directory in which we place output, can cache files etc
 	OutDir string
@@ -144,7 +144,7 @@ type ApplyClusterCmd struct {
 	GetAssets bool
 
 	// TaskMap is the map of tasks that we built (output)
-	TaskMap map[string]fi.Task
+	TaskMap map[string]fi.CloudupTask
 
 	// ImageAssets are the image assets we use (output).
 	ImageAssets []*assets.ImageAsset
@@ -704,7 +704,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		return fmt.Errorf("error building tasks: %v", err)
 	}
 
-	var target fi.Target
+	var target fi.CloudupTarget
 	shouldPrecreateDNS := true
 
 	switch c.TargetName {
@@ -766,7 +766,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		if c.GetAssets {
 			out = io.Discard
 		}
-		target = fi.NewDryRunTarget(assetBuilder, out)
+		target = fi.NewCloudupDryRunTarget(assetBuilder, out)
 
 		// Avoid making changes on a dry-run
 		shouldPrecreateDNS = false
@@ -783,7 +783,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		}
 	}
 
-	context, err := fi.NewContext(ctx, target, cluster, cloud, keyStore, secretStore, configBase, checkExisting, c.TaskMap)
+	context, err := fi.NewCloudupContext(ctx, target, cluster, cloud, keyStore, secretStore, configBase, checkExisting, c.TaskMap)
 	if err != nil {
 		return fmt.Errorf("error building context: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -101,7 +101,7 @@ type AutoscalingGroup struct {
 }
 
 var _ fi.CompareWithID = &AutoscalingGroup{}
-var _ fi.TaskNormalize = &AutoscalingGroup{}
+var _ fi.CloudupTaskNormalize = &AutoscalingGroup{}
 
 // CompareWithID returns the ID of the ASG
 func (e *AutoscalingGroup) CompareWithID() *string {
@@ -109,7 +109,7 @@ func (e *AutoscalingGroup) CompareWithID() *string {
 }
 
 // Find is used to discover the ASG in the cloud provider
-func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
+func (e *AutoscalingGroup) Find(c *fi.CloudupContext) (*AutoscalingGroup, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	g, err := findAutoscalingGroup(cloud, fi.ValueOf(e.Name))
@@ -316,7 +316,7 @@ func findAutoscalingGroup(cloud awsup.AWSCloud, name string) (*autoscaling.Group
 	return nil, fmt.Errorf("found multiple AutoscalingGroups with name: %q", name)
 }
 
-func (e *AutoscalingGroup) Normalize(c *fi.Context) error {
+func (e *AutoscalingGroup) Normalize(c *fi.CloudupContext) error {
 	sort.Strings(e.Metrics)
 	c.Cloud.(awsup.AWSCloud).AddTags(e.Name, e.Tags)
 
@@ -324,8 +324,8 @@ func (e *AutoscalingGroup) Normalize(c *fi.Context) error {
 }
 
 // Run is responsible for running the task
-func (e *AutoscalingGroup) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *AutoscalingGroup) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 // CheckChanges is responsible for checking for changes??

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_fitask.go
@@ -48,5 +48,5 @@ func (o *AutoscalingGroup) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *AutoscalingGroup) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
@@ -52,7 +52,7 @@ func (h *AutoscalingLifecycleHook) CompareWithID() *string {
 	return h.Name
 }
 
-func (h *AutoscalingLifecycleHook) Find(c *fi.Context) (*AutoscalingLifecycleHook, error) {
+func (h *AutoscalingLifecycleHook) Find(c *fi.CloudupContext) (*AutoscalingLifecycleHook, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &autoscaling.DescribeLifecycleHooksInput{
@@ -91,8 +91,8 @@ func (h *AutoscalingLifecycleHook) Find(c *fi.Context) (*AutoscalingLifecycleHoo
 	return actual, nil
 }
 
-func (h *AutoscalingLifecycleHook) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(h, c)
+func (h *AutoscalingLifecycleHook) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(h, c)
 }
 
 func (_ *AutoscalingLifecycleHook) CheckChanges(a, e, changes *AutoscalingLifecycleHook) error {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook_fitask.go
@@ -48,5 +48,5 @@ func (o *AutoscalingLifecycleHook) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *AutoscalingLifecycleHook) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/block_device_mappings.go
+++ b/upup/pkg/fi/cloudup/awstasks/block_device_mappings.go
@@ -181,9 +181,9 @@ func (i *BlockDeviceMapping) ToLaunchTemplateBootDeviceRequest(deviceName string
 	return o
 }
 
-var _ fi.HasDependencies = &BlockDeviceMapping{}
+var _ fi.CloudupHasDependencies = &BlockDeviceMapping{}
 
 // GetDependencies is for future use
-func (i *BlockDeviceMapping) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (i *BlockDeviceMapping) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }

--- a/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
@@ -75,7 +75,7 @@ type ClassicLoadBalancer struct {
 }
 
 var _ fi.CompareWithID = &ClassicLoadBalancer{}
-var _ fi.TaskNormalize = &ClassicLoadBalancer{}
+var _ fi.CloudupTaskNormalize = &ClassicLoadBalancer{}
 
 func (e *ClassicLoadBalancer) CompareWithID() *string {
 	return e.Name
@@ -104,9 +104,9 @@ func (e *ClassicLoadBalancerListener) mapToAWS(loadBalancerPort int64) *elb.List
 	return l
 }
 
-var _ fi.HasDependencies = &ClassicLoadBalancerListener{}
+var _ fi.CloudupHasDependencies = &ClassicLoadBalancerListener{}
 
-func (e *ClassicLoadBalancerListener) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (e *ClassicLoadBalancerListener) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 
@@ -209,7 +209,7 @@ func (e *ClassicLoadBalancer) getHostedZoneId() *string {
 	return e.HostedZoneId
 }
 
-func (e *ClassicLoadBalancer) Find(c *fi.Context) (*ClassicLoadBalancer, error) {
+func (e *ClassicLoadBalancer) Find(c *fi.CloudupContext) (*ClassicLoadBalancer, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	lb, err := cloud.FindELBByNameTag(fi.ValueOf(e.Name))
@@ -345,7 +345,7 @@ func (e *ClassicLoadBalancer) IsForAPIServer() bool {
 	return e.ForAPIServer
 }
 
-func (e *ClassicLoadBalancer) FindAddresses(context *fi.Context) ([]string, error) {
+func (e *ClassicLoadBalancer) FindAddresses(context *fi.CloudupContext) ([]string, error) {
 	cloud := context.Cloud.(awsup.AWSCloud)
 
 	lb, err := cloud.FindELBByNameTag(fi.ValueOf(e.Name))
@@ -363,8 +363,8 @@ func (e *ClassicLoadBalancer) FindAddresses(context *fi.Context) ([]string, erro
 	return []string{lbDnsName}, nil
 }
 
-func (e *ClassicLoadBalancer) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *ClassicLoadBalancer) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *ClassicLoadBalancer) ShouldCreate(a, e, changes *ClassicLoadBalancer) (bool, error) {
@@ -374,7 +374,7 @@ func (_ *ClassicLoadBalancer) ShouldCreate(a, e, changes *ClassicLoadBalancer) (
 	return true, nil
 }
 
-func (e *ClassicLoadBalancer) Normalize(c *fi.Context) error {
+func (e *ClassicLoadBalancer) Normalize(c *fi.CloudupContext) error {
 	// We need to sort our arrays consistently, so we don't get spurious changes
 	sort.Stable(OrderSubnetsById(e.Subnets))
 	sort.Stable(OrderSecurityGroupsById(e.SecurityGroups))

--- a/upup/pkg/fi/cloudup/awstasks/classic_loadbalancer_attributes.go
+++ b/upup/pkg/fi/cloudup/awstasks/classic_loadbalancer_attributes.go
@@ -33,7 +33,7 @@ type ClassicLoadBalancerAccessLog struct {
 	S3BucketPrefix *string
 }
 
-func (_ *ClassicLoadBalancerAccessLog) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (_ *ClassicLoadBalancerAccessLog) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 
@@ -58,7 +58,7 @@ type ClassicLoadBalancerConnectionDraining struct {
 	Timeout *int64
 }
 
-func (_ *ClassicLoadBalancerConnectionDraining) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (_ *ClassicLoadBalancerConnectionDraining) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 
@@ -66,7 +66,7 @@ type ClassicLoadBalancerCrossZoneLoadBalancing struct {
 	Enabled *bool
 }
 
-func (_ *ClassicLoadBalancerCrossZoneLoadBalancing) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (_ *ClassicLoadBalancerCrossZoneLoadBalancing) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 
@@ -74,7 +74,7 @@ type ClassicLoadBalancerConnectionSettings struct {
 	IdleTimeout *int64
 }
 
-func (_ *ClassicLoadBalancerConnectionSettings) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (_ *ClassicLoadBalancerConnectionSettings) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/classic_loadbalancer_healthchecks.go
+++ b/upup/pkg/fi/cloudup/awstasks/classic_loadbalancer_healthchecks.go
@@ -31,9 +31,9 @@ type ClassicLoadBalancerHealthCheck struct {
 	Timeout  *int64
 }
 
-var _ fi.HasDependencies = &ClassicLoadBalancerListener{}
+var _ fi.CloudupHasDependencies = &ClassicLoadBalancerListener{}
 
-func (e *ClassicLoadBalancerHealthCheck) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (e *ClassicLoadBalancerHealthCheck) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/classicloadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/classicloadbalancer_fitask.go
@@ -48,5 +48,5 @@ func (o *ClassicLoadBalancer) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *ClassicLoadBalancer) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
@@ -51,7 +51,7 @@ func (e *DHCPOptions) CompareWithID() *string {
 	return e.ID
 }
 
-func (e *DHCPOptions) Find(c *fi.Context) (*DHCPOptions, error) {
+func (e *DHCPOptions) Find(c *fi.CloudupContext) (*DHCPOptions, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &ec2.DescribeDhcpOptionsInput{}
@@ -109,8 +109,8 @@ func (e *DHCPOptions) Find(c *fi.Context) (*DHCPOptions, error) {
 	return actual, nil
 }
 
-func (e *DHCPOptions) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *DHCPOptions) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *DHCPOptions) CheckChanges(a, e, changes *DHCPOptions) error {

--- a/upup/pkg/fi/cloudup/awstasks/dhcpoptions_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcpoptions_fitask.go
@@ -48,5 +48,5 @@ func (o *DHCPOptions) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *DHCPOptions) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -43,13 +43,13 @@ type DNSName struct {
 }
 
 type DNSTarget interface {
-	fi.Task
+	fi.CloudupTask
 	getDNSName() *string
 	getHostedZoneId() *string
 	TerraformLink(...string) *terraformWriter.Literal
 }
 
-func (e *DNSName) Find(c *fi.Context) (*DNSName, error) {
+func (e *DNSName) Find(c *fi.CloudupContext) (*DNSName, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if e.Zone == nil || e.Zone.ZoneID == nil {
@@ -187,8 +187,8 @@ func findDNSTargetELB(cloud awsup.AWSCloud, aliasTarget *route53.AliasTarget, dn
 	return nil, nil
 }
 
-func (e *DNSName) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *DNSName) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *DNSName) CheckChanges(a, e, changes *DNSName) error {

--- a/upup/pkg/fi/cloudup/awstasks/dnsname_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname_fitask.go
@@ -48,5 +48,5 @@ func (o *DNSName) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *DNSName) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/dnszone.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnszone.go
@@ -51,7 +51,7 @@ func (e *DNSZone) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *DNSZone) Find(c *fi.Context) (*DNSZone, error) {
+func (e *DNSZone) Find(c *fi.CloudupContext) (*DNSZone, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	z, err := e.findExisting(cloud)
@@ -160,8 +160,8 @@ func (e *DNSZone) findExisting(cloud awsup.AWSCloud) (*route53.GetHostedZoneOutp
 	}
 }
 
-func (e *DNSZone) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *DNSZone) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *DNSZone) CheckChanges(a, e, changes *DNSZone) error {

--- a/upup/pkg/fi/cloudup/awstasks/dnszone_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnszone_fitask.go
@@ -48,5 +48,5 @@ func (o *DNSZone) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *DNSZone) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
@@ -46,13 +46,13 @@ type EBSVolume struct {
 }
 
 var _ fi.CompareWithID = &EBSVolume{}
-var _ fi.TaskNormalize = &EBSVolume{}
+var _ fi.CloudupTaskNormalize = &EBSVolume{}
 
 func (e *EBSVolume) CompareWithID() *string {
 	return e.ID
 }
 
-func (e *EBSVolume) Find(context *fi.Context) (*EBSVolume, error) {
+func (e *EBSVolume) Find(context *fi.CloudupContext) (*EBSVolume, error) {
 	cloud := context.Cloud.(awsup.AWSCloud)
 
 	filters := cloud.BuildFilters(e.Name)
@@ -96,13 +96,13 @@ func (e *EBSVolume) Find(context *fi.Context) (*EBSVolume, error) {
 	return actual, nil
 }
 
-func (e *EBSVolume) Normalize(c *fi.Context) error {
+func (e *EBSVolume) Normalize(c *fi.CloudupContext) error {
 	c.Cloud.(awsup.AWSCloud).AddTags(e.Name, e.Tags)
 	return nil
 }
 
-func (e *EBSVolume) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *EBSVolume) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *EBSVolume) CheckChanges(a, e, changes *EBSVolume) error {
@@ -242,7 +242,7 @@ func (e *EBSVolume) TerraformName() (string, bool) {
 }
 
 // PreRun is run before general task execution, and checks for terraform breaking changes.
-func (e *EBSVolume) PreRun(c *fi.Context) error {
+func (e *EBSVolume) PreRun(c *fi.CloudupContext) error {
 	if _, ok := c.Target.(*terraform.TerraformTarget); ok {
 		_, usedPrefix := e.TerraformName()
 		if usedPrefix {

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume_fitask.go
@@ -48,5 +48,5 @@ func (o *EBSVolume) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *EBSVolume) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway.go
@@ -63,7 +63,7 @@ func findEgressOnlyInternetGateway(cloud awsup.AWSCloud, request *ec2.DescribeEg
 	return igw, nil
 }
 
-func (e *EgressOnlyInternetGateway) Find(c *fi.Context) (*EgressOnlyInternetGateway, error) {
+func (e *EgressOnlyInternetGateway) Find(c *fi.CloudupContext) (*EgressOnlyInternetGateway, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &ec2.DescribeEgressOnlyInternetGatewaysInput{}
@@ -120,8 +120,8 @@ func (e *EgressOnlyInternetGateway) Find(c *fi.Context) (*EgressOnlyInternetGate
 	return actual, nil
 }
 
-func (e *EgressOnlyInternetGateway) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *EgressOnlyInternetGateway) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *EgressOnlyInternetGateway) CheckChanges(a, e, changes *EgressOnlyInternetGateway) error {

--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_fitask.go
@@ -48,5 +48,5 @@ func (o *EgressOnlyInternetGateway) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *EgressOnlyInternetGateway) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_test.go
@@ -66,7 +66,7 @@ func TestSharedEgressOnlyInternetGatewayDoesNotRename(t *testing.T) {
 	}
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		vpc1 := &VPC{
 			Name:      s("vpc1"),
 			Lifecycle: fi.LifecycleSync,
@@ -84,7 +84,7 @@ func TestSharedEgressOnlyInternetGatewayDoesNotRename(t *testing.T) {
 			Tags:      make(map[string]string),
 		}
 
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"eigw1": eigw1,
 			"vpc1":  vpc1,
 		}
@@ -98,7 +98,7 @@ func TestSharedEgressOnlyInternetGatewayDoesNotRename(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -59,7 +59,7 @@ func (e *ElasticIP) CompareWithID() *string {
 }
 
 // Find returns the actual ElasticIP state, or nil if not found
-func (e *ElasticIP) Find(context *fi.Context) (*ElasticIP, error) {
+func (e *ElasticIP) Find(context *fi.CloudupContext) (*ElasticIP, error) {
 	return e.find(context.Cloud.(awsup.AWSCloud))
 }
 
@@ -189,8 +189,8 @@ func (e *ElasticIP) find(cloud awsup.AWSCloud) (*ElasticIP, error) {
 // This is the main entry point of the task, and will actually
 // connect our internal resource representation to an actual
 // resource in AWS
-func (e *ElasticIP) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *ElasticIP) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 // CheckChanges validates the resource. EIPs are simple, so virtually no

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
@@ -45,7 +45,7 @@ func TestElasticIPCreate(t *testing.T) {
 	c := &mockec2.MockEC2{}
 	cloud.MockEC2 = c
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		vpc1 := &VPC{
 			Name:      s("vpc1"),
 			Lifecycle: fi.LifecycleSync,
@@ -66,7 +66,7 @@ func TestElasticIPCreate(t *testing.T) {
 			Tags:        map[string]string{"Name": "eip1"},
 		}
 
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"eip1":    eip1,
 			"subnet1": subnet1,
 			"vpc1":    vpc1,
@@ -81,7 +81,7 @@ func TestElasticIPCreate(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -122,15 +122,15 @@ func TestElasticIPCreate(t *testing.T) {
 	}
 }
 
-func checkNoChanges(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks map[string]fi.Task) {
+func checkNoChanges(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks map[string]fi.CloudupTask) {
 	cluster := &kops.Cluster{
 		Spec: kops.ClusterSpec{
 			KubernetesVersion: "v1.9.0",
 		},
 	}
 	assetBuilder := assets.NewAssetBuilder(cluster, false)
-	target := fi.NewDryRunTarget(assetBuilder, os.Stderr)
-	context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+	target := fi.NewCloudupDryRunTarget(assetBuilder, os.Stderr)
+	context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 	if err != nil {
 		t.Fatalf("error building context: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awstasks/elasticip_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/elasticip_fitask.go
@@ -48,5 +48,5 @@ func (o *ElasticIP) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *ElasticIP) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
@@ -47,7 +47,7 @@ func (eb *EventBridgeRule) CompareWithID() *string {
 	return eb.Name
 }
 
-func (eb *EventBridgeRule) Find(c *fi.Context) (*EventBridgeRule, error) {
+func (eb *EventBridgeRule) Find(c *fi.CloudupContext) (*EventBridgeRule, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if eb.Name == nil {
@@ -86,8 +86,8 @@ func (eb *EventBridgeRule) Find(c *fi.Context) (*EventBridgeRule, error) {
 	return actual, nil
 }
 
-func (eb *EventBridgeRule) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(eb, c)
+func (eb *EventBridgeRule) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(eb, c)
 }
 
 func (_ *EventBridgeRule) CheckChanges(a, e, changes *EventBridgeRule) error {

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgerule_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgerule_fitask.go
@@ -48,5 +48,5 @@ func (o *EventBridgeRule) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *EventBridgeRule) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
@@ -45,7 +45,7 @@ func (eb *EventBridgeTarget) CompareWithID() *string {
 	return eb.Name
 }
 
-func (eb *EventBridgeTarget) Find(c *fi.Context) (*EventBridgeTarget, error) {
+func (eb *EventBridgeTarget) Find(c *fi.CloudupContext) (*EventBridgeTarget, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if eb.Rule == nil || eb.SQSQueue == nil {
@@ -88,8 +88,8 @@ func (eb *EventBridgeTarget) Find(c *fi.Context) (*EventBridgeTarget, error) {
 	return nil, nil
 }
 
-func (eb *EventBridgeTarget) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(eb, c)
+func (eb *EventBridgeTarget) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(eb, c)
 }
 
 func (_ *EventBridgeTarget) CheckChanges(a, e, changes *EventBridgeTarget) error {

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgetarget_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgetarget_fitask.go
@@ -48,5 +48,5 @@ func (o *EventBridgeTarget) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *EventBridgeTarget) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
@@ -66,7 +66,7 @@ func findIAMInstanceProfile(cloud awsup.AWSCloud, name string) (*iam.InstancePro
 	return response.InstanceProfile, nil
 }
 
-func (e *IAMInstanceProfile) Find(c *fi.Context) (*IAMInstanceProfile, error) {
+func (e *IAMInstanceProfile) Find(c *fi.CloudupContext) (*IAMInstanceProfile, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	p, err := findIAMInstanceProfile(cloud, *e.Name)
@@ -94,8 +94,8 @@ func (e *IAMInstanceProfile) Find(c *fi.Context) (*IAMInstanceProfile, error) {
 	return actual, nil
 }
 
-func (e *IAMInstanceProfile) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *IAMInstanceProfile) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *IAMInstanceProfile) CheckChanges(a, e, changes *IAMInstanceProfile) error {

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile_fitask.go
@@ -48,5 +48,5 @@ func (o *IAMInstanceProfile) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *IAMInstanceProfile) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
@@ -38,7 +38,7 @@ type IAMInstanceProfileRole struct {
 	Role            *IAMRole
 }
 
-func (e *IAMInstanceProfileRole) Find(c *fi.Context) (*IAMInstanceProfileRole, error) {
+func (e *IAMInstanceProfileRole) Find(c *fi.CloudupContext) (*IAMInstanceProfileRole, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if e.Role == nil || e.Role.ID == nil {
@@ -78,8 +78,8 @@ func (e *IAMInstanceProfileRole) Find(c *fi.Context) (*IAMInstanceProfileRole, e
 	return nil, nil
 }
 
-func (e *IAMInstanceProfileRole) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *IAMInstanceProfileRole) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *IAMInstanceProfileRole) CheckChanges(a, e, changes *IAMInstanceProfileRole) error {

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole_fitask.go
@@ -48,5 +48,5 @@ func (o *IAMInstanceProfileRole) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *IAMInstanceProfileRole) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
@@ -50,7 +50,7 @@ func (e *IAMOIDCProvider) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *IAMOIDCProvider) Find(c *fi.Context) (*IAMOIDCProvider, error) {
+func (e *IAMOIDCProvider) Find(c *fi.CloudupContext) (*IAMOIDCProvider, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	response, err := cloud.IAM().ListOpenIDConnectProviders(&iam.ListOpenIDConnectProvidersInput{})
@@ -93,8 +93,8 @@ func (e *IAMOIDCProvider) Find(c *fi.Context) (*IAMOIDCProvider, error) {
 	return nil, nil
 }
 
-func (e *IAMOIDCProvider) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *IAMOIDCProvider) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *IAMOIDCProvider) CheckChanges(a, e, changes *IAMOIDCProvider) error {

--- a/upup/pkg/fi/cloudup/awstasks/iamoidcprovider_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamoidcprovider_fitask.go
@@ -48,5 +48,5 @@ func (o *IAMOIDCProvider) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *IAMOIDCProvider) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/iamrole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole.go
@@ -60,7 +60,7 @@ func (e *IAMRole) CompareWithID() *string {
 	return e.ID
 }
 
-func (e *IAMRole) Find(c *fi.Context) (*IAMRole, error) {
+func (e *IAMRole) Find(c *fi.CloudupContext) (*IAMRole, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &iam.GetRoleInput{RoleName: e.Name}
@@ -128,8 +128,8 @@ func (e *IAMRole) Find(c *fi.Context) (*IAMRole, error) {
 	return actual, nil
 }
 
-func (e *IAMRole) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *IAMRole) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *IAMRole) ShouldCreate(a, e, changes *IAMRole) (bool, error) {

--- a/upup/pkg/fi/cloudup/awstasks/iamrole_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole_fitask.go
@@ -48,5 +48,5 @@ func (o *IAMRole) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *IAMRole) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -52,7 +52,7 @@ type IAMRolePolicy struct {
 	Managed bool
 }
 
-func (e *IAMRolePolicy) Find(c *fi.Context) (*IAMRolePolicy, error) {
+func (e *IAMRolePolicy) Find(c *fi.CloudupContext) (*IAMRolePolicy, error) {
 	var actual IAMRolePolicy
 
 	cloud := c.Cloud.(awsup.AWSCloud)
@@ -142,8 +142,8 @@ func (e *IAMRolePolicy) Find(c *fi.Context) (*IAMRolePolicy, error) {
 	return &actual, nil
 }
 
-func (e *IAMRolePolicy) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *IAMRolePolicy) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *IAMRolePolicy) CheckChanges(a, e, changes *IAMRolePolicy) error {

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy_fitask.go
@@ -48,5 +48,5 @@ func (o *IAMRolePolicy) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *IAMRolePolicy) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/instance.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance.go
@@ -62,7 +62,7 @@ func (s *Instance) CompareWithID() *string {
 	return s.ID
 }
 
-func (e *Instance) Find(c *fi.Context) (*Instance, error) {
+func (e *Instance) Find(c *fi.CloudupContext) (*Instance, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 	var request *ec2.DescribeInstancesInput
 
@@ -194,8 +194,8 @@ func nameFromIAMARN(arn *string) *string {
 	return &name
 }
 
-func (e *Instance) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Instance) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *Instance) CheckChanges(a, e, changes *Instance) error {

--- a/upup/pkg/fi/cloudup/awstasks/instance_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance_fitask.go
@@ -48,5 +48,5 @@ func (o *Instance) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Instance) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/instancerequirements.go
+++ b/upup/pkg/fi/cloudup/awstasks/instancerequirements.go
@@ -30,9 +30,9 @@ type InstanceRequirements struct {
 	MemoryMax    *int64
 }
 
-var _ fi.HasDependencies = &InstanceRequirements{}
+var _ fi.CloudupHasDependencies = &InstanceRequirements{}
 
-func (e *InstanceRequirements) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (e *InstanceRequirements) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway.go
@@ -63,7 +63,7 @@ func findInternetGateway(cloud awsup.AWSCloud, request *ec2.DescribeInternetGate
 	return igw, nil
 }
 
-func (e *InternetGateway) Find(c *fi.Context) (*InternetGateway, error) {
+func (e *InternetGateway) Find(c *fi.CloudupContext) (*InternetGateway, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &ec2.DescribeInternetGatewaysInput{}
@@ -120,8 +120,8 @@ func (e *InternetGateway) Find(c *fi.Context) (*InternetGateway, error) {
 	return actual, nil
 }
 
-func (e *InternetGateway) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *InternetGateway) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *InternetGateway) CheckChanges(a, e, changes *InternetGateway) error {

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway_fitask.go
@@ -48,5 +48,5 @@ func (o *InternetGateway) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *InternetGateway) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
@@ -82,7 +82,7 @@ func TestSharedInternetGatewayDoesNotRename(t *testing.T) {
 	}
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		vpc1 := &VPC{
 			Name:      s("vpc1"),
 			Lifecycle: fi.LifecycleSync,
@@ -100,7 +100,7 @@ func TestSharedInternetGatewayDoesNotRename(t *testing.T) {
 			Tags:      make(map[string]string),
 		}
 
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"igw1": igw1,
 			"vpc1": vpc1,
 		}
@@ -114,7 +114,7 @@ func TestSharedInternetGatewayDoesNotRename(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -91,10 +91,10 @@ type LaunchTemplate struct {
 }
 
 var (
-	_ fi.CompareWithID     = &LaunchTemplate{}
-	_ fi.ProducesDeletions = &LaunchTemplate{}
-	_ fi.TaskNormalize     = &LaunchTemplate{}
-	_ fi.Deletion          = &deleteLaunchTemplate{}
+	_ fi.CompareWithID            = &LaunchTemplate{}
+	_ fi.CloudupProducesDeletions = &LaunchTemplate{}
+	_ fi.CloudupTaskNormalize     = &LaunchTemplate{}
+	_ fi.CloudupDeletion          = &deleteLaunchTemplate{}
 )
 
 // CompareWithID implements the comparable interface
@@ -136,14 +136,14 @@ func (t *LaunchTemplate) buildRootDevice(cloud awsup.AWSCloud) (map[string]*Bloc
 	return bm, nil
 }
 
-func (t *LaunchTemplate) Normalize(c *fi.Context) error {
+func (t *LaunchTemplate) Normalize(c *fi.CloudupContext) error {
 	sort.Stable(OrderSecurityGroupsById(t.SecurityGroups))
 	return nil
 }
 
 // Run is responsible for
-func (t *LaunchTemplate) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(t, c)
+func (t *LaunchTemplate) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(t, c)
 }
 
 // CheckChanges is responsible for ensuring certains fields
@@ -161,8 +161,8 @@ func (t *LaunchTemplate) CheckChanges(a, e, changes *LaunchTemplate) error {
 }
 
 // FindDeletions is responsible for finding launch templates which can be deleted
-func (t *LaunchTemplate) FindDeletions(c *fi.Context) ([]fi.Deletion, error) {
-	var removals []fi.Deletion
+func (t *LaunchTemplate) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletion, error) {
+	var removals []fi.CloudupDeletion
 
 	list, err := t.findAllLaunchTemplates(c)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_fitask.go
@@ -48,5 +48,5 @@ func (o *LaunchTemplate) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *LaunchTemplate) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -192,7 +192,7 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchT
 }
 
 // Find is responsible for finding the launch template for us
-func (t *LaunchTemplate) Find(c *fi.Context) (*LaunchTemplate, error) {
+func (t *LaunchTemplate) Find(c *fi.CloudupContext) (*LaunchTemplate, error) {
 	cloud, ok := c.Cloud.(awsup.AWSCloud)
 	if !ok {
 		return nil, fmt.Errorf("invalid cloud provider: %v, expected: %s", c.Cloud, "awsup.AWSCloud")
@@ -341,7 +341,7 @@ func (t *LaunchTemplate) Find(c *fi.Context) (*LaunchTemplate, error) {
 }
 
 // findAllLaunchTemplates returns all the launch templates for us
-func (t *LaunchTemplate) findAllLaunchTemplates(c *fi.Context) ([]*ec2.LaunchTemplate, error) {
+func (t *LaunchTemplate) findAllLaunchTemplates(c *fi.CloudupContext) ([]*ec2.LaunchTemplate, error) {
 	cloud, ok := c.Cloud.(awsup.AWSCloud)
 	if !ok {
 		return nil, fmt.Errorf("invalid cloud provider: %v, expected: %s", c.Cloud, "awsup.AWSCloud")
@@ -369,7 +369,7 @@ func (t *LaunchTemplate) findAllLaunchTemplates(c *fi.Context) ([]*ec2.LaunchTem
 }
 
 // findLatestLaunchTemplateVersion returns the latest template version
-func (t *LaunchTemplate) findLatestLaunchTemplateVersion(c *fi.Context) (*ec2.LaunchTemplateVersion, error) {
+func (t *LaunchTemplate) findLatestLaunchTemplateVersion(c *fi.CloudupContext) (*ec2.LaunchTemplateVersion, error) {
 	cloud, ok := c.Cloud.(awsup.AWSCloud)
 	if !ok {
 		return nil, fmt.Errorf("invalid cloud provider: %v, expected: awsup.AWSCloud", c.Cloud)
@@ -403,7 +403,7 @@ type deleteLaunchTemplate struct {
 	lc *ec2.LaunchTemplate
 }
 
-var _ fi.Deletion = &deleteLaunchTemplate{}
+var _ fi.CloudupDeletion = &deleteLaunchTemplate{}
 
 // TaskName returns the task name
 func (d *deleteLaunchTemplate) TaskName() string {
@@ -415,7 +415,7 @@ func (d *deleteLaunchTemplate) Item() string {
 	return fi.ValueOf(d.lc.LaunchTemplateName)
 }
 
-func (d *deleteLaunchTemplate) Delete(t fi.Target) error {
+func (d *deleteLaunchTemplate) Delete(t fi.CloudupTarget) error {
 	awsTarget, ok := t.(*awsup.AWSAPITarget)
 	if !ok {
 		return fmt.Errorf("unexpected target type for deletion: %T", t)

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -58,7 +58,7 @@ func (e *NatGateway) CompareWithID() *string {
 	return e.ID
 }
 
-func (e *NatGateway) Find(c *fi.Context) (*NatGateway, error) {
+func (e *NatGateway) Find(c *fi.CloudupContext) (*NatGateway, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 	var ngw *ec2.NatGateway
 	actual := &NatGateway{}
@@ -126,7 +126,7 @@ func (e *NatGateway) Find(c *fi.Context) (*NatGateway, error) {
 	return actual, nil
 }
 
-func (e *NatGateway) findNatGateway(c *fi.Context) (*ec2.NatGateway, error) {
+func (e *NatGateway) findNatGateway(c *fi.CloudupContext) (*ec2.NatGateway, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	id := e.ID
@@ -291,8 +291,8 @@ func (s *NatGateway) CheckChanges(a, e, changes *NatGateway) error {
 	return nil
 }
 
-func (e *NatGateway) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *NatGateway) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *NatGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *NatGateway) error {

--- a/upup/pkg/fi/cloudup/awstasks/natgateway_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway_fitask.go
@@ -48,5 +48,5 @@ func (o *NatGateway) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *NatGateway) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/networkloadbalancer_attributes.go
+++ b/upup/pkg/fi/cloudup/awstasks/networkloadbalancer_attributes.go
@@ -33,7 +33,7 @@ type NetworkLoadBalancerAccessLog struct {
 	S3BucketPrefix *string
 }
 
-func (_ *NetworkLoadBalancerAccessLog) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (_ *NetworkLoadBalancerAccessLog) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/networkloadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/networkloadbalancer_fitask.go
@@ -48,5 +48,5 @@ func (o *NetworkLoadBalancer) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *NetworkLoadBalancer) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/render_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/render_test.go
@@ -65,7 +65,7 @@ func doRenderTests(t *testing.T, method string, cases []*renderTest) {
 			}
 
 			// @step: invoke the target finish up
-			in := []reflect.Value{reflect.ValueOf(make(map[string]fi.Task))}
+			in := []reflect.Value{reflect.ValueOf(make(map[string]fi.CloudupTask))}
 			resp = reflect.ValueOf(target).MethodByName("Finish").Call(in)
 			if err := resp[0].Interface(); err != nil {
 				return err.(error)

--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -47,7 +47,7 @@ type Route struct {
 	VPCPeeringConnectionID    *string
 }
 
-func (e *Route) Find(c *fi.Context) (*Route, error) {
+func (e *Route) Find(c *fi.CloudupContext) (*Route, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if e.RouteTable == nil || (e.CIDR == nil && e.IPv6CIDR == nil) {
@@ -123,8 +123,8 @@ func (e *Route) Find(c *fi.Context) (*Route, error) {
 	return nil, nil
 }
 
-func (e *Route) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Route) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *Route) CheckChanges(a, e, changes *Route) error {

--- a/upup/pkg/fi/cloudup/awstasks/route_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/route_fitask.go
@@ -48,5 +48,5 @@ func (o *Route) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Route) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/routetable.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable.go
@@ -48,7 +48,7 @@ func (e *RouteTable) CompareWithID() *string {
 	return e.ID
 }
 
-func (e *RouteTable) Find(c *fi.Context) (*RouteTable, error) {
+func (e *RouteTable) Find(c *fi.CloudupContext) (*RouteTable, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	var rt *ec2.RouteTable
@@ -146,8 +146,8 @@ func findRouteTableByFilters(cloud awsup.AWSCloud, filters []*ec2.Filter) (*ec2.
 	return rt, nil
 }
 
-func (e *RouteTable) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *RouteTable) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *RouteTable) CheckChanges(a, e, changes *RouteTable) error {

--- a/upup/pkg/fi/cloudup/awstasks/routetable_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable_fitask.go
@@ -48,5 +48,5 @@ func (o *RouteTable) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *RouteTable) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
@@ -42,7 +42,7 @@ func (s *RouteTableAssociation) CompareWithID() *string {
 	return s.ID
 }
 
-func (e *RouteTableAssociation) Find(c *fi.Context) (*RouteTableAssociation, error) {
+func (e *RouteTableAssociation) Find(c *fi.CloudupContext) (*RouteTableAssociation, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	routeTableID := e.RouteTable.ID
@@ -90,8 +90,8 @@ func (e *RouteTableAssociation) Find(c *fi.Context) (*RouteTableAssociation, err
 	return nil, nil
 }
 
-func (e *RouteTableAssociation) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *RouteTableAssociation) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *RouteTableAssociation) CheckChanges(a, e, changes *RouteTableAssociation) error {

--- a/upup/pkg/fi/cloudup/awstasks/routetableassociation_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetableassociation_fitask.go
@@ -48,5 +48,5 @@ func (o *RouteTableAssociation) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *RouteTableAssociation) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -48,8 +48,8 @@ type SecurityGroup struct {
 }
 
 var (
-	_ fi.CompareWithID     = &SecurityGroup{}
-	_ fi.ProducesDeletions = &SecurityGroup{}
+	_ fi.CompareWithID            = &SecurityGroup{}
+	_ fi.CloudupProducesDeletions = &SecurityGroup{}
 )
 
 func (e *SecurityGroup) CompareWithID() *string {
@@ -65,7 +65,7 @@ func (a OrderSecurityGroupsById) Less(i, j int) bool {
 	return fi.ValueOf(a[i].ID) < fi.ValueOf(a[j].ID)
 }
 
-func (e *SecurityGroup) Find(c *fi.Context) (*SecurityGroup, error) {
+func (e *SecurityGroup) Find(c *fi.CloudupContext) (*SecurityGroup, error) {
 	sg, err := e.findEc2(c)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func (e *SecurityGroup) Find(c *fi.Context) (*SecurityGroup, error) {
 	return actual, nil
 }
 
-func (e *SecurityGroup) findEc2(c *fi.Context) (*ec2.SecurityGroup, error) {
+func (e *SecurityGroup) findEc2(c *fi.CloudupContext) (*ec2.SecurityGroup, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 	request := &ec2.DescribeSecurityGroupsInput{}
 
@@ -130,8 +130,8 @@ func (e *SecurityGroup) findEc2(c *fi.Context) (*ec2.SecurityGroup, error) {
 	return sg, nil
 }
 
-func (e *SecurityGroup) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *SecurityGroup) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *SecurityGroup) ShouldCreate(a, e, changes *SecurityGroup) (bool, error) {
@@ -226,9 +226,9 @@ type deleteSecurityGroupRule struct {
 	rule *ec2.SecurityGroupRule
 }
 
-var _ fi.Deletion = &deleteSecurityGroupRule{}
+var _ fi.CloudupDeletion = &deleteSecurityGroupRule{}
 
-func (d *deleteSecurityGroupRule) Delete(t fi.Target) error {
+func (d *deleteSecurityGroupRule) Delete(t fi.CloudupTarget) error {
 	klog.V(2).Infof("deleting security group permission: %v", fi.DebugAsJsonString(d.rule))
 
 	awsTarget, ok := t.(*awsup.AWSAPITarget)
@@ -290,8 +290,8 @@ func (d *deleteSecurityGroupRule) Item() string {
 	return s
 }
 
-func (e *SecurityGroup) FindDeletions(c *fi.Context) ([]fi.Deletion, error) {
-	var removals []fi.Deletion
+func (e *SecurityGroup) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletion, error) {
+	var removals []fi.CloudupDeletion
 
 	if len(e.RemoveExtraRules) == 0 {
 		return nil, nil

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup_fitask.go
@@ -48,5 +48,5 @@ func (o *SecurityGroup) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *SecurityGroup) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
@@ -102,7 +102,7 @@ func TestSecurityGroupCreate(t *testing.T) {
 	cloud.MockEC2 = c
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		vpc1 := &VPC{
 			Name:      s("vpc1"),
 			Lifecycle: fi.LifecycleSync,
@@ -117,7 +117,7 @@ func TestSecurityGroupCreate(t *testing.T) {
 			Tags:        map[string]string{"Name": "sg1"},
 		}
 
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"sg1":  sg1,
 			"vpc1": vpc1,
 		}
@@ -132,7 +132,7 @@ func TestSecurityGroupCreate(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
@@ -54,7 +54,7 @@ type SecurityGroupRule struct {
 	Tags map[string]string
 }
 
-func (e *SecurityGroupRule) Find(c *fi.Context) (*SecurityGroupRule, error) {
+func (e *SecurityGroupRule) Find(c *fi.CloudupContext) (*SecurityGroupRule, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if e.SecurityGroup == nil || e.SecurityGroup.ID == nil {
@@ -197,8 +197,8 @@ func (e *SecurityGroupRule) matches(rule *ec2.SecurityGroupRule) bool {
 	return true
 }
 
-func (e *SecurityGroupRule) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *SecurityGroupRule) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *SecurityGroupRule) CheckChanges(a, e, changes *SecurityGroupRule) error {

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule_fitask.go
@@ -48,5 +48,5 @@ func (o *SecurityGroupRule) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *SecurityGroupRule) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/sqs.go
+++ b/upup/pkg/fi/cloudup/awstasks/sqs.go
@@ -52,7 +52,7 @@ func (q *SQS) CompareWithID() *string {
 	return q.ARN
 }
 
-func (q *SQS) Find(c *fi.Context) (*SQS, error) {
+func (q *SQS) Find(c *fi.CloudupContext) (*SQS, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if q.Name == nil {
@@ -136,8 +136,8 @@ func (q *SQS) Find(c *fi.Context) (*SQS, error) {
 	return actual, nil
 }
 
-func (q *SQS) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(q, c)
+func (q *SQS) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(q, c)
 }
 
 func (q *SQS) CheckChanges(a, e, changes *SQS) error {

--- a/upup/pkg/fi/cloudup/awstasks/sqs_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/sqs_fitask.go
@@ -48,5 +48,5 @@ func (o *SQS) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *SQS) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey.go
@@ -46,13 +46,13 @@ type SSHKey struct {
 }
 
 var _ fi.CompareWithID = &SSHKey{}
-var _ fi.TaskNormalize = &SSHKey{}
+var _ fi.CloudupTaskNormalize = &SSHKey{}
 
 func (e *SSHKey) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
+func (e *SSHKey) Find(c *fi.CloudupContext) (*SSHKey, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	return e.find(cloud)
@@ -120,7 +120,7 @@ func (e *SSHKey) find(cloud awsup.AWSCloud) (*SSHKey, error) {
 	return actual, nil
 }
 
-func (e *SSHKey) Normalize(c *fi.Context) error {
+func (e *SSHKey) Normalize(c *fi.CloudupContext) error {
 	if e.KeyFingerprint == nil && e.PublicKey != nil {
 		publicKey, err := fi.ResourceAsString(e.PublicKey)
 		if err != nil {
@@ -138,8 +138,8 @@ func (e *SSHKey) Normalize(c *fi.Context) error {
 	return nil
 }
 
-func (e *SSHKey) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *SSHKey) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *SSHKey) CheckChanges(a, e, changes *SSHKey) error {

--- a/upup/pkg/fi/cloudup/awstasks/sshkey_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey_fitask.go
@@ -48,5 +48,5 @@ func (o *SSHKey) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *SSHKey) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/subnet_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet_fitask.go
@@ -48,5 +48,5 @@ func (o *Subnet) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Subnet) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/subnet_mapping.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet_mapping.go
@@ -92,8 +92,8 @@ func subnetMappingSlicesEqualIgnoreOrder(l, r []*SubnetMapping) bool {
 	return true
 }
 
-func (e *SubnetMapping) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *SubnetMapping) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*Subnet); ok {
 			deps = append(deps, task)

--- a/upup/pkg/fi/cloudup/awstasks/subnet_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet_test.go
@@ -72,7 +72,7 @@ func TestSubnetCreate(t *testing.T) {
 	cloud.MockEC2 = c
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		vpc1 := &VPC{
 			Name:      s("vpc1"),
 			Lifecycle: fi.LifecycleSync,
@@ -88,7 +88,7 @@ func TestSubnetCreate(t *testing.T) {
 			Tags:                map[string]string{"Name": "subnet1"},
 		}
 
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"subnet1": subnet1,
 			"vpc1":    vpc1,
 		}
@@ -102,7 +102,7 @@ func TestSubnetCreate(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -157,7 +157,7 @@ func TestSubnetCreateIPv6(t *testing.T) {
 	cloud.MockEC2 = c
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		vpc1 := &VPC{
 			Name:      s("vpc1"),
 			Lifecycle: fi.LifecycleSync,
@@ -180,7 +180,7 @@ func TestSubnetCreateIPv6(t *testing.T) {
 			Tags:                map[string]string{"Name": "subnet1"},
 		}
 
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"vpc1":    vpc1,
 			"cidr1":   cidr1,
 			"subnet1": subnet1,
@@ -195,7 +195,7 @@ func TestSubnetCreateIPv6(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -259,7 +259,7 @@ func TestSubnetCreateIPv6NetNum(t *testing.T) {
 	cloud.MockEC2 = c
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		vpc1 := &VPC{
 			Name:      s("vpc1"),
 			Lifecycle: fi.LifecycleSync,
@@ -281,7 +281,7 @@ func TestSubnetCreateIPv6NetNum(t *testing.T) {
 			Tags:      map[string]string{"Name": "subnet1"},
 		}
 
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"vpc1":    vpc1,
 			"cidr1":   cidr1,
 			"subnet1": subnet1,
@@ -296,7 +296,7 @@ func TestSubnetCreateIPv6NetNum(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -398,7 +398,7 @@ func TestSharedSubnetCreateDoesNotCreateNew(t *testing.T) {
 	}
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		vpc1 := &VPC{
 			Name:      s("vpc1"),
 			Lifecycle: fi.LifecycleSync,
@@ -417,7 +417,7 @@ func TestSharedSubnetCreateDoesNotCreateNew(t *testing.T) {
 			ID:        subnet.Subnet.SubnetId,
 		}
 
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"subnet1": subnet1,
 			"vpc1":    vpc1,
 		}
@@ -431,7 +431,7 @@ func TestSharedSubnetCreateDoesNotCreateNew(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -67,7 +67,7 @@ func (e *TargetGroup) CompareWithID() *string {
 	return e.ARN
 }
 
-func (e *TargetGroup) Find(c *fi.Context) (*TargetGroup, error) {
+func (e *TargetGroup) Find(c *fi.CloudupContext) (*TargetGroup, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &elbv2.DescribeTargetGroupsInput{}
@@ -147,8 +147,8 @@ func (e *TargetGroup) Find(c *fi.Context) (*TargetGroup, error) {
 	return actual, nil
 }
 
-func (e *TargetGroup) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *TargetGroup) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *TargetGroup) ShouldCreate(a, e, changes *TargetGroup) (bool, error) {

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup_fitask.go
@@ -48,5 +48,5 @@ func (o *TargetGroup) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *TargetGroup) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -58,15 +58,15 @@ type VPC struct {
 }
 
 var (
-	_ fi.CompareWithID     = &VPC{}
-	_ fi.ProducesDeletions = &VPC{}
+	_ fi.CompareWithID            = &VPC{}
+	_ fi.CloudupProducesDeletions = &VPC{}
 )
 
 func (e *VPC) CompareWithID() *string {
 	return e.ID
 }
 
-func (e *VPC) Find(c *fi.Context) (*VPC, error) {
+func (e *VPC) Find(c *fi.CloudupContext) (*VPC, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	request := &ec2.DescribeVpcsInput{}
@@ -167,8 +167,8 @@ func (s *VPC) CheckChanges(a, e, changes *VPC) error {
 	return nil
 }
 
-func (e *VPC) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *VPC) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *VPC) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPC) error {
@@ -232,12 +232,12 @@ func (_ *VPC) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPC) error {
 	return t.AddAWSTags(*e.ID, e.Tags)
 }
 
-func (e *VPC) FindDeletions(c *fi.Context) ([]fi.Deletion, error) {
+func (e *VPC) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletion, error) {
 	if fi.IsNilOrEmpty(e.ID) || fi.ValueOf(e.Shared) {
 		return nil, nil
 	}
 
-	var removals []fi.Deletion
+	var removals []fi.CloudupDeletion
 	request := &ec2.DescribeVpcsInput{
 		VpcIds: []*string{e.ID},
 	}
@@ -370,9 +370,9 @@ type deleteVPCCIDRBlock struct {
 	associationID *string
 }
 
-var _ fi.Deletion = &deleteVPCCIDRBlock{}
+var _ fi.CloudupDeletion = &deleteVPCCIDRBlock{}
 
-func (d *deleteVPCCIDRBlock) Delete(t fi.Target) error {
+func (d *deleteVPCCIDRBlock) Delete(t fi.CloudupTarget) error {
 	awsTarget, ok := t.(*awsup.AWSAPITarget)
 	if !ok {
 		return fmt.Errorf("unexpected target type for deletion: %T", t)

--- a/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
@@ -36,7 +36,7 @@ type VPCDHCPOptionsAssociation struct {
 	DHCPOptions *DHCPOptions
 }
 
-func (e *VPCDHCPOptionsAssociation) Find(c *fi.Context) (*VPCDHCPOptionsAssociation, error) {
+func (e *VPCDHCPOptionsAssociation) Find(c *fi.CloudupContext) (*VPCDHCPOptionsAssociation, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	vpcID := e.VPC.ID
@@ -62,8 +62,8 @@ func (e *VPCDHCPOptionsAssociation) Find(c *fi.Context) (*VPCDHCPOptionsAssociat
 	return actual, nil
 }
 
-func (e *VPCDHCPOptionsAssociation) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *VPCDHCPOptionsAssociation) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *VPCDHCPOptionsAssociation) CheckChanges(a, e, changes *VPCDHCPOptionsAssociation) error {

--- a/upup/pkg/fi/cloudup/awstasks/vpc_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_fitask.go
@@ -48,5 +48,5 @@ func (o *VPC) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *VPC) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/vpc_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_test.go
@@ -36,14 +36,14 @@ func TestVPCCreate(t *testing.T) {
 	cloud.MockEC2 = c
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		vpc1 := &VPC{
 			Name:      s("vpc1"),
 			Lifecycle: fi.LifecycleSync,
 			CIDR:      s("172.21.0.0/16"),
 			Tags:      map[string]string{"Name": "vpc1"},
 		}
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"vpc1": vpc1,
 		}
 	}
@@ -56,7 +56,7 @@ func TestVPCCreate(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -161,7 +161,7 @@ func TestSharedVPCAdditionalCIDR(t *testing.T) {
 	cloud.MockEC2 = c
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		vpc1 := &VPC{
 			Name:      s("vpc-1"),
 			Lifecycle: fi.LifecycleSync,
@@ -169,7 +169,7 @@ func TestSharedVPCAdditionalCIDR(t *testing.T) {
 			Tags:      map[string]string{"Name": "vpc-1"},
 			Shared:    fi.PtrTo(true),
 		}
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"vpc-1": vpc1,
 		}
 	}
@@ -182,7 +182,7 @@ func TestSharedVPCAdditionalCIDR(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
@@ -37,7 +37,7 @@ type VPCAmazonIPv6CIDRBlock struct {
 	Shared *bool
 }
 
-func (e *VPCAmazonIPv6CIDRBlock) Find(c *fi.Context) (*VPCAmazonIPv6CIDRBlock, error) {
+func (e *VPCAmazonIPv6CIDRBlock) Find(c *fi.CloudupContext) (*VPCAmazonIPv6CIDRBlock, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	// If the VPC doesn't (yet) exist, there is no association
@@ -65,8 +65,8 @@ func (e *VPCAmazonIPv6CIDRBlock) Find(c *fi.Context) (*VPCAmazonIPv6CIDRBlock, e
 	return actual, nil
 }
 
-func (e *VPCAmazonIPv6CIDRBlock) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *VPCAmazonIPv6CIDRBlock) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *VPCAmazonIPv6CIDRBlock) CheckChanges(a, e, changes *VPCAmazonIPv6CIDRBlock) error {

--- a/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock_fitask.go
@@ -48,5 +48,5 @@ func (o *VPCAmazonIPv6CIDRBlock) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *VPCAmazonIPv6CIDRBlock) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
@@ -39,7 +39,7 @@ type VPCCIDRBlock struct {
 	Shared *bool
 }
 
-func (e *VPCCIDRBlock) Find(c *fi.Context) (*VPCCIDRBlock, error) {
+func (e *VPCCIDRBlock) Find(c *fi.CloudupContext) (*VPCCIDRBlock, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	vpcID := aws.StringValue(e.VPC.ID)
@@ -89,8 +89,8 @@ func (e *VPCCIDRBlock) Find(c *fi.Context) (*VPCCIDRBlock, error) {
 	return actual, nil
 }
 
-func (e *VPCCIDRBlock) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *VPCCIDRBlock) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *VPCCIDRBlock) CheckChanges(a, e, changes *VPCCIDRBlock) error {

--- a/upup/pkg/fi/cloudup/awstasks/vpccidrblock_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpccidrblock_fitask.go
@@ -48,5 +48,5 @@ func (o *VPCCIDRBlock) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *VPCCIDRBlock) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/vpcdhcpoptionsassociation_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcdhcpoptionsassociation_fitask.go
@@ -48,5 +48,5 @@ func (o *VPCDHCPOptionsAssociation) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *VPCDHCPOptionsAssociation) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awstasks/warmpool.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool.go
@@ -44,7 +44,7 @@ type WarmPool struct {
 }
 
 // Find is used to discover the ASG in the cloud provider.
-func (e *WarmPool) Find(c *fi.Context) (*WarmPool, error) {
+func (e *WarmPool) Find(c *fi.CloudupContext) (*WarmPool, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 	svc := cloud.Autoscaling()
 	warmPool, err := svc.DescribeWarmPool(&autoscaling.DescribeWarmPoolInput{
@@ -74,8 +74,8 @@ func (e *WarmPool) Find(c *fi.Context) (*WarmPool, error) {
 	return actual, nil
 }
 
-func (e *WarmPool) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *WarmPool) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (*WarmPool) CheckChanges(a, e, changes *WarmPool) error {

--- a/upup/pkg/fi/cloudup/awstasks/warmpool_fitask.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool_fitask.go
@@ -48,5 +48,5 @@ func (o *WarmPool) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *WarmPool) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
@@ -30,7 +30,7 @@ type AWSAPITarget struct {
 	Cloud AWSCloud
 }
 
-var _ fi.Target = &AWSAPITarget{}
+var _ fi.CloudupTarget = &AWSAPITarget{}
 
 func NewAWSAPITarget(cloud AWSCloud) *AWSAPITarget {
 	return &AWSAPITarget{
@@ -42,7 +42,7 @@ func (t *AWSAPITarget) ProcessDeletions() bool {
 	return true
 }
 
-func (t *AWSAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *AWSAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/azure/azure_apitarget.go
+++ b/upup/pkg/fi/cloudup/azure/azure_apitarget.go
@@ -25,7 +25,7 @@ type AzureAPITarget struct {
 	Cloud AzureCloud
 }
 
-var _ fi.Target = &AzureAPITarget{}
+var _ fi.CloudupTarget = &AzureAPITarget{}
 
 // NewAzureAPITarget returns a new AzureAPITarget.
 func NewAzureAPITarget(cloud AzureCloud) *AzureAPITarget {
@@ -36,7 +36,7 @@ func NewAzureAPITarget(cloud AzureCloud) *AzureAPITarget {
 
 // Finish is called by a lifecycle drive to finish the lifecycle of
 // the target.
-func (t *AzureAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *AzureAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/azuretasks/disk.go
+++ b/upup/pkg/fi/cloudup/azuretasks/disk.go
@@ -39,9 +39,9 @@ type Disk struct {
 }
 
 var (
-	_ fi.Task          = &Disk{}
-	_ fi.CompareWithID = &Disk{}
-	_ fi.TaskNormalize = &Disk{}
+	_ fi.CloudupTask          = &Disk{}
+	_ fi.CompareWithID        = &Disk{}
+	_ fi.CloudupTaskNormalize = &Disk{}
 )
 
 // CompareWithID returns the Name of the Disk.
@@ -50,7 +50,7 @@ func (d *Disk) CompareWithID() *string {
 }
 
 // Find discovers the Disk in the cloud provider.
-func (d *Disk) Find(c *fi.Context) (*Disk, error) {
+func (d *Disk) Find(c *fi.CloudupContext) (*Disk, error) {
 	cloud := c.Cloud.(azure.AzureCloud)
 	l, err := cloud.Disk().List(context.TODO(), *d.ResourceGroup.Name)
 	if err != nil {
@@ -79,14 +79,14 @@ func (d *Disk) Find(c *fi.Context) (*Disk, error) {
 	}, nil
 }
 
-func (d *Disk) Normalize(c *fi.Context) error {
+func (d *Disk) Normalize(c *fi.CloudupContext) error {
 	c.Cloud.(azure.AzureCloud).AddClusterTags(d.Tags)
 	return nil
 }
 
 // Run implements fi.Task.Run.
-func (d *Disk) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(d, c)
+func (d *Disk) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(d, c)
 }
 
 // CheckChanges returns an error if a change is not allowed.

--- a/upup/pkg/fi/cloudup/azuretasks/disk_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/disk_fitask.go
@@ -48,5 +48,5 @@ func (o *Disk) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Disk) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/azuretasks/disk_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/disk_test.go
@@ -73,7 +73,7 @@ func TestDiskRenderAzure(t *testing.T) {
 
 func TestDiskFind(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud: cloud,
 	}
 
@@ -132,7 +132,7 @@ func TestDiskFind(t *testing.T) {
 
 func TestDiskRun(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud:  cloud,
 		Target: azure.NewAzureAPITarget(cloud),
 	}

--- a/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
@@ -43,9 +43,9 @@ type LoadBalancer struct {
 }
 
 var (
-	_ fi.Task          = &LoadBalancer{}
-	_ fi.CompareWithID = &LoadBalancer{}
-	_ fi.TaskNormalize = &LoadBalancer{}
+	_ fi.CloudupTask          = &LoadBalancer{}
+	_ fi.CompareWithID        = &LoadBalancer{}
+	_ fi.CloudupTaskNormalize = &LoadBalancer{}
 )
 
 // CompareWithID returns the Name of the LoadBalancer
@@ -59,7 +59,7 @@ func (lb *LoadBalancer) IsForAPIServer() bool {
 }
 
 // Find discovers the LoadBalancer in the cloud provider
-func (lb *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
+func (lb *LoadBalancer) Find(c *fi.CloudupContext) (*LoadBalancer, error) {
 	cloud := c.Cloud.(azure.AzureCloud)
 	l, err := cloud.LoadBalancer().List(context.TODO(), *lb.ResourceGroup.Name)
 	if err != nil {
@@ -99,14 +99,14 @@ func (lb *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
 	}, nil
 }
 
-func (lb *LoadBalancer) Normalize(c *fi.Context) error {
+func (lb *LoadBalancer) Normalize(c *fi.CloudupContext) error {
 	c.Cloud.(azure.AzureCloud).AddClusterTags(lb.Tags)
 	return nil
 }
 
 // Run implements fi.Task.Run.
-func (lb *LoadBalancer) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(lb, c)
+func (lb *LoadBalancer) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(lb, c)
 }
 
 // CheckChanges returns an error if a change is not allowed.

--- a/upup/pkg/fi/cloudup/azuretasks/loadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/loadbalancer_fitask.go
@@ -48,5 +48,5 @@ func (o *LoadBalancer) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *LoadBalancer) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/azuretasks/loadbalancer_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/loadbalancer_test.go
@@ -70,7 +70,7 @@ func TestLoadBalancerRenderAzure(t *testing.T) {
 
 func TestLoadBalancerFind(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud: cloud,
 	}
 
@@ -139,7 +139,7 @@ func TestLoadBalancerFind(t *testing.T) {
 
 func TestLoadBalancerRun(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud:  cloud,
 		Target: azure.NewAzureAPITarget(cloud),
 	}

--- a/upup/pkg/fi/cloudup/azuretasks/publicipaddress.go
+++ b/upup/pkg/fi/cloudup/azuretasks/publicipaddress.go
@@ -37,9 +37,9 @@ type PublicIPAddress struct {
 }
 
 var (
-	_ fi.Task          = &PublicIPAddress{}
-	_ fi.CompareWithID = &PublicIPAddress{}
-	_ fi.TaskNormalize = &PublicIPAddress{}
+	_ fi.CloudupTask          = &PublicIPAddress{}
+	_ fi.CompareWithID        = &PublicIPAddress{}
+	_ fi.CloudupTaskNormalize = &PublicIPAddress{}
 )
 
 // CompareWithID returns the Name of the Public IP Address
@@ -48,7 +48,7 @@ func (p *PublicIPAddress) CompareWithID() *string {
 }
 
 // Find discovers the Public IP Address in the cloud provider
-func (p *PublicIPAddress) Find(c *fi.Context) (*PublicIPAddress, error) {
+func (p *PublicIPAddress) Find(c *fi.CloudupContext) (*PublicIPAddress, error) {
 	cloud := c.Cloud.(azure.AzureCloud)
 	l, err := cloud.PublicIPAddress().List(context.TODO(), *p.ResourceGroup.Name)
 	if err != nil {
@@ -76,14 +76,14 @@ func (p *PublicIPAddress) Find(c *fi.Context) (*PublicIPAddress, error) {
 	}, nil
 }
 
-func (p *PublicIPAddress) Normalize(c *fi.Context) error {
+func (p *PublicIPAddress) Normalize(c *fi.CloudupContext) error {
 	c.Cloud.(azure.AzureCloud).AddClusterTags(p.Tags)
 	return nil
 }
 
 // Run implements fi.Task.Run.
-func (p *PublicIPAddress) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(p, c)
+func (p *PublicIPAddress) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(p, c)
 }
 
 // CheckChanges returns an error if a change is not allowed.

--- a/upup/pkg/fi/cloudup/azuretasks/publicipaddress_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/publicipaddress_fitask.go
@@ -48,5 +48,5 @@ func (o *PublicIPAddress) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *PublicIPAddress) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/azuretasks/publicipaddress_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/publicipaddress_test.go
@@ -61,7 +61,7 @@ func TestPublicIPAddressRenderAzure(t *testing.T) {
 
 func TestPublicIPAddressFind(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud: cloud,
 	}
 
@@ -111,7 +111,7 @@ func TestPublicIPAddressFind(t *testing.T) {
 
 func TestPublicIPAddressRun(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud:  cloud,
 		Target: azure.NewAzureAPITarget(cloud),
 	}

--- a/upup/pkg/fi/cloudup/azuretasks/resourcegroup.go
+++ b/upup/pkg/fi/cloudup/azuretasks/resourcegroup.go
@@ -39,9 +39,9 @@ type ResourceGroup struct {
 }
 
 var (
-	_ fi.Task          = &ResourceGroup{}
-	_ fi.CompareWithID = &ResourceGroup{}
-	_ fi.TaskNormalize = &ResourceGroup{}
+	_ fi.CloudupTask          = &ResourceGroup{}
+	_ fi.CompareWithID        = &ResourceGroup{}
+	_ fi.CloudupTaskNormalize = &ResourceGroup{}
 )
 
 // CompareWithID returns the Name of the VM Scale Set.
@@ -50,7 +50,7 @@ func (r *ResourceGroup) CompareWithID() *string {
 }
 
 // Find discovers the ResourceGroup in the cloud provider.
-func (r *ResourceGroup) Find(c *fi.Context) (*ResourceGroup, error) {
+func (r *ResourceGroup) Find(c *fi.CloudupContext) (*ResourceGroup, error) {
 	cloud := c.Cloud.(azure.AzureCloud)
 	l, err := cloud.ResourceGroup().List(context.TODO(), "" /* filter*/)
 	if err != nil {
@@ -75,14 +75,14 @@ func (r *ResourceGroup) Find(c *fi.Context) (*ResourceGroup, error) {
 	}, nil
 }
 
-func (r *ResourceGroup) Normalize(c *fi.Context) error {
+func (r *ResourceGroup) Normalize(c *fi.CloudupContext) error {
 	c.Cloud.(azure.AzureCloud).AddClusterTags(r.Tags)
 	return nil
 }
 
 // Run implements fi.Task.Run.
-func (r *ResourceGroup) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(r, c)
+func (r *ResourceGroup) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(r, c)
 }
 
 // CheckChanges returns an error if a change is not allowed.

--- a/upup/pkg/fi/cloudup/azuretasks/resourcegroup_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/resourcegroup_fitask.go
@@ -48,5 +48,5 @@ func (o *ResourceGroup) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *ResourceGroup) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/azuretasks/resourcegroup_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/resourcegroup_test.go
@@ -83,7 +83,7 @@ func TestResourceGroupRenderAzure(t *testing.T) {
 
 func TestResourceGroupFind(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud: cloud,
 	}
 
@@ -140,7 +140,7 @@ func TestResourceGroupFind(t *testing.T) {
 
 func TestResourceGroupRun(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud:  cloud,
 		Target: azure.NewAzureAPITarget(cloud),
 	}

--- a/upup/pkg/fi/cloudup/azuretasks/roleassignment.go
+++ b/upup/pkg/fi/cloudup/azuretasks/roleassignment.go
@@ -54,7 +54,7 @@ type RoleAssignment struct {
 }
 
 var (
-	_ fi.Task          = &RoleAssignment{}
+	_ fi.CloudupTask   = &RoleAssignment{}
 	_ fi.CompareWithID = &RoleAssignment{}
 )
 
@@ -64,7 +64,7 @@ func (r *RoleAssignment) CompareWithID() *string {
 }
 
 // Find discovers the RoleAssignment in the cloud provider.
-func (r *RoleAssignment) Find(c *fi.Context) (*RoleAssignment, error) {
+func (r *RoleAssignment) Find(c *fi.CloudupContext) (*RoleAssignment, error) {
 	if r.VMScaleSet.PrincipalID == nil {
 		// PrincipalID of the VM Scale Set hasn't yet been
 		// populated. No corresponding Role Assignment
@@ -129,8 +129,8 @@ func (r *RoleAssignment) Find(c *fi.Context) (*RoleAssignment, error) {
 }
 
 // Run implements fi.Task.Run.
-func (r *RoleAssignment) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(r, c)
+func (r *RoleAssignment) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(r, c)
 }
 
 // CheckChanges returns an error if a change is not allowed.

--- a/upup/pkg/fi/cloudup/azuretasks/roleassignment_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/roleassignment_fitask.go
@@ -48,5 +48,5 @@ func (o *RoleAssignment) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *RoleAssignment) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/azuretasks/roleassignment_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/roleassignment_test.go
@@ -61,7 +61,7 @@ func TestRoleAssignmentRenderAzure(t *testing.T) {
 
 func TestRoleAssignmentFind(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud: cloud,
 	}
 
@@ -134,7 +134,7 @@ func TestRoleAssignmentFind(t *testing.T) {
 // when the principal ID of VM Scale Set hasn't yet been set.
 func TestRoleAssignmentFind_NoPrincipalID(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud: cloud,
 	}
 

--- a/upup/pkg/fi/cloudup/azuretasks/routetable.go
+++ b/upup/pkg/fi/cloudup/azuretasks/routetable.go
@@ -37,9 +37,9 @@ type RouteTable struct {
 }
 
 var (
-	_ fi.Task          = &RouteTable{}
-	_ fi.CompareWithID = &RouteTable{}
-	_ fi.TaskNormalize = &RouteTable{}
+	_ fi.CloudupTask          = &RouteTable{}
+	_ fi.CompareWithID        = &RouteTable{}
+	_ fi.CloudupTaskNormalize = &RouteTable{}
 )
 
 // CompareWithID returns the Name of the VM Scale Set.
@@ -48,7 +48,7 @@ func (r *RouteTable) CompareWithID() *string {
 }
 
 // Find discovers the RouteTable in the cloud provider.
-func (r *RouteTable) Find(c *fi.Context) (*RouteTable, error) {
+func (r *RouteTable) Find(c *fi.CloudupContext) (*RouteTable, error) {
 	cloud := c.Cloud.(azure.AzureCloud)
 	l, err := cloud.RouteTable().List(context.TODO(), *r.ResourceGroup.Name)
 	if err != nil {
@@ -75,14 +75,14 @@ func (r *RouteTable) Find(c *fi.Context) (*RouteTable, error) {
 	}, nil
 }
 
-func (r *RouteTable) Normalize(c *fi.Context) error {
+func (r *RouteTable) Normalize(c *fi.CloudupContext) error {
 	c.Cloud.(azure.AzureCloud).AddClusterTags(r.Tags)
 	return nil
 }
 
 // Run implements fi.Task.Run.
-func (r *RouteTable) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(r, c)
+func (r *RouteTable) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(r, c)
 }
 
 // CheckChanges returns an error if a change is not allowed.

--- a/upup/pkg/fi/cloudup/azuretasks/routetable_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/routetable_fitask.go
@@ -48,5 +48,5 @@ func (o *RouteTable) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *RouteTable) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/azuretasks/subnet.go
+++ b/upup/pkg/fi/cloudup/azuretasks/subnet.go
@@ -38,7 +38,7 @@ type Subnet struct {
 }
 
 var (
-	_ fi.Task          = &Subnet{}
+	_ fi.CloudupTask   = &Subnet{}
 	_ fi.CompareWithID = &Subnet{}
 )
 
@@ -48,7 +48,7 @@ func (s *Subnet) CompareWithID() *string {
 }
 
 // Find discovers the Subnet in the cloud provider.
-func (s *Subnet) Find(c *fi.Context) (*Subnet, error) {
+func (s *Subnet) Find(c *fi.CloudupContext) (*Subnet, error) {
 	cloud := c.Cloud.(azure.AzureCloud)
 	l, err := cloud.Subnet().List(context.TODO(), *s.ResourceGroup.Name, *s.VirtualNetwork.Name)
 	if err != nil {
@@ -80,8 +80,8 @@ func (s *Subnet) Find(c *fi.Context) (*Subnet, error) {
 }
 
 // Run implements fi.Task.Run.
-func (s *Subnet) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(s, c)
+func (s *Subnet) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(s, c)
 }
 
 // CheckChanges returns an error if a change is not allowed.

--- a/upup/pkg/fi/cloudup/azuretasks/subnet_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/subnet_fitask.go
@@ -48,5 +48,5 @@ func (o *Subnet) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Subnet) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/azuretasks/subnet_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/subnet_test.go
@@ -56,7 +56,7 @@ func TestSubnetRenderAzure(t *testing.T) {
 
 func TestSubnetFind(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud: cloud,
 	}
 

--- a/upup/pkg/fi/cloudup/azuretasks/virtualnetwork.go
+++ b/upup/pkg/fi/cloudup/azuretasks/virtualnetwork.go
@@ -41,9 +41,9 @@ type VirtualNetwork struct {
 }
 
 var (
-	_ fi.Task          = &VirtualNetwork{}
-	_ fi.CompareWithID = &VirtualNetwork{}
-	_ fi.TaskNormalize = &VirtualNetwork{}
+	_ fi.CloudupTask          = &VirtualNetwork{}
+	_ fi.CompareWithID        = &VirtualNetwork{}
+	_ fi.CloudupTaskNormalize = &VirtualNetwork{}
 )
 
 // CompareWithID returns the Name of the VM Scale Set.
@@ -52,7 +52,7 @@ func (n *VirtualNetwork) CompareWithID() *string {
 }
 
 // Find discovers the VirtualNetwork in the cloud provider.
-func (n *VirtualNetwork) Find(c *fi.Context) (*VirtualNetwork, error) {
+func (n *VirtualNetwork) Find(c *fi.CloudupContext) (*VirtualNetwork, error) {
 	cloud := c.Cloud.(azure.AzureCloud)
 	l, err := cloud.VirtualNetwork().List(context.TODO(), *n.ResourceGroup.Name)
 	if err != nil {
@@ -86,14 +86,14 @@ func (n *VirtualNetwork) Find(c *fi.Context) (*VirtualNetwork, error) {
 	}, nil
 }
 
-func (n *VirtualNetwork) Normalize(c *fi.Context) error {
+func (n *VirtualNetwork) Normalize(c *fi.CloudupContext) error {
 	c.Cloud.(azure.AzureCloud).AddClusterTags(n.Tags)
 	return nil
 }
 
 // Run implements fi.Task.Run.
-func (n *VirtualNetwork) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(n, c)
+func (n *VirtualNetwork) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(n, c)
 }
 
 // CheckChanges returns an error if a change is not allowed.

--- a/upup/pkg/fi/cloudup/azuretasks/virtualnetwork_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/virtualnetwork_fitask.go
@@ -48,5 +48,5 @@ func (o *VirtualNetwork) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *VirtualNetwork) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/azuretasks/virtualnetwork_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/virtualnetwork_test.go
@@ -64,7 +64,7 @@ func TestVirtualNetworkRenderAzure(t *testing.T) {
 
 func TestVirtualNetworkFind(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud: cloud,
 	}
 
@@ -121,7 +121,7 @@ func TestVirtualNetworkFind(t *testing.T) {
 
 func TestVirtualNetworkRun(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud:  cloud,
 		Target: azure.NewAzureAPITarget(cloud),
 	}

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
@@ -120,7 +120,7 @@ type VMScaleSet struct {
 	PrincipalID *string
 }
 
-var _ fi.TaskNormalize = &VMScaleSet{}
+var _ fi.CloudupTaskNormalize = &VMScaleSet{}
 
 // VMScaleSetStorageProfile wraps *compute.VirtualMachineScaleSetStorageProfile
 // and implements fi.HasDependencies.
@@ -133,15 +133,15 @@ type VMScaleSetStorageProfile struct {
 	*compute.VirtualMachineScaleSetStorageProfile
 }
 
-var _ fi.HasDependencies = &VMScaleSetStorageProfile{}
+var _ fi.CloudupHasDependencies = &VMScaleSetStorageProfile{}
 
 // GetDependencies returns a slice of tasks on which the tasks depends on.
-func (p *VMScaleSetStorageProfile) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (p *VMScaleSetStorageProfile) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 
 var (
-	_ fi.Task          = &VMScaleSet{}
+	_ fi.CloudupTask   = &VMScaleSet{}
 	_ fi.CompareWithID = &VMScaleSet{}
 )
 
@@ -151,7 +151,7 @@ func (s *VMScaleSet) CompareWithID() *string {
 }
 
 // Find discovers the VMScaleSet in the cloud provider.
-func (s *VMScaleSet) Find(c *fi.Context) (*VMScaleSet, error) {
+func (s *VMScaleSet) Find(c *fi.CloudupContext) (*VMScaleSet, error) {
 	cloud := c.Cloud.(azure.AzureCloud)
 	found, err := cloud.VMScaleSet().Get(context.TODO(), *s.ResourceGroup.Name, *s.Name)
 	if err != nil && !strings.Contains(err.Error(), "ResourceNotFound") {
@@ -239,14 +239,14 @@ func (s *VMScaleSet) Find(c *fi.Context) (*VMScaleSet, error) {
 	return vmss, nil
 }
 
-func (s *VMScaleSet) Normalize(c *fi.Context) error {
+func (s *VMScaleSet) Normalize(c *fi.CloudupContext) error {
 	c.Cloud.(azure.AzureCloud).AddClusterTags(s.Tags)
 	return nil
 }
 
 // Run implements fi.Task.Run.
-func (s *VMScaleSet) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(s, c)
+func (s *VMScaleSet) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(s, c)
 }
 
 // CheckChanges returns an error if a change is not allowed.

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset_fitask.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset_fitask.go
@@ -48,5 +48,5 @@ func (o *VMScaleSet) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *VMScaleSet) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
@@ -137,7 +137,7 @@ func TestVMScaleSetRenderAzure(t *testing.T) {
 
 func TestVMScaleSetFind(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud: cloud,
 	}
 
@@ -301,7 +301,7 @@ func TestVMScaleSetFind(t *testing.T) {
 
 func TestVMScaleSetRun(t *testing.T) {
 	cloud := NewMockAzureCloud("eastus")
-	ctx := &fi.Context{
+	ctx := &fi.CloudupContext{
 		Cloud:  cloud,
 		Target: azure.NewAzureAPITarget(cloud),
 	}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -58,7 +58,7 @@ type BootstrapChannelBuilder struct {
 	assetBuilder  *assets.AssetBuilder
 }
 
-var _ fi.ModelBuilder = &BootstrapChannelBuilder{}
+var _ fi.CloudupModelBuilder = &BootstrapChannelBuilder{}
 
 // networkSelector is the labels set on networking addons
 //
@@ -99,7 +99,7 @@ func NewBootstrapChannelBuilder(modelContext *model.KopsModelContext,
 }
 
 // Build is responsible for adding the addons to the channel
-func (b *BootstrapChannelBuilder) Build(c *fi.ModelBuilderContext) error {
+func (b *BootstrapChannelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	addons, serviceAccounts, err := b.buildAddons(c)
 	if err != nil {
 		return err
@@ -324,7 +324,7 @@ type Addon struct {
 	BuildPrune bool
 }
 
-func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*AddonList, map[string]iam.Subject, error) {
+func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) (*AddonList, map[string]iam.Subject, error) {
 	addons := &AddonList{}
 
 	serviceAccountRoles := []iam.Subject{}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -165,8 +165,8 @@ func runChannelBuilderTest(t *testing.T, key string, addonManifests []string) {
 		nil,
 	)
 
-	context := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	context := &fi.CloudupModelBuilderContext{
+		Tasks: make(map[string]fi.CloudupTask),
 	}
 	err = bcb.Build(context)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/do/api_target.go
+++ b/upup/pkg/fi/cloudup/do/api_target.go
@@ -24,7 +24,7 @@ type DOAPITarget struct {
 	Cloud DOCloud
 }
 
-var _ fi.Target = &DOAPITarget{}
+var _ fi.CloudupTarget = &DOAPITarget{}
 
 func NewDOAPITarget(cloud DOCloud) *DOAPITarget {
 	return &DOAPITarget{
@@ -32,7 +32,7 @@ func NewDOAPITarget(cloud DOCloud) *DOAPITarget {
 	}
 }
 
-func (t *DOAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *DOAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -48,7 +48,7 @@ type Droplet struct {
 }
 
 var (
-	_ fi.Task          = &Droplet{}
+	_ fi.CloudupTask   = &Droplet{}
 	_ fi.CompareWithID = &Droplet{}
 )
 
@@ -56,7 +56,7 @@ func (d *Droplet) CompareWithID() *string {
 	return d.Name
 }
 
-func (d *Droplet) Find(c *fi.Context) (*Droplet, error) {
+func (d *Droplet) Find(c *fi.CloudupContext) (*Droplet, error) {
 	cloud := c.Cloud.(do.DOCloud)
 
 	droplets, err := listDroplets(cloud)
@@ -120,8 +120,8 @@ func listDroplets(cloud do.DOCloud) ([]godo.Droplet, error) {
 	return allDroplets, nil
 }
 
-func (d *Droplet) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(d, c)
+func (d *Droplet) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(d, c)
 }
 
 func (_ *Droplet) RenderDO(t *do.DOAPITarget, a, e, changes *Droplet) error {

--- a/upup/pkg/fi/cloudup/dotasks/droplet_fitask.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet_fitask.go
@@ -48,5 +48,5 @@ func (o *Droplet) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Droplet) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
@@ -63,7 +63,7 @@ func (lb *LoadBalancer) CompareWithID() *string {
 	return lb.ID
 }
 
-func (lb *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
+func (lb *LoadBalancer) Find(c *fi.CloudupContext) (*LoadBalancer, error) {
 	klog.V(10).Infof("load balancer FIND - ID=%s, name=%s", fi.ValueOf(lb.ID), fi.ValueOf(lb.Name))
 	if fi.ValueOf(lb.ID) == "" {
 		// Loadbalancer = nil if not found
@@ -89,8 +89,8 @@ func (lb *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
 	}, nil
 }
 
-func (lb *LoadBalancer) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(lb, c)
+func (lb *LoadBalancer) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(lb, c)
 }
 
 func (_ *LoadBalancer) CheckChanges(a, e, changes *LoadBalancer) error {
@@ -193,7 +193,7 @@ func (lb *LoadBalancer) IsForAPIServer() bool {
 	return lb.ForAPIServer
 }
 
-func (lb *LoadBalancer) FindAddresses(c *fi.Context) ([]string, error) {
+func (lb *LoadBalancer) FindAddresses(c *fi.CloudupContext) ([]string, error) {
 	cloud := c.Cloud.(do.DOCloud)
 	loadBalancerService := cloud.LoadBalancersService()
 	address := ""

--- a/upup/pkg/fi/cloudup/dotasks/loadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/dotasks/loadbalancer_fitask.go
@@ -48,5 +48,5 @@ func (o *LoadBalancer) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *LoadBalancer) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/dotasks/volume.go
+++ b/upup/pkg/fi/cloudup/dotasks/volume.go
@@ -45,7 +45,7 @@ func (v *Volume) CompareWithID() *string {
 	return v.ID
 }
 
-func (v *Volume) Find(c *fi.Context) (*Volume, error) {
+func (v *Volume) Find(c *fi.CloudupContext) (*Volume, error) {
 	cloud := c.Cloud.(do.DOCloud)
 	volService := cloud.VolumeService()
 
@@ -73,8 +73,8 @@ func (v *Volume) Find(c *fi.Context) (*Volume, error) {
 	return nil, nil
 }
 
-func (v *Volume) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(v, c)
+func (v *Volume) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(v, c)
 }
 
 func (_ *Volume) CheckChanges(a, e, changes *Volume) error {

--- a/upup/pkg/fi/cloudup/dotasks/volume_fitask.go
+++ b/upup/pkg/fi/cloudup/dotasks/volume_fitask.go
@@ -48,5 +48,5 @@ func (o *Volume) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Volume) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/dotasks/volume_test.go
+++ b/upup/pkg/fi/cloudup/dotasks/volume_test.go
@@ -70,8 +70,8 @@ func (f fakeStorageClient) DeleteSnapshot(ctx context.Context, id string) (*godo
 	return f.deleteSnapshotFn(ctx, id)
 }
 
-func newContext(cloud fi.Cloud) *fi.Context {
-	return &fi.Context{
+func newContext(cloud fi.Cloud) *fi.CloudupContext {
+	return &fi.CloudupContext{
 		Cloud: cloud,
 	}
 }

--- a/upup/pkg/fi/cloudup/dotasks/vpc.go
+++ b/upup/pkg/fi/cloudup/dotasks/vpc.go
@@ -40,7 +40,7 @@ func (v *VPC) CompareWithID() *string {
 	return v.ID
 }
 
-func (v *VPC) Find(c *fi.Context) (*VPC, error) {
+func (v *VPC) Find(c *fi.CloudupContext) (*VPC, error) {
 	cloud := c.Cloud.(do.DOCloud)
 	vpcService := cloud.VPCsService()
 
@@ -66,8 +66,8 @@ func (v *VPC) Find(c *fi.Context) (*VPC, error) {
 	return nil, nil
 }
 
-func (v *VPC) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(v, c)
+func (v *VPC) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(v, c)
 }
 
 func (_ *VPC) CheckChanges(a, e, changes *VPC) error {

--- a/upup/pkg/fi/cloudup/dotasks/vpc_fitask.go
+++ b/upup/pkg/fi/cloudup/dotasks/vpc_fitask.go
@@ -48,5 +48,5 @@ func (o *VPC) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *VPC) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gce/gce_apitarget.go
+++ b/upup/pkg/fi/cloudup/gce/gce_apitarget.go
@@ -24,7 +24,7 @@ type GCEAPITarget struct {
 	Cloud GCECloud
 }
 
-var _ fi.Target = &GCEAPITarget{}
+var _ fi.CloudupTarget = &GCEAPITarget{}
 
 func NewGCEAPITarget(cloud GCECloud) *GCEAPITarget {
 	return &GCEAPITarget{
@@ -32,7 +32,7 @@ func NewGCEAPITarget(cloud GCECloud) *GCEAPITarget {
 	}
 }
 
-func (t *GCEAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *GCEAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/gcetasks/accelerator_config.go
+++ b/upup/pkg/fi/cloudup/gcetasks/accelerator_config.go
@@ -29,10 +29,10 @@ type AcceleratorConfig struct {
 }
 
 var (
-	_ fi.HasDependencies = &AcceleratorConfig{}
+	_ fi.CloudupHasDependencies = &AcceleratorConfig{}
 )
 
-func (a *AcceleratorConfig) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (a *AcceleratorConfig) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/gcetasks/address.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address.go
@@ -42,7 +42,7 @@ func (e *Address) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *Address) Find(c *fi.Context) (*Address, error) {
+func (e *Address) Find(c *fi.CloudupContext) (*Address, error) {
 	actual, err := e.find(c.Cloud.(gce.GCECloud))
 	if actual != nil && err == nil {
 		if e.IPAddress == nil {
@@ -100,7 +100,7 @@ func (e *Address) IsForAPIServer() bool {
 	return e.ForAPIServer
 }
 
-func (e *Address) FindAddresses(context *fi.Context) ([]string, error) {
+func (e *Address) FindAddresses(context *fi.CloudupContext) ([]string, error) {
 	actual, err := e.find(context.Cloud.(gce.GCECloud))
 	if err != nil {
 		return nil, fmt.Errorf("error querying for IP Address: %v", err)
@@ -111,8 +111,8 @@ func (e *Address) FindAddresses(context *fi.Context) ([]string, error) {
 	return []string{fi.ValueOf(actual.IPAddress)}, nil
 }
 
-func (e *Address) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Address) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *Address) CheckChanges(a, e, changes *Address) error {

--- a/upup/pkg/fi/cloudup/gcetasks/address_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address_fitask.go
@@ -48,5 +48,5 @@ func (o *Address) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Address) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/backend_service.go
+++ b/upup/pkg/fi/cloudup/gcetasks/backend_service.go
@@ -47,7 +47,7 @@ func (e *BackendService) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *BackendService) Find(c *fi.Context) (*BackendService, error) {
+func (e *BackendService) Find(c *fi.CloudupContext) (*BackendService, error) {
 	actual, err := e.find(c.Cloud.(gce.GCECloud))
 	if actual != nil && err == nil {
 		// Ignore system fields
@@ -90,8 +90,8 @@ func (e *BackendService) find(cloud gce.GCECloud) (*BackendService, error) {
 	return actual, nil
 }
 
-func (e *BackendService) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *BackendService) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *BackendService) CheckChanges(a, e, changes *BackendService) error {

--- a/upup/pkg/fi/cloudup/gcetasks/backendservice_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/backendservice_fitask.go
@@ -48,5 +48,5 @@ func (o *BackendService) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *BackendService) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/disk.go
+++ b/upup/pkg/fi/cloudup/gcetasks/disk.go
@@ -45,7 +45,7 @@ func (e *Disk) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *Disk) Find(c *fi.Context) (*Disk, error) {
+func (e *Disk) Find(c *fi.CloudupContext) (*Disk, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 
 	r, err := cloud.Compute().Disks().Get(cloud.Project(), *e.Zone, *e.Name)
@@ -80,8 +80,8 @@ func (e *Disk) URL(project string) string {
 	return u.BuildURL()
 }
 
-func (e *Disk) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Disk) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *Disk) CheckChanges(a, e, changes *Disk) error {

--- a/upup/pkg/fi/cloudup/gcetasks/disk_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/disk_fitask.go
@@ -48,5 +48,5 @@ func (o *Disk) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Disk) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
@@ -48,13 +48,13 @@ type FirewallRule struct {
 }
 
 var _ fi.CompareWithID = &FirewallRule{}
-var _ fi.TaskNormalize = &FirewallRule{}
+var _ fi.CloudupTaskNormalize = &FirewallRule{}
 
 func (e *FirewallRule) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *FirewallRule) Find(c *fi.Context) (*FirewallRule, error) {
+func (e *FirewallRule) Find(c *fi.CloudupContext) (*FirewallRule, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 
 	r, err := cloud.Compute().Firewalls().Get(cloud.Project(), *e.Name)
@@ -82,13 +82,13 @@ func (e *FirewallRule) Find(c *fi.Context) (*FirewallRule, error) {
 	return actual, nil
 }
 
-func (e *FirewallRule) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *FirewallRule) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 // Normalize applies some validation that isn't technically required,
 // but avoids some problems with surprising behaviours.
-func (e *FirewallRule) Normalize(c *fi.Context) error {
+func (e *FirewallRule) Normalize(c *fi.CloudupContext) error {
 	if !e.Disabled {
 		// Treat it as an error if SourceRanges _and_ SourceTags empty with Disabled=false
 		// this is interpreted as SourceRanges="0.0.0.0/0", which is likely not what was intended.

--- a/upup/pkg/fi/cloudup/gcetasks/firewallrule_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/firewallrule_fitask.go
@@ -48,5 +48,5 @@ func (o *FirewallRule) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *FirewallRule) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
@@ -55,7 +55,7 @@ func (e *ForwardingRule) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *ForwardingRule) Find(c *fi.Context) (*ForwardingRule, error) {
+func (e *ForwardingRule) Find(c *fi.CloudupContext) (*ForwardingRule, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 	name := fi.ValueOf(e.Name)
 
@@ -97,8 +97,8 @@ func (e *ForwardingRule) Find(c *fi.Context) (*ForwardingRule, error) {
 	return actual, nil
 }
 
-func (e *ForwardingRule) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *ForwardingRule) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *ForwardingRule) CheckChanges(a, e, changes *ForwardingRule) error {

--- a/upup/pkg/fi/cloudup/gcetasks/forwardingrule_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/forwardingrule_fitask.go
@@ -48,5 +48,5 @@ func (o *ForwardingRule) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *ForwardingRule) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
@@ -44,7 +44,7 @@ func (e *HealthCheck) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *HealthCheck) Find(c *fi.Context) (*HealthCheck, error) {
+func (e *HealthCheck) Find(c *fi.CloudupContext) (*HealthCheck, error) {
 	actual, err := e.find(c.Cloud.(gce.GCECloud))
 	if actual != nil && err == nil {
 		// Ignore system fields
@@ -79,8 +79,8 @@ func (e *HealthCheck) find(cloud gce.GCECloud) (*HealthCheck, error) {
 	return actual, nil
 }
 
-func (e *HealthCheck) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *HealthCheck) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *HealthCheck) CheckChanges(a, e, changes *HealthCheck) error {

--- a/upup/pkg/fi/cloudup/gcetasks/healthcheck_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/healthcheck_fitask.go
@@ -48,5 +48,5 @@ func (o *HealthCheck) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *HealthCheck) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/httphealthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/httphealthcheck.go
@@ -41,7 +41,7 @@ func (e *HTTPHealthcheck) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *HTTPHealthcheck) Find(c *fi.Context) (*HTTPHealthcheck, error) {
+func (e *HTTPHealthcheck) Find(c *fi.CloudupContext) (*HTTPHealthcheck, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 	name := fi.ValueOf(e.Name)
 	r, err := cloud.Compute().HTTPHealthChecks().Get(cloud.Project(), name)
@@ -62,8 +62,8 @@ func (e *HTTPHealthcheck) Find(c *fi.Context) (*HTTPHealthcheck, error) {
 	return actual, nil
 }
 
-func (e *HTTPHealthcheck) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *HTTPHealthcheck) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *HTTPHealthcheck) CheckChanges(a, e, changes *HTTPHealthcheck) error {

--- a/upup/pkg/fi/cloudup/gcetasks/httphealthcheck_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/httphealthcheck_fitask.go
@@ -48,5 +48,5 @@ func (o *HTTPHealthcheck) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *HTTPHealthcheck) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/instance.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance.go
@@ -62,7 +62,7 @@ func (e *Instance) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *Instance) Find(c *fi.Context) (*Instance, error) {
+func (e *Instance) Find(c *fi.CloudupContext) (*Instance, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 
 	r, err := cloud.Compute().Instances().Get(cloud.Project(), *e.Zone, *e.Name)
@@ -148,8 +148,8 @@ func (e *Instance) Find(c *fi.Context) (*Instance, error) {
 	return actual, nil
 }
 
-func (e *Instance) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Instance) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *Instance) CheckChanges(a, e, changes *Instance) error {

--- a/upup/pkg/fi/cloudup/gcetasks/instance_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance_fitask.go
@@ -48,5 +48,5 @@ func (o *Instance) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Instance) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
@@ -46,7 +46,7 @@ func (e *InstanceGroupManager) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *InstanceGroupManager) Find(c *fi.Context) (*InstanceGroupManager, error) {
+func (e *InstanceGroupManager) Find(c *fi.CloudupContext) (*InstanceGroupManager, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 
 	r, err := cloud.Compute().InstanceGroupManagers().Get(cloud.Project(), *e.Zone, *e.Name)
@@ -77,8 +77,8 @@ func (e *InstanceGroupManager) Find(c *fi.Context) (*InstanceGroupManager, error
 	return actual, nil
 }
 
-func (e *InstanceGroupManager) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *InstanceGroupManager) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *InstanceGroupManager) CheckChanges(a, e, changes *InstanceGroupManager) error {

--- a/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager_fitask.go
@@ -48,5 +48,5 @@ func (o *InstanceGroupManager) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *InstanceGroupManager) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -81,7 +81,7 @@ type InstanceTemplate struct {
 }
 
 var (
-	_ fi.Task          = &InstanceTemplate{}
+	_ fi.CloudupTask   = &InstanceTemplate{}
 	_ fi.CompareWithID = &InstanceTemplate{}
 )
 
@@ -89,7 +89,7 @@ func (e *InstanceTemplate) CompareWithID() *string {
 	return e.ID
 }
 
-func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
+func (e *InstanceTemplate) Find(c *fi.CloudupContext) (*InstanceTemplate, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 
 	templates, err := cloud.Compute().InstanceTemplates().List(context.Background(), cloud.Project())
@@ -229,8 +229,8 @@ func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
 	return nil, nil
 }
 
-func (e *InstanceTemplate) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *InstanceTemplate) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *InstanceTemplate) CheckChanges(a, e, changes *InstanceTemplate) error {

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate_fitask.go
@@ -48,5 +48,5 @@ func (o *InstanceTemplate) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *InstanceTemplate) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/network.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network.go
@@ -46,7 +46,7 @@ func (e *Network) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *Network) Find(c *fi.Context) (*Network, error) {
+func (e *Network) Find(c *fi.CloudupContext) (*Network, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 	project := cloud.Project()
 	if e.Project != nil {
@@ -100,8 +100,8 @@ func (e *Network) URL(project string) string {
 	return u.BuildURL()
 }
 
-func (e *Network) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Network) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *Network) CheckChanges(a, e, changes *Network) error {

--- a/upup/pkg/fi/cloudup/gcetasks/network_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network_fitask.go
@@ -48,5 +48,5 @@ func (o *Network) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Network) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/poolhealthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/poolhealthcheck.go
@@ -36,8 +36,8 @@ type PoolHealthCheck struct {
 var _ fi.CompareWithID = &PoolHealthCheck{}
 
 // GetDependencies returns the dependencies of the PoolHealthCheck task
-func (_ *PoolHealthCheck) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (_ *PoolHealthCheck) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*HTTPHealthcheck); ok {
 			deps = append(deps, task)
@@ -53,7 +53,7 @@ func (e *PoolHealthCheck) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *PoolHealthCheck) Find(c *fi.Context) (*PoolHealthCheck, error) {
+func (e *PoolHealthCheck) Find(c *fi.CloudupContext) (*PoolHealthCheck, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 	name := fi.ValueOf(e.Pool.Name)
 	r, err := cloud.Compute().TargetPools().Get(cloud.Project(), cloud.Region(), name)
@@ -76,8 +76,8 @@ func (e *PoolHealthCheck) Find(c *fi.Context) (*PoolHealthCheck, error) {
 	return nil, nil
 }
 
-func (e *PoolHealthCheck) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *PoolHealthCheck) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *PoolHealthCheck) CheckChanges(a, e, changes *PoolHealthCheck) error {

--- a/upup/pkg/fi/cloudup/gcetasks/poolhealthcheck_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/poolhealthcheck_fitask.go
@@ -48,5 +48,5 @@ func (o *PoolHealthCheck) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *PoolHealthCheck) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/projectiambinding.go
+++ b/upup/pkg/fi/cloudup/gcetasks/projectiambinding.go
@@ -44,7 +44,7 @@ func (e *ProjectIAMBinding) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *ProjectIAMBinding) Find(c *fi.Context) (*ProjectIAMBinding, error) {
+func (e *ProjectIAMBinding) Find(c *fi.CloudupContext) (*ProjectIAMBinding, error) {
 	ctx := context.TODO()
 
 	cloud := c.Cloud.(gce.GCECloud)
@@ -80,8 +80,8 @@ func (e *ProjectIAMBinding) Find(c *fi.Context) (*ProjectIAMBinding, error) {
 	return actual, nil
 }
 
-func (e *ProjectIAMBinding) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *ProjectIAMBinding) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *ProjectIAMBinding) CheckChanges(a, e, changes *ProjectIAMBinding) error {

--- a/upup/pkg/fi/cloudup/gcetasks/projectiambinding_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/projectiambinding_fitask.go
@@ -48,5 +48,5 @@ func (o *ProjectIAMBinding) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *ProjectIAMBinding) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/projectiambinding_test.go
+++ b/upup/pkg/fi/cloudup/gcetasks/projectiambinding_test.go
@@ -33,7 +33,7 @@ func TestProjectIAMBinding(t *testing.T) {
 	cloud := gcemock.InstallMockGCECloud(region, project)
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		binding := &ProjectIAMBinding{
 			Lifecycle: fi.LifecycleSync,
 
@@ -42,7 +42,7 @@ func TestProjectIAMBinding(t *testing.T) {
 			Role:    fi.PtrTo("roles/owner"),
 		}
 
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"binding": binding,
 		}
 	}

--- a/upup/pkg/fi/cloudup/gcetasks/router.go
+++ b/upup/pkg/fi/cloudup/gcetasks/router.go
@@ -42,9 +42,8 @@ const (
 	subnetNatAllIPRanges = "ALL_IP_RANGES"
 )
 
-// +kops:fitask
-
 // Router is a Router task.
+// +kops:fitask
 type Router struct {
 	Name      *string
 	Lifecycle fi.Lifecycle
@@ -66,7 +65,7 @@ func (r *Router) CompareWithID() *string {
 }
 
 // Find discovers the Router in the cloud provider.
-func (r *Router) Find(c *fi.Context) (*Router, error) {
+func (r *Router) Find(c *fi.CloudupContext) (*Router, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 
 	found, err := cloud.Compute().Routers().Get(cloud.Project(), *r.Region, *r.Name)
@@ -119,8 +118,8 @@ func (r *Router) url(project string) string {
 }
 
 // Run implements fi.Task.Run.
-func (r *Router) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(r, c)
+func (r *Router) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(r, c)
 }
 
 // CheckChanges returns an error if a change is not allowed.

--- a/upup/pkg/fi/cloudup/gcetasks/router_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/router_fitask.go
@@ -48,5 +48,5 @@ func (o *Router) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Router) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/serviceaccount.go
+++ b/upup/pkg/fi/cloudup/gcetasks/serviceaccount.go
@@ -47,7 +47,7 @@ func (e *ServiceAccount) CompareWithID() *string {
 	return e.Email
 }
 
-func (e *ServiceAccount) Find(c *fi.Context) (*ServiceAccount, error) {
+func (e *ServiceAccount) Find(c *fi.CloudupContext) (*ServiceAccount, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 
 	ctx := context.TODO()
@@ -90,8 +90,8 @@ func (e *ServiceAccount) Find(c *fi.Context) (*ServiceAccount, error) {
 	return actual, nil
 }
 
-func (e *ServiceAccount) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *ServiceAccount) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *ServiceAccount) CheckChanges(a, e, changes *ServiceAccount) error {

--- a/upup/pkg/fi/cloudup/gcetasks/serviceaccount_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/serviceaccount_fitask.go
@@ -48,5 +48,5 @@ func (o *ServiceAccount) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *ServiceAccount) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/serviceaccount_test.go
+++ b/upup/pkg/fi/cloudup/gcetasks/serviceaccount_test.go
@@ -39,7 +39,7 @@ func TestServiceAccount(t *testing.T) {
 	cloud := gcemock.InstallMockGCECloud(region, project)
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		serviceAccount := &ServiceAccount{
 			Name:      fi.PtrTo("test"),
 			Lifecycle: fi.LifecycleSync,
@@ -49,7 +49,7 @@ func TestServiceAccount(t *testing.T) {
 			DisplayName: fi.PtrTo("display name of ServiceAccount"),
 		}
 
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			*serviceAccount.Name: serviceAccount,
 		}
 	}
@@ -77,7 +77,7 @@ var testRunTasksOptions = fi.RunTasksOptions{
 }
 
 // TODO: Dedup with awstasks
-func checkNoChanges(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks map[string]fi.Task) {
+func checkNoChanges(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks map[string]fi.CloudupTask) {
 	target := doDryRun(t, ctx, cloud, allTasks)
 
 	if target.HasChanges() {
@@ -89,7 +89,7 @@ func checkNoChanges(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks 
 	}
 }
 
-func checkHasChanges(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks map[string]fi.Task) {
+func checkHasChanges(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks map[string]fi.CloudupTask) {
 	target := doDryRun(t, ctx, cloud, allTasks)
 
 	if !target.HasChanges() {
@@ -97,10 +97,10 @@ func checkHasChanges(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks
 	}
 }
 
-func runTasks(t *testing.T, ctx context.Context, cloud gce.GCECloud, allTasks map[string]fi.Task) {
+func runTasks(t *testing.T, ctx context.Context, cloud gce.GCECloud, allTasks map[string]fi.CloudupTask) {
 	target := gce.NewGCEAPITarget(cloud)
 
-	context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+	context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 	if err != nil {
 		t.Fatalf("error building context: %v", err)
 	}
@@ -111,7 +111,7 @@ func runTasks(t *testing.T, ctx context.Context, cloud gce.GCECloud, allTasks ma
 	}
 }
 
-func doDryRun(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks map[string]fi.Task) *fi.DryRunTarget {
+func doDryRun(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks map[string]fi.CloudupTask) *fi.CloudupDryRunTarget {
 
 	cluster := &kops.Cluster{
 		Spec: kops.ClusterSpec{
@@ -119,8 +119,8 @@ func doDryRun(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks map[st
 		},
 	}
 	assetBuilder := assets.NewAssetBuilder(cluster, false)
-	target := fi.NewDryRunTarget(assetBuilder, os.Stderr)
-	context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
+	target := fi.NewCloudupDryRunTarget(assetBuilder, os.Stderr)
+	context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 	if err != nil {
 		t.Fatalf("error building context: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketacl.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketacl.go
@@ -44,7 +44,7 @@ func (e *StorageBucketAcl) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *StorageBucketAcl) Find(c *fi.Context) (*StorageBucketAcl, error) {
+func (e *StorageBucketAcl) Find(c *fi.CloudupContext) (*StorageBucketAcl, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 
 	bucket := fi.ValueOf(e.Bucket)
@@ -72,8 +72,8 @@ func (e *StorageBucketAcl) Find(c *fi.Context) (*StorageBucketAcl, error) {
 	return actual, nil
 }
 
-func (e *StorageBucketAcl) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *StorageBucketAcl) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *StorageBucketAcl) CheckChanges(a, e, changes *StorageBucketAcl) error {

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketacl_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketacl_fitask.go
@@ -48,5 +48,5 @@ func (o *StorageBucketAcl) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *StorageBucketAcl) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketiam.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketiam.go
@@ -44,7 +44,7 @@ func (e *StorageBucketIAM) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *StorageBucketIAM) Find(c *fi.Context) (*StorageBucketIAM, error) {
+func (e *StorageBucketIAM) Find(c *fi.CloudupContext) (*StorageBucketIAM, error) {
 	ctx := context.TODO()
 
 	cloud := c.Cloud.(gce.GCECloud)
@@ -79,8 +79,8 @@ func (e *StorageBucketIAM) Find(c *fi.Context) (*StorageBucketIAM, error) {
 	return actual, nil
 }
 
-func (e *StorageBucketIAM) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *StorageBucketIAM) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *StorageBucketIAM) CheckChanges(a, e, changes *StorageBucketIAM) error {

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketiam_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketiam_fitask.go
@@ -48,5 +48,5 @@ func (o *StorageBucketIAM) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *StorageBucketIAM) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketiam_test.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketiam_test.go
@@ -33,7 +33,7 @@ func TestStorageBucketIAM(t *testing.T) {
 	cloud := gcemock.InstallMockGCECloud(region, project)
 
 	// We define a function so we can rebuild the tasks, because we modify in-place when running
-	buildTasks := func() map[string]fi.Task {
+	buildTasks := func() map[string]fi.CloudupTask {
 		binding := &StorageBucketIAM{
 			Lifecycle: fi.LifecycleSync,
 
@@ -42,7 +42,7 @@ func TestStorageBucketIAM(t *testing.T) {
 			Role:   fi.PtrTo("roles/owner"),
 		}
 
-		return map[string]fi.Task{
+		return map[string]fi.CloudupTask{
 			"binding": binding,
 		}
 	}

--- a/upup/pkg/fi/cloudup/gcetasks/storageobjectacl.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storageobjectacl.go
@@ -45,7 +45,7 @@ func (e *StorageObjectAcl) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *StorageObjectAcl) Find(c *fi.Context) (*StorageObjectAcl, error) {
+func (e *StorageObjectAcl) Find(c *fi.CloudupContext) (*StorageObjectAcl, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 
 	bucket := fi.ValueOf(e.Bucket)
@@ -75,8 +75,8 @@ func (e *StorageObjectAcl) Find(c *fi.Context) (*StorageObjectAcl, error) {
 	return actual, nil
 }
 
-func (e *StorageObjectAcl) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *StorageObjectAcl) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *StorageObjectAcl) CheckChanges(a, e, changes *StorageObjectAcl) error {

--- a/upup/pkg/fi/cloudup/gcetasks/storageobjectacl_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storageobjectacl_fitask.go
@@ -48,5 +48,5 @@ func (o *StorageObjectAcl) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *StorageObjectAcl) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/subnet.go
+++ b/upup/pkg/fi/cloudup/gcetasks/subnet.go
@@ -48,7 +48,7 @@ func (e *Subnet) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *Subnet) Find(c *fi.Context) (*Subnet, error) {
+func (e *Subnet) Find(c *fi.CloudupContext) (*Subnet, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 	_, project, err := gce.ParseNameAndProjectFromNetworkID(c.Cluster.Spec.Networking.NetworkID)
 	if err != nil {
@@ -93,8 +93,8 @@ func (e *Subnet) Find(c *fi.Context) (*Subnet, error) {
 	return actual, nil
 }
 
-func (e *Subnet) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Subnet) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *Subnet) CheckChanges(a, e, changes *Subnet) error {

--- a/upup/pkg/fi/cloudup/gcetasks/subnet_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/subnet_fitask.go
@@ -48,5 +48,5 @@ func (o *Subnet) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Subnet) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/targetpool.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool.go
@@ -40,7 +40,7 @@ func (e *TargetPool) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *TargetPool) Find(c *fi.Context) (*TargetPool, error) {
+func (e *TargetPool) Find(c *fi.CloudupContext) (*TargetPool, error) {
 	cloud := c.Cloud.(gce.GCECloud)
 	name := fi.ValueOf(e.Name)
 
@@ -61,8 +61,8 @@ func (e *TargetPool) Find(c *fi.Context) (*TargetPool, error) {
 	return actual, nil
 }
 
-func (e *TargetPool) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *TargetPool) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *TargetPool) CheckChanges(a, e, changes *TargetPool) error {

--- a/upup/pkg/fi/cloudup/gcetasks/targetpool_fitask.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool_fitask.go
@@ -48,5 +48,5 @@ func (o *TargetPool) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *TargetPool) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/hetzner/api_target.go
+++ b/upup/pkg/fi/cloudup/hetzner/api_target.go
@@ -24,7 +24,7 @@ type HetznerAPITarget struct {
 	Cloud HetznerCloud
 }
 
-var _ fi.Target = &HetznerAPITarget{}
+var _ fi.CloudupTarget = &HetznerAPITarget{}
 
 func NewHetznerAPITarget(cloud HetznerCloud) *HetznerAPITarget {
 	return &HetznerAPITarget{
@@ -32,7 +32,7 @@ func NewHetznerAPITarget(cloud HetznerCloud) *HetznerAPITarget {
 	}
 }
 
-func (t *HetznerAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *HetznerAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/hetznertasks/firewall.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/firewall.go
@@ -45,7 +45,7 @@ func (v *Firewall) CompareWithID() *string {
 	return fi.PtrTo(strconv.Itoa(fi.ValueOf(v.ID)))
 }
 
-func (v *Firewall) Find(c *fi.Context) (*Firewall, error) {
+func (v *Firewall) Find(c *fi.CloudupContext) (*Firewall, error) {
 	cloud := c.Cloud.(hetzner.HetznerCloud)
 	client := cloud.FirewallClient()
 
@@ -85,8 +85,8 @@ func (v *Firewall) Find(c *fi.Context) (*Firewall, error) {
 	return nil, nil
 }
 
-func (v *Firewall) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(v, c)
+func (v *Firewall) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(v, c)
 }
 
 func (_ *Firewall) CheckChanges(a, e, changes *Firewall) error {
@@ -201,9 +201,9 @@ type FirewallRule struct {
 	Port      *string
 }
 
-var _ fi.HasDependencies = &FirewallRule{}
+var _ fi.CloudupHasDependencies = &FirewallRule{}
 
-func (e *FirewallRule) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (e *FirewallRule) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/hetznertasks/firewall_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/firewall_fitask.go
@@ -48,5 +48,5 @@ func (o *Firewall) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Firewall) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
@@ -56,7 +56,7 @@ func (e *LoadBalancer) IsForAPIServer() bool {
 	return true
 }
 
-func (v *LoadBalancer) FindAddresses(c *fi.Context) ([]string, error) {
+func (v *LoadBalancer) FindAddresses(c *fi.CloudupContext) ([]string, error) {
 	// TODO(hakman): Use mock to handle this more gracefully
 	if strings.HasPrefix(c.ClusterConfigBase.Path(), "memfs://tests/") {
 		return nil, nil
@@ -92,7 +92,7 @@ func (v *LoadBalancer) FindAddresses(c *fi.Context) ([]string, error) {
 	return nil, nil
 }
 
-func (v *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
+func (v *LoadBalancer) Find(c *fi.CloudupContext) (*LoadBalancer, error) {
 	ctx := context.TODO()
 	cloud := c.Cloud.(hetzner.HetznerCloud)
 	client := cloud.LoadBalancerClient()
@@ -145,8 +145,8 @@ func (v *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
 	return nil, nil
 }
 
-func (v *LoadBalancer) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(v, c)
+func (v *LoadBalancer) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(v, c)
 }
 
 func (_ *LoadBalancer) CheckChanges(a, e, changes *LoadBalancer) error {
@@ -311,9 +311,9 @@ type LoadBalancerService struct {
 	DestinationPort *int
 }
 
-var _ fi.HasDependencies = &LoadBalancerService{}
+var _ fi.CloudupHasDependencies = &LoadBalancerService{}
 
-func (e *LoadBalancerService) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (e *LoadBalancerService) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/hetznertasks/loadbalancer_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/loadbalancer_fitask.go
@@ -48,5 +48,5 @@ func (o *LoadBalancer) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *LoadBalancer) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/hetznertasks/network.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/network.go
@@ -49,7 +49,7 @@ func (v *Network) CompareWithID() *string {
 	return v.ID
 }
 
-func (v *Network) Find(c *fi.Context) (*Network, error) {
+func (v *Network) Find(c *fi.CloudupContext) (*Network, error) {
 	cloud := c.Cloud.(hetzner.HetznerCloud)
 	client := cloud.NetworkClient()
 
@@ -95,8 +95,8 @@ func (v *Network) Find(c *fi.Context) (*Network, error) {
 	return matches, nil
 }
 
-func (v *Network) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(v, c)
+func (v *Network) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(v, c)
 }
 
 func (_ *Network) CheckChanges(a, e, changes *Network) error {

--- a/upup/pkg/fi/cloudup/hetznertasks/network_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/network_fitask.go
@@ -48,5 +48,5 @@ func (o *Network) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Network) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/hetznertasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/servergroup.go
@@ -54,7 +54,7 @@ type ServerGroup struct {
 	Labels map[string]string
 }
 
-func (v *ServerGroup) Find(c *fi.Context) (*ServerGroup, error) {
+func (v *ServerGroup) Find(c *fi.CloudupContext) (*ServerGroup, error) {
 	cloud := c.Cloud.(hetzner.HetznerCloud)
 	client := cloud.ServerClient()
 
@@ -131,8 +131,8 @@ func (v *ServerGroup) Find(c *fi.Context) (*ServerGroup, error) {
 	return &actual, nil
 }
 
-func (v *ServerGroup) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(v, c)
+func (v *ServerGroup) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(v, c)
 }
 
 func (_ *ServerGroup) CheckChanges(a, e, changes *ServerGroup) error {

--- a/upup/pkg/fi/cloudup/hetznertasks/servergroup_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/servergroup_fitask.go
@@ -48,5 +48,5 @@ func (o *ServerGroup) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *ServerGroup) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/hetznertasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/sshkey.go
@@ -47,7 +47,7 @@ func (v *SSHKey) CompareWithID() *string {
 	return fi.PtrTo(strconv.Itoa(fi.ValueOf(v.ID)))
 }
 
-func (v *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
+func (v *SSHKey) Find(c *fi.CloudupContext) (*SSHKey, error) {
 	cloud := c.Cloud.(hetzner.HetznerCloud)
 	client := cloud.SSHKeyClient()
 
@@ -77,8 +77,8 @@ func (v *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
 	return nil, nil
 }
 
-func (v *SSHKey) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(v, c)
+func (v *SSHKey) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(v, c)
 }
 
 func (_ *SSHKey) CheckChanges(a, e, changes *SSHKey) error {

--- a/upup/pkg/fi/cloudup/hetznertasks/sshkey_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/sshkey_fitask.go
@@ -48,5 +48,5 @@ func (o *SSHKey) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *SSHKey) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/hetznertasks/volume.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/volume.go
@@ -44,7 +44,7 @@ func (v *Volume) CompareWithID() *string {
 	return fi.PtrTo(strconv.Itoa(fi.ValueOf(v.ID)))
 }
 
-func (v *Volume) Find(c *fi.Context) (*Volume, error) {
+func (v *Volume) Find(c *fi.CloudupContext) (*Volume, error) {
 	cloud := c.Cloud.(hetzner.HetznerCloud)
 	client := cloud.VolumeClient()
 
@@ -75,8 +75,8 @@ func (v *Volume) Find(c *fi.Context) (*Volume, error) {
 	return nil, nil
 }
 
-func (v *Volume) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(v, c)
+func (v *Volume) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(v, c)
 }
 
 func (_ *Volume) CheckChanges(a, e, changes *Volume) error {

--- a/upup/pkg/fi/cloudup/hetznertasks/volume_fitask.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/volume_fitask.go
@@ -48,5 +48,5 @@ func (o *Volume) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Volume) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/loader.go
+++ b/upup/pkg/fi/cloudup/loader.go
@@ -28,18 +28,18 @@ import (
 )
 
 type Loader struct {
-	Builders []fi.ModelBuilder
+	Builders []fi.CloudupModelBuilder
 
-	tasks map[string]fi.Task
+	tasks map[string]fi.CloudupTask
 }
 
 func (l *Loader) Init() {
-	l.tasks = make(map[string]fi.Task)
+	l.tasks = make(map[string]fi.CloudupTask)
 }
 
-func (l *Loader) BuildTasks(ctx context.Context, lifecycleOverrides map[string]fi.Lifecycle) (map[string]fi.Task, error) {
+func (l *Loader) BuildTasks(ctx context.Context, lifecycleOverrides map[string]fi.Lifecycle) (map[string]fi.CloudupTask, error) {
 	for _, builder := range l.Builders {
-		context := &fi.ModelBuilderContext{
+		context := &fi.CloudupModelBuilderContext{
 			Tasks:              l.tasks,
 			LifecycleOverrides: lifecycleOverrides,
 		}
@@ -115,10 +115,10 @@ func (l *Loader) processDeferrals() error {
 	return nil
 }
 
-func (l *Loader) FindDeletions(cloud fi.Cloud, lifecycleOverrides map[string]fi.Lifecycle) (map[string]fi.Task, error) {
+func (l *Loader) FindDeletions(cloud fi.Cloud, lifecycleOverrides map[string]fi.Lifecycle) (map[string]fi.CloudupTask, error) {
 	for _, builder := range l.Builders {
 		if hasDeletions, ok := builder.(fi.HasDeletions); ok {
-			context := &fi.ModelBuilderContext{
+			context := &fi.CloudupModelBuilderContext{
 				Tasks:              l.tasks,
 				LifecycleOverrides: lifecycleOverrides,
 			}

--- a/upup/pkg/fi/cloudup/openstack/apitarget.go
+++ b/upup/pkg/fi/cloudup/openstack/apitarget.go
@@ -24,7 +24,7 @@ type OpenstackAPITarget struct {
 	Cloud OpenstackCloud
 }
 
-var _ fi.Target = &OpenstackAPITarget{}
+var _ fi.CloudupTarget = &OpenstackAPITarget{}
 
 func NewOpenstackAPITarget(cloud OpenstackCloud) *OpenstackAPITarget {
 	return &OpenstackAPITarget{
@@ -32,7 +32,7 @@ func NewOpenstackAPITarget(cloud OpenstackCloud) *OpenstackAPITarget {
 	}
 }
 
-func (t *OpenstackAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *OpenstackAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
@@ -77,7 +77,7 @@ func (e *FloatingIP) IsForAPIServer() bool {
 	return e.ForAPIServer
 }
 
-func (e *FloatingIP) FindAddresses(context *fi.Context) ([]string, error) {
+func (e *FloatingIP) FindAddresses(context *fi.CloudupContext) ([]string, error) {
 	if e.ID == nil {
 		if e.LB != nil && e.LB.ID == nil {
 			return nil, nil
@@ -107,8 +107,8 @@ func (e *FloatingIP) FindAddresses(context *fi.Context) ([]string, error) {
 }
 
 // GetDependencies returns the dependencies of the Instance task
-func (e *FloatingIP) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *FloatingIP) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*LB); ok {
 			deps = append(deps, task)
@@ -128,7 +128,7 @@ func (e *FloatingIP) CompareWithID() *string {
 	return e.ID
 }
 
-func (e *FloatingIP) Find(c *fi.Context) (*FloatingIP, error) {
+func (e *FloatingIP) Find(c *fi.CloudupContext) (*FloatingIP, error) {
 	if e == nil {
 		return nil, nil
 	}
@@ -222,8 +222,8 @@ func findFipByPortID(cloud openstack.OpenstackCloud, id string) (fip *l3floating
 	return &fips[0], nil
 }
 
-func (e *FloatingIP) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *FloatingIP) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *FloatingIP) CheckChanges(a, e, changes *FloatingIP) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/floatingip_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/floatingip_fitask.go
@@ -48,5 +48,5 @@ func (o *FloatingIP) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *FloatingIP) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -58,9 +58,9 @@ type Instance struct {
 }
 
 var (
-	_ fi.Task            = &Instance{}
-	_ fi.HasAddress      = &Instance{}
-	_ fi.HasDependencies = &Instance{}
+	_ fi.CloudupTask            = &Instance{}
+	_ fi.HasAddress             = &Instance{}
+	_ fi.CloudupHasDependencies = &Instance{}
 )
 
 // Constants for truncating Tags
@@ -73,8 +73,8 @@ var TRUNCATE_OPT = truncate.TruncateStringOptions{
 }
 
 // GetDependencies returns the dependencies of the Instance task
-func (e *Instance) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *Instance) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*ServerGroup); ok {
 			deps = append(deps, task)
@@ -108,7 +108,7 @@ func (e *Instance) IsForAPIServer() bool {
 	return e.ForAPIServer
 }
 
-func (e *Instance) FindAddresses(context *fi.Context) ([]string, error) {
+func (e *Instance) FindAddresses(context *fi.CloudupContext) ([]string, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 	if e.Port == nil {
 		return nil, nil
@@ -149,7 +149,7 @@ func filterInstancePorts(allPorts []ports.Port, clusterName string) []ports.Port
 	return taggedPorts
 }
 
-func (e *Instance) Find(c *fi.Context) (*Instance, error) {
+func (e *Instance) Find(c *fi.CloudupContext) (*Instance, error) {
 	if e == nil || e.Name == nil {
 		return nil, nil
 	}
@@ -261,8 +261,8 @@ func (e *Instance) Find(c *fi.Context) (*Instance, error) {
 	return actual, nil
 }
 
-func (e *Instance) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Instance) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *Instance) CheckChanges(a, e, changes *Instance) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/instance_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance_fitask.go
@@ -48,5 +48,5 @@ func (o *Instance) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Instance) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/lb.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lb.go
@@ -87,8 +87,8 @@ func waitLoadbalancerActiveProvisioningStatus(client *gophercloud.ServiceClient,
 }
 
 // GetDependencies returns the dependencies of the Instance task
-func (e *LB) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *LB) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*Subnet); ok {
 			deps = append(deps, task)
@@ -144,7 +144,7 @@ func NewLBTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle fi.Lifecycle, 
 	return actual, nil
 }
 
-func (s *LB) Find(context *fi.Context) (*LB, error) {
+func (s *LB) Find(context *fi.CloudupContext) (*LB, error) {
 	if s.Name == nil {
 		return nil, nil
 	}
@@ -170,8 +170,8 @@ func (s *LB) Find(context *fi.Context) (*LB, error) {
 	return NewLBTaskFromCloud(cloud, s.Lifecycle, &lbs[0], s)
 }
 
-func (s *LB) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(s, context)
+func (s *LB) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(s, context)
 }
 
 func (_ *LB) CheckChanges(a, e, changes *LB) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/lb_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lb_fitask.go
@@ -48,5 +48,5 @@ func (o *LB) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *LB) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
@@ -36,8 +36,8 @@ type LBListener struct {
 }
 
 // GetDependencies returns the dependencies of the Instance task
-func (e *LBListener) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *LBListener) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*LB); ok {
 			deps = append(deps, task)
@@ -96,7 +96,7 @@ func NewLBListenerTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle fi.Lif
 	return listenerTask, nil
 }
 
-func (s *LBListener) Find(context *fi.Context) (*LBListener, error) {
+func (s *LBListener) Find(context *fi.CloudupContext) (*LBListener, error) {
 	if s.Name == nil {
 		return nil, nil
 	}
@@ -119,8 +119,8 @@ func (s *LBListener) Find(context *fi.Context) (*LBListener, error) {
 	return NewLBListenerTaskFromCloud(cloud, s.Lifecycle, &listenerList[0], s)
 }
 
-func (s *LBListener) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(s, context)
+func (s *LBListener) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(s, context)
 }
 
 func (_ *LBListener) CheckChanges(a, e, changes *LBListener) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/lblistener_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lblistener_fitask.go
@@ -48,5 +48,5 @@ func (o *LBListener) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *LBListener) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/lbpool.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lbpool.go
@@ -34,8 +34,8 @@ type LBPool struct {
 }
 
 // GetDependencies returns the dependencies of the Instance task
-func (e *LBPool) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *LBPool) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*LB); ok {
 			deps = append(deps, task)
@@ -80,7 +80,7 @@ func NewLBPoolTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle fi.Lifecyc
 	return a, nil
 }
 
-func (p *LBPool) Find(context *fi.Context) (*LBPool, error) {
+func (p *LBPool) Find(context *fi.CloudupContext) (*LBPool, error) {
 	if p.Name == nil && p.ID == nil {
 		return nil, nil
 	}
@@ -103,8 +103,8 @@ func (p *LBPool) Find(context *fi.Context) (*LBPool, error) {
 	return NewLBPoolTaskFromCloud(cloud, p.Lifecycle, &poolList[0], p)
 }
 
-func (s *LBPool) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(s, context)
+func (s *LBPool) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(s, context)
 }
 
 func (_ *LBPool) CheckChanges(a, e, changes *LBPool) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/lbpool_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lbpool_fitask.go
@@ -48,5 +48,5 @@ func (o *LBPool) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *LBPool) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/network.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/network.go
@@ -56,7 +56,7 @@ func NewNetworkTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle fi.Lifecy
 	return task, nil
 }
 
-func (n *Network) Find(context *fi.Context) (*Network, error) {
+func (n *Network) Find(context *fi.CloudupContext) (*Network, error) {
 	if n.Name == nil && n.ID == nil {
 		return nil, nil
 	}
@@ -84,8 +84,8 @@ func (n *Network) Find(context *fi.Context) (*Network, error) {
 	return actual, nil
 }
 
-func (c *Network) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(c, context)
+func (c *Network) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(c, context)
 }
 
 func (_ *Network) CheckChanges(a, e, changes *Network) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/network_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/network_fitask.go
@@ -48,5 +48,5 @@ func (o *Network) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Network) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
@@ -41,8 +41,8 @@ type PoolAssociation struct {
 }
 
 // GetDependencies returns the dependencies of the Instance task
-func (e *PoolAssociation) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *PoolAssociation) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*LB); ok {
 			deps = append(deps, task)
@@ -63,7 +63,7 @@ func (s *PoolAssociation) CompareWithID() *string {
 	return s.ID
 }
 
-func (p *PoolAssociation) Find(context *fi.Context) (*PoolAssociation, error) {
+func (p *PoolAssociation) Find(context *fi.CloudupContext) (*PoolAssociation, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 
 	opt := v2pools.ListOpts{
@@ -118,8 +118,8 @@ func (p *PoolAssociation) Find(context *fi.Context) (*PoolAssociation, error) {
 	return actual, nil
 }
 
-func (s *PoolAssociation) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(s, context)
+func (s *PoolAssociation) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(s, context)
 }
 
 func (_ *PoolAssociation) CheckChanges(a, e, changes *PoolAssociation) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/poolassociation_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolassociation_fitask.go
@@ -48,5 +48,5 @@ func (o *PoolAssociation) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *PoolAssociation) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/poolmonitor.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolmonitor.go
@@ -34,8 +34,8 @@ type PoolMonitor struct {
 }
 
 // GetDependencies returns the dependencies of the Instance task
-func (p *PoolMonitor) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (p *PoolMonitor) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*LBPool); ok {
 			deps = append(deps, task)
@@ -50,7 +50,7 @@ func (p *PoolMonitor) CompareWithID() *string {
 	return p.ID
 }
 
-func (p *PoolMonitor) Find(context *fi.Context) (*PoolMonitor, error) {
+func (p *PoolMonitor) Find(context *fi.CloudupContext) (*PoolMonitor, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 
 	opt := monitors.ListOpts{
@@ -78,8 +78,8 @@ func (p *PoolMonitor) Find(context *fi.Context) (*PoolMonitor, error) {
 	return actual, nil
 }
 
-func (p *PoolMonitor) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(p, context)
+func (p *PoolMonitor) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(p, context)
 }
 
 func (_ *PoolMonitor) CheckChanges(a, e, changes *PoolMonitor) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/poolmonitor_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolmonitor_fitask.go
@@ -48,5 +48,5 @@ func (o *PoolMonitor) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *PoolMonitor) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -42,8 +42,8 @@ type Port struct {
 }
 
 // GetDependencies returns the dependencies of the Port task
-func (e *Port) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *Port) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*Subnet); ok {
 			deps = append(deps, task)
@@ -146,7 +146,7 @@ func newPortTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle fi.Lifecycle
 	return actual, nil
 }
 
-func (s *Port) Find(context *fi.Context) (*Port, error) {
+func (s *Port) Find(context *fi.CloudupContext) (*Port, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 	opt := ports.ListOpts{
 		Name: fi.ValueOf(s.Name),
@@ -167,8 +167,8 @@ func (s *Port) Find(context *fi.Context) (*Port, error) {
 	return newPortTaskFromCloud(cloud, s.Lifecycle, &rs[0], s)
 }
 
-func (s *Port) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(s, context)
+func (s *Port) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(s, context)
 }
 
 func (_ *Port) CheckChanges(a, e, changes *Port) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/port_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port_fitask.go
@@ -48,5 +48,5 @@ func (o *Port) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Port) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/port_test.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func Test_Port_GetDependencies(t *testing.T) {
-	tasks := map[string]fi.Task{
+	tasks := map[string]fi.CloudupTask{
 		"foo": &SecurityGroup{Name: fi.PtrTo("security-group")},
 		"bar": &Subnet{Name: fi.PtrTo("subnet")},
 		"baz": &Instance{Name: fi.PtrTo("instance")},
@@ -43,7 +43,7 @@ func Test_Port_GetDependencies(t *testing.T) {
 
 	actual := port.GetDependencies(tasks)
 
-	expected := []fi.Task{
+	expected := []fi.CloudupTask{
 		&Subnet{Name: fi.PtrTo("subnet")},
 		&Network{Name: fi.PtrTo("network")},
 		&SecurityGroup{Name: fi.PtrTo("security-group")},
@@ -360,14 +360,14 @@ func Test_NewPortTaskFromCloud(t *testing.T) {
 func Test_Port_Find(t *testing.T) {
 	tests := []struct {
 		desc             string
-		context          *fi.Context
+		context          *fi.CloudupContext
 		port             *Port
 		expectedPortTask *Port
 		expectedError    error
 	}{
 		{
 			desc: "nothing found",
-			context: &fi.Context{
+			context: &fi.CloudupContext{
 				Cluster: &kops.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "clusterName",
@@ -384,7 +384,7 @@ func Test_Port_Find(t *testing.T) {
 		},
 		{
 			desc: "port found no tags",
-			context: &fi.Context{
+			context: &fi.CloudupContext{
 				Cluster: &kops.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "clusterName",
@@ -431,7 +431,7 @@ func Test_Port_Find(t *testing.T) {
 		},
 		{
 			desc: "port found with tags",
-			context: &fi.Context{
+			context: &fi.CloudupContext{
 				Cluster: &kops.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "clusterName",
@@ -480,7 +480,7 @@ func Test_Port_Find(t *testing.T) {
 		},
 		{
 			desc: "multiple ports found",
-			context: &fi.Context{
+			context: &fi.CloudupContext{
 				Cluster: &kops.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "clusterName",
@@ -510,7 +510,7 @@ func Test_Port_Find(t *testing.T) {
 		},
 		{
 			desc: "error listing ports",
-			context: &fi.Context{
+			context: &fi.CloudupContext{
 				Cluster: &kops.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "clusterName",
@@ -910,7 +910,7 @@ func (p *portCloud) ListSecurityGroups(opt sg.ListOpts) ([]sg.SecGroup, error) {
 	return p.listSecurityGroups[opt.Name], p.listSecurityGroupsError
 }
 
-type sortedTasks []fi.Task
+type sortedTasks []fi.CloudupTask
 
 func (s sortedTasks) Len() int           { return len(s) }
 func (s sortedTasks) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }

--- a/upup/pkg/fi/cloudup/openstacktasks/router.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/router.go
@@ -53,7 +53,7 @@ func NewRouterTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle fi.Lifecyc
 	return actual, nil
 }
 
-func (n *Router) Find(context *fi.Context) (*Router, error) {
+func (n *Router) Find(context *fi.CloudupContext) (*Router, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 	opt := routers.ListOpts{
 		Name: fi.ValueOf(n.Name),
@@ -71,8 +71,8 @@ func (n *Router) Find(context *fi.Context) (*Router, error) {
 	return NewRouterTaskFromCloud(cloud, n.Lifecycle, &rs[0], n)
 }
 
-func (c *Router) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(c, context)
+func (c *Router) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(c, context)
 }
 
 func (_ *Router) CheckChanges(a, e, changes *Router) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/router_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/router_fitask.go
@@ -48,5 +48,5 @@ func (o *Router) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Router) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/routerinterface.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/routerinterface.go
@@ -36,8 +36,8 @@ type RouterInterface struct {
 }
 
 // GetDependencies returns the dependencies of the RouterInterface task
-func (e *RouterInterface) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *RouterInterface) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*Router); ok {
 			deps = append(deps, task)
@@ -55,7 +55,7 @@ func (i *RouterInterface) CompareWithID() *string {
 	return i.ID
 }
 
-func (i *RouterInterface) Find(context *fi.Context) (*RouterInterface, error) {
+func (i *RouterInterface) Find(context *fi.CloudupContext) (*RouterInterface, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 	opt := ports.ListOpts{
 		NetworkID: fi.ValueOf(i.Subnet.Network.ID),
@@ -93,8 +93,8 @@ func (i *RouterInterface) Find(context *fi.Context) (*RouterInterface, error) {
 	return actual, nil
 }
 
-func (i *RouterInterface) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(i, context)
+func (i *RouterInterface) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(i, context)
 }
 
 func (*RouterInterface) CheckChanges(a, e, changes *RouterInterface) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/routerinterface_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/routerinterface_fitask.go
@@ -48,5 +48,5 @@ func (o *RouterInterface) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *RouterInterface) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
@@ -53,7 +53,7 @@ func (s *SecurityGroup) CompareWithID() *string {
 	return s.ID
 }
 
-func (s *SecurityGroup) Find(context *fi.Context) (*SecurityGroup, error) {
+func (s *SecurityGroup) Find(context *fi.CloudupContext) (*SecurityGroup, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 	// avoid creating new group if it has removegroup flag
 	if s.RemoveGroup {
@@ -89,8 +89,8 @@ func getSecurityGroupByName(s *SecurityGroup, cloud openstack.OpenstackCloud) (*
 	return actual, nil
 }
 
-func (s *SecurityGroup) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(s, context)
+func (s *SecurityGroup) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(s, context)
 }
 
 func (_ *SecurityGroup) CheckChanges(a, e, changes *SecurityGroup) error {
@@ -131,8 +131,8 @@ func (_ *SecurityGroup) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, c
 	return nil
 }
 
-func (s *SecurityGroup) FindDeletions(c *fi.Context) ([]fi.Deletion, error) {
-	var removals []fi.Deletion
+func (s *SecurityGroup) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletion, error) {
+	var removals []fi.CloudupDeletion
 
 	if len(s.RemoveExtraRules) == 0 && !s.RemoveGroup {
 		return nil, nil
@@ -234,9 +234,9 @@ type deleteSecurityGroup struct {
 	securityGroup *SecurityGroup
 }
 
-var _ fi.Deletion = &deleteSecurityGroup{}
+var _ fi.CloudupDeletion = &deleteSecurityGroup{}
 
-func (d *deleteSecurityGroup) Delete(t fi.Target) error {
+func (d *deleteSecurityGroup) Delete(t fi.CloudupTarget) error {
 	klog.V(2).Infof("deleting security group: %v", fi.DebugAsJsonString(d.securityGroup.Name))
 
 	os, ok := t.(*openstack.OpenstackAPITarget)
@@ -264,9 +264,9 @@ type deleteSecurityGroupRule struct {
 	securityGroup *SecurityGroup
 }
 
-var _ fi.Deletion = &deleteSecurityGroupRule{}
+var _ fi.CloudupDeletion = &deleteSecurityGroupRule{}
 
-func (d *deleteSecurityGroupRule) Delete(t fi.Target) error {
+func (d *deleteSecurityGroupRule) Delete(t fi.CloudupTarget) error {
 	klog.V(2).Infof("deleting security group permission: %v", fi.DebugAsJsonString(d.rule))
 
 	os, ok := t.(*openstack.OpenstackAPITarget)

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygroup_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygroup_fitask.go
@@ -48,5 +48,5 @@ func (o *SecurityGroup) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *SecurityGroup) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygrouprule.go
@@ -53,8 +53,8 @@ type SecurityGroupRule struct {
 }
 
 // GetDependencies returns the dependencies of the Instance task
-func (e *SecurityGroupRule) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *SecurityGroupRule) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*SecurityGroup); ok {
 			deps = append(deps, task)
@@ -69,7 +69,7 @@ func (r *SecurityGroupRule) CompareWithID() *string {
 	return r.ID
 }
 
-func (r *SecurityGroupRule) Find(context *fi.Context) (*SecurityGroupRule, error) {
+func (r *SecurityGroupRule) Find(context *fi.CloudupContext) (*SecurityGroupRule, error) {
 	if r.SecGroup == nil || r.SecGroup.ID == nil {
 		return nil, nil
 	}
@@ -117,8 +117,8 @@ func (r *SecurityGroupRule) Find(context *fi.Context) (*SecurityGroupRule, error
 	return actual, nil
 }
 
-func (r *SecurityGroupRule) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(r, context)
+func (r *SecurityGroupRule) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(r, context)
 }
 
 func (*SecurityGroupRule) CheckChanges(a, e, changes *SecurityGroupRule) error {
@@ -227,7 +227,7 @@ func (o *SecurityGroupRule) String() string {
 		proto, fi.ValueOf(o.SecGroup.Name), dst, fi.ValueOf(o.PortRangeMin), fi.ValueOf(o.PortRangeMax))
 }
 
-func (o *SecurityGroupRule) FindDeletions(c *fi.Context) ([]fi.Deletion, error) {
+func (o *SecurityGroupRule) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletion, error) {
 	if !fi.ValueOf(o.Delete) {
 		return nil, nil
 	}
@@ -236,7 +236,7 @@ func (o *SecurityGroupRule) FindDeletions(c *fi.Context) ([]fi.Deletion, error) 
 	if err != nil {
 		return nil, err
 	}
-	return []fi.Deletion{
+	return []fi.CloudupDeletion{
 		&deleteSecurityGroupRule{
 			rule:          *rule,
 			securityGroup: o.SecGroup,

--- a/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
@@ -55,7 +55,7 @@ func (s *ServerGroup) CompareWithID() *string {
 	return s.ID
 }
 
-func (s *ServerGroup) Find(context *fi.Context) (*ServerGroup, error) {
+func (s *ServerGroup) Find(context *fi.CloudupContext) (*ServerGroup, error) {
 	if s == nil || s.Name == nil {
 		return nil, nil
 	}
@@ -102,8 +102,8 @@ func (s *ServerGroup) Find(context *fi.Context) (*ServerGroup, error) {
 	return actual, nil
 }
 
-func (s *ServerGroup) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(s, context)
+func (s *ServerGroup) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(s, context)
 }
 
 func (_ *ServerGroup) CheckChanges(a, e, changes *ServerGroup) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/servergroup_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/servergroup_fitask.go
@@ -48,5 +48,5 @@ func (o *ServerGroup) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *ServerGroup) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
@@ -39,13 +39,13 @@ type SSHKey struct {
 }
 
 var _ fi.CompareWithID = &SSHKey{}
-var _ fi.TaskNormalize = &SSHKey{}
+var _ fi.CloudupTaskNormalize = &SSHKey{}
 
 func (e *SSHKey) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
+func (e *SSHKey) Find(c *fi.CloudupContext) (*SSHKey, error) {
 	cloud := c.Cloud.(openstack.OpenstackCloud)
 	rs, err := cloud.GetKeypair(openstackKeyPairName(fi.ValueOf(e.Name)))
 	if err != nil {
@@ -70,7 +70,7 @@ func (e *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
 	return actual, nil
 }
 
-func (e *SSHKey) Normalize(c *fi.Context) error {
+func (e *SSHKey) Normalize(c *fi.CloudupContext) error {
 	if e.KeyFingerprint == nil && e.PublicKey != nil {
 		publicKey, err := fi.ResourceAsString(e.PublicKey)
 		if err != nil {
@@ -87,8 +87,8 @@ func (e *SSHKey) Normalize(c *fi.Context) error {
 	return nil
 }
 
-func (e *SSHKey) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *SSHKey) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *SSHKey) CheckChanges(a, e, changes *SSHKey) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/sshkey_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/sshkey_fitask.go
@@ -48,5 +48,5 @@ func (o *SSHKey) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *SSHKey) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/subnet.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/subnet.go
@@ -38,8 +38,8 @@ type Subnet struct {
 }
 
 // GetDependencies returns the dependencies of the Port task
-func (e *Subnet) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *Subnet) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*Network); ok {
 			deps = append(deps, task)
@@ -89,7 +89,7 @@ func NewSubnetTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle fi.Lifecyc
 	return actual, nil
 }
 
-func (s *Subnet) Find(context *fi.Context) (*Subnet, error) {
+func (s *Subnet) Find(context *fi.CloudupContext) (*Subnet, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 	opt := subnets.ListOpts{
 		ID:         fi.ValueOf(s.ID),
@@ -111,8 +111,8 @@ func (s *Subnet) Find(context *fi.Context) (*Subnet, error) {
 	return NewSubnetTaskFromCloud(cloud, s.Lifecycle, &rs[0], s)
 }
 
-func (s *Subnet) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(s, context)
+func (s *Subnet) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(s, context)
 }
 
 func (*Subnet) CheckChanges(a, e, changes *Subnet) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/subnet_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/subnet_fitask.go
@@ -48,5 +48,5 @@ func (o *Subnet) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Subnet) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/volume.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/volume.go
@@ -37,13 +37,13 @@ type Volume struct {
 }
 
 var _ fi.CompareWithID = &Volume{}
-var _ fi.TaskNormalize = &Volume{}
+var _ fi.CloudupTaskNormalize = &Volume{}
 
 func (c *Volume) CompareWithID() *string {
 	return c.ID
 }
 
-func (c *Volume) Find(context *fi.Context) (*Volume, error) {
+func (c *Volume) Find(context *fi.CloudupContext) (*Volume, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 	opt := cinderv3.ListOpts{
 		Name:     fi.ValueOf(c.Name),
@@ -78,7 +78,7 @@ func (c *Volume) Find(context *fi.Context) (*Volume, error) {
 	return actual, nil
 }
 
-func (c *Volume) Normalize(context *fi.Context) error {
+func (c *Volume) Normalize(context *fi.CloudupContext) error {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 	for k, v := range cloud.GetCloudTags() {
 		c.Tags[k] = v
@@ -86,8 +86,8 @@ func (c *Volume) Normalize(context *fi.Context) error {
 	return nil
 }
 
-func (c *Volume) Run(context *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(c, context)
+func (c *Volume) Run(context *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(c, context)
 }
 
 func (_ *Volume) CheckChanges(a, e, changes *Volume) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/volume_fitask.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/volume_fitask.go
@@ -48,5 +48,5 @@ func (o *Volume) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Volume) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/scaleway/api_target.go
+++ b/upup/pkg/fi/cloudup/scaleway/api_target.go
@@ -22,7 +22,7 @@ type ScwAPITarget struct {
 	Cloud ScwCloud
 }
 
-var _ fi.Target = &ScwAPITarget{}
+var _ fi.CloudupTarget = &ScwAPITarget{}
 
 func NewScwAPITarget(cloud ScwCloud) *ScwAPITarget {
 	return &ScwAPITarget{
@@ -30,7 +30,7 @@ func NewScwAPITarget(cloud ScwCloud) *ScwAPITarget {
 	}
 }
 
-func (s ScwAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (s ScwAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/scalewaytasks/instance.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/instance.go
@@ -39,14 +39,14 @@ type Instance struct {
 	UserData       *fi.Resource
 }
 
-var _ fi.Task = &Instance{}
+var _ fi.CloudupTask = &Instance{}
 var _ fi.CompareWithID = &Instance{}
 
 func (s *Instance) CompareWithID() *string {
 	return s.Name
 }
 
-func (s *Instance) Find(c *fi.Context) (*Instance, error) {
+func (s *Instance) Find(c *fi.CloudupContext) (*Instance, error) {
 	cloud := c.Cloud.(scaleway.ScwCloud)
 
 	servers, err := cloud.GetClusterServers(cloud.ClusterName(s.Tags), s.Name)
@@ -71,8 +71,8 @@ func (s *Instance) Find(c *fi.Context) (*Instance, error) {
 	}, nil
 }
 
-func (s *Instance) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(s, c)
+func (s *Instance) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(s, c)
 }
 
 func (_ *Instance) CheckChanges(actual, expected, changes *Instance) error {
@@ -106,7 +106,7 @@ func (_ *Instance) CheckChanges(actual, expected, changes *Instance) error {
 	return nil
 }
 
-func (_ *Instance) RenderScw(c *fi.Context, actual, expected, changes *Instance) error {
+func (_ *Instance) RenderScw(c *fi.CloudupContext, actual, expected, changes *Instance) error {
 	cloud := c.Cloud.(scaleway.ScwCloud)
 	instanceService := cloud.InstanceService()
 	zone := scw.Zone(fi.ValueOf(expected.Zone))

--- a/upup/pkg/fi/cloudup/scalewaytasks/instance_fitask.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/instance_fitask.go
@@ -48,5 +48,5 @@ func (o *Instance) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Instance) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/scalewaytasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/sshkey.go
@@ -44,7 +44,7 @@ func (s *SSHKey) CompareWithID() *string {
 	return s.Name
 }
 
-func (s *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
+func (s *SSHKey) Find(c *fi.CloudupContext) (*SSHKey, error) {
 	cloud := c.Cloud.(scaleway.ScwCloud)
 
 	keysResp, err := cloud.IamService().ListSSHKeys(&iam.ListSSHKeysRequest{
@@ -81,7 +81,7 @@ func (s *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
 	return sshKey, nil
 }
 
-func (s *SSHKey) Run(c *fi.Context) error {
+func (s *SSHKey) Run(c *fi.CloudupContext) error {
 	if s.KeyPairFingerPrint == nil && s.PublicKey != nil {
 		publicKey, err := fi.ResourceAsString(*s.PublicKey)
 		if err != nil {
@@ -95,7 +95,7 @@ func (s *SSHKey) Run(c *fi.Context) error {
 		klog.V(2).Infof("Computed SSH key fingerprint as %q", keyPairFingerPrint)
 		s.KeyPairFingerPrint = &keyPairFingerPrint
 	}
-	return fi.DefaultDeltaRunMethod(s, c)
+	return fi.CloudupDefaultDeltaRunMethod(s, c)
 }
 
 func (s *SSHKey) CheckChanges(actual, expected, changes *SSHKey) error {
@@ -107,7 +107,7 @@ func (s *SSHKey) CheckChanges(actual, expected, changes *SSHKey) error {
 	return nil
 }
 
-func (*SSHKey) RenderScw(c *fi.Context, actual, expected, changes *SSHKey) error {
+func (*SSHKey) RenderScw(c *fi.CloudupContext, actual, expected, changes *SSHKey) error {
 	if actual != nil {
 		klog.Infof("Scaleway does not support changes to ssh keys for the moment")
 		return nil

--- a/upup/pkg/fi/cloudup/scalewaytasks/sshkey_fitask.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/sshkey_fitask.go
@@ -48,5 +48,5 @@ func (o *SSHKey) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *SSHKey) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/scalewaytasks/volume.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/volume.go
@@ -42,7 +42,7 @@ func (v *Volume) CompareWithID() *string {
 	return v.ID
 }
 
-func (v *Volume) Find(c *fi.Context) (*Volume, error) {
+func (v *Volume) Find(c *fi.CloudupContext) (*Volume, error) {
 	cloud := c.Cloud.(scaleway.ScwCloud)
 	instanceService := cloud.InstanceService()
 	zone := cloud.Zone()
@@ -71,8 +71,8 @@ func (v *Volume) Find(c *fi.Context) (*Volume, error) {
 	return nil, nil
 }
 
-func (v *Volume) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(v, c)
+func (v *Volume) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(v, c)
 }
 
 func (_ *Volume) CheckChanges(a, e, changes *Volume) error {

--- a/upup/pkg/fi/cloudup/scalewaytasks/volume_fitask.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/volume_fitask.go
@@ -48,5 +48,5 @@ func (o *Volume) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Volume) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -113,17 +113,17 @@ type AutoScalerResourceLimitsOpts struct {
 }
 
 var (
-	_ fi.Task            = &Elastigroup{}
-	_ fi.CompareWithID   = &Elastigroup{}
-	_ fi.HasDependencies = &Elastigroup{}
+	_ fi.CloudupTask            = &Elastigroup{}
+	_ fi.CompareWithID          = &Elastigroup{}
+	_ fi.CloudupHasDependencies = &Elastigroup{}
 )
 
 func (e *Elastigroup) CompareWithID() *string {
 	return e.Name
 }
 
-func (e *Elastigroup) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *Elastigroup) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 
 	if e.IAMInstanceProfile != nil {
 		deps = append(deps, e.IAMInstanceProfile)
@@ -187,9 +187,9 @@ func (e *Elastigroup) find(svc spotinst.InstanceGroupService) (*aws.Group, error
 	return out, nil
 }
 
-var _ fi.HasCheckExisting = &Elastigroup{}
+var _ fi.CloudupHasCheckExisting = &Elastigroup{}
 
-func (e *Elastigroup) Find(c *fi.Context) (*Elastigroup, error) {
+func (e *Elastigroup) Find(c *fi.CloudupContext) (*Elastigroup, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	group, err := e.find(cloud.Spotinst().Elastigroup())
@@ -479,14 +479,14 @@ func (e *Elastigroup) Find(c *fi.Context) (*Elastigroup, error) {
 	return actual, nil
 }
 
-func (e *Elastigroup) CheckExisting(c *fi.Context) bool {
+func (e *Elastigroup) CheckExisting(c *fi.CloudupContext) bool {
 	cloud := c.Cloud.(awsup.AWSCloud)
 	group, err := e.find(cloud.Spotinst().Elastigroup())
 	return err == nil && group != nil
 }
 
-func (e *Elastigroup) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Elastigroup) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *Elastigroup) CheckChanges(a, e, changes *Elastigroup) error {

--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup_fitask.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup_fitask.go
@@ -48,5 +48,5 @@ func (o *Elastigroup) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Elastigroup) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -59,17 +59,17 @@ type LaunchSpec struct {
 }
 
 var (
-	_ fi.Task            = &LaunchSpec{}
-	_ fi.CompareWithID   = &LaunchSpec{}
-	_ fi.HasDependencies = &LaunchSpec{}
+	_ fi.CloudupTask            = &LaunchSpec{}
+	_ fi.CompareWithID          = &LaunchSpec{}
+	_ fi.CloudupHasDependencies = &LaunchSpec{}
 )
 
 func (o *LaunchSpec) CompareWithID() *string {
 	return o.Name
 }
 
-func (o *LaunchSpec) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (o *LaunchSpec) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 
 	if o.IAMInstanceProfile != nil {
 		deps = append(deps, o.IAMInstanceProfile)
@@ -124,9 +124,9 @@ func (o *LaunchSpec) find(svc spotinst.LaunchSpecService, oceanID string) (*aws.
 	return out, nil
 }
 
-var _ fi.HasCheckExisting = &LaunchSpec{}
+var _ fi.CloudupHasCheckExisting = &LaunchSpec{}
 
-func (o *LaunchSpec) Find(c *fi.Context) (*LaunchSpec, error) {
+func (o *LaunchSpec) Find(c *fi.CloudupContext) (*LaunchSpec, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	ocean, err := o.Ocean.find(cloud.Spotinst().Ocean())
@@ -333,13 +333,13 @@ func (o *LaunchSpec) Find(c *fi.Context) (*LaunchSpec, error) {
 	return actual, nil
 }
 
-func (o *LaunchSpec) CheckExisting(c *fi.Context) bool {
+func (o *LaunchSpec) CheckExisting(c *fi.CloudupContext) bool {
 	spec, err := o.Find(c)
 	return err == nil && spec != nil
 }
 
-func (o *LaunchSpec) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(o, c)
+func (o *LaunchSpec) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(o, c)
 }
 
 func (s *LaunchSpec) CheckChanges(a, e, changes *LaunchSpec) error {

--- a/upup/pkg/fi/cloudup/spotinsttasks/launchspec_fitask.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launchspec_fitask.go
@@ -48,5 +48,5 @@ func (o *LaunchSpec) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *LaunchSpec) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -66,17 +66,17 @@ type Ocean struct {
 }
 
 var (
-	_ fi.Task            = &Ocean{}
-	_ fi.CompareWithID   = &Ocean{}
-	_ fi.HasDependencies = &Ocean{}
+	_ fi.CloudupTask            = &Ocean{}
+	_ fi.CompareWithID          = &Ocean{}
+	_ fi.CloudupHasDependencies = &Ocean{}
 )
 
 func (o *Ocean) CompareWithID() *string {
 	return o.Name
 }
 
-func (o *Ocean) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (o *Ocean) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 
 	if o.IAMInstanceProfile != nil {
 		deps = append(deps, o.IAMInstanceProfile)
@@ -128,9 +128,9 @@ func (o *Ocean) find(svc spotinst.InstanceGroupService) (*aws.Cluster, error) {
 	return out, nil
 }
 
-var _ fi.HasCheckExisting = &Ocean{}
+var _ fi.CloudupHasCheckExisting = &Ocean{}
 
-func (o *Ocean) Find(c *fi.Context) (*Ocean, error) {
+func (o *Ocean) Find(c *fi.CloudupContext) (*Ocean, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	ocean, err := o.find(cloud.Spotinst().Ocean())
@@ -326,14 +326,14 @@ func (o *Ocean) Find(c *fi.Context) (*Ocean, error) {
 	return actual, nil
 }
 
-func (o *Ocean) CheckExisting(c *fi.Context) bool {
+func (o *Ocean) CheckExisting(c *fi.CloudupContext) bool {
 	cloud := c.Cloud.(awsup.AWSCloud)
 	ocean, err := o.find(cloud.Spotinst().Ocean())
 	return err == nil && ocean != nil
 }
 
-func (o *Ocean) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(o, c)
+func (o *Ocean) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(o, c)
 }
 
 func (s *Ocean) CheckChanges(a, e, changes *Ocean) error {

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean_fitask.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean_fitask.go
@@ -48,5 +48,5 @@ func (o *Ocean) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Ocean) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -54,7 +54,7 @@ func NewTerraformTarget(cloud fi.Cloud, project string, filesProvider *vfs.Terra
 	return &target
 }
 
-var _ fi.Target = &TerraformTarget{}
+var _ fi.CloudupTarget = &TerraformTarget{}
 
 func (t *TerraformTarget) AddFileResource(resourceType string, resourceName string, key string, r fi.Resource, base64 bool) (*terraformWriter.Literal, error) {
 	d, err := fi.ResourceAsBytes(r)
@@ -91,7 +91,7 @@ func tfGetFilesProviderExtraConfig(c *kops.TargetSpec) map[string]string {
 	return nil
 }
 
-func (t *TerraformTarget) Finish(taskMap map[string]fi.Task) error {
+func (t *TerraformTarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	if err := t.finishHCL2(); err != nil {
 		return err
 	}

--- a/upup/pkg/fi/deletions.go
+++ b/upup/pkg/fi/deletions.go
@@ -16,12 +16,16 @@ limitations under the License.
 
 package fi
 
-type ProducesDeletions interface {
-	FindDeletions(*Context) ([]Deletion, error)
+type ProducesDeletions[T SubContext] interface {
+	FindDeletions(*Context[T]) ([]Deletion[T], error)
 }
 
-type Deletion interface {
-	Delete(target Target) error
+type CloudupProducesDeletions = ProducesDeletions[CloudupSubContext]
+
+type Deletion[T SubContext] interface {
+	Delete(target Target[T]) error
 	TaskName() string
 	Item() string
 }
+
+type CloudupDeletion = Deletion[CloudupSubContext]

--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -34,11 +34,11 @@ import (
 // DryRunTarget is a special Target that does not execute anything, but instead tracks all changes.
 // By running against a DryRunTarget, a list of changes that would be made can be easily collected,
 // without any special support from the Tasks.
-type DryRunTarget struct {
+type DryRunTarget[T SubContext] struct {
 	mutex sync.Mutex
 
-	changes   []*render
-	deletions []Deletion
+	changes   []*render[T]
+	deletions []Deletion[T]
 
 	// The destination to which the final report will be printed on Finish()
 	out io.Writer
@@ -47,53 +47,64 @@ type DryRunTarget struct {
 	assetBuilder *assets.AssetBuilder
 }
 
-type render struct {
-	a       Task
+type NodeupDryRunTarget = DryRunTarget[NodeupSubContext]
+type CloudupDryRunTarget = DryRunTarget[CloudupSubContext]
+
+type render[T SubContext] struct {
+	a       Task[T]
 	aIsNil  bool
-	e       Task
-	changes Task
+	e       Task[T]
+	changes Task[T]
 }
 
 // ByTaskKey sorts []*render by TaskKey (type/name)
-type ByTaskKey []*render
+type ByTaskKey[T SubContext] []*render[T]
 
-func (a ByTaskKey) Len() int      { return len(a) }
-func (a ByTaskKey) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a ByTaskKey) Less(i, j int) bool {
+func (a ByTaskKey[T]) Len() int      { return len(a) }
+func (a ByTaskKey[T]) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByTaskKey[T]) Less(i, j int) bool {
 	return buildTaskKey(a[i].e) < buildTaskKey(a[j].e)
 }
 
 // DeletionByTaskName sorts []Deletion by TaskName
-type DeletionByTaskName []Deletion
+type DeletionByTaskName[T SubContext] []Deletion[T]
 
-func (a DeletionByTaskName) Len() int      { return len(a) }
-func (a DeletionByTaskName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a DeletionByTaskName) Less(i, j int) bool {
+func (a DeletionByTaskName[T]) Len() int      { return len(a) }
+func (a DeletionByTaskName[T]) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a DeletionByTaskName[T]) Less(i, j int) bool {
 	return a[i].TaskName() < a[j].TaskName()
 }
 
-var _ Target = &DryRunTarget{}
+var _ Target[CloudupSubContext] = &DryRunTarget[CloudupSubContext]{}
 
-func NewDryRunTarget(assetBuilder *assets.AssetBuilder, out io.Writer) *DryRunTarget {
-	t := &DryRunTarget{}
+func NewDryRunTarget[T SubContext](assetBuilder *assets.AssetBuilder, out io.Writer) *DryRunTarget[T] {
+	t := &DryRunTarget[T]{}
 	t.out = out
 	t.assetBuilder = assetBuilder
 	return t
 }
 
-func (t *DryRunTarget) ProcessDeletions() bool {
+func NewCloudupDryRunTarget(assetBuilder *assets.AssetBuilder, out io.Writer) *CloudupDryRunTarget {
+	return NewDryRunTarget[CloudupSubContext](assetBuilder, out)
+}
+
+func NewNodeupDryRunTarget(assetBuilder *assets.AssetBuilder, out io.Writer) *NodeupDryRunTarget {
+	return NewDryRunTarget[NodeupSubContext](assetBuilder, out)
+}
+
+func (t *DryRunTarget[T]) ProcessDeletions() bool {
 	// We display deletions
 	return true
 }
 
-func (t *DryRunTarget) Render(a, e, changes Task) error {
+func (t *DryRunTarget[T]) Render(a, e, changes Task[T]) error {
 	valA := reflect.ValueOf(a)
 	aIsNil := valA.IsNil()
 
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
-	t.changes = append(t.changes, &render{
+	t.changes = append(t.changes, &render[T]{
 		a:       a,
 		aIsNil:  aIsNil,
 		e:       e,
@@ -102,7 +113,7 @@ func (t *DryRunTarget) Render(a, e, changes Task) error {
 	return nil
 }
 
-func (t *DryRunTarget) Delete(deletion Deletion) error {
+func (t *DryRunTarget[T]) Delete(deletion Deletion[T]) error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -111,7 +122,7 @@ func (t *DryRunTarget) Delete(deletion Deletion) error {
 	return nil
 }
 
-func idForTask(taskMap map[string]Task, t Task) string {
+func idForTask[T SubContext](taskMap map[string]Task[T], t Task[T]) string {
 	for k, v := range taskMap {
 		if v == t {
 			// Skip task type, if present (taskType/taskName)
@@ -126,12 +137,12 @@ func idForTask(taskMap map[string]Task, t Task) string {
 	return "?"
 }
 
-func (t *DryRunTarget) PrintReport(taskMap map[string]Task, out io.Writer) error {
+func (t *DryRunTarget[T]) PrintReport(taskMap map[string]Task[T], out io.Writer) error {
 	b := &bytes.Buffer{}
 
 	if len(t.changes) != 0 {
-		var creates []*render
-		var updates []*render
+		var creates []*render[T]
+		var updates []*render[T]
 
 		for _, r := range t.changes {
 			if r.aIsNil {
@@ -142,8 +153,8 @@ func (t *DryRunTarget) PrintReport(taskMap map[string]Task, out io.Writer) error
 		}
 
 		// Give everything a consistent ordering
-		sort.Sort(ByTaskKey(creates))
-		sort.Sort(ByTaskKey(updates))
+		sort.Sort(ByTaskKey[T](creates))
+		sort.Sort(ByTaskKey[T](updates))
 
 		if len(creates) != 0 {
 			fmt.Fprintf(b, "Will create resources:\n")
@@ -244,7 +255,7 @@ func (t *DryRunTarget) PrintReport(taskMap map[string]Task, out io.Writer) error
 
 	if len(t.deletions) != 0 {
 		// Give everything a consistent ordering
-		sort.Sort(DeletionByTaskName(t.deletions))
+		sort.Sort(DeletionByTaskName[T](t.deletions))
 
 		fmt.Fprintf(b, "Will delete items:\n")
 		for _, d := range t.deletions {
@@ -277,7 +288,7 @@ type change struct {
 	Description string
 }
 
-func buildChangeList(a, e, changes Task) ([]change, error) {
+func buildChangeList[T SubContext](a, e, changes Task[T]) ([]change, error) {
 	var changeList []change
 
 	valC := reflect.ValueOf(changes)
@@ -377,7 +388,7 @@ func tryResourceAsString(v reflect.Value) (string, bool) {
 	return "", false
 }
 
-func getTaskName(t Task) string {
+func getTaskName[T SubContext](t Task[T]) string {
 	s := fmt.Sprintf("%T", t)
 	lastDot := strings.LastIndexByte(s, '.')
 	if lastDot != -1 {
@@ -387,12 +398,12 @@ func getTaskName(t Task) string {
 }
 
 // Finish is called at the end of a run, and prints a list of changes to the configured Writer
-func (t *DryRunTarget) Finish(taskMap map[string]Task) error {
+func (t *DryRunTarget[T]) Finish(taskMap map[string]Task[T]) error {
 	return t.PrintReport(taskMap, t.out)
 }
 
 // Deletions returns all task names which is going to be deleted
-func (t *DryRunTarget) Deletions() []string {
+func (t *DryRunTarget[T]) Deletions() []string {
 	var deletions []string
 	for _, d := range t.deletions {
 		deletions = append(deletions, d.TaskName())
@@ -401,9 +412,9 @@ func (t *DryRunTarget) Deletions() []string {
 }
 
 // Changes returns tasks which is going to be created or updated
-func (t *DryRunTarget) Changes() (map[string]Task, map[string]Task) {
-	creates := make(map[string]Task)
-	updates := make(map[string]Task)
+func (t *DryRunTarget[T]) Changes() (map[string]Task[T], map[string]Task[T]) {
+	creates := make(map[string]Task[T])
+	updates := make(map[string]Task[T])
 	for _, r := range t.changes {
 		if r.aIsNil {
 			creates[getTaskName(r.changes)] = r.changes
@@ -415,6 +426,6 @@ func (t *DryRunTarget) Changes() (map[string]Task, map[string]Task) {
 }
 
 // HasChanges returns true iff any changes would have been made
-func (t *DryRunTarget) HasChanges() bool {
+func (t *DryRunTarget[T]) HasChanges() bool {
 	return len(t.changes)+len(t.deletions) != 0
 }

--- a/upup/pkg/fi/dryruntarget_test.go
+++ b/upup/pkg/fi/dryruntarget_test.go
@@ -60,9 +60,9 @@ type testTask struct {
 	Tags      map[string]string
 }
 
-var _ Task = &testTask{}
+var _ CloudupTask = &testTask{}
 
-func (*testTask) Run(_ *Context) error {
+func (*testTask) Run(_ *CloudupContext) error {
 	panic("not implemented")
 }
 
@@ -73,8 +73,8 @@ func Test_DryrunTarget_PrintReport(t *testing.T) {
 		},
 	}, false)
 	var stdout bytes.Buffer
-	target := NewDryRunTarget(builder, &stdout)
-	tasks := map[string]Task{}
+	target := NewDryRunTarget[CloudupSubContext](builder, &stdout)
+	tasks := map[string]CloudupTask{}
 	a := &testTask{
 		Name:      PtrTo("TestName"),
 		Lifecycle: LifecycleSync,
@@ -85,7 +85,7 @@ func Test_DryrunTarget_PrintReport(t *testing.T) {
 		Lifecycle: LifecycleSync,
 		Tags:      map[string]string{"key": "value"},
 	}
-	changes := reflect.New(reflect.TypeOf(e).Elem()).Interface().(Task)
+	changes := reflect.New(reflect.TypeOf(e).Elem()).Interface().(CloudupTask)
 	_ = BuildChanges(a, e, changes)
 	err := target.Render(a, e, changes)
 	tasks[*e.Name] = e

--- a/upup/pkg/fi/fitasks/keypair.go
+++ b/upup/pkg/fi/fitasks/keypair.go
@@ -47,18 +47,18 @@ type Keypair struct {
 	// LegacyFormat is whether the keypair is stored in a legacy format.
 	LegacyFormat bool `json:"oldFormat"`
 
-	certificates *fi.TaskDependentResource
+	certificates *fi.CloudupTaskDependentResource
 	keyset       *fi.Keyset
 }
 
 var (
-	_ fi.HasCheckExisting = &Keypair{}
-	_ fi.HasName          = &Keypair{}
-	_ fi.TaskNormalize    = &Keypair{}
+	_ fi.CloudupHasCheckExisting = &Keypair{}
+	_ fi.HasName                 = &Keypair{}
+	_ fi.CloudupTaskNormalize    = &Keypair{}
 )
 
 // It's important always to check for the existing key, so we don't regenerate keys e.g. on terraform
-func (e *Keypair) CheckExisting(c *fi.Context) bool {
+func (e *Keypair) CheckExisting(c *fi.CloudupContext) bool {
 	return true
 }
 
@@ -68,7 +68,7 @@ func (e *Keypair) CompareWithID() *string {
 	return &e.Subject
 }
 
-func (e *Keypair) Find(c *fi.Context) (*Keypair, error) {
+func (e *Keypair) Find(c *fi.CloudupContext) (*Keypair, error) {
 	name := fi.ValueOf(e.Name)
 	if name == "" {
 		return nil, nil
@@ -115,11 +115,11 @@ func (e *Keypair) Find(c *fi.Context) (*Keypair, error) {
 	return actual, nil
 }
 
-func (e *Keypair) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Keypair) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
-func (e *Keypair) Normalize(c *fi.Context) error {
+func (e *Keypair) Normalize(c *fi.CloudupContext) error {
 	var alternateNames []string
 
 	for _, s := range e.AlternateNames {
@@ -158,7 +158,7 @@ func (_ *Keypair) ShouldCreate(a, e, changes *Keypair) (bool, error) {
 	return true, nil
 }
 
-func (_ *Keypair) Render(c *fi.Context, a, e, changes *Keypair) error {
+func (_ *Keypair) Render(c *fi.CloudupContext, a, e, changes *Keypair) error {
 	name := fi.ValueOf(e.Name)
 	if name == "" {
 		return fi.RequiredField("Name")
@@ -322,7 +322,7 @@ func parsePkixName(s string) (*pkix.Name, error) {
 
 func (e *Keypair) ensureResources() {
 	if e.certificates == nil {
-		e.certificates = &fi.TaskDependentResource{
+		e.certificates = &fi.CloudupTaskDependentResource{
 			Resource: fi.NewStringResource("<< TO BE GENERATED >>\n"),
 			Task:     e,
 		}
@@ -352,7 +352,7 @@ func (e *Keypair) Keyset() *fi.Keyset {
 	return e.keyset
 }
 
-func (e *Keypair) Certificates() *fi.TaskDependentResource {
+func (e *Keypair) Certificates() *fi.CloudupTaskDependentResource {
 	e.ensureResources()
 	return e.certificates
 }

--- a/upup/pkg/fi/fitasks/keypair_fitask.go
+++ b/upup/pkg/fi/fitasks/keypair_fitask.go
@@ -48,5 +48,5 @@ func (o *Keypair) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Keypair) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/fitasks/keypair_test.go
+++ b/upup/pkg/fi/fitasks/keypair_test.go
@@ -32,7 +32,7 @@ func TestKeypairDeps(t *testing.T) {
 		Signer: ca,
 	}
 
-	tasks := make(map[string]fi.Task)
+	tasks := make(map[string]fi.CloudupTask)
 	tasks["ca"] = ca
 	tasks["cert"] = cert
 

--- a/upup/pkg/fi/fitasks/managedfile.go
+++ b/upup/pkg/fi/fitasks/managedfile.go
@@ -48,7 +48,7 @@ type ManagedFile struct {
 	PublicACL *bool
 }
 
-func (e *ManagedFile) Find(c *fi.Context) (*ManagedFile, error) {
+func (e *ManagedFile) Find(c *fi.CloudupContext) (*ManagedFile, error) {
 	managedFiles, err := getBasePath(c, e)
 	if err != nil {
 		return nil, err
@@ -106,8 +106,8 @@ func (e *ManagedFile) Find(c *fi.Context) (*ManagedFile, error) {
 	return actual, nil
 }
 
-func (e *ManagedFile) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *ManagedFile) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *ManagedFile) CheckChanges(a, e, changes *ManagedFile) error {
@@ -122,7 +122,7 @@ func (s *ManagedFile) CheckChanges(a, e, changes *ManagedFile) error {
 	return nil
 }
 
-func (e *ManagedFile) getACL(c *fi.Context, p vfs.Path) (vfs.ACL, error) {
+func (e *ManagedFile) getACL(c *fi.CloudupContext, p vfs.Path) (vfs.ACL, error) {
 	var acl vfs.ACL
 	if fi.ValueOf(e.PublicACL) {
 		switch p := p.(type) {
@@ -146,7 +146,7 @@ func (e *ManagedFile) getACL(c *fi.Context, p vfs.Path) (vfs.ACL, error) {
 	return acls.GetACL(p, c.Cluster)
 }
 
-func (_ *ManagedFile) Render(c *fi.Context, a, e, changes *ManagedFile) error {
+func (_ *ManagedFile) Render(c *fi.CloudupContext, a, e, changes *ManagedFile) error {
 	location := fi.ValueOf(e.Location)
 	if location == "" {
 		return fi.RequiredField("Location")
@@ -176,7 +176,7 @@ func (_ *ManagedFile) Render(c *fi.Context, a, e, changes *ManagedFile) error {
 	return nil
 }
 
-func getBasePath(c *fi.Context, e *ManagedFile) (vfs.Path, error) {
+func getBasePath(c *fi.CloudupContext, e *ManagedFile) (vfs.Path, error) {
 	base := fi.ValueOf(e.Base)
 	if base != "" {
 		p, err := vfs.Context.BuildVfsPath(base)
@@ -190,7 +190,7 @@ func getBasePath(c *fi.Context, e *ManagedFile) (vfs.Path, error) {
 }
 
 // RenderTerraform is responsible for rendering the terraform json.
-func (f *ManagedFile) RenderTerraform(c *fi.Context, t *terraform.TerraformTarget, a, e, changes *ManagedFile) error {
+func (f *ManagedFile) RenderTerraform(c *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *ManagedFile) error {
 	if !featureflag.TerraformManagedFiles.Enabled() {
 		return f.Render(c, a, e, changes)
 	}

--- a/upup/pkg/fi/fitasks/managedfile_fitask.go
+++ b/upup/pkg/fi/fitasks/managedfile_fitask.go
@@ -48,5 +48,5 @@ func (o *ManagedFile) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *ManagedFile) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/fitasks/mirrorkeystore.go
+++ b/upup/pkg/fi/fitasks/mirrorkeystore.go
@@ -30,11 +30,11 @@ type MirrorKeystore struct {
 	MirrorPath vfs.Path
 }
 
-var _ fi.HasDependencies = &MirrorKeystore{}
+var _ fi.CloudupHasDependencies = &MirrorKeystore{}
 
 // GetDependencies returns the dependencies for a MirrorKeystore task - it must run after all secrets have been run
-func (e *MirrorKeystore) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *MirrorKeystore) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*Secret); ok {
 			deps = append(deps, task)
@@ -44,7 +44,7 @@ func (e *MirrorKeystore) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 }
 
 // Find implements fi.Task::Find
-func (e *MirrorKeystore) Find(c *fi.Context) (*MirrorKeystore, error) {
+func (e *MirrorKeystore) Find(c *fi.CloudupContext) (*MirrorKeystore, error) {
 	if vfsKeystore, ok := c.Keystore.(*fi.VFSCAStore); ok {
 		if vfsKeystore.VFSPath().Path() == e.MirrorPath.Path() {
 			return e, nil
@@ -57,8 +57,8 @@ func (e *MirrorKeystore) Find(c *fi.Context) (*MirrorKeystore, error) {
 }
 
 // Run implements fi.Task::Run
-func (e *MirrorKeystore) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *MirrorKeystore) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 // CheckChanges implements fi.Task::CheckChanges
@@ -72,7 +72,7 @@ func (s *MirrorKeystore) CheckChanges(a, e, changes *MirrorKeystore) error {
 }
 
 // Render implements fi.Task::Render
-func (_ *MirrorKeystore) Render(c *fi.Context, a, e, changes *MirrorKeystore) error {
+func (_ *MirrorKeystore) Render(c *fi.CloudupContext, a, e, changes *MirrorKeystore) error {
 	keystore := c.Keystore
 
 	return keystore.MirrorTo(e.MirrorPath)

--- a/upup/pkg/fi/fitasks/mirrorkeystore_fitask.go
+++ b/upup/pkg/fi/fitasks/mirrorkeystore_fitask.go
@@ -48,5 +48,5 @@ func (o *MirrorKeystore) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *MirrorKeystore) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/fitasks/mirrorsecrets.go
+++ b/upup/pkg/fi/fitasks/mirrorsecrets.go
@@ -31,11 +31,11 @@ type MirrorSecrets struct {
 	MirrorPath vfs.Path
 }
 
-var _ fi.HasDependencies = &MirrorSecrets{}
+var _ fi.CloudupHasDependencies = &MirrorSecrets{}
 
 // GetDependencies returns the dependencies for a MirrorSecrets task - it must run after all secrets have been run
-func (e *MirrorSecrets) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *MirrorSecrets) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
 	for _, task := range tasks {
 		if _, ok := task.(*Secret); ok {
 			deps = append(deps, task)
@@ -45,7 +45,7 @@ func (e *MirrorSecrets) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 }
 
 // Find implements fi.Task::Find
-func (e *MirrorSecrets) Find(c *fi.Context) (*MirrorSecrets, error) {
+func (e *MirrorSecrets) Find(c *fi.CloudupContext) (*MirrorSecrets, error) {
 	if vfsSecretStore, ok := c.SecretStore.(*secrets.VFSSecretStore); ok {
 		if vfsSecretStore.VFSPath().Path() == e.MirrorPath.Path() {
 			return e, nil
@@ -58,8 +58,8 @@ func (e *MirrorSecrets) Find(c *fi.Context) (*MirrorSecrets, error) {
 }
 
 // Run implements fi.Task::Run
-func (e *MirrorSecrets) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *MirrorSecrets) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 // CheckChanges implements fi.Task::CheckChanges
@@ -73,7 +73,7 @@ func (s *MirrorSecrets) CheckChanges(a, e, changes *MirrorSecrets) error {
 }
 
 // Render implements fi.Task::Render
-func (_ *MirrorSecrets) Render(c *fi.Context, a, e, changes *MirrorSecrets) error {
+func (_ *MirrorSecrets) Render(c *fi.CloudupContext, a, e, changes *MirrorSecrets) error {
 	secrets := c.SecretStore
 	return secrets.MirrorTo(e.MirrorPath)
 }

--- a/upup/pkg/fi/fitasks/mirrorsecrets_fitask.go
+++ b/upup/pkg/fi/fitasks/mirrorsecrets_fitask.go
@@ -48,5 +48,5 @@ func (o *MirrorSecrets) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *MirrorSecrets) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/fitasks/secret.go
+++ b/upup/pkg/fi/fitasks/secret.go
@@ -28,14 +28,14 @@ type Secret struct {
 	Lifecycle fi.Lifecycle
 }
 
-var _ fi.HasCheckExisting = &Secret{}
+var _ fi.CloudupHasCheckExisting = &Secret{}
 
 // It's important always to check for the existing Secret, so we don't regenerate tokens e.g. on terraform
-func (e *Secret) CheckExisting(c *fi.Context) bool {
+func (e *Secret) CheckExisting(c *fi.CloudupContext) bool {
 	return true
 }
 
-func (e *Secret) Find(c *fi.Context) (*Secret, error) {
+func (e *Secret) Find(c *fi.CloudupContext) (*Secret, error) {
 	secrets := c.SecretStore
 
 	name := fi.ValueOf(e.Name)
@@ -61,8 +61,8 @@ func (e *Secret) Find(c *fi.Context) (*Secret, error) {
 	return actual, nil
 }
 
-func (e *Secret) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Secret) Run(c *fi.CloudupContext) error {
+	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *Secret) CheckChanges(a, e, changes *Secret) error {
@@ -74,7 +74,7 @@ func (s *Secret) CheckChanges(a, e, changes *Secret) error {
 	return nil
 }
 
-func (_ *Secret) Render(c *fi.Context, a, e, changes *Secret) error {
+func (_ *Secret) Render(c *fi.CloudupContext, a, e, changes *Secret) error {
 	name := fi.ValueOf(e.Name)
 	if name == "" {
 		return fi.RequiredField("Name")

--- a/upup/pkg/fi/fitasks/secret_fitask.go
+++ b/upup/pkg/fi/fitasks/secret_fitask.go
@@ -48,5 +48,5 @@ func (o *Secret) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *Secret) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }

--- a/upup/pkg/fi/has_address.go
+++ b/upup/pkg/fi/has_address.go
@@ -19,9 +19,9 @@ package fi
 // HasAddress is implemented by elastic/floating IP addresses in order to include
 // relevant dynamically allocated addresses in the api-server's server TLS certificate.
 type HasAddress interface {
-	Task
+	Task[CloudupSubContext]
 	// IsForAPIServer indicates whether the implementation provides an address that needs to be added to the api-server server certificate.
 	IsForAPIServer() bool
 	// FindIPAddress returns the address associated with the implementor.  If there is no address, returns (nil, nil).
-	FindAddresses(context *Context) ([]string, error)
+	FindAddresses(context *CloudupContext) ([]string, error)
 }

--- a/upup/pkg/fi/nodeup/cloudinit/cloud_init_target.go
+++ b/upup/pkg/fi/nodeup/cloudinit/cloud_init_target.go
@@ -48,7 +48,7 @@ func NewCloudInitTarget(out io.Writer) *CloudInitTarget {
 	return t
 }
 
-var _ fi.Target = &CloudInitTarget{}
+var _ fi.NodeupTarget = &CloudInitTarget{}
 
 type CloudConfig struct {
 	PackageUpdate bool `json:"package_update"`
@@ -168,7 +168,7 @@ func (t *CloudInitTarget) AddCommand(addBehaviour AddBehaviour, args ...string) 
 	t.Config.RunCommmands = append(t.Config.RunCommmands, args)
 }
 
-func (t *CloudInitTarget) Finish(taskMap map[string]fi.Task) error {
+func (t *CloudInitTarget) Finish(taskMap map[string]fi.NodeupTask) error {
 	d, err := utils.YamlMarshal(t.Config)
 	if err != nil {
 		return fmt.Errorf("error serializing config to yaml: %v", err)

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -363,7 +363,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	}
 	// Protokube load image task is in ProtokubeBuilder
 
-	var target fi.Target
+	var target fi.NodeupTarget
 	checkExisting := true
 
 	switch c.Target {
@@ -376,7 +376,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 		}
 	case "dryrun":
 		assetBuilder := assets.NewAssetBuilder(c.cluster, false)
-		target = fi.NewDryRunTarget(assetBuilder, out)
+		target = fi.NewNodeupDryRunTarget(assetBuilder, out)
 	case "cloudinit":
 		checkExisting = false
 		target = cloudinit.NewCloudInitTarget(out)
@@ -384,7 +384,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 		return fmt.Errorf("unsupported target type %q", c.Target)
 	}
 
-	context, err := fi.NewContext(ctx, target, c.cluster, cloud, keyStore, secretStore, configBase, checkExisting, taskMap)
+	context, err := fi.NewNodeupContext(ctx, target, c.cluster, cloud, keyStore, secretStore, configBase, checkExisting, taskMap)
 	if err != nil {
 		klog.Exitf("error building context: %v", err)
 	}

--- a/upup/pkg/fi/nodeup/loader.go
+++ b/upup/pkg/fi/nodeup/loader.go
@@ -26,14 +26,14 @@ import (
 )
 
 type Loader struct {
-	Builders []fi.ModelBuilder
+	Builders []fi.NodeupModelBuilder
 }
 
 // Build is responsible for running the build tasks for nodeup
-func (l *Loader) Build() (map[string]fi.Task, error) {
-	tasks := make(map[string]fi.Task)
+func (l *Loader) Build() (map[string]fi.NodeupTask, error) {
+	tasks := make(map[string]fi.NodeupTask)
 	for _, builder := range l.Builders {
-		context := &fi.ModelBuilderContext{
+		context := &fi.NodeupModelBuilderContext{
 			Tasks: tasks,
 		}
 		err := builder.Build(context)

--- a/upup/pkg/fi/nodeup/local/local_target.go
+++ b/upup/pkg/fi/nodeup/local/local_target.go
@@ -30,9 +30,9 @@ type LocalTarget struct {
 	Cluster    *kops.Cluster
 }
 
-var _ fi.Target = &LocalTarget{}
+var _ fi.NodeupTarget = &LocalTarget{}
 
-func (t *LocalTarget) Finish(taskMap map[string]fi.Task) error {
+func (t *LocalTarget) Finish(taskMap map[string]fi.NodeupTask) error {
 	return nil
 }
 

--- a/upup/pkg/fi/nodeup/nodetasks/aptsource.go
+++ b/upup/pkg/fi/nodeup/nodetasks/aptsource.go
@@ -35,7 +35,7 @@ type AptSource struct {
 	Sources []string
 }
 
-func (e *AptSource) Find(c *fi.Context) (*AptSource, error) {
+func (e *AptSource) Find(c *fi.NodeupContext) (*AptSource, error) {
 	return nil, nil
 }
 
@@ -47,8 +47,8 @@ func (f *AptSource) String() string {
 	return f.Name
 }
 
-func (f *AptSource) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(f, c)
+func (f *AptSource) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(f, c)
 }
 
 func (*AptSource) CheckChanges(a, e, changes *AptSource) error {

--- a/upup/pkg/fi/nodeup/nodetasks/archive.go
+++ b/upup/pkg/fi/nodeup/nodetasks/archive.go
@@ -58,11 +58,11 @@ const (
 	localArchiveStateDir = "/var/cache/nodeup/archives/state/"
 )
 
-var _ fi.HasDependencies = &Archive{}
+var _ fi.NodeupHasDependencies = &Archive{}
 
 // GetDependencies implements HasDependencies::GetDependencies
-func (e *Archive) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *Archive) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
+	var deps []fi.NodeupTask
 
 	// Requires parent directories to be created
 	deps = append(deps, findCreatesDirParents(e.TargetDir, tasks)...)
@@ -89,7 +89,7 @@ func (e *Archive) Dir() string {
 }
 
 // Find implements fi.Task::Find
-func (e *Archive) Find(c *fi.Context) (*Archive, error) {
+func (e *Archive) Find(c *fi.NodeupContext) (*Archive, error) {
 	// We write a marker file to prevent re-execution
 	localStateFile := path.Join(localArchiveStateDir, e.Name)
 	stateBytes, err := os.ReadFile(localStateFile)
@@ -124,8 +124,8 @@ func (e *Archive) Find(c *fi.Context) (*Archive, error) {
 }
 
 // Run implements fi.Task::Run
-func (e *Archive) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Archive) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 // CheckChanges implements fi.Task::CheckChanges

--- a/upup/pkg/fi/nodeup/nodetasks/archive_test.go
+++ b/upup/pkg/fi/nodeup/nodetasks/archive_test.go
@@ -24,8 +24,8 @@ import (
 
 func TestArchiveDependencies(t *testing.T) {
 	grid := []struct {
-		parent fi.Task
-		child  fi.Task
+		parent fi.NodeupTask
+		child  fi.NodeupTask
 	}{
 		{
 			parent: &File{
@@ -48,16 +48,16 @@ func TestArchiveDependencies(t *testing.T) {
 	}
 
 	for _, g := range grid {
-		allTasks := make(map[string]fi.Task)
+		allTasks := make(map[string]fi.NodeupTask)
 		allTasks["parent"] = g.parent
 		allTasks["child"] = g.child
 
-		deps := g.parent.(fi.HasDependencies).GetDependencies(allTasks)
+		deps := g.parent.(fi.NodeupHasDependencies).GetDependencies(allTasks)
 		if len(deps) != 0 {
 			t.Errorf("found unexpected dependencies for parent: %v %v", g.parent, deps)
 		}
 
-		childDeps := g.child.(fi.HasDependencies).GetDependencies(allTasks)
+		childDeps := g.child.(fi.NodeupHasDependencies).GetDependencies(allTasks)
 		if len(childDeps) != 1 {
 			t.Errorf("found unexpected dependencies for child: %v %v", g.child, childDeps)
 		}

--- a/upup/pkg/fi/nodeup/nodetasks/bindmount.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bindmount.go
@@ -36,7 +36,7 @@ type BindMount struct {
 	Recursive  bool     `json:"recursive"`
 }
 
-var _ fi.Task = &BindMount{}
+var _ fi.NodeupTask = &BindMount{}
 
 func (s *BindMount) String() string {
 	return fmt.Sprintf("BindMount: %s->%s", s.Source, s.Mountpoint)
@@ -55,11 +55,11 @@ func (e *BindMount) GetName() *string {
 	return fi.PtrTo("BindMount-" + e.Mountpoint)
 }
 
-var _ fi.HasDependencies = &BindMount{}
+var _ fi.NodeupHasDependencies = &BindMount{}
 
 // GetDependencies implements HasDependencies::GetDependencies
-func (e *BindMount) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *BindMount) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
+	var deps []fi.NodeupTask
 
 	// Requires parent directories to be created
 	deps = append(deps, findCreatesDirParents(e.Mountpoint, tasks)...)
@@ -84,7 +84,7 @@ func (e *BindMount) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 	return deps
 }
 
-func findTaskInSlice(tasks []fi.Task, task fi.Task) int {
+func findTaskInSlice(tasks []fi.NodeupTask, task fi.NodeupTask) int {
 	for i, t := range tasks {
 		if t == task {
 			return i
@@ -93,7 +93,7 @@ func findTaskInSlice(tasks []fi.Task, task fi.Task) int {
 	return -1
 }
 
-func (e *BindMount) Find(c *fi.Context) (*BindMount, error) {
+func (e *BindMount) Find(c *fi.NodeupContext) (*BindMount, error) {
 	mounts, err := os.ReadFile("/proc/self/mountinfo")
 	if err != nil {
 		return nil, fmt.Errorf("error reading /proc/self/mountinfo: %v", err)
@@ -172,8 +172,8 @@ func (e *BindMount) Find(c *fi.Context) (*BindMount, error) {
 	return nil, nil
 }
 
-func (e *BindMount) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *BindMount) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *BindMount) CheckChanges(a, e, changes *BindMount) error {

--- a/upup/pkg/fi/nodeup/nodetasks/bindmount_test.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bindmount_test.go
@@ -113,8 +113,8 @@ func TestBindMountDependencies(t *testing.T) {
 	containerizedMounterHome := "/containerized_mounter"
 
 	grid := []struct {
-		parent fi.Task
-		child  fi.Task
+		parent fi.NodeupTask
+		child  fi.NodeupTask
 	}{
 		{
 			parent: &File{
@@ -189,16 +189,16 @@ func TestBindMountDependencies(t *testing.T) {
 	}
 
 	for _, g := range grid {
-		allTasks := make(map[string]fi.Task)
+		allTasks := make(map[string]fi.NodeupTask)
 		allTasks["parent"] = g.parent
 		allTasks["child"] = g.child
 
-		deps := g.parent.(fi.HasDependencies).GetDependencies(allTasks)
+		deps := g.parent.(fi.NodeupHasDependencies).GetDependencies(allTasks)
 		if len(deps) != 0 {
 			t.Errorf("found unexpected dependencies for parent: %v %v", g.parent, deps)
 		}
 
-		childDeps := g.child.(fi.HasDependencies).GetDependencies(allTasks)
+		childDeps := g.child.(fi.NodeupHasDependencies).GetDependencies(allTasks)
 		if len(childDeps) != 1 {
 			t.Errorf("found unexpected dependencies for child: %v %v", g.child, childDeps)
 		}

--- a/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
@@ -54,19 +54,19 @@ type BootstrapClientTask struct {
 }
 
 type BootstrapCert struct {
-	Cert *fi.TaskDependentResource
-	Key  *fi.TaskDependentResource
+	Cert *fi.NodeupTaskDependentResource
+	Key  *fi.NodeupTaskDependentResource
 }
 
 var (
-	_ fi.Task            = &BootstrapClientTask{}
-	_ fi.HasName         = &BootstrapClientTask{}
-	_ fi.HasDependencies = &BootstrapClientTask{}
+	_ fi.NodeupTask            = &BootstrapClientTask{}
+	_ fi.HasName               = &BootstrapClientTask{}
+	_ fi.NodeupHasDependencies = &BootstrapClientTask{}
 )
 
-func (b *BootstrapClientTask) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (b *BootstrapClientTask) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
 	// BootstrapClient depends on the protokube service to ensure gossip DNS
-	var deps []fi.Task
+	var deps []fi.NodeupTask
 	for _, v := range tasks {
 		if svc, ok := v.(*Service); ok && svc.Name == protokubeService {
 			deps = append(deps, v)
@@ -84,7 +84,7 @@ func (b *BootstrapClientTask) String() string {
 	return "BootstrapClientTask"
 }
 
-func (b *BootstrapClientTask) Run(c *fi.Context) error {
+func (b *BootstrapClientTask) Run(c *fi.NodeupContext) error {
 	ctx := context.TODO()
 
 	req := nodeup.BootstrapRequest{

--- a/upup/pkg/fi/nodeup/nodetasks/chattr.go
+++ b/upup/pkg/fi/nodeup/nodetasks/chattr.go
@@ -31,10 +31,10 @@ type Chattr struct {
 	File string `json:"file"`
 	Mode string `json:"mode"`
 
-	Deps []fi.Task `json:"-"`
+	Deps []fi.NodeupTask `json:"-"`
 }
 
-var _ fi.Task = &Chattr{}
+var _ fi.NodeupTask = &Chattr{}
 
 func (s *Chattr) String() string {
 	return fmt.Sprintf("Chattr: chattr %s %s", s.Mode, s.File)
@@ -46,20 +46,20 @@ func (e *Chattr) GetName() *string {
 	return fi.PtrTo("Chattr-" + e.File)
 }
 
-var _ fi.HasDependencies = &Chattr{}
+var _ fi.NodeupHasDependencies = &Chattr{}
 
 // GetDependencies implements HasDependencies::GetDependencies
-func (e *Chattr) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (e *Chattr) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
 	return e.Deps
 }
 
-func (e *Chattr) Find(c *fi.Context) (*Chattr, error) {
+func (e *Chattr) Find(c *fi.NodeupContext) (*Chattr, error) {
 	// We always re-run the chattr command
 	return nil, nil
 }
 
-func (e *Chattr) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Chattr) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *Chattr) CheckChanges(a, e, changes *Chattr) error {

--- a/upup/pkg/fi/nodeup/nodetasks/createsdir.go
+++ b/upup/pkg/fi/nodeup/nodetasks/createsdir.go
@@ -30,8 +30,8 @@ type CreatesDir interface {
 var _ CreatesDir = &File{}
 
 // findCreatesDirParents finds the tasks which create parent directories for the given task
-func findCreatesDirParents(p string, tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func findCreatesDirParents(p string, tasks map[string]fi.NodeupTask) []fi.NodeupTask {
+	var deps []fi.NodeupTask
 	for _, v := range tasks {
 		if createsDirectory, ok := v.(CreatesDir); ok {
 			dirPath := createsDirectory.Dir()
@@ -54,12 +54,12 @@ func findCreatesDirParents(p string, tasks map[string]fi.Task) []fi.Task {
 }
 
 // findCreatesDirMatching finds the tasks which create the specified directory (matching, non-recursive)
-func findCreatesDirMatching(p string, tasks map[string]fi.Task) []fi.Task {
+func findCreatesDirMatching(p string, tasks map[string]fi.NodeupTask) []fi.NodeupTask {
 	if !strings.HasSuffix(p, "/") {
 		p += "/"
 	}
 
-	var deps []fi.Task
+	var deps []fi.NodeupTask
 	for _, v := range tasks {
 		if createsDirectory, ok := v.(CreatesDir); ok {
 			dirPath := createsDirectory.Dir()

--- a/upup/pkg/fi/nodeup/nodetasks/file.go
+++ b/upup/pkg/fi/nodeup/nodetasks/file.go
@@ -55,14 +55,14 @@ type File struct {
 }
 
 var (
-	_ fi.Task            = &File{}
-	_ fi.HasDependencies = &File{}
-	_ fi.HasName         = &File{}
+	_ fi.NodeupTask            = &File{}
+	_ fi.NodeupHasDependencies = &File{}
+	_ fi.HasName               = &File{}
 )
 
 // GetDependencies implements HasDependencies::GetDependencies
-func (e *File) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *File) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
+	var deps []fi.NodeupTask
 
 	if e.Owner != nil {
 		ownerTask := tasks["UserTask/"+*e.Owner]
@@ -77,7 +77,7 @@ func (e *File) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 	// Requires parent directories to be created
 	deps = append(deps, findCreatesDirParents(e.Path, tasks)...)
 
-	if hasDep, ok := e.Contents.(fi.HasDependencies); ok {
+	if hasDep, ok := e.Contents.(fi.NodeupHasDependencies); ok {
 		deps = append(deps, hasDep.GetDependencies(tasks)...)
 	}
 
@@ -167,7 +167,7 @@ func findFile(p string) (*File, error) {
 	return actual, nil
 }
 
-func (e *File) Find(c *fi.Context) (*File, error) {
+func (e *File) Find(c *fi.NodeupContext) (*File, error) {
 	actual, err := findFile(e.Path)
 	if err != nil {
 		return nil, err
@@ -186,8 +186,8 @@ func (e *File) Find(c *fi.Context) (*File, error) {
 	return actual, nil
 }
 
-func (e *File) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *File) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *File) CheckChanges(a, e, changes *File) error {

--- a/upup/pkg/fi/nodeup/nodetasks/file_test.go
+++ b/upup/pkg/fi/nodeup/nodetasks/file_test.go
@@ -28,8 +28,8 @@ func TestFileDependencies(t *testing.T) {
 
 	grid := []struct {
 		name   string
-		parent fi.Task
-		child  fi.Task
+		parent fi.NodeupTask
+		child  fi.NodeupTask
 	}{
 		{
 			name: "user",
@@ -76,20 +76,20 @@ func TestFileDependencies(t *testing.T) {
 
 	for _, g := range grid {
 		t.Run(g.name, func(t *testing.T) {
-			context := &fi.ModelBuilderContext{
-				Tasks: make(map[string]fi.Task),
+			context := &fi.NodeupModelBuilderContext{
+				Tasks: make(map[string]fi.NodeupTask),
 			}
 			context.AddTask(g.parent)
 			context.AddTask(g.child)
 
-			if _, ok := g.parent.(fi.HasDependencies); ok {
-				deps := g.parent.(fi.HasDependencies).GetDependencies(context.Tasks)
+			if _, ok := g.parent.(fi.NodeupHasDependencies); ok {
+				deps := g.parent.(fi.NodeupHasDependencies).GetDependencies(context.Tasks)
 				if len(deps) != 0 {
 					t.Errorf("found unexpected dependencies for parent: %v %v", g.parent, deps)
 				}
 			}
 
-			childDeps := g.child.(fi.HasDependencies).GetDependencies(context.Tasks)
+			childDeps := g.child.(fi.NodeupHasDependencies).GetDependencies(context.Tasks)
 			if len(childDeps) != 1 {
 				t.Errorf("found unexpected dependencies for child: %v %v", g.child, childDeps)
 			}

--- a/upup/pkg/fi/nodeup/nodetasks/group.go
+++ b/upup/pkg/fi/nodeup/nodetasks/group.go
@@ -35,7 +35,7 @@ type GroupTask struct {
 	System bool
 }
 
-var _ fi.Task = &GroupTask{}
+var _ fi.NodeupTask = &GroupTask{}
 
 func (e *GroupTask) String() string {
 	return fmt.Sprintf("Group: %s", e.Name)
@@ -47,7 +47,7 @@ func (f *GroupTask) GetName() *string {
 	return &f.Name
 }
 
-func (e *GroupTask) Find(c *fi.Context) (*GroupTask, error) {
+func (e *GroupTask) Find(c *fi.NodeupContext) (*GroupTask, error) {
 	info, err := fi.LookupGroup(e.Name)
 	if err != nil {
 		return nil, err
@@ -68,8 +68,8 @@ func (e *GroupTask) Find(c *fi.Context) (*GroupTask, error) {
 	return actual, nil
 }
 
-func (e *GroupTask) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *GroupTask) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *GroupTask) CheckChanges(a, e, changes *GroupTask) error {

--- a/upup/pkg/fi/nodeup/nodetasks/issue_cert.go
+++ b/upup/pkg/fi/nodeup/nodetasks/issue_cert.go
@@ -34,7 +34,7 @@ import (
 
 // PKIXName is a simplified form of pkix.Name, for better golden test output
 type PKIXName struct {
-	fi.NotADependency
+	fi.NodeupNotADependency
 	CommonName   string
 	Organization []string `json:",omitempty"`
 }
@@ -58,14 +58,14 @@ type IssueCert struct {
 	// IncludeRootCertificate will force the certificate data to include the full chain, not just the leaf
 	IncludeRootCertificate bool `json:"includeRootCertificate,omitempty"`
 
-	cert *fi.TaskDependentResource
-	key  *fi.TaskDependentResource
-	ca   *fi.TaskDependentResource
+	cert *fi.NodeupTaskDependentResource
+	key  *fi.NodeupTaskDependentResource
+	ca   *fi.NodeupTaskDependentResource
 }
 
 var (
-	_ fi.Task    = &IssueCert{}
-	_ fi.HasName = &IssueCert{}
+	_ fi.NodeupTask = &IssueCert{}
+	_ fi.HasName    = &IssueCert{}
 )
 
 func (i *IssueCert) GetName() *string {
@@ -77,16 +77,16 @@ func (i *IssueCert) String() string {
 	return fmt.Sprintf("IssueCert: %s", i.Name)
 }
 
-func (i *IssueCert) GetResources() (certResource, keyResource, caResource *fi.TaskDependentResource) {
+func (i *IssueCert) GetResources() (certResource, keyResource, caResource *fi.NodeupTaskDependentResource) {
 	if i.cert == nil {
-		i.cert = &fi.TaskDependentResource{Task: i}
-		i.key = &fi.TaskDependentResource{Task: i}
-		i.ca = &fi.TaskDependentResource{Task: i}
+		i.cert = &fi.NodeupTaskDependentResource{Task: i}
+		i.key = &fi.NodeupTaskDependentResource{Task: i}
+		i.ca = &fi.NodeupTaskDependentResource{Task: i}
 	}
 	return i.cert, i.key, i.ca
 }
 
-func (i *IssueCert) AddFileTasks(c *fi.ModelBuilderContext, dir string, name string, caName string, owner *string) error {
+func (i *IssueCert) AddFileTasks(c *fi.NodeupModelBuilderContext, dir string, name string, caName string, owner *string) error {
 	certResource, keyResource, caResource := i.GetResources()
 	err := c.EnsureTask(&File{
 		Path: dir,
@@ -129,7 +129,7 @@ func (i *IssueCert) AddFileTasks(c *fi.ModelBuilderContext, dir string, name str
 	return nil
 }
 
-func (e *IssueCert) Run(c *fi.Context) error {
+func (e *IssueCert) Run(c *fi.NodeupContext) error {
 	// Skew the certificate lifetime by up to 30 days based on information about the generating node.
 	// This is so that different nodes created at the same time have the certificates they generated
 	// expire at different times, but all certificates on a given node expire around the same time.

--- a/upup/pkg/fi/nodeup/nodetasks/issue_cert_test.go
+++ b/upup/pkg/fi/nodeup/nodetasks/issue_cert_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 func TestIssueCertFileDependencies(t *testing.T) {
-	context := &fi.ModelBuilderContext{
-		Tasks: make(map[string]fi.Task),
+	context := &fi.NodeupModelBuilderContext{
+		Tasks: make(map[string]fi.NodeupTask),
 	}
 
 	issue := &IssueCert{Name: "testCert"}
@@ -43,7 +43,7 @@ func TestIssueCertFileDependencies(t *testing.T) {
 		if !assert.NotNil(t, task) {
 			continue
 		}
-		deps := task.(fi.HasDependencies).GetDependencies(context.Tasks)
+		deps := task.(fi.NodeupHasDependencies).GetDependencies(context.Tasks)
 
 		taskNames = nil
 		for _, task := range deps {

--- a/upup/pkg/fi/nodeup/nodetasks/kubeconfig.go
+++ b/upup/pkg/fi/nodeup/nodetasks/kubeconfig.go
@@ -31,13 +31,13 @@ type KubeConfig struct {
 	CA        fi.Resource
 	ServerURL string
 
-	config *fi.TaskDependentResource
+	config *fi.NodeupTaskDependentResource
 }
 
 var (
-	_ fi.Task            = &KubeConfig{}
-	_ fi.HasName         = &KubeConfig{}
-	_ fi.HasDependencies = &KubeConfig{}
+	_ fi.NodeupTask            = &KubeConfig{}
+	_ fi.HasName               = &KubeConfig{}
+	_ fi.NodeupHasDependencies = &KubeConfig{}
 )
 
 func (k *KubeConfig) GetName() *string {
@@ -49,30 +49,30 @@ func (k *KubeConfig) String() string {
 	return fmt.Sprintf("KubeConfig: %s", k.Name)
 }
 
-func (k *KubeConfig) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (k *KubeConfig) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
+	var deps []fi.NodeupTask
 
-	if hasDep, ok := k.Cert.(fi.HasDependencies); ok {
+	if hasDep, ok := k.Cert.(fi.NodeupHasDependencies); ok {
 		deps = append(deps, hasDep.GetDependencies(tasks)...)
 	}
-	if hasDep, ok := k.Key.(fi.HasDependencies); ok {
+	if hasDep, ok := k.Key.(fi.NodeupHasDependencies); ok {
 		deps = append(deps, hasDep.GetDependencies(tasks)...)
 	}
-	if hasDep, ok := k.CA.(fi.HasDependencies); ok {
+	if hasDep, ok := k.CA.(fi.NodeupHasDependencies); ok {
 		deps = append(deps, hasDep.GetDependencies(tasks)...)
 	}
 
 	return deps
 }
 
-func (k *KubeConfig) GetConfig() *fi.TaskDependentResource {
+func (k *KubeConfig) GetConfig() *fi.NodeupTaskDependentResource {
 	if k.config == nil {
-		k.config = &fi.TaskDependentResource{Task: k}
+		k.config = &fi.NodeupTaskDependentResource{Task: k}
 	}
 	return k.config
 }
 
-func (k *KubeConfig) Run(_ *fi.Context) error {
+func (k *KubeConfig) Run(_ *fi.NodeupContext) error {
 	cert, err := fi.ResourceAsBytes(k.Cert)
 	if err != nil {
 		return err

--- a/upup/pkg/fi/nodeup/nodetasks/load_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/load_image.go
@@ -42,15 +42,15 @@ type LoadImageTask struct {
 }
 
 var (
-	_ fi.Task            = &LoadImageTask{}
-	_ fi.HasDependencies = &LoadImageTask{}
+	_ fi.NodeupTask            = &LoadImageTask{}
+	_ fi.NodeupHasDependencies = &LoadImageTask{}
 )
 
-func (t *LoadImageTask) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (t *LoadImageTask) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
 	// LoadImageTask depends on the docker service to ensure we
 	// sideload images after docker is completely updated and
 	// configured.
-	var deps []fi.Task
+	var deps []fi.NodeupTask
 	for _, v := range tasks {
 		if svc, ok := v.(*Service); ok && svc.Name == containerdService {
 			deps = append(deps, v)
@@ -75,13 +75,13 @@ func (t *LoadImageTask) String() string {
 	return fmt.Sprintf("LoadImageTask: %v", t.Sources)
 }
 
-func (e *LoadImageTask) Find(c *fi.Context) (*LoadImageTask, error) {
+func (e *LoadImageTask) Find(c *fi.NodeupContext) (*LoadImageTask, error) {
 	klog.Warningf("LoadImageTask checking if image present not yet implemented")
 	return nil, nil
 }
 
-func (e *LoadImageTask) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *LoadImageTask) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *LoadImageTask) CheckChanges(a, e, changes *LoadImageTask) error {

--- a/upup/pkg/fi/nodeup/nodetasks/loadimage_test.go
+++ b/upup/pkg/fi/nodeup/nodetasks/loadimage_test.go
@@ -26,14 +26,14 @@ import (
 func TestLoadImageTask_Deps(t *testing.T) {
 	l := &LoadImageTask{}
 
-	tasks := make(map[string]fi.Task)
+	tasks := make(map[string]fi.NodeupTask)
 	tasks["LoadImageTask1"] = &LoadImageTask{}
 	tasks["FileTask1"] = &File{}
 	tasks["ServiceDocker"] = &Service{Name: "docker.service"}
 	tasks["Service2"] = &Service{Name: "two.service"}
 
 	deps := l.GetDependencies(tasks)
-	expected := []fi.Task{tasks["ServiceDocker"]}
+	expected := []fi.NodeupTask{tasks["ServiceDocker"]}
 	if !reflect.DeepEqual(expected, deps) {
 		t.Fatalf("unexpected deps.  expected=%v, actual=%v", expected, deps)
 	}

--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -60,11 +60,11 @@ const (
 	dockerPackageName           = "docker-ce"
 )
 
-var _ fi.HasDependencies = &Package{}
+var _ fi.NodeupHasDependencies = &Package{}
 
 // GetDependencies computes dependencies for the package task
-func (e *Package) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (e *Package) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
+	var deps []fi.NodeupTask
 
 	// UpdatePackages before we install any packages
 	for _, v := range tasks {
@@ -128,7 +128,7 @@ func (p *Package) String() string {
 	return fmt.Sprintf("Package: %s", p.Name)
 }
 
-func (e *Package) Find(c *fi.Context) (*Package, error) {
+func (e *Package) Find(c *fi.NodeupContext) (*Package, error) {
 	d, err := distributions.FindDistribution("/")
 	if err != nil {
 		return nil, fmt.Errorf("unknown or unsupported distro: %v", err)
@@ -145,7 +145,7 @@ func (e *Package) Find(c *fi.Context) (*Package, error) {
 	return nil, fmt.Errorf("unsupported package system")
 }
 
-func (e *Package) findDpkg(c *fi.Context) (*Package, error) {
+func (e *Package) findDpkg(c *fi.NodeupContext) (*Package, error) {
 	args := []string{"dpkg-query", "-f", "${db:Status-Abbrev}${Version}\\n", "-W", e.Name}
 	human := strings.Join(args, " ")
 
@@ -212,7 +212,7 @@ func (e *Package) findDpkg(c *fi.Context) (*Package, error) {
 	}, nil
 }
 
-func (e *Package) findYum(c *fi.Context) (*Package, error) {
+func (e *Package) findYum(c *fi.NodeupContext) (*Package, error) {
 	args := []string{"/usr/bin/rpm", "-q", e.Name, "--queryformat", "%{NAME} %{VERSION}"}
 	human := strings.Join(args, " ")
 
@@ -263,8 +263,8 @@ func (e *Package) findYum(c *fi.Context) (*Package, error) {
 	}, nil
 }
 
-func (e *Package) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Package) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *Package) CheckChanges(a, e, changes *Package) error {

--- a/upup/pkg/fi/nodeup/nodetasks/prefix.go
+++ b/upup/pkg/fi/nodeup/nodetasks/prefix.go
@@ -49,7 +49,7 @@ func (p *Prefix) String() string {
 	return fmt.Sprintf("Prefix: %s", p.Name)
 }
 
-func (e *Prefix) Find(c *fi.Context) (*Prefix, error) {
+func (e *Prefix) Find(c *fi.NodeupContext) (*Prefix, error) {
 	if c.Cluster.Spec.GetCloudProvider() != kops.CloudProviderAWS {
 		return nil, fmt.Errorf("unsupported cloud provider: %s", c.Cluster.Spec.GetCloudProvider())
 	}
@@ -74,8 +74,8 @@ func (e *Prefix) Find(c *fi.Context) (*Prefix, error) {
 	return actual, nil
 }
 
-func (e *Prefix) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Prefix) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *Prefix) CheckChanges(a, e, changes *Prefix) error {

--- a/upup/pkg/fi/nodeup/nodetasks/pull_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/pull_image.go
@@ -32,15 +32,15 @@ type PullImageTask struct {
 }
 
 var (
-	_ fi.Task            = &PullImageTask{}
-	_ fi.HasDependencies = &PullImageTask{}
+	_ fi.NodeupTask            = &PullImageTask{}
+	_ fi.NodeupHasDependencies = &PullImageTask{}
 )
 
-func (t *PullImageTask) GetDependencies(tasks map[string]fi.Task) []fi.Task {
+func (t *PullImageTask) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
 	// ImagePullTask depends on the container runtime service to ensure we
 	// sideload images after the container runtime is completely updated and
 	// configured.
-	var deps []fi.Task
+	var deps []fi.NodeupTask
 	for _, v := range tasks {
 		if svc, ok := v.(*Service); ok && svc.Name == containerdService {
 			deps = append(deps, v)
@@ -59,7 +59,7 @@ func (t *PullImageTask) GetName() *string {
 	return &t.Name
 }
 
-func (e *PullImageTask) Run(c *fi.Context) error {
+func (e *PullImageTask) Run(c *fi.NodeupContext) error {
 	runtime := e.Runtime
 	if runtime != "docker" && runtime != "containerd" {
 		return fmt.Errorf("no runtime specified")

--- a/upup/pkg/fi/nodeup/nodetasks/service.go
+++ b/upup/pkg/fi/nodeup/nodetasks/service.go
@@ -60,12 +60,12 @@ type Service struct {
 }
 
 var (
-	_ fi.HasDependencies = &Service{}
-	_ fi.HasName         = &Service{}
+	_ fi.NodeupHasDependencies = &Service{}
+	_ fi.HasName               = &Service{}
 )
 
-func (p *Service) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	var deps []fi.Task
+func (p *Service) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
+	var deps []fi.NodeupTask
 	for _, v := range tasks {
 		// We assume that services depend on everything except for
 		// LoadImageTask or IssueCert. If there are any LoadImageTasks (e.g. we're
@@ -163,7 +163,7 @@ func (e *Service) systemdSystemPath() (string, error) {
 	}
 }
 
-func (e *Service) Find(c *fi.Context) (*Service, error) {
+func (e *Service) Find(c *fi.NodeupContext) (*Service, error) {
 	systemdSystemPath, err := e.systemdSystemPath()
 	if err != nil {
 		return nil, err
@@ -253,8 +253,8 @@ func getSystemdDependencies(serviceName string, definition string) ([]string, er
 	return dependencies, nil
 }
 
-func (e *Service) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *Service) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *Service) CheckChanges(a, e, changes *Service) error {

--- a/upup/pkg/fi/nodeup/nodetasks/service_test.go
+++ b/upup/pkg/fi/nodeup/nodetasks/service_test.go
@@ -26,12 +26,12 @@ import (
 func TestServiceTask_Deps(t *testing.T) {
 	s := &Service{}
 
-	tasks := make(map[string]fi.Task)
+	tasks := make(map[string]fi.NodeupTask)
 	tasks["LoadImageTask1"] = &LoadImageTask{}
 	tasks["FileTask1"] = &File{}
 
 	deps := s.GetDependencies(tasks)
-	expected := []fi.Task{tasks["FileTask1"]}
+	expected := []fi.NodeupTask{tasks["FileTask1"]}
 	if !reflect.DeepEqual(expected, deps) {
 		t.Fatalf("unexpected deps.  expected=%v, actual=%v", expected, deps)
 	}
@@ -39,18 +39,18 @@ func TestServiceTask_Deps(t *testing.T) {
 
 type FakeTask struct{}
 
-func (t *FakeTask) Run(*fi.Context) error {
+func (t *FakeTask) Run(*fi.NodeupContext) error {
 	panic("not implemented")
 }
 
 func TestServiceTask_UnknownTypes(t *testing.T) {
 	s := &Service{}
 
-	tasks := make(map[string]fi.Task)
+	tasks := make(map[string]fi.NodeupTask)
 	tasks["FakeTask1"] = &FakeTask{}
 
 	deps := s.GetDependencies(tasks)
-	expected := []fi.Task{tasks["FakeTask1"]}
+	expected := []fi.NodeupTask{tasks["FakeTask1"]}
 	if !reflect.DeepEqual(expected, deps) {
 		t.Fatalf("unexpected deps.  expected=%v, actual=%v", expected, deps)
 	}

--- a/upup/pkg/fi/nodeup/nodetasks/update_etc_hosts_task.go
+++ b/upup/pkg/fi/nodeup/nodetasks/update_etc_hosts_task.go
@@ -37,7 +37,7 @@ type UpdateEtcHostsTask struct {
 
 // HostRecord holds an individual host's addresses.
 type HostRecord struct {
-	fi.NotADependency
+	fi.NodeupNotADependency
 
 	// Hostname is the "DNS" name that we want to configure.
 	Hostname string
@@ -46,7 +46,7 @@ type HostRecord struct {
 	Addresses []string
 }
 
-var _ fi.Task = &UpdateEtcHostsTask{}
+var _ fi.NodeupTask = &UpdateEtcHostsTask{}
 
 func (e *UpdateEtcHostsTask) String() string {
 	return fmt.Sprintf("UpdateEtcHostsTask: %s", e.Name)
@@ -58,14 +58,14 @@ func (f *UpdateEtcHostsTask) GetName() *string {
 	return &f.Name
 }
 
-func (e *UpdateEtcHostsTask) Find(c *fi.Context) (*UpdateEtcHostsTask, error) {
+func (e *UpdateEtcHostsTask) Find(c *fi.NodeupContext) (*UpdateEtcHostsTask, error) {
 	// UpdateHostsFileWithRecords skips the update /etc/hosts if there are no changes,
 	// so we don't check existing values here.
 	return nil, nil
 }
 
-func (e *UpdateEtcHostsTask) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *UpdateEtcHostsTask) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *UpdateEtcHostsTask) CheckChanges(a, e, changes *UpdateEtcHostsTask) error {

--- a/upup/pkg/fi/nodeup/nodetasks/update_packages.go
+++ b/upup/pkg/fi/nodeup/nodetasks/update_packages.go
@@ -34,14 +34,14 @@ type UpdatePackages struct {
 	Updated bool
 }
 
-var _ fi.HasDependencies = &UpdatePackages{}
+var _ fi.NodeupHasDependencies = &UpdatePackages{}
 
 func NewUpdatePackages() *UpdatePackages {
 	return &UpdatePackages{Updated: true}
 }
 
-func (p *UpdatePackages) GetDependencies(tasks map[string]fi.Task) []fi.Task {
-	deps := []fi.Task{}
+func (p *UpdatePackages) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
+	var deps []fi.NodeupTask
 	for _, v := range tasks {
 		if _, ok := v.(*AptSource); ok {
 			deps = append(deps, v)
@@ -54,12 +54,12 @@ func (p *UpdatePackages) String() string {
 	return "UpdatePackages"
 }
 
-func (e *UpdatePackages) Find(c *fi.Context) (*UpdatePackages, error) {
+func (e *UpdatePackages) Find(c *fi.NodeupContext) (*UpdatePackages, error) {
 	return nil, nil
 }
 
-func (e *UpdatePackages) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *UpdatePackages) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 func (s *UpdatePackages) CheckChanges(a, e, changes *UpdatePackages) error {

--- a/upup/pkg/fi/nodeup/nodetasks/user.go
+++ b/upup/pkg/fi/nodeup/nodetasks/user.go
@@ -37,7 +37,7 @@ type UserTask struct {
 	Home  string `json:"home"`
 }
 
-var _ fi.Task = &UserTask{}
+var _ fi.NodeupTask = &UserTask{}
 
 func (e *UserTask) String() string {
 	return fmt.Sprintf("User: %s", e.Name)
@@ -49,7 +49,7 @@ func (f *UserTask) GetName() *string {
 	return &f.Name
 }
 
-func (e *UserTask) Find(c *fi.Context) (*UserTask, error) {
+func (e *UserTask) Find(c *fi.NodeupContext) (*UserTask, error) {
 	info, err := fi.LookupUser(e.Name)
 	if err != nil {
 		return nil, err
@@ -68,8 +68,8 @@ func (e *UserTask) Find(c *fi.Context) (*UserTask, error) {
 	return actual, nil
 }
 
-func (e *UserTask) Run(c *fi.Context) error {
-	return fi.DefaultDeltaRunMethod(e, c)
+func (e *UserTask) Run(c *fi.NodeupContext) error {
+	return fi.NodeupDefaultDeltaRunMethod(e, c)
 }
 
 func (_ *UserTask) CheckChanges(a, e, changes *UserTask) error {

--- a/upup/pkg/fi/resources.go
+++ b/upup/pkg/fi/resources.go
@@ -199,30 +199,33 @@ func (r *VFSResource) Open() (io.Reader, error) {
 	return b, err
 }
 
-type TaskDependentResource struct {
+type TaskDependentResource[T SubContext] struct {
 	Resource Resource `json:"resource,omitempty"`
-	Task     Task     `json:"task,omitempty"`
+	Task     Task[T]  `json:"task,omitempty"`
 }
 
+type CloudupTaskDependentResource = TaskDependentResource[CloudupSubContext]
+type NodeupTaskDependentResource = TaskDependentResource[NodeupSubContext]
+
 var (
-	_ Resource        = &TaskDependentResource{}
-	_ HasDependencies = &TaskDependentResource{}
-	_ HasIsReady      = &TaskDependentResource{}
+	_ Resource                           = &TaskDependentResource[CloudupSubContext]{}
+	_ HasDependencies[CloudupSubContext] = &TaskDependentResource[CloudupSubContext]{}
+	_ HasIsReady                         = &TaskDependentResource[CloudupSubContext]{}
 )
 
-func (r *TaskDependentResource) Open() (io.Reader, error) {
+func (r *TaskDependentResource[T]) Open() (io.Reader, error) {
 	if r.Resource == nil {
 		return nil, fmt.Errorf("resource opened before it is ready (task=%v)", r.Task)
 	}
 	return r.Resource.Open()
 }
 
-func (r *TaskDependentResource) GetDependencies(tasks map[string]Task) []Task {
-	return []Task{r.Task}
+func (r *TaskDependentResource[T]) GetDependencies(tasks map[string]Task[T]) []Task[T] {
+	return []Task[T]{r.Task}
 }
 
 // IsReady implements HasIsReady::IsReady
-func (r *TaskDependentResource) IsReady() bool {
+func (r *TaskDependentResource[T]) IsReady() bool {
 	return r.Resource != nil
 }
 

--- a/upup/pkg/fi/target.go
+++ b/upup/pkg/fi/target.go
@@ -16,11 +16,14 @@ limitations under the License.
 
 package fi
 
-type Target interface {
+type Target[T SubContext] interface {
 	// Lifecycle methods, called by the driver
-	Finish(taskMap map[string]Task) error
+	Finish(taskMap map[string]Task[T]) error
 
 	// ProcessDeletions returns true if we should delete resources
 	// Some providers (e.g. Terraform) actively keep state, and will delete resources automatically
 	ProcessDeletions() bool
 }
+
+type CloudupTarget = Target[CloudupSubContext]
+type NodeupTarget = Target[NodeupSubContext]

--- a/upup/pkg/fi/task.go
+++ b/upup/pkg/fi/task.go
@@ -25,69 +25,93 @@ import (
 	"k8s.io/klog/v2"
 )
 
-type Task interface {
-	Run(*Context) error
+type Task[T SubContext] interface {
+	Run(*Context[T]) error
 }
 
+type CloudupTask = Task[CloudupSubContext]
+type NodeupTask = Task[NodeupSubContext]
+
 // TaskPreRun is implemented by tasks that perform some initial validation.
-type TaskPreRun interface {
-	Task
-	// PreRun will be run for all TaskPreRuns, before the Run function of any Task is invoked.
-	// Invocation order does not pay attention to Task dependencies.
-	PreRun(*Context) error
+type TaskPreRun[T SubContext] interface {
+	Task[T]
+	// PreRun will be run for all TaskPreRuns, before any Run functions are invoked.
+	PreRun(*Context[T]) error
 }
 
 // TaskNormalize is implemented by tasks that perform some initial normalization.
-type TaskNormalize interface {
-	Task
+type TaskNormalize[T SubContext] interface {
+	Task[T]
 	// Normalize will be run for all TaskNormalizes, before the Run function of
 	// the TaskNormalize and after the Run function of any Task it is dependent on.
-	Normalize(*Context) error
+	Normalize(*Context[T]) error
 }
+
+type CloudupTaskNormalize = TaskNormalize[CloudupSubContext]
 
 // TaskAsString renders the task for debug output
 // TODO: Use reflection to make this cleaner: don't recurse into tasks - print their names instead
 // also print resources in a cleaner way (use the resource source information?)
-func TaskAsString(t Task) string {
+func TaskAsString[T SubContext](t Task[T]) string {
 	return fmt.Sprintf("%T %s", t, DebugAsJsonString(t))
 }
 
-type HasCheckExisting interface {
-	Task
-	CheckExisting(c *Context) bool
+// CloudupTaskAsString renders the task for debug output
+// TODO: Use reflection to make this cleaner: don't recurse into tasks - print their names instead
+// also print resources in a cleaner way (use the resource source information?)
+func CloudupTaskAsString(t CloudupTask) string {
+	return TaskAsString(t)
 }
+
+// NodeupTaskAsString renders the task for debug output
+// TODO: Use reflection to make this cleaner: don't recurse into tasks - print their names instead
+// also print resources in a cleaner way (use the resource source information?)
+func NodeupTaskAsString(t NodeupTask) string {
+	return TaskAsString(t)
+}
+
+type HasCheckExisting[T SubContext] interface {
+	Task[T]
+	CheckExisting(c *Context[T]) bool
+}
+
+type NodeupHasCheckExisting = HasCheckExisting[NodeupSubContext]
+type CloudupHasCheckExisting = HasCheckExisting[CloudupSubContext]
 
 // ModelBuilder allows for plugins that configure an aspect of the model, based on the configuration
-type ModelBuilder interface {
-	Build(context *ModelBuilderContext) error
+type ModelBuilder[T SubContext] interface {
+	Build(context *ModelBuilderContext[T]) error
 }
 
-// HasDeletions is a ModelBuilder that creates tasks to delete cloud objects that no longer exist in the model.
+type CloudupModelBuilder = ModelBuilder[CloudupSubContext]
+type NodeupModelBuilder = ModelBuilder[NodeupSubContext]
+
+// HasDeletions is a ModelBuilder[CloudupContext] that creates tasks to delete cloud objects that no longer exist in the model.
 type HasDeletions interface {
-	ModelBuilder
+	ModelBuilder[CloudupSubContext]
 	// FindDeletions finds cloud objects that are owned by the cluster but no longer in the model and creates tasks to delete them.
 	// It is not called for the Terraform target.
-	FindDeletions(context *ModelBuilderContext, cloud Cloud) error
+	FindDeletions(context *ModelBuilderContext[CloudupSubContext], cloud Cloud) error
 }
 
 // ModelBuilderContext is a context object that holds state we want to pass to ModelBuilder
-type ModelBuilderContext struct {
+type ModelBuilderContext[T SubContext] struct {
 	// ctx holds the context.Context, ideally we would pass this in to every handler,
 	// but that is a fairly large refactor, and arguably ModelBuilderContext has a similar
 	// lifecycle to a context.Context
 	ctx context.Context
 
-	Tasks              map[string]Task
+	Tasks              map[string]Task[T]
 	LifecycleOverrides map[string]Lifecycle
 }
 
-func (c *ModelBuilderContext) WithContext(ctx context.Context) *ModelBuilderContext {
+func (c *ModelBuilderContext[T]) WithContext(ctx context.Context) *ModelBuilderContext[T] {
 	c2 := *c
 	c2.ctx = ctx
 	return &c2
 }
 
-func (c *ModelBuilderContext) Context() context.Context {
+func (c *ModelBuilderContext[T]) Context() context.Context {
 	ctx := c.ctx
 	if ctx == nil {
 		ctx = context.TODO()
@@ -95,7 +119,10 @@ func (c *ModelBuilderContext) Context() context.Context {
 	return ctx
 }
 
-func (c *ModelBuilderContext) AddTask(task Task) {
+type NodeupModelBuilderContext = ModelBuilderContext[NodeupSubContext]
+type CloudupModelBuilderContext = ModelBuilderContext[CloudupSubContext]
+
+func (c *ModelBuilderContext[T]) AddTask(task Task[T]) {
 	task = c.setLifecycleOverride(task)
 	key := buildTaskKey(task)
 
@@ -110,7 +137,7 @@ func (c *ModelBuilderContext) AddTask(task Task) {
 // It adds the task if it does not already exist.
 // If it does exist, it verifies that the existing task reflect.DeepEqual the new task,
 // if they are different an error is returned.
-func (c *ModelBuilderContext) EnsureTask(task Task) error {
+func (c *ModelBuilderContext[T]) EnsureTask(task Task[T]) error {
 	task = c.setLifecycleOverride(task)
 	key := buildTaskKey(task)
 
@@ -133,7 +160,7 @@ func (c *ModelBuilderContext) EnsureTask(task Task) error {
 // setLifecycleOverride determines if a Lifecycle is in the LifecycleOverrides map for the current task.
 // If the lifecycle exist then the task lifecycle is set to the lifecycle provides in LifecycleOverrides.
 // This func allows for lifecycles to be passed in dynamically and have the task lifecycle set accordingly.
-func (c *ModelBuilderContext) setLifecycleOverride(task Task) Task {
+func (c *ModelBuilderContext[T]) setLifecycleOverride(task Task[T]) Task[T] {
 	// TODO(@chrislovecnm) - wonder if we should update the nodeup tasks to have lifecycle
 	// TODO - so that we can return an error here, rather than just returning.
 	// certain tasks have not implemented HasLifecycle interface
@@ -155,7 +182,7 @@ func (c *ModelBuilderContext) setLifecycleOverride(task Task) Task {
 	return task
 }
 
-func buildTaskKey(task Task) string {
+func buildTaskKey[T SubContext](task Task[T]) string {
 	hasName, ok := task.(HasName)
 	if !ok {
 		klog.Fatalf("task %T does not implement HasName", task)

--- a/upup/tools/generators/fitask/generator.go
+++ b/upup/tools/generators/fitask/generator.go
@@ -62,7 +62,7 @@ func (o *{{.Name}}) GetName() *string {
 
 // String is the stringer function for the task, producing readable output using fi.TaskAsString
 func (o *{{.Name}}) String() string {
-	return fi.TaskAsString(o)
+	return fi.CloudupTaskAsString(o)
 }
 `
 


### PR DESCRIPTION
This separates the `Context`, `Task`, and related types to distinguish those used in cloudup from those used in nodeup. Followup PRs will move some fields only used in cloudup into `CloudupContext`.

The basics of this refactor are:

```go
type Context[T SubContext] struct {
	 ...

	T T
}

type SubContext interface {
	CloudupContext | NodeupContext
}
type CloudupContext struct{}
type NodeupContext struct{}

type Task[T SubContext] interface {
	Run(*Context[T]) error
}

type ModelBuilderContext[T SubContext] struct {
	Tasks              map[string]Task[T]
	LifecycleOverrides map[string]Lifecycle
}
```