### PR TITLE
Add e2e template for dedicated APIserver nodes without DNS

### DIFF
--- a/tests/e2e/templates/apiserver-dns-none.yaml.tmpl
+++ b/tests/e2e/templates/apiserver-dns-none.yaml.tmpl
@@ -6,6 +6,10 @@ metadata:
 spec:
   kubernetesApiAccess:
   - {{.publicIP}}
+  api:
+    loadBalancer:
+      type: Public
+      class: Network
   channel: stable
   cloudProvider: {{.cloudProvider}}
   configBase: "{{.stateStore}}/{{.clusterName}}"
@@ -23,7 +27,6 @@ spec:
     anonymousAuth: false
   kubernetesVersion: {{.kubernetesVersion}}
   masterInternalName: api.internal.{{.clusterName}}
-  masterPublicName: api.{{.clusterName}}
   networkCIDR: 172.20.0.0/16
   networking:
     calico: {}
@@ -33,6 +36,8 @@ spec:
   sshAccess:
     - {{.publicIP}}
   topology:
+    dns:
+      type: None
     masters: public
     nodes: public
   subnets:


### PR DESCRIPTION
To be used in the future, when adding support for the feature. Should be pretty easy to add some new target groups for `etcd.main` and `etcd.events` (in theory).

/cc @olemarkus @johngmyers 