### PR TITLE
Automated cherry pick of #14576: aws: Fix SIGSEGV when using instance selector

### DIFF
--- a/cmd/kops/toolbox_instance-selector.go
+++ b/cmd/kops/toolbox_instance-selector.go
@@ -271,9 +271,11 @@ func RunToolboxInstanceSelector(ctx context.Context, f commandutils.Factory, out
 		return fmt.Errorf("error initializing AWS client: %v", err)
 	}
 
-	instanceSelector := selector.Selector{
-		EC2: cloud.EC2(),
+	sess, err := cloud.Session()
+	if err != nil {
+		return err
 	}
+	instanceSelector := selector.New(sess)
 
 	igCount := options.InstanceGroupCount
 	filters := getFilters(commandline, region, zones)

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -386,4 +387,8 @@ func (c *MockAWSCloud) DescribeInstanceType(instanceType string) (*ec2.InstanceT
 // AccountInfo returns the AWS account ID and AWS partition that we are deploying into
 func (c *MockAWSCloud) AccountInfo() (string, string, error) {
 	return "123456789012", "aws-test", nil
+}
+
+func (c *MockAWSCloud) Session() (*session.Session, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Cherry pick of #14576 on release-1.25.

#14576: aws: Fix SIGSEGV when using instance selector

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```