### PR TITLE
Automated cherry pick of #14551: Update Calico and Canal to latest versions

### DIFF
--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.25
     manifest: networking.projectcalico.org/k8s-1.25.yaml
-    manifestHash: dcbcb9669848fb613827e3097a58e1e6045eeff2794e0341bc6774e670a5d575
+    manifestHash: decc34a7f133bfc9bed78456047eccd399a67a4e17c49259e06f487a4b74092e
     name: networking.projectcalico.org
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.25_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.25_content
@@ -4576,7 +4576,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.24.3
+        image: docker.io/calico/node:v3.24.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4648,7 +4648,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.24.3
+        image: docker.io/calico/cni:v3.24.5
         imagePullPolicy: IfNotPresent
         name: upgrade-ipam
         securityContext:
@@ -4683,7 +4683,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.24.3
+        image: docker.io/calico/cni:v3.24.5
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -4697,7 +4697,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.24.3
+        image: docker.io/calico/node:v3.24.5
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:
@@ -4823,7 +4823,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.24.3
+        image: docker.io/calico/kube-controllers:v3.24.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.25
     manifest: networking.projectcalico.org/k8s-1.25.yaml
-    manifestHash: 7ef2b66912f04284088aaa77335cc83d3f038474353abc837b275a9dccae3fd7
+    manifestHash: 1852ad0416c94707c3939d43248c81a9f3d209c94f0e33808aeb1c7f87c0b56a
     name: networking.projectcalico.org
     prune:
       kinds:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.25_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.25_content
@@ -4571,7 +4571,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.24.3
+        image: docker.io/calico/node:v3.24.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4645,7 +4645,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.24.3
+        image: docker.io/calico/cni:v3.24.5
         imagePullPolicy: IfNotPresent
         name: upgrade-ipam
         securityContext:
@@ -4680,7 +4680,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.24.3
+        image: docker.io/calico/cni:v3.24.5
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -4694,7 +4694,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.24.3
+        image: docker.io/calico/node:v3.24.5
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:
@@ -4820,7 +4820,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.24.3
+        image: docker.io/calico/kube-controllers:v3.24.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.25
     manifest: networking.projectcalico.org.canal/k8s-1.25.yaml
-    manifestHash: 42436763ffc066240350fc2429b61ef5f0d8168036e87869675fdb4c1efb8780
+    manifestHash: 0de2c92594096a040369eb190d7090380deb470af2262716bdbad660da07d067
     name: networking.projectcalico.org.canal
     prune:
       kinds:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.25_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.25_content
@@ -4570,7 +4570,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.24.3
+        image: docker.io/calico/node:v3.24.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4688,7 +4688,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.24.3
+        image: docker.io/calico/cni:v3.24.5
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -4702,7 +4702,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.24.3
+        image: docker.io/calico/node:v3.24.5
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:
@@ -4828,7 +4828,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.24.3
+        image: docker.io/calico/kube-controllers:v3.24.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
@@ -4370,7 +4370,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.23.4
+      - image: calico/typha:v3.23.5
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -4480,7 +4480,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.23.4
+          image: docker.io/calico/cni:v3.23.5
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4528,7 +4528,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.23.4
+          image: docker.io/calico/node:v3.23.5
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
             - mountPath: /sys/fs
@@ -4553,7 +4553,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.23.4
+          image: docker.io/calico/node:v3.23.5
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4844,7 +4844,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.23.4
+          image: docker.io/calico/kube-controllers:v3.23.5
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.25.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.25.yaml.template
@@ -4454,7 +4454,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.24.3
+          image: docker.io/calico/cni:v3.24.5
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4503,7 +4503,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.24.3
+          image: docker.io/calico/node:v3.24.5
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4529,7 +4529,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.24.3
+          image: docker.io/calico/node:v3.24.5
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4814,7 +4814,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.24.3
+          image: docker.io/calico/kube-controllers:v3.24.5
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.
@@ -4891,7 +4891,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.24.3" }}
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.24.5" }}
         imagePullPolicy: IfNotPresent
         name: calico-typha
         ports:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.22.yaml.template
@@ -4371,7 +4371,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.23.4" }}
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.23.5" }}
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -4492,7 +4492,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.23.4" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.23.5" }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -4519,7 +4519,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.23.4" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.23.5" }}
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4561,7 +4561,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.23.4" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.23.5" }}
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
             - mountPath: /sys/fs
@@ -4589,7 +4589,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.23.4" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.23.5" }}
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4913,7 +4913,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.23.4" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.23.5" }}
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.25.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.25.yaml.template
@@ -4456,7 +4456,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.24.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.24.5" }}
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4484,7 +4484,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.24.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.24.5" }}
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4527,7 +4527,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.24.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.24.5" }}
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4553,7 +4553,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.24.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.24.5" }}
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4886,7 +4886,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.24.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.24.5" }}
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.
@@ -4963,7 +4963,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.24.3" }}
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.24.5" }}
         imagePullPolicy: IfNotPresent
         name: calico-typha
         ports:


### PR DESCRIPTION
Cherry pick of #14551 on release-1.25.

#14551: Update Calico to v3.24.5 for k8s 1.25+

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```