### PR TITLE
Drop support for k8s 1.23 in kOps 1.28

### DIFF
--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -19,7 +19,7 @@ This is a document to gather the release notes prior to the release.
 
 * Support for Kubernetes version 1.21 is deprecated and will be removed in kOps 1.27.
 
-* Support for Kubernetes version 1.22 is deprecated and will be removed in kOps 1.28.
+* Support for Kubernetes versions 1.22 and 1.23 are deprecated and will be removed in kOps 1.28.
 
 * Support for AWS Classic Load Balancer for API is deprecated and should not be used for newly created clusters.
 

--- a/permalinks/upgrade_k8s.md
+++ b/permalinks/upgrade_k8s.md
@@ -15,7 +15,7 @@ Kops will remove support for Kubernetes versions as follows:
 | 1.25         | 1.19                                   |
 | 1.26         | 1.20                                   |
 | 1.27         | 1.21                                   |
-| 1.28         | 1.22                                   |
+| 1.28         | 1.22 and 1.23                          |
 
 You are running a version of kubernetes that we recommend upgrading.
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -83,7 +83,7 @@ const (
 	// OldestSupportedKubernetesVersion is the oldest kubernetes version that is supported in kOps.
 	OldestSupportedKubernetesVersion = "1.21.0"
 	// OldestRecommendedKubernetesVersion is the oldest kubernetes version that is not deprecated in kOps.
-	OldestRecommendedKubernetesVersion = "1.23.0"
+	OldestRecommendedKubernetesVersion = "1.24.0"
 )
 
 // TerraformCloudProviders is the list of cloud providers with terraform target support


### PR DESCRIPTION
With Kubernetes releasing three times a year, it makes sense to narrow our supported range a bit.

/hold for wide consensus
/kind office-hours
