### PR TITLE
Automated cherry pick of #14595: Add generics alternatives for fi.Bool/Float*/Int*/String*()

### DIFF
--- a/upup/pkg/fi/values.go
+++ b/upup/pkg/fi/values.go
@@ -23,6 +23,19 @@ import (
 	"strconv"
 )
 
+// PtrTo returns a pointer to a copy of any value.
+func PtrTo[T any](v T) *T {
+	return &v
+}
+
+// ValueOf returns the value of a pointer or its zero value
+func ValueOf[T any](v *T) T {
+	if v == nil {
+		return *new(T)
+	}
+	return *v
+}
+
 func StringValue(s *string) string {
 	if s == nil {
 		return ""


### PR DESCRIPTION
Cherry pick of #14595 on release-1.24.

#14595: Add generics alternatives for fi.Bool/Float*/Int*/String*()

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```