### PR TITLE
Fix Prometheus scraping for pod-identity-webhook

### DIFF
--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ca08e870a5c376a65d6b41ce9ddcf5a12db858e2971398f6a06ac3e7071bea49
+    manifestHash: a1573fc78e0b9cc5a30570251082c6af7d5f44fc4e383d80a68a84f0be392922
     name: eks-pod-identity-webhook.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
@@ -242,8 +242,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    prometheus.io/port: "443"
-    prometheus.io/scheme: https
+    prometheus.io/port: "9999"
+    prometheus.io/scheme: http
     prometheus.io/scrape: "true"
   creationTimestamp: null
   labels:
@@ -268,8 +268,8 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    prometheus.io/port: "443"
-    prometheus.io/scheme: https
+    prometheus.io/port: "9999"
+    prometheus.io/scheme: http
     prometheus.io/scrape: "true"
   creationTimestamp: null
   labels:

--- a/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
@@ -184,8 +184,8 @@ metadata:
   name: pod-identity-webhook
   namespace: kube-system
   annotations:
-    prometheus.io/port: "443"
-    prometheus.io/scheme: "https"
+    prometheus.io/port: "9999"
+    prometheus.io/scheme: "http"
     prometheus.io/scrape: "true"
 spec:
   ports:
@@ -201,8 +201,8 @@ metadata:
   name: pod-identity-webhook
   namespace: kube-system
   annotations:
-    prometheus.io/port: "443"
-    prometheus.io/scheme: "https"
+    prometheus.io/port: "9999"
+    prometheus.io/scheme: "http"
     prometheus.io/scrape: "true"
 data:
   config: {{ PodIdentityWebhookConfigMapData }}


### PR DESCRIPTION
The Service annotation for the pod-identity-webhook is asking Prometheus to scrape its metrics from `https://` but this results in a HTTP 404 Not Found response.
The pod-identity-webhook pods expose their metrics via HTTP on TCP port 9999 (the same port where the healthz checks go).
Therefore update the annotations to use `http://:9999` instead.