### PR TITLE
support new spot `price-capacity-optimized` allocation strategy

### DIFF
--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -215,7 +215,7 @@ const (
 	SpotAllocationStrategyCapacityOptimized = "capacity-optimized"
 	// SpotAllocationStrategyCapacityOptimizedPrioritized indicates a capacity optimized prioritized strategy
 	SpotAllocationStrategyCapacityOptimizedPrioritized = "capacity-optimized-prioritized"
-	// SpotAllocationStrategyPriceCap indicates a price capacity optimized strategy
+	// SpotAllocationStrategyPriceCapacityOptimized indicates a price capacity optimized strategy
 	SpotAllocationStrategyPriceCapacityOptimized = "price-capacity-optimized"
 )
 

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -215,6 +215,8 @@ const (
 	SpotAllocationStrategyCapacityOptimized = "capacity-optimized"
 	// SpotAllocationStrategyCapacityOptimizedPrioritized indicates a capacity optimized prioritized strategy
 	SpotAllocationStrategyCapacityOptimizedPrioritized = "capacity-optimized-prioritized"
+	// SpotAllocationStrategyPriceCap indicates a price capacity optimized strategy
+	SpotAllocationStrategyPriceCapacityOptimized = "price-capacity-optimized"
 )
 
 // SpotAllocationStrategies is a collection of supported strategies
@@ -223,6 +225,7 @@ var SpotAllocationStrategies = []string{
 	SpotAllocationStrategyDiversified,
 	SpotAllocationStrategyCapacityOptimized,
 	SpotAllocationStrategyCapacityOptimizedPrioritized,
+	SpotAllocationStrategyPriceCapacityOptimized,
 }
 
 // InstanceMetadataOptions defines the EC2 instance metadata service options (AWS Only)


### PR DESCRIPTION
AWS released a new spot allocation strategy, `price-capacity-optimized`: https://aws.amazon.com/blogs/compute/introducing-price-capacity-optimized-allocation-strategy-for-ec2-spot-instances/

Updating valid `SpotAllocationStrategies` to include the same.