### PR TITLE
Automated cherry pick of #14563: Add missing create tags permissions for cilium operator in

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -1210,6 +1210,7 @@ func addCiliumEniPermissions(p *Policy) {
 		"ec2:DeleteNetworkInterface",
 		"ec2:ModifyNetworkInterfaceAttribute",
 		"ec2:DescribeVpcs",
+		"ec2:CreateTags",
 	)
 }
 


### PR DESCRIPTION
Cherry pick of #14563 on release-1.25.

#14563: Add missing create tags permissions for cilium operator in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```