### PR TITLE
Automated cherry pick of #14513: add a condition for the aws-cni ClusterRole based on the

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 3d0b6e9ba917b473ca908ea08750d8bd6034d242ebc7b21c99701d952b142e2c
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 3d0b6e9ba917b473ca908ea08750d8bd6034d242ebc7b21c99701d952b142e2c
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 3d0b6e9ba917b473ca908ea08750d8bd6034d242ebc7b21c99701d952b142e2c
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 3d0b6e9ba917b473ca908ea08750d8bd6034d242ebc7b21c99701d952b142e2c
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 3d0b6e9ba917b473ca908ea08750d8bd6034d242ebc7b21c99701d952b142e2c
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 3d0b6e9ba917b473ca908ea08750d8bd6034d242ebc7b21c99701d952b142e2c
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: da1a13abe387e36b409914ba1158040eaaa780f5dc1d925ee83f9d6cb73c9292
+    manifestHash: 3d0b6e9ba917b473ca908ea08750d8bd6034d242ebc7b21c99701d952b142e2c
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -220,7 +220,11 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
+          value: "1"
+        - name: WARM_PREFIX_TARGET
           value: "1"
         - name: MY_NODE_NAME
           valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -59,10 +59,17 @@ rules:
     resources:
       - namespaces
     verbs: ["list", "watch", "get"]
+{{- if AmazonVpcEnvVars.ANNOTATE_POD_IP }}
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs: ["list", "watch", "get", "patch"]
+{{- else }}
   - apiGroups: [""]
     resources:
       - pods
     verbs: ["list", "watch", "get"]
+{{- end }}
   - apiGroups: [""]
     resources:
       - nodes

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -195,6 +195,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			envVars := map[string]string{
 				// Use defaults from the official AWS VPC CNI Helm chart:
 				// https://github.com/aws/amazon-vpc-cni-k8s/blob/master/charts/aws-vpc-cni/values.yaml
+				"ADDITIONAL_ENI_TAGS": 	                 "{}",
 				"AWS_VPC_CNI_NODE_PORT_SUPPORT":         "true",
 				"AWS_VPC_ENI_MTU":                       "9001",
 				"AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER":    "false",
@@ -209,7 +210,9 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 				"DISABLE_INTROSPECTION":                 "false",
 				"DISABLE_METRICS":                       "false",
 				"ENABLE_POD_ENI":                        "false",
+				"ENABLE_PREFIX_DELEGATION":              "false",
 				"WARM_ENI_TARGET":                       "1",
+				"WARM_PREFIX_TARGET":                    "1",
 				"DISABLE_NETWORK_RESOURCE_PROVISIONING": "false",
 			}
 			for _, e := range c.Env {

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -195,7 +195,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			envVars := map[string]string{
 				// Use defaults from the official AWS VPC CNI Helm chart:
 				// https://github.com/aws/amazon-vpc-cni-k8s/blob/master/charts/aws-vpc-cni/values.yaml
-				"ADDITIONAL_ENI_TAGS": 	                 "{}",
+				"ADDITIONAL_ENI_TAGS":                   "{}",
 				"AWS_VPC_CNI_NODE_PORT_SUPPORT":         "true",
 				"AWS_VPC_ENI_MTU":                       "9001",
 				"AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER":    "false",

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: a9de2acf0395378a11c61c053493ec621229d6bd585dbd0afff99cc0d659242a
+    manifestHash: 876c86936ef5b28bb3ca35e6532d18066fed8188cd1f5bf4b70e2b03369b4393
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -220,10 +220,14 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_IP_TARGET
           value: "10"
+        - name: WARM_PREFIX_TARGET
+          value: "1"
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: a9de2acf0395378a11c61c053493ec621229d6bd585dbd0afff99cc0d659242a
+    manifestHash: 876c86936ef5b28bb3ca35e6532d18066fed8188cd1f5bf4b70e2b03369b4393
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -220,10 +220,14 @@ spec:
           value: "false"
         - name: ENABLE_POD_ENI
           value: "false"
+        - name: ENABLE_PREFIX_DELEGATION
+          value: "false"
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_IP_TARGET
           value: "10"
+        - name: WARM_PREFIX_TARGET
+          value: "1"
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Cherry pick of #14513 on release-1.25.

#14513: add a condition for the aws-cni ClusterRole based on the

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```