### PR TITLE
set default dns ttl of 5mins

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -19,6 +19,7 @@ package awstasks
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -216,6 +217,7 @@ func (_ *DNSName) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *DNSName) error
 	rrs := &route53.ResourceRecordSet{
 		Name: e.ResourceName,
 		Type: e.ResourceType,
+		TTL:  aws.Int64(int64(5 * time.Minute)),
 	}
 
 	if e.TargetLoadBalancer != nil {


### PR DESCRIPTION
Currently, DNS records created via `kops update` have no TTL. Setting a default TTL of 5mins.