### PR TITLE
option to add extra volume tags with ebs csi driver

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -328,6 +328,12 @@ spec:
                         description: 'Enabled enables the AWS EBS CSI driver Default:
                           false'
                         type: boolean
+                      extraVolumeTags:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraVolumeTags are additional tags added to
+                          EBS volumes created by the CSI driver. Default: none'
+                        type: object
                       managed:
                         description: Managed controls if aws-ebs-csi-driver is manged
                           and deployed by kOps. The deployment of aws-ebs-csi-driver

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -902,6 +902,10 @@ type AWSEBSCSIDriver struct {
 	// PodAnnotations are the annotations added to AWS EBS CSI node and controller Pods.
 	// Default: none
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+
+	//ExtraVolumeTags are additional tags added to EBS volumes created by the CSI driver.
+	// Default: none
+	ExtraVolumeTags map[string]string `json:"extraVolumeTags,omitempty"`
 }
 
 // GCPPDCSIDriver is the config for the GCP PD CSI driver

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -928,6 +928,10 @@ type AWSEBSCSIDriver struct {
 	// PodAnnotations are the annotations added to AWS EBS CSI node and controller Pods.
 	// Default: none
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+
+	//ExtraVolumeTags are additional tags added to EBS volumes created by the CSI driver.
+	// Default: none
+	ExtraVolumeTags map[string]string `json:"extraVolumeTags,omitempty"`
 }
 
 // GCPPDCSIDriver is the config for the GCP PD CSI driver

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1321,6 +1321,7 @@ func autoConvert_v1alpha2_AWSEBSCSIDriver_To_kops_AWSEBSCSIDriver(in *AWSEBSCSID
 	out.Version = in.Version
 	out.VolumeAttachLimit = in.VolumeAttachLimit
 	out.PodAnnotations = in.PodAnnotations
+	out.ExtraVolumeTags = in.ExtraVolumeTags
 	return nil
 }
 
@@ -1335,6 +1336,7 @@ func autoConvert_kops_AWSEBSCSIDriver_To_v1alpha2_AWSEBSCSIDriver(in *kops.AWSEB
 	out.Version = in.Version
 	out.VolumeAttachLimit = in.VolumeAttachLimit
 	out.PodAnnotations = in.PodAnnotations
+	out.ExtraVolumeTags = in.ExtraVolumeTags
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -122,6 +122,13 @@ func (in *AWSEBSCSIDriver) DeepCopyInto(out *AWSEBSCSIDriver) {
 			(*out)[key] = val
 		}
 	}
+	if in.ExtraVolumeTags != nil {
+		in, out := &in.ExtraVolumeTags, &out.ExtraVolumeTags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -899,6 +899,10 @@ type AWSEBSCSIDriver struct {
 	// PodAnnotations are the annotations added to AWS EBS CSI node and controller Pods.
 	// Default: none
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+
+	//ExtraVolumeTags are additional tags added to EBS volumes created by the CSI driver.
+	// Default: none
+	ExtraVolumeTags map[string]string `json:"extraVolumeTags,omitempty"`
 }
 
 // GCPPDCSIDriver is the config for the GCP PD CSI driver

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1331,6 +1331,7 @@ func autoConvert_v1alpha3_AWSEBSCSIDriver_To_kops_AWSEBSCSIDriver(in *AWSEBSCSID
 	out.Version = in.Version
 	out.VolumeAttachLimit = in.VolumeAttachLimit
 	out.PodAnnotations = in.PodAnnotations
+	out.ExtraVolumeTags = in.ExtraVolumeTags
 	return nil
 }
 
@@ -1345,6 +1346,7 @@ func autoConvert_kops_AWSEBSCSIDriver_To_v1alpha3_AWSEBSCSIDriver(in *kops.AWSEB
 	out.Version = in.Version
 	out.VolumeAttachLimit = in.VolumeAttachLimit
 	out.PodAnnotations = in.PodAnnotations
+	out.ExtraVolumeTags = in.ExtraVolumeTags
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -123,6 +123,13 @@ func (in *AWSEBSCSIDriver) DeepCopyInto(out *AWSEBSCSIDriver) {
 			(*out)[key] = val
 		}
 	}
+	if in.ExtraVolumeTags != nil {
+		in, out := &in.ExtraVolumeTags, &out.ExtraVolumeTags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -122,6 +122,13 @@ func (in *AWSEBSCSIDriver) DeepCopyInto(out *AWSEBSCSIDriver) {
 			(*out)[key] = val
 		}
 	}
+	if in.ExtraVolumeTags != nil {
+		in, out := &in.ExtraVolumeTags, &out.ExtraVolumeTags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -355,7 +355,7 @@ spec:
               mountPath: /registration
           securityContext:
             readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false 
+            allowPrivilegeEscalation: false
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
           imagePullPolicy: IfNotPresent
@@ -478,6 +478,13 @@ spec:
             - "--extra-tags={{ CloudLabels }}"
             - --http-endpoint=0.0.0.0:3301
             - --v=5
+            {{- $tags := list }}
+            {{- range $key, $value := .ExtraVolumeTags }}
+            {{- $tags = append $tags (printf "%s=%v" $key $value) }}
+            {{- end }}
+            {{- if gt (len $tags) 0 }}
+            {{ printf "- \"--extra-tags=%s\"" (join "," $tags) }}
+            {{- end }}
           env:
             {{- if IsIPv6Only }}
             - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
@@ -528,7 +535,7 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
-          securityContext:   
+          securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
         - name: csi-provisioner
@@ -549,7 +556,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           securityContext:
             readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false 
+            allowPrivilegeEscalation: false
         - name: csi-attacher
           image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
           imagePullPolicy: IfNotPresent
@@ -565,7 +572,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           securityContext:
             readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false 
+            allowPrivilegeEscalation: false
         {{ if HasSnapshotController }}
         - name: csi-snapshotter
           image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
@@ -581,7 +588,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           securityContext:
             readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false 
+            allowPrivilegeEscalation: false
         {{ end }}
         - name: csi-resizer
           image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
@@ -597,7 +604,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           securityContext:
             readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false 
+            allowPrivilegeEscalation: false
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
           imagePullPolicy: IfNotPresent

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -77,13 +77,13 @@ data:
           ttl 30
         }
     {{- if GossipDomains }}
-        hosts /rootfs/etc/hosts {{ join GossipDomains " " }} {
+        hosts /rootfs/etc/hosts {{ join " " GossipDomains }} {
           ttl 30
           fallthrough
         }
     {{- end }}
         prometheus :9153
-        forward . {{ or (join KubeDNS.UpstreamNameservers " ") "/etc/resolv.conf" }} {
+        forward . {{ or (join " " KubeDNS.UpstreamNameservers) "/etc/resolv.conf" }} {
           max_concurrent 1000
         }
         cache 30

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -91,9 +91,6 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["replace"] = func(s, find, replace string) string {
 		return strings.Replace(s, find, replace, -1)
 	}
-	dest["join"] = func(a []string, sep string) string {
-		return strings.Join(a, sep)
-	}
 	dest["joinHostPort"] = net.JoinHostPort
 
 	sprigTxtFuncMap := sprig.TxtFuncMap()
@@ -103,6 +100,11 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["trimPrefix"] = sprigTxtFuncMap["trimPrefix"]
 	dest["semverCompare"] = sprigTxtFuncMap["semverCompare"]
 	dest["ternary"] = sprigTxtFuncMap["ternary"]
+	dest["dict"] = sprigTxtFuncMap["dict"]
+	dest["list"] = sprigTxtFuncMap["list"]
+	dest["set"] = sprigTxtFuncMap["set"]
+	dest["append"] = sprigTxtFuncMap["append"]
+	dest["join"] = sprigTxtFuncMap["join"]
 
 	dest["ClusterName"] = tf.ClusterName
 	dest["WithDefaultBool"] = func(v *bool, defaultValue bool) bool {


### PR DESCRIPTION
Adds `cloudConfig.awsEBSCSIDriver.extraVolumeTags` to add extra AWS tags to volumes provisioned by the EBS CSI Driver.

Changes the `join` template function to use the Sprig-defined function instead of `strings.Join` to get better type handling with the Sprig function. Updates other templates to fit the Sprig `join` expectations.

Testing:
`kops update cluster`:
```
Will modify resources:
  LaunchTemplate/master-us-west-2a.masters.bronson.cluster.doordash.cloud
        UserData
                                ...
                                      extraVolumeTags:
                                        testKey: testValue
                                +       testKey2: testValue2
                                      managed: true
                                      podAnnotations:
                                ...


  LaunchTemplate/nodes-us-west-2a.bronson.cluster.doordash.cloud
        UserData
                                ...
                                      extraVolumeTags:
                                        testKey: testValue
                                +       testKey2: testValue2
                                      managed: true
                                      podAnnotations:
                                ...


  LaunchTemplate/nodes-us-west-2b.bronson.cluster.doordash.cloud
        UserData
                                ...
                                      extraVolumeTags:
                                        testKey: testValue
                                +       testKey2: testValue2
                                      managed: true
                                      podAnnotations:
                                ...


  LaunchTemplate/nodes-us-west-2c.bronson.cluster.doordash.cloud
        UserData
                                ...
                                      extraVolumeTags:
                                        testKey: testValue
                                +       testKey2: testValue2
                                      managed: true
                                      podAnnotations:
                                ...


  ManagedFile/bronson.cluster.doordash.cloud-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17
        Contents
                                ...
                                          - --http-endpoint=0.0.0.0:3301
                                          - --v=5
                                +         - --extra-tags=testKey=testValue,testKey2=testValue2
                                -         - --extra-tags=testKey=testValue
                                          env:
                                          - name: CSI_ENDPOINT
                                ...


  ManagedFile/bronson.cluster.doordash.cloud-addons-bootstrap
        Contents
                                ...
                                    - id: k8s-1.17
                                      manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
                                +     manifestHash: f84f76f9db04b6d51d42922182b570343fccf1d83f7a0cf1a257b68626f6776e
                                -     manifestHash: f2af46d8a54c397193b9d970fbe2777d8cdf94913d04eea943880d7216d7b0ee
                                      name: aws-ebs-csi-driver.addons.k8s.io
                                      selector:
                                ...


  ManagedFile/cluster-completed.spec
        Contents
                                ...
                                  metadata:
                                    creationTimestamp: "2022-05-11T22:35:23Z"
                                +   generation: 15
                                -   generation: 14
                                    name: bronson.cluster.doordash.cloud
                                  spec:
                                ...
                                        extraVolumeTags:
                                          testKey: testValue
                                +         testKey2: testValue2
                                        managed: true
                                        podAnnotations:
                                ...
```

`kubectl describe pod`:
```
❯ kubectl get deploy -n kube-system ebs-csi-controller -ojson | jq '.spec.template.spec.containers[0].args'
[
  "controller",
  "--endpoint=$(CSI_ENDPOINT)",
  "--logtostderr",
  "--k8s-tag-cluster-id=bronson.cluster.doordash.cloud",
  "--extra-tags=KubernetesCluster=bronson.cluster.doordash.cloud",
  "--http-endpoint=0.0.0.0:3301",
  "--v=5",
  "--extra-tags=testKey=testValue,testKey2=testValue2"
]
```

Confirmed tags are on new PVs:
![image](https://user-images.githubusercontent.com/30124037/201762897-c2418d40-f2b4-48ac-ad9e-63441c7239fa.png)
