### PR TITLE
Automated cherry pick of #14586: Bump cilium to 1.11.11

### DIFF
--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.11.8"
+		c.Version = "v1.11.11"
 	}
 
 	if c.EnableEndpointHealthChecking == nil {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -223,7 +223,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.11.8
+      version: v1.11.11
   nonMasqueradeCIDR: ::/0
   secretStore: memfs://clusters.example.com/minimal-ipv6.example.com/secrets
   serviceClusterIPRange: fd00:5e4f:ce::/108

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 885eef8af3ca9960806352dc7d904fec987750df68325dc6f55bfc157248e352
+    manifestHash: 3caef18f09da33c5404bb35ec52dc684d983410a0d08aad129355d1921598fc3
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -366,7 +366,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.8
+        image: quay.io/cilium/cilium:v1.11.11
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -424,6 +424,7 @@ spec:
             scheme: HTTP
           periodSeconds: 2
           successThreshold: null
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
@@ -462,7 +463,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.8
+        image: quay.io/cilium/cilium:v1.11.11
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -473,6 +474,7 @@ spec:
             memory: 100Mi
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -598,7 +600,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.8
+        image: quay.io/cilium/operator:v1.11.11
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -614,6 +616,7 @@ spec:
           requests:
             cpu: 25m
             memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -166,7 +166,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-warmpool.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: KBUetKApv4MyDXF/ofNogmU3zvOvd5s7es2L2d+m1m4=
+NodeupConfigHash: woWcouAKFe/MiFErkB5K0jaLxR96AZ12DKSUbiDYAOQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -206,7 +206,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.11.8
+      version: v1.11.11
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/minimal-warmpool.example.com/secrets

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 6e64c69e829725c3a7392cdced0ea1517047848fa966a4a30cb0bc71ba1ace34
+    manifestHash: 925bfdc2b33c36273d5c2b1589b801bcf8d1d2b789ff5bd2bd80a840e278795a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -366,7 +366,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.8
+        image: quay.io/cilium/cilium:v1.11.11
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -424,6 +424,7 @@ spec:
             scheme: HTTP
           periodSeconds: 2
           successThreshold: null
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
@@ -462,7 +463,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.8
+        image: quay.io/cilium/cilium:v1.11.11
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -473,6 +474,7 @@ spec:
             memory: 100Mi
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -598,7 +600,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.8
+        image: quay.io/cilium/operator:v1.11.11
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -614,6 +616,7 @@ spec:
           requests:
             cpu: 25m
             memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
@@ -67,8 +67,8 @@ containerdConfig:
   logLevel: info
   version: 1.4.13
 warmPoolImages:
-- quay.io/cilium/cilium:v1.11.8
-- quay.io/cilium/operator:v1.11.8
+- quay.io/cilium/cilium:v1.11.11
+- quay.io/cilium/operator:v1.11.11
 - registry.k8s.io/kube-proxy:v1.21.0
 - registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.12.0
 - registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -196,7 +196,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.11.8
+      version: v1.11.11
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/privatecilium.example.com/secrets

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: b3dc5c75dba840f3a254ea92e2625a15b7eb5a1620c3cdc7a2388171a4f5dbd3
+    manifestHash: b8e6ace39f88ef81ca852eb08adc0f0fa294449c3387849a5a8b5808ad08207b
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -370,7 +370,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.8
+        image: quay.io/cilium/cilium:v1.11.11
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -428,6 +428,7 @@ spec:
             scheme: HTTP
           periodSeconds: 2
           successThreshold: null
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
@@ -466,7 +467,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.8
+        image: quay.io/cilium/cilium:v1.11.11
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -477,6 +478,7 @@ spec:
             memory: 100Mi
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -602,7 +604,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.8
+        image: quay.io/cilium/operator:v1.11.11
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -618,6 +620,7 @@ spec:
           requests:
             cpu: 25m
             memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -221,7 +221,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.11.8
+      version: v1.11.11
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/privatecilium.example.com/secrets

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: b3acce4adc999d84807deebdc166709c2df1879e69c944b09fd63f18ba8acd2d
+    manifestHash: e2e5c9b1c0641e661bedfa24749597167be409d1e13e4511c62b68af88f09dc5
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -477,7 +477,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.8
+        image: quay.io/cilium/cilium:v1.11.11
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -535,6 +535,7 @@ spec:
             scheme: HTTP
           periodSeconds: 2
           successThreshold: null
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
@@ -576,7 +577,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.8
+        image: quay.io/cilium/cilium:v1.11.11
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -587,6 +588,7 @@ spec:
             memory: 100Mi
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -716,7 +718,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.8
+        image: quay.io/cilium/operator:v1.11.11
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -732,6 +734,7 @@ spec:
           requests:
             cpu: 25m
             memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
@@ -803,7 +806,7 @@ spec:
         env:
         - name: GODEBUG
           value: x509ignoreCN=0
-        image: quay.io/cilium/hubble-relay:v1.11.8
+        image: quay.io/cilium/hubble-relay:v1.11.11
         imagePullPolicy: IfNotPresent
         livenessProbe:
           tcpSocket:
@@ -815,6 +818,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: grpc
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/cilium
           name: hubble-sock-dir

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -202,7 +202,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.11.8
+      version: v1.11.11
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/privateciliumadvanced.example.com/secrets

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 7599559ab676fd5770f5fc352c0e8826c25487fc6d30e4747766eae256494fb8
+    manifestHash: e4a99245537437ec9596da5feea66740b45d873c840ae3b7dc917884cda582eb
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -380,7 +380,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.8
+        image: quay.io/cilium/cilium:v1.11.11
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -438,6 +438,7 @@ spec:
             scheme: HTTP
           periodSeconds: 2
           successThreshold: null
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
@@ -482,7 +483,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.8
+        image: quay.io/cilium/cilium:v1.11.11
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -493,6 +494,7 @@ spec:
             memory: 100Mi
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -629,7 +631,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.8
+        image: quay.io/cilium/operator:v1.11.11
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -645,6 +647,7 @@ spec:
           requests:
             cpu: 25m
             memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.11.yaml.template
@@ -715,7 +715,7 @@ spec:
           protocol: TCP
         {{- end }}
         {{ end }}
-
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           privileged: true
         volumeMounts:
@@ -787,6 +787,7 @@ spec:
         image: "quay.io/cilium/cilium:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           privileged: true
         volumeMounts:
@@ -973,6 +974,7 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
@@ -1074,6 +1076,7 @@ spec:
           livenessProbe:
             tcpSocket:
               port: grpc
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
           - mountPath: /var/run/cilium
             name: hubble-sock-dir

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 0e32186e63e0a1df3398bacd6c6ee5827e6738cb5b20558331b8f9c4e0859d68
+    manifestHash: 678572068ce63e2afc9fafd712bdef61d715f2fec45f04a2c2de875271dd6e6d
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 0e32186e63e0a1df3398bacd6c6ee5827e6738cb5b20558331b8f9c4e0859d68
+    manifestHash: 678572068ce63e2afc9fafd712bdef61d715f2fec45f04a2c2de875271dd6e6d
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 0e32186e63e0a1df3398bacd6c6ee5827e6738cb5b20558331b8f9c4e0859d68
+    manifestHash: 678572068ce63e2afc9fafd712bdef61d715f2fec45f04a2c2de875271dd6e6d
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #14586 on release-1.25.

#14586: Bump cilium to 1.11.11

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```