### PR TITLE
Upgrade Amazon VPC CNI to v1.12.0

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
         livenessProbe:
           exec:
             command:
@@ -258,6 +258,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
@@ -265,8 +266,6 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/dockershim.sock
-          name: dockershim
         - mountPath: /var/run/aws-node
           name: run-dir
         - mountPath: /run/xtables.lock
@@ -278,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -298,9 +297,6 @@ spec:
       - hostPath:
           path: /etc/cni/net.d
         name: cni-net-dir
-      - hostPath:
-          path: /run/containerd/containerd.sock
-        name: dockershim
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
         livenessProbe:
           exec:
             command:
@@ -258,6 +258,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
@@ -265,8 +266,6 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/dockershim.sock
-          name: dockershim
         - mountPath: /var/run/aws-node
           name: run-dir
         - mountPath: /run/xtables.lock
@@ -278,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -298,9 +297,6 @@ spec:
       - hostPath:
           path: /etc/cni/net.d
         name: cni-net-dir
-      - hostPath:
-          path: /run/containerd/containerd.sock
-        name: dockershim
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
         livenessProbe:
           exec:
             command:
@@ -258,6 +258,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
@@ -265,8 +266,6 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/dockershim.sock
-          name: dockershim
         - mountPath: /var/run/aws-node
           name: run-dir
         - mountPath: /run/xtables.lock
@@ -278,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -298,9 +297,6 @@ spec:
       - hostPath:
           path: /etc/cni/net.d
         name: cni-net-dir
-      - hostPath:
-          path: /run/containerd/containerd.sock
-        name: dockershim
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
         livenessProbe:
           exec:
             command:
@@ -258,6 +258,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
@@ -265,8 +266,6 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/dockershim.sock
-          name: dockershim
         - mountPath: /var/run/aws-node
           name: run-dir
         - mountPath: /run/xtables.lock
@@ -278,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -298,9 +297,6 @@ spec:
       - hostPath:
           path: /etc/cni/net.d
         name: cni-net-dir
-      - hostPath:
-          path: /run/containerd/containerd.sock
-        name: dockershim
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
         livenessProbe:
           exec:
             command:
@@ -258,6 +258,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
@@ -265,8 +266,6 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/dockershim.sock
-          name: dockershim
         - mountPath: /var/run/aws-node
           name: run-dir
         - mountPath: /run/xtables.lock
@@ -278,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -298,9 +297,6 @@ spec:
       - hostPath:
           path: /etc/cni/net.d
         name: cni-net-dir
-      - hostPath:
-          path: /run/containerd/containerd.sock
-        name: dockershim
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
         livenessProbe:
           exec:
             command:
@@ -258,6 +258,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
@@ -265,8 +266,6 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/dockershim.sock
-          name: dockershim
         - mountPath: /var/run/aws-node
           name: run-dir
         - mountPath: /run/xtables.lock
@@ -278,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -298,9 +297,6 @@ spec:
       - hostPath:
           path: /etc/cni/net.d
         name: cni-net-dir
-      - hostPath:
-          path: /run/containerd/containerd.sock
-        name: dockershim
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
         livenessProbe:
           exec:
             command:
@@ -258,6 +258,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
@@ -265,8 +266,6 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/dockershim.sock
-          name: dockershim
         - mountPath: /var/run/aws-node
           name: run-dir
         - mountPath: /run/xtables.lock
@@ -278,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -298,9 +297,6 @@ spec:
       - hostPath:
           path: /etc/cni/net.d
         name: cni-net-dir
-      - hostPath:
-          path: /run/containerd/containerd.sock
-        name: dockershim
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,4 +1,4 @@
-# Vendored from https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.11/config/master/aws-k8s-cni.yaml
+# Vendored from https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.12/config/master/aws-k8s-cni.yaml
 ---
 # Source: aws-vpc-cni/templates/serviceaccount.yaml
 apiVersion: v1
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.4"
+    app.kubernetes.io/version: "v1.12.0"
 ---
 # Source: aws-vpc-cni/templates/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.4"
+    app.kubernetes.io/version: "v1.12.0"
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.4"
+    app.kubernetes.io/version: "v1.12.0"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -85,7 +85,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.4"
+    app.kubernetes.io/version: "v1.12.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,7 +105,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.4"
+    app.kubernetes.io/version: "v1.12.0"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -126,7 +126,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4" }}"
+        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0" }}"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -144,7 +144,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4" }}"
+          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0" }}"
           ports:
             - containerPort: 61678
               name: metrics
@@ -228,6 +228,7 @@ spec:
             capabilities:
               add:
               - NET_ADMIN
+              - NET_RAW
           volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
@@ -235,8 +236,6 @@ spec:
             name: cni-net-dir
           - mountPath: /host/var/log/aws-routed-eni
             name: log-dir
-          - mountPath: /var/run/dockershim.sock
-            name: dockershim
           - mountPath: /var/run/aws-node
             name: run-dir
           - mountPath: /run/xtables.lock
@@ -248,9 +247,6 @@ spec:
       - name: cni-net-dir
         hostPath:
           path: /etc/cni/net.d
-      - name: dockershim
-        hostPath:
-          path: "{{ if eq .ContainerRuntime "containerd" }}/run/containerd/containerd.sock{{ else }}/var/run/dockershim.sock{{ end }}"
       - name: log-dir
         hostPath:
           path: /var/log/aws-routed-eni

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: a9de2acf0395378a11c61c053493ec621229d6bd585dbd0afff99cc0d659242a
+    manifestHash: 500058623d10114e2de790f0fb39ad62a53b1ef3517db252ab82e8fdad87d25d
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -230,7 +230,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
         livenessProbe:
           exec:
             command:
@@ -260,6 +260,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
@@ -267,8 +268,6 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/dockershim.sock
-          name: dockershim
         - mountPath: /var/run/aws-node
           name: run-dir
         - mountPath: /run/xtables.lock
@@ -280,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -300,9 +299,6 @@ spec:
       - hostPath:
           path: /etc/cni/net.d
         name: cni-net-dir
-      - hostPath:
-          path: /run/containerd/containerd.sock
-        name: dockershim
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: a9de2acf0395378a11c61c053493ec621229d6bd585dbd0afff99cc0d659242a
+    manifestHash: 500058623d10114e2de790f0fb39ad62a53b1ef3517db252ab82e8fdad87d25d
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.12.0
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -230,7 +230,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
         livenessProbe:
           exec:
             command:
@@ -260,6 +260,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
@@ -267,8 +268,6 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/dockershim.sock
-          name: dockershim
         - mountPath: /var/run/aws-node
           name: run-dir
         - mountPath: /run/xtables.lock
@@ -280,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -300,9 +299,6 @@ spec:
       - hostPath:
           path: /etc/cni/net.d
         name: cni-net-dir
-      - hostPath:
-          path: /run/containerd/containerd.sock
-        name: dockershim
       - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate


### PR DESCRIPTION
### [Release Page](https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.12.0)

/cc @rifelpet @hakman @olemarkus @johngmyers 
Hey y'all!

Wanted to point out the below updates from the release page:

> This new version removes dependency on CRI socket(e.g. dockershim.sock).
> 
> 🚨 🚨 🚨 Action Required For Upgrading
> 
> To upgrade to VPC CNI >=v1.12.0, you must upgrade to VPC CNI >=v1.7.x first. We recommend that you update one minor version at a time.
> aws-vpc-cni Helm chart v1.2.0 is released with VPC CNI v1.12.0, thus no longer supports the cri.hostPath.path. If you need to install a VPC CNI <v1.12.0 with helm chart, a aws-vpc-cni Helm chart with version <v1.2.0 should be used.

Regarding the `dockershim.sock` removal, I suppose we should be good since it was already remove everywhere else already, correct?

And about the requirement to have a minimum version of v1.7 first (of the CNI plugin) - I suppose we should be good there as well, since the general `kOps` best practice is to _always_ upgrade one major version at a time- is that a correct assumption? 

Let me know if something seems off, but I went by the general practice of vendorizing our template from the original chart (updated the link at the top of the template to point to the new version now).

Thanks!