### PR TITLE
Automated cherry pick of #14573: Allow using the price-capacity-optimized spot allocation

### DIFF
--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -215,6 +215,8 @@ const (
 	SpotAllocationStrategyCapacityOptimized = "capacity-optimized"
 	// SpotAllocationStrategyCapacityOptimizedPrioritized indicates a capacity optimized prioritized strategy
 	SpotAllocationStrategyCapacityOptimizedPrioritized = "capacity-optimized-prioritized"
+	// SpotAllocationStrategyPriceCapacityOptimized indicates a price/capacity optimized strategy
+	SpotAllocationStrategyPriceCapacityOptimized = "price-capacity-optimized"
 )
 
 // SpotAllocationStrategies is a collection of supported strategies
@@ -223,6 +225,7 @@ var SpotAllocationStrategies = []string{
 	SpotAllocationStrategyDiversified,
 	SpotAllocationStrategyCapacityOptimized,
 	SpotAllocationStrategyCapacityOptimizedPrioritized,
+	SpotAllocationStrategyPriceCapacityOptimized,
 }
 
 // InstanceMetadataOptions defines the EC2 instance metadata service options (AWS Only)


### PR DESCRIPTION
Cherry pick of #14573 on release-1.25.

#14573: Allow using the price-capacity-optimized spot allocation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.