### PR TITLE
ipv6: NPE fixes for IPv6-only instances

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -2432,7 +2432,9 @@ func GetInstanceCertificateNames(instances *ec2.DescribeInstancesOutput, useInst
 		addrs = append(addrs, *instance.InstanceId)
 	}
 
-	addrs = append(addrs, *instance.PrivateDnsName)
+	if instance.PrivateDnsName != nil {
+		addrs = append(addrs, *instance.PrivateDnsName)
+	}
 
 	// We only use data for the first interface, and only the first IP
 	for _, iface := range instance.NetworkInterfaces {
@@ -2442,7 +2444,9 @@ func GetInstanceCertificateNames(instances *ec2.DescribeInstancesOutput, useInst
 		if *iface.Attachment.DeviceIndex != 0 {
 			continue
 		}
-		addrs = append(addrs, *iface.PrivateIpAddress)
+		if iface.PrivateIpAddress != nil {
+			addrs = append(addrs, *iface.PrivateIpAddress)
+		}
 		if iface.Ipv6Addresses != nil && len(iface.Ipv6Addresses) > 0 {
 			addrs = append(addrs, *iface.Ipv6Addresses[0].Ipv6Address)
 		}

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1231,6 +1231,13 @@ func setupTopology(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.S
 					PublicName: "bastion." + cluster.Name,
 				}
 			}
+			if opt.IPv6 {
+				for _, s := range cluster.Spec.Subnets {
+					if s.Type == kopsapi.SubnetTypeDualStack {
+						bastionGroup.Spec.Subnets = append(bastionGroup.Spec.Subnets, s.Name)
+					}
+				}
+			}
 			if cluster.Spec.GetCloudProvider() == api.CloudProviderGCE {
 				bastionGroup.Spec.Zones = allZones.List()
 			}


### PR DESCRIPTION
With this, an IPv6 cluster with private topology comes up (though without LBC).