### PR TITLE
Automated cherry pick of #14463: Fix Prometheus scraping for pod-identity-webhook

### DIFF
--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0bec2a812bd438f03cb28b18391b78453430e17c7123c4b87a165cb5a1a03a92
+    manifestHash: 7b8cee18c8828975bf34d41c10e2915777d63b5e14bae5272b003aafb439dc34
     name: eks-pod-identity-webhook.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
@@ -243,8 +243,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    prometheus.io/port: "443"
-    prometheus.io/scheme: https
+    prometheus.io/port: "9999"
+    prometheus.io/scheme: http
     prometheus.io/scrape: "true"
   creationTimestamp: null
   labels:
@@ -269,8 +269,8 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    prometheus.io/port: "443"
-    prometheus.io/scheme: https
+    prometheus.io/port: "9999"
+    prometheus.io/scheme: http
     prometheus.io/scrape: "true"
   creationTimestamp: null
   labels:

--- a/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
@@ -185,8 +185,8 @@ metadata:
   name: pod-identity-webhook
   namespace: kube-system
   annotations:
-    prometheus.io/port: "443"
-    prometheus.io/scheme: "https"
+    prometheus.io/port: "9999"
+    prometheus.io/scheme: "http"
     prometheus.io/scrape: "true"
 spec:
   ports:
@@ -202,8 +202,8 @@ metadata:
   name: pod-identity-webhook
   namespace: kube-system
   annotations:
-    prometheus.io/port: "443"
-    prometheus.io/scheme: "https"
+    prometheus.io/port: "9999"
+    prometheus.io/scheme: "http"
     prometheus.io/scrape: "true"
 data:
   config: {{ PodIdentityWebhookConfigMapData }}


### PR DESCRIPTION
Cherry pick of #14463 on release-1.25.

#14463: Fix Prometheus scraping for pod-identity-webhook

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.