### PR TITLE
AWS CNI template updates

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
+    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
+    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
+    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
+    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
+    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
+    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 2dbc5844330df7de478e4d739f390c1525ce00426302a9bcd5cd7f7ffa9af437
+    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -59,10 +59,17 @@ rules:
     resources:
       - namespaces
     verbs: ["list", "watch", "get"]
+{{- if AmazonVpcEnvVars.ANNOTATE_POD_IP }}
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs: ["list", "watch", "get", "patch"]
+{{- else }}
   - apiGroups: [""]
     resources:
       - pods
     verbs: ["list", "watch", "get"]
+{{- end }}
   - apiGroups: [""]
     resources:
       - nodes

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -195,6 +195,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			envVars := map[string]string{
 				// Use defaults from the official AWS VPC CNI Helm chart:
 				// https://github.com/aws/amazon-vpc-cni-k8s/blob/master/charts/aws-vpc-cni/values.yaml
+				"ADDITIONAL_ENI_TAGS": 	                 "{}",
 				"AWS_VPC_CNI_NODE_PORT_SUPPORT":         "true",
 				"AWS_VPC_ENI_MTU":                       "9001",
 				"AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER":    "false",
@@ -209,7 +210,9 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 				"DISABLE_INTROSPECTION":                 "false",
 				"DISABLE_METRICS":                       "false",
 				"ENABLE_POD_ENI":                        "false",
+				"ENABLE_PREFIX_DELEGATION":              "false",
 				"WARM_ENI_TARGET":                       "1",
+				"WARM_PREFIX_TARGET":                    "1",
 				"DISABLE_NETWORK_RESOURCE_PROVISIONING": "false",
 			}
 			for _, e := range c.Env {

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -195,7 +195,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			envVars := map[string]string{
 				// Use defaults from the official AWS VPC CNI Helm chart:
 				// https://github.com/aws/amazon-vpc-cni-k8s/blob/master/charts/aws-vpc-cni/values.yaml
-				"ADDITIONAL_ENI_TAGS": 	                 "{}",
+				"ADDITIONAL_ENI_TAGS":                   "{}",
 				"AWS_VPC_CNI_NODE_PORT_SUPPORT":         "true",
 				"AWS_VPC_ENI_MTU":                       "9001",
 				"AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER":    "false",

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 500058623d10114e2de790f0fb39ad62a53b1ef3517db252ab82e8fdad87d25d
+    manifestHash: 550350671833a707fdcdc8a2d95f96694e9fadff927db9ed6af5924ca91df1c5
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -220,10 +220,14 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_IP_TARGET
           value: "10"
+        - name: WARM_PREFIX_TARGET
+          value: "1"
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 500058623d10114e2de790f0fb39ad62a53b1ef3517db252ab82e8fdad87d25d
+    manifestHash: 550350671833a707fdcdc8a2d95f96694e9fadff927db9ed6af5924ca91df1c5
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -220,10 +220,14 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_IP_TARGET
           value: "10"
+        - name: WARM_PREFIX_TARGET
+          value: "1"
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Fixes #14495 
1. As listed in the above issue, this PR introduces a template update to account for a case of `ANNOTATE_POD_IP` env. When set to `true`- the `ClusterRole` should also allow patching a pod. Based on the upstream template [here](https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.12/charts/aws-vpc-cni/templates/clusterrole.yaml#L17-L27)
2. I also noticed that there were some newly introduced default ENVs that I overlooked in previous bumps, so adding those (based on the default values.yaml of the upstream chart [here](https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.12/charts/aws-vpc-cni/values.yaml#L35-L56))