### PR TITLE
Promote Ubuntu Version from Alpha to Stable

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -58,11 +58,11 @@ spec:
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220924
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20221018
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0"

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -63,7 +63,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -81,7 +81,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -84,7 +84,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -102,7 +102,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -120,7 +120,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -138,7 +138,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -156,7 +156,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -174,7 +174,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -84,7 +84,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -102,7 +102,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -120,7 +120,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -138,7 +138,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -156,7 +156,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -174,7 +174,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -76,7 +76,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-1
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -94,7 +94,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-2
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -112,7 +112,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-3
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -130,7 +130,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -92,7 +92,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-1
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -110,7 +110,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-2
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -128,7 +128,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1a-3
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -146,7 +146,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b-1
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -164,7 +164,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: master-us-test-1b-2
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -182,7 +182,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -200,7 +200,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -73,7 +73,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -91,7 +91,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -109,7 +109,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
@@ -66,7 +66,7 @@ metadata:
     kops.k8s.io/cluster: ipv6.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 3
     httpTokens: required
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: ipv6.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required

--- a/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
@@ -78,7 +78,7 @@ metadata:
     kops.k8s.io/cluster: karpenter.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 3
     httpTokens: required
@@ -99,7 +99,7 @@ metadata:
     kops.k8s.io/cluster: karpenter.example.com
   name: nodes
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required

--- a/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -82,7 +82,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-1.21/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.21/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -82,7 +82,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-1.22/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.22/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 3
     httpTokens: required
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required

--- a/tests/integration/create_cluster/minimal-1.23/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.23/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 3
     httpTokens: required
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required

--- a/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 3
     httpTokens: required
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required

--- a/tests/integration/create_cluster/minimal-1.25/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.25/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 3
     httpTokens: required
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required

--- a/tests/integration/create_cluster/minimal-1.26-arm64/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-arm64/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 3
     httpTokens: required
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required

--- a/tests/integration/create_cluster/minimal-1.26/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 3
     httpTokens: required
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -73,7 +73,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -91,7 +91,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -109,7 +109,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -67,7 +67,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -76,7 +76,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -97,7 +97,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid3
   - sg-exampleid4
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -118,7 +118,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid
   - sg-exampleid2
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -73,7 +73,7 @@ metadata:
     kops.k8s.io/cluster: private-subnets.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -91,7 +91,7 @@ metadata:
     kops.k8s.io/cluster: private-subnets.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -66,7 +66,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -84,7 +84,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -66,7 +66,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -84,7 +84,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -65,7 +65,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -83,7 +83,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220924
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
   machineType: t2.medium
   maxSize: 1
   minSize: 1


### PR DESCRIPTION
Version was updated in alpha over 3 weeks ago, seems ready to promote (ref #14433)
