### PR TITLE
use sprig join for template functions

### DIFF
--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -77,13 +77,13 @@ data:
           ttl 30
         }
     {{- if GossipDomains }}
-        hosts /rootfs/etc/hosts {{ join GossipDomains " " }} {
+        hosts /rootfs/etc/hosts {{ join " " GossipDomains }} {
           ttl 30
           fallthrough
         }
     {{- end }}
         prometheus :9153
-        forward . {{ or (join KubeDNS.UpstreamNameservers " ") "/etc/resolv.conf" }} {
+        forward . {{ or (join " " KubeDNS.UpstreamNameservers) "/etc/resolv.conf" }} {
           max_concurrent 1000
         }
         cache 30

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -91,9 +91,6 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["replace"] = func(s, find, replace string) string {
 		return strings.Replace(s, find, replace, -1)
 	}
-	dest["join"] = func(a []string, sep string) string {
-		return strings.Join(a, sep)
-	}
 	dest["joinHostPort"] = net.JoinHostPort
 
 	sprigTxtFuncMap := sprig.TxtFuncMap()
@@ -103,6 +100,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["trimPrefix"] = sprigTxtFuncMap["trimPrefix"]
 	dest["semverCompare"] = sprigTxtFuncMap["semverCompare"]
 	dest["ternary"] = sprigTxtFuncMap["ternary"]
+	dest["join"] = sprigTxtFuncMap["join"]
 
 	dest["ClusterName"] = tf.ClusterName
 	dest["WithDefaultBool"] = func(v *bool, defaultValue bool) bool {


### PR DESCRIPTION
Switching template `join` function to Sprig's `join`, which can handle `[]interface{}` inputs instead of `[]string` only. This makes `join` easier to use in templates that define variables within the template itself.

Updates existing uses of `join` to fix the new function signature.

related to: https://github.com/kubernetes/kops/pull/14547