### PR TITLE
skip Loadbalancer UDP tests

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -45,6 +45,13 @@ func (t *Tester) setSkipRegexFlag() error {
 
 	skipRegex := skipRegexBase
 
+	// All the loadbalancer tests in the suite fail on IPv6, however,
+	// they were skipped because they were tagged as [Slow]
+	// skip these tests temporary since they fail always on IPv6
+	// TODO: aojea
+	// https://github.com/kubernetes/kubernetes/issues/113964
+	skipRegex += "|LoadBalancers.should.be.able.to.preserve.UDP.traffic"
+
 	networking := cluster.Spec.Networking
 	switch {
 	case networking.Kubenet != nil, networking.Canal != nil, networking.Weave != nil, networking.Cilium != nil:


### PR DESCRIPTION
All the loadbalancer tests in the kubernetes e2e suite fail on IPv6, however, they were skipped until now because they were tagged as [Slow]. Antonio messed it up adding a new loadbalancer test without  the Slow tag and now it fails trying to run on IPv6.
Skip these tests temporary since they fail always on IPv6