### PR TITLE
aws: Add capacityRebalance flag for ASGs

### DIFF
--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -261,6 +261,9 @@ Used only when the Spot allocation strategy is lowest-price.
 The number of Spot Instance pools across which to allocate your Spot Instances. The Spot pools are determined from the different instance types in the Overrides array of LaunchTemplate. Default if not set is 2.
 
 ### CapacityRebalance
+
+{{ kops_feature_table(kops_added_default='1.26') }}
+
 If using spot instances, it's recommended to enable CapacityRebalance in your InstanceGroup. This configures ASGs to proactively replace spot instances when ASG receives a rebalance recommendation.
 https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-capacity-rebalancing.html
 

--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -2,7 +2,7 @@
 
 The `InstanceGroup` resource represents a group of similar machines typically provisioned in the same availability zone. On AWS, instance groups map directly to an autoscaling group.
 
-The complete list of keys can be found at the [InstanceGroup](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#InstanceGroupSpec) reference page. 
+The complete list of keys can be found at the [InstanceGroup](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#InstanceGroupSpec) reference page.
 
 You can also find concrete use cases for the configurations on the [Instance Group operations page](instance_groups.md)
 
@@ -101,7 +101,7 @@ spec:
 
 ## additionalUserData
 
-kOps utilizes cloud-init to initialize and setup a host at boot time. However in certain cases you may already be leveraging certain features of cloud-init in your infrastructure and would like to continue doing so. More information on cloud-init can be found [here](http://cloudinit.readthedocs.io/en/latest/). 
+kOps utilizes cloud-init to initialize and setup a host at boot time. However in certain cases you may already be leveraging certain features of cloud-init in your infrastructure and would like to continue doing so. More information on cloud-init can be found [here](http://cloudinit.readthedocs.io/en/latest/).
 
 Additional user-data can be passed to the host provisioning by setting the `additionalUserData` field. A list of valid user-data content-types can be found [here](http://cloudinit.readthedocs.io/en/latest/topics/format.html#mime-multi-part-archive).
 
@@ -135,7 +135,7 @@ spec:
 ## compressUserData
 {{ kops_feature_table(kops_added_default='1.19') }}
 
-Compresses parts of the user-data to save space and help with the size limit 
+Compresses parts of the user-data to save space and help with the size limit
 in certain clouds. Currently only the Specs in nodeup.sh will be compressed.
 
 ```YAML
@@ -191,10 +191,10 @@ which would end up in a drop-in file on nodes of the instance group in question.
 
 ## mixedInstancesPolicy (AWS Only)
 
-A Mixed Instances Policy utilizing EC2 Spot and the `capacity-optimized` allocation strategy allows an EC2 Autoscaling Group to select the instance types with the highest capacity. This reduces the chance of a spot interruption on your instance group. 
+A Mixed Instances Policy utilizing EC2 Spot and the `capacity-optimized` allocation strategy allows an EC2 Autoscaling Group to select the instance types with the highest capacity. This reduces the chance of a spot interruption on your instance group.
 
-Instance groups with a mixedInstancesPolicy can be generated with the `kops toolbox instance-selector` command. 
-The instance-selector accepts user supplied resource parameters like vcpus, memory, and much more to dynamically select instance types that match your criteria. 
+Instance groups with a mixedInstancesPolicy can be generated with the `kops toolbox instance-selector` command.
+The instance-selector accepts user supplied resource parameters like vcpus, memory, and much more to dynamically select instance types that match your criteria.
 
 ```bash
 kops toolbox instance-selector --vcpus 4 --flexible --usage-class spot --instance-group-name spotgroup
@@ -259,6 +259,10 @@ https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstancesDistributi
 ### spotInstancePools
 Used only when the Spot allocation strategy is lowest-price.
 The number of Spot Instance pools across which to allocate your Spot Instances. The Spot pools are determined from the different instance types in the Overrides array of LaunchTemplate. Default if not set is 2.
+
+### CapacityRebalance
+If using spot instances, it's recommended to enable CapacityRebalance in your InstanceGroup. This configures ASGs to proactively replace spot instances when ASG receives a rebalance recommendation.
+https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-capacity-rebalancing.html
 
 ### instanceRequirements
 
@@ -326,7 +330,7 @@ spec:
 {{ kops_feature_table(kops_added_default='1.24') }}
 
 The maximum instance lifetime specifies the maximum amount of time (in go duration [format](https://pkg.go.dev/time#ParseDuration)) that an instance can be in service before it is terminated and replaced.
-A common use case might be a requirement to replace your instances on a schedule because of internal security policies or external compliance controls. 
+A common use case might be a requirement to replace your instances on a schedule because of internal security policies or external compliance controls.
 In other words, this feature helps you to put a bit of ephemerality in your cluster.
 You must specify a value of at least 24h (86,400 seconds). To clear a previously set value, specify a new value of 0.
 

--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -20,6 +20,8 @@ This is a document to gather the release notes prior to the release.
 
 * New IPv6 clusters now default to using private topology.
 
+* CapacityRebalance can be enabled/disabled on ASGs through a new `capacityRebalance` field in InstanceGroup specs.
+
 # Breaking changes
 
 ## Other breaking changes

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -92,8 +92,9 @@ spec:
                   this instance group if cluster autoscaler is enabled
                 type: boolean
               capacityRebalance:
-                description: CapacityRebalance configures capacity rebalancing for
-                  an AWS ASG (AWS Only)
+                description: CapacityRebalance makes ASGs proactively replace spot
+                  instances when the ASG receives a rebalance recommendation (AWS
+                  Only).
                 type: boolean
               cloudLabels:
                 additionalProperties:

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -91,6 +91,10 @@ spec:
                 description: Autoscale determines if autoscaling will be enabled for
                   this instance group if cluster autoscaler is enabled
                 type: boolean
+              capacityRebalance:
+                description: CapacityRebalance configures capacity rebalancing for
+                  an AWS ASG (AWS Only)
+                type: boolean
               cloudLabels:
                 additionalProperties:
                   type: string

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -155,6 +155,8 @@ type InstanceGroupSpec struct {
 	Taints []string `json:"taints,omitempty"`
 	// MixedInstancesPolicy defined a optional backing of an AWS ASG by a EC2 Fleet (AWS Only)
 	MixedInstancesPolicy *MixedInstancesPolicySpec `json:"mixedInstancesPolicy,omitempty"`
+	// CapacityRebalance configures capacity rebalancing for an AWS ASG (AWS Only)
+	CapacityRebalance *bool `json:"capacityRebalance,omitempty"`
 	// AdditionalUserData is any additional user-data to be passed to the host
 	AdditionalUserData []UserData `json:"additionalUserData,omitempty"`
 	// SuspendProcesses disables the listed Scaling Policies

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -155,7 +155,7 @@ type InstanceGroupSpec struct {
 	Taints []string `json:"taints,omitempty"`
 	// MixedInstancesPolicy defined a optional backing of an AWS ASG by a EC2 Fleet (AWS Only)
 	MixedInstancesPolicy *MixedInstancesPolicySpec `json:"mixedInstancesPolicy,omitempty"`
-	// CapacityRebalance configures capacity rebalancing for an AWS ASG (AWS Only)
+	// CapacityRebalance makes ASGs proactively replace spot instances when the ASG receives a rebalance recommendation (AWS Only).
 	CapacityRebalance *bool `json:"capacityRebalance,omitempty"`
 	// AdditionalUserData is any additional user-data to be passed to the host
 	AdditionalUserData []UserData `json:"additionalUserData,omitempty"`

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -121,7 +121,7 @@ type InstanceGroupSpec struct {
 	Taints []string `json:"taints,omitempty"`
 	// MixedInstancesPolicy defined a optional backing of an AWS ASG by a EC2 Fleet (AWS Only)
 	MixedInstancesPolicy *MixedInstancesPolicySpec `json:"mixedInstancesPolicy,omitempty"`
-	// CapacityRebalance configures capacity rebalancing for an AWS ASG (AWS Only)
+	// CapacityRebalance makes ASGs proactively replace spot instances when the ASG receives a rebalance recommendation (AWS Only).
 	CapacityRebalance *bool `json:"capacityRebalance,omitempty"`
 	// AdditionalUserData is any additional user-data to be passed to the host
 	AdditionalUserData []UserData `json:"additionalUserData,omitempty"`

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -121,6 +121,8 @@ type InstanceGroupSpec struct {
 	Taints []string `json:"taints,omitempty"`
 	// MixedInstancesPolicy defined a optional backing of an AWS ASG by a EC2 Fleet (AWS Only)
 	MixedInstancesPolicy *MixedInstancesPolicySpec `json:"mixedInstancesPolicy,omitempty"`
+	// CapacityRebalance configures capacity rebalancing for an AWS ASG (AWS Only)
+	CapacityRebalance *bool `json:"capacityRebalance,omitempty"`
 	// AdditionalUserData is any additional user-data to be passed to the host
 	AdditionalUserData []UserData `json:"additionalUserData,omitempty"`
 	// SuspendProcesses disables the listed Scaling Policies

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4414,6 +4414,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	} else {
 		out.MixedInstancesPolicy = nil
 	}
+	out.CapacityRebalance = in.CapacityRebalance
 	if in.AdditionalUserData != nil {
 		in, out := &in.AdditionalUserData, &out.AdditionalUserData
 		*out = make([]kops.UserData, len(*in))
@@ -4599,6 +4600,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	} else {
 		out.MixedInstancesPolicy = nil
 	}
+	out.CapacityRebalance = in.CapacityRebalance
 	if in.AdditionalUserData != nil {
 		in, out := &in.AdditionalUserData, &out.AdditionalUserData
 		*out = make([]UserData, len(*in))

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2524,6 +2524,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(MixedInstancesPolicySpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CapacityRebalance != nil {
+		in, out := &in.CapacityRebalance, &out.CapacityRebalance
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AdditionalUserData != nil {
 		in, out := &in.AdditionalUserData, &out.AdditionalUserData
 		*out = make([]UserData, len(*in))

--- a/pkg/apis/kops/v1alpha3/instancegroup.go
+++ b/pkg/apis/kops/v1alpha3/instancegroup.go
@@ -118,6 +118,8 @@ type InstanceGroupSpec struct {
 	Taints []string `json:"taints,omitempty"`
 	// MixedInstancesPolicy defined a optional backing of an AWS ASG by a EC2 Fleet (AWS Only)
 	MixedInstancesPolicy *MixedInstancesPolicySpec `json:"mixedInstancesPolicy,omitempty"`
+	// CapacityRebalance configures capacity rebalancing for an AWS ASG (AWS Only)
+	CapacityRebalance *bool `json:"capacityRebalance,omitempty"`
 	// AdditionalUserData is any additional user-data to be passed to the host
 	AdditionalUserData []UserData `json:"additionalUserData,omitempty"`
 	// SuspendProcesses disables the listed Scaling Policies

--- a/pkg/apis/kops/v1alpha3/instancegroup.go
+++ b/pkg/apis/kops/v1alpha3/instancegroup.go
@@ -118,7 +118,7 @@ type InstanceGroupSpec struct {
 	Taints []string `json:"taints,omitempty"`
 	// MixedInstancesPolicy defined a optional backing of an AWS ASG by a EC2 Fleet (AWS Only)
 	MixedInstancesPolicy *MixedInstancesPolicySpec `json:"mixedInstancesPolicy,omitempty"`
-	// CapacityRebalance configures capacity rebalancing for an AWS ASG (AWS Only)
+	// CapacityRebalance makes ASGs proactively replace spot instances when the ASG receives a rebalance recommendation (AWS Only).
 	CapacityRebalance *bool `json:"capacityRebalance,omitempty"`
 	// AdditionalUserData is any additional user-data to be passed to the host
 	AdditionalUserData []UserData `json:"additionalUserData,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -4575,6 +4575,7 @@ func autoConvert_v1alpha3_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	} else {
 		out.MixedInstancesPolicy = nil
 	}
+	out.CapacityRebalance = in.CapacityRebalance
 	if in.AdditionalUserData != nil {
 		in, out := &in.AdditionalUserData, &out.AdditionalUserData
 		*out = make([]kops.UserData, len(*in))
@@ -4760,6 +4761,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha3_InstanceGroupSpec(in *kops.I
 	} else {
 		out.MixedInstancesPolicy = nil
 	}
+	out.CapacityRebalance = in.CapacityRebalance
 	if in.AdditionalUserData != nil {
 		in, out := &in.AdditionalUserData, &out.AdditionalUserData
 		*out = make([]UserData, len(*in))

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -2494,6 +2494,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(MixedInstancesPolicySpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CapacityRebalance != nil {
+		in, out := &in.CapacityRebalance, &out.CapacityRebalance
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AdditionalUserData != nil {
 		in, out := &in.AdditionalUserData, &out.AdditionalUserData
 		*out = make([]UserData, len(*in))

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2657,6 +2657,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(MixedInstancesPolicySpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CapacityRebalance != nil {
+		in, out := &in.CapacityRebalance, &out.CapacityRebalance
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AdditionalUserData != nil {
 		in, out := &in.AdditionalUserData, &out.AdditionalUserData
 		*out = make([]UserData, len(*in))

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -440,6 +440,10 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 		t.InstanceProtection = ig.Spec.InstanceProtection
 	}
 
+	if ig.Spec.CapacityRebalance != nil {
+		t.CapacityRebalance = ig.Spec.CapacityRebalance
+	}
+
 	t.LoadBalancers = []*awstasks.ClassicLoadBalancer{}
 	t.TargetGroups = []*awstasks.TargetGroup{}
 

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -920,6 +920,7 @@ type terraformAutoscalingGroup struct {
 	LoadBalancers           []*terraformWriter.Literal                       `cty:"load_balancers"`
 	TargetGroupARNs         []*terraformWriter.Literal                       `cty:"target_group_arns"`
 	MaxInstanceLifetime     *int64                                           `cty:"max_instance_lifetime"`
+	CapacityRebalance       *bool                                            `cty:"capacity_rebalance"`
 }
 
 // RenderTerraform is responsible for rendering the terraform codebase
@@ -932,6 +933,7 @@ func (_ *AutoscalingGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, c
 		EnabledMetrics:      aws.StringSlice(e.Metrics),
 		InstanceProtection:  e.InstanceProtection,
 		MaxInstanceLifetime: e.MaxInstanceLifetime,
+		CapacityRebalance:   e.CapacityRebalance,
 	}
 
 	for _, s := range e.Subnets {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -90,6 +90,8 @@ type AutoscalingGroup struct {
 	Tags map[string]string
 	// TargetGroups is a list of ALB/NLB target group ARNs to add to the autoscaling group
 	TargetGroups []*TargetGroup
+	// CapacityRebalance makes ASG proactively replace spot instances when ASG receives a rebalance recommendation
+	CapacityRebalance *bool
 }
 
 var _ fi.CompareWithID = &AutoscalingGroup{}
@@ -348,6 +350,7 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 			NewInstancesProtectedFromScaleIn: e.InstanceProtection,
 			Tags:                             v.AutoscalingGroupTags(),
 			VPCZoneIdentifier:                fi.PtrTo(strings.Join(e.AutoscalingGroupSubnets(), ",")),
+			CapacityRebalance:                e.CapacityRebalance,
 		}
 
 		//On ASG creation 0 value is forbidden
@@ -639,6 +642,11 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 		if changes.InstanceProtection != nil {
 			request.NewInstancesProtectedFromScaleIn = e.InstanceProtection
 			changes.InstanceProtection = nil
+		}
+
+		if changes.CapacityRebalance != nil {
+			request.CapacityRebalance = e.CapacityRebalance
+			changes.CapacityRebalance = nil
 		}
 
 		empty := &AutoscalingGroup{}


### PR DESCRIPTION
Exposes a new `CapacityRebalance` flag which enables/disables ASG capacity rebalancing: https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-capacity-rebalancing.html

This is very helpful for users who have spot instanceGroups and want to proactively have ASG replace instances that have received a rebalance recommendation (meaning they're at elevated risk of interruption by AWS).