### PR TITLE
Automated cherry pick of #14503: use the same tolerations config for coredns-autoscaler

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -346,8 +346,12 @@ spec:
           - --v=2
       priorityClassName: system-cluster-critical
       tolerations:
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
+        {{- if KubeDNS.Tolerations }}
+{{ ToYAML .KubeDNS.Tolerations | indent 8 }}
+        {{- else }}
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        {{- end }}
       serviceAccountName: coredns-autoscaler
       nodeSelector:
         kubernetes.io/os: linux

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -355,4 +355,8 @@ spec:
       serviceAccountName: coredns-autoscaler
       nodeSelector:
         kubernetes.io/os: linux
+{{- if .KubeDNS.Affinity }}
+      affinity:
+{{ ToYAML .KubeDNS.Affinity | indent 8 }}
+{{- end }}
 ---

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/coredns.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/coredns.addons.k8s.io-k8s-1.12.yaml
@@ -402,5 +402,5 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns-autoscaler
       tolerations:
-      - key: CriticalAddonsOnly
+      - effect: NoSchedule
         operator: Exists

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/coredns.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/coredns.addons.k8s.io-k8s-1.12.yaml
@@ -382,6 +382,27 @@ spec:
         k8s-app: coredns-autoscaler
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kops.k8s.io/instancegroup
+                operator: In
+                values:
+                - master
+                - ondemand-nodes
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - kube-dns
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - command:
         - /cluster-proportional-autoscaler

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b8b81e0980542ff1ee37db3421be070a9c618a6978b88b06c4e8907bb6c0b73f
+    manifestHash: 57f9e5ba2d92659ac6e372542eaacf81ace960accb8e7ac755bf654c493efe1b
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8243c0d971de35e487a87897dea725bc2ee32c9308cb73e9e5b58eb013cf63bd
+    manifestHash: 43e067fd51c57475523abedb1e1ce9faa24876ac15184c0a14e799e3555dce48
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 43e067fd51c57475523abedb1e1ce9faa24876ac15184c0a14e799e3555dce48
+    manifestHash: b8b81e0980542ff1ee37db3421be070a9c618a6978b88b06c4e8907bb6c0b73f
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #14503 on release-1.24.

#14503: use the same tolerations config for coredns-autoscaler

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```