### PR TITLE
Update aws.md

### DIFF
--- a/docs/getting_started/aws.md
+++ b/docs/getting_started/aws.md
@@ -368,7 +368,7 @@ while.  Once it finishes you'll have to wait longer while the booted instances
 finish downloading Kubernetes components and reach a "ready" state.
 
 ```bash
-kops update cluster --name ${NAME} --yes
+kops update cluster --name ${NAME} --yes --admin
 ```
 
 ### Use the Cluster


### PR DESCRIPTION
Adding `--admin` flag to getting started guide for AWS,  this seems to be required since 1.19 to follow the guide.