### PR TITLE
Revert deprecation of positional clustername args

### DIFF
--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -265,12 +265,6 @@ func (c *RootCmd) clusterNameArgsAllowNoCluster(clusterName *string) func(cmd *c
 //
 // Everything else is an error.
 func (c *RootCmd) ProcessArgs(args []string) error {
-	if len(args) > 0 {
-		fmt.Fprintf(os.Stderr, "\n")
-		fmt.Fprintf(os.Stderr, "\nClusterName as positional argument is deprecated and will be removed in a future version\n")
-		fmt.Fprintf(os.Stderr, "\n")
-	}
-
 	if len(args) == 0 {
 		return nil
 	}


### PR DESCRIPTION
What's the point of making people type an extra seven characters every time they create or delete a cluster?