### PR TITLE
Need to setup topology before control plane for IPv6 private topology

### DIFF
--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -340,6 +340,16 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 		return nil, err
 	}
 
+	err = setupNetworking(opt, &cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	bastions, err := setupTopology(opt, &cluster, allZones)
+	if err != nil {
+		return nil, err
+	}
+
 	masters, err := setupMasters(opt, &cluster, zoneToSubnetMap)
 	if err != nil {
 		return nil, err
@@ -369,16 +379,6 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 	}
 
 	apiservers, err := setupAPIServers(opt, &cluster, zoneToSubnetMap)
-	if err != nil {
-		return nil, err
-	}
-
-	err = setupNetworking(opt, &cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	bastions, err := setupTopology(opt, &cluster, allZones)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Creating an IPv6 cluster with private topology previously failed with:

```
Error: cannot find subnet "dualstack-us-east-1a" (declared in instance group "master-us-east-1a", not found in cluster)
```

This is because `setupMasters()` tried to validate the control plane IG's subnet before `setupTopology()` created the dualstack subnets.