### PR TITLE
Automated cherry pick of #14513: add a condition for the aws-cni ClusterRole based on the

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
+    manifestHash: 32d83e9d76bfc756c57096c6b0715beb6bc9e571044990c6144b5344a89ff58f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -221,7 +221,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
+    manifestHash: 32d83e9d76bfc756c57096c6b0715beb6bc9e571044990c6144b5344a89ff58f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -221,7 +221,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
+    manifestHash: 32d83e9d76bfc756c57096c6b0715beb6bc9e571044990c6144b5344a89ff58f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -221,7 +221,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
+    manifestHash: 32d83e9d76bfc756c57096c6b0715beb6bc9e571044990c6144b5344a89ff58f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -221,7 +221,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 997ab80727a6e60a6bb03b0a008054a71e032590a9795d4e20dc584dcb4a5478
+    manifestHash: 32d83e9d76bfc756c57096c6b0715beb6bc9e571044990c6144b5344a89ff58f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -221,7 +221,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -59,10 +59,17 @@ rules:
     resources:
       - namespaces
     verbs: ["list", "watch", "get"]
+{{- if AmazonVpcEnvVars.ANNOTATE_POD_IP }}
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs: ["list", "watch", "get", "patch"]
+{{- else }}
   - apiGroups: [""]
     resources:
       - pods
     verbs: ["list", "watch", "get"]
+{{- end }}
   - apiGroups: [""]
     resources:
       - nodes

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -189,6 +189,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			envVars := map[string]string{
 				// Use defaults from the official AWS VPC CNI Helm chart:
 				// https://github.com/aws/amazon-vpc-cni-k8s/blob/master/charts/aws-vpc-cni/values.yaml
+				"ADDITIONAL_ENI_TAGS": 	                 "{}",
 				"AWS_VPC_CNI_NODE_PORT_SUPPORT":         "true",
 				"AWS_VPC_ENI_MTU":                       "9001",
 				"AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER":    "false",
@@ -203,7 +204,9 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 				"DISABLE_INTROSPECTION":                 "false",
 				"DISABLE_METRICS":                       "false",
 				"ENABLE_POD_ENI":                        "false",
+				"ENABLE_PREFIX_DELEGATION":              "false",
 				"WARM_ENI_TARGET":                       "1",
+				"WARM_PREFIX_TARGET":                    "1",
 				"DISABLE_NETWORK_RESOURCE_PROVISIONING": "false",
 			}
 			for _, e := range c.Env {

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -189,7 +189,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			envVars := map[string]string{
 				// Use defaults from the official AWS VPC CNI Helm chart:
 				// https://github.com/aws/amazon-vpc-cni-k8s/blob/master/charts/aws-vpc-cni/values.yaml
-				"ADDITIONAL_ENI_TAGS": 	                 "{}",
+				"ADDITIONAL_ENI_TAGS":                   "{}",
 				"AWS_VPC_CNI_NODE_PORT_SUPPORT":         "true",
 				"AWS_VPC_ENI_MTU":                       "9001",
 				"AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER":    "false",

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 5af8e56dc28de2e5d7d6b89939b253bdd03f40f41ab1d0e20b873f9cf1530fac
+    manifestHash: a75f204dc2f54d5d0f14ab798d0482016aaf1c9192a57d797d143b91a20cf934
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -221,10 +221,14 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_IP_TARGET
           value: "10"
+        - name: WARM_PREFIX_TARGET
+          value: "1"
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 5af8e56dc28de2e5d7d6b89939b253bdd03f40f41ab1d0e20b873f9cf1530fac
+    manifestHash: a75f204dc2f54d5d0f14ab798d0482016aaf1c9192a57d797d143b91a20cf934
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -221,10 +221,14 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_IP_TARGET
           value: "10"
+        - name: WARM_PREFIX_TARGET
+          value: "1"
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Cherry pick of #14513 on release-1.24.

#14513: add a condition for the aws-cni ClusterRole based on the

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```