### PR TITLE
Fix disabling StorageClass management

### DIFF
--- a/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml.template
@@ -1,4 +1,3 @@
-{{ if WithDefaultBool .CloudConfig.ManageStorageClasses true }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -98,5 +97,3 @@ subjects:
 - kind: ServiceAccount
   name: aws-cloud-provider
   namespace: kube-system
-
-{{ end }}

--- a/upup/models/cloudup/resources/addons/storage-gce.addons.k8s.io/v1.7.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-gce.addons.k8s.io/v1.7.0.yaml.template
@@ -1,4 +1,3 @@
-{{ if WithDefaultBool .CloudConfig.ManageStorageClasses true }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -14,4 +13,3 @@ metadata:
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-standard
-{{ end }}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -722,20 +722,23 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*Addon
 		}
 	}
 
-	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderAWS {
-		key := "storage-aws.addons.k8s.io"
+	if fi.BoolValue(b.Cluster.Spec.CloudConfig.ManageStorageClasses) {
+		if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderAWS {
+			key := "storage-aws.addons.k8s.io"
 
-		{
-			id := "v1.15.0"
-			location := key + "/" + id + ".yaml"
+			{
+				id := "v1.15.0"
+				location := key + "/" + id + ".yaml"
 
-			addons.Add(&channelsapi.AddonSpec{
-				Name:     fi.String(key),
-				Selector: map[string]string{"k8s-addon": key},
-				Manifest: fi.String(location),
-				Id:       id,
-			})
+				addons.Add(&channelsapi.AddonSpec{
+					Name:     fi.String(key),
+					Selector: map[string]string{"k8s-addon": key},
+					Manifest: fi.String(location),
+					Id:       id,
+				})
+			}
 		}
+
 	}
 
 	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderDO {
@@ -796,20 +799,21 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*Addon
 	}
 
 	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderGCE {
-		key := "storage-gce.addons.k8s.io"
+		if fi.BoolValue(b.Cluster.Spec.CloudConfig.ManageStorageClasses) {
+			key := "storage-gce.addons.k8s.io"
 
-		{
-			id := "v1.7.0"
-			location := key + "/" + id + ".yaml"
+			{
+				id := "v1.7.0"
+				location := key + "/" + id + ".yaml"
 
-			addons.Add(&channelsapi.AddonSpec{
-				Name:     fi.String(key),
-				Selector: map[string]string{"k8s-addon": key},
-				Manifest: fi.String(location),
-				Id:       id,
-			})
+				addons.Add(&channelsapi.AddonSpec{
+					Name:     fi.String(key),
+					Selector: map[string]string{"k8s-addon": key},
+					Manifest: fi.String(location),
+					Id:       id,
+				})
+			}
 		}
-
 		if b.Cluster.Spec.CloudConfig != nil && b.Cluster.Spec.CloudConfig.GCPPDCSIDriver != nil && fi.BoolValue(b.Cluster.Spec.CloudConfig.GCPPDCSIDriver.Enabled) {
 			key := "gcp-pd-csi-driver.addons.k8s.io"
 			{


### PR DESCRIPTION
Previously this was done in the manifests leading to empty files. kubectl doesn't like this, so protokube will always fail updating the addon when StorageClass management is disabled.

/kind bug