### PR TITLE
Karpenter: Template improvement

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1451,6 +1451,9 @@ spec:
                 properties:
                   enabled:
                     type: boolean
+                  version:
+                    description: Version is the version of karpenter to run.
+                    type: string
                 type: object
               keyStore:
                 description: KeyStore is the VFS path to where SSL keys and certificates

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -266,6 +266,8 @@ type ScalewaySpec struct {
 
 type KarpenterConfig struct {
 	Enabled bool `json:"enabled,omitempty"`
+	// Version is the version of karpenter to run.
+	Version string `json:"version,omitempty"`
 }
 
 // ServiceAccountIssuerDiscoveryConfig configures an OIDC Issuer.

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -235,7 +235,7 @@ type PodIdentityWebhookConfig struct {
 type KarpenterConfig struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// Version is the version of karpenter to run.
-	Version               string           `json:"version,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 // ServiceAccountIssuerDiscoveryConfig configures an OIDC Issuer.

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -234,6 +234,8 @@ type PodIdentityWebhookConfig struct {
 
 type KarpenterConfig struct {
 	Enabled bool `json:"enabled,omitempty"`
+	// Version is the version of karpenter to run.
+	Version               string           `json:"version,omitempty"`
 }
 
 // ServiceAccountIssuerDiscoveryConfig configures an OIDC Issuer.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4782,6 +4782,7 @@ func Convert_kops_InstanceRequirementsSpec_To_v1alpha2_InstanceRequirementsSpec(
 
 func autoConvert_v1alpha2_KarpenterConfig_To_kops_KarpenterConfig(in *KarpenterConfig, out *kops.KarpenterConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Version = in.Version
 	return nil
 }
 
@@ -4792,6 +4793,7 @@ func Convert_v1alpha2_KarpenterConfig_To_kops_KarpenterConfig(in *KarpenterConfi
 
 func autoConvert_kops_KarpenterConfig_To_v1alpha2_KarpenterConfig(in *kops.KarpenterConfig, out *KarpenterConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Version = in.Version
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -264,7 +264,7 @@ type ScalewaySpec struct {
 type KarpenterConfig struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// Version is the version of karpenter to run.
-	Version               string           `json:"version,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 // ServiceAccountIssuerDiscoveryConfig configures an OIDC Issuer.

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -263,6 +263,8 @@ type ScalewaySpec struct {
 
 type KarpenterConfig struct {
 	Enabled bool `json:"enabled,omitempty"`
+	// Version is the version of karpenter to run.
+	Version               string           `json:"version,omitempty"`
 }
 
 // ServiceAccountIssuerDiscoveryConfig configures an OIDC Issuer.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -4947,6 +4947,7 @@ func Convert_kops_InstanceRequirementsSpec_To_v1alpha3_InstanceRequirementsSpec(
 
 func autoConvert_v1alpha3_KarpenterConfig_To_kops_KarpenterConfig(in *KarpenterConfig, out *kops.KarpenterConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Version = in.Version
 	return nil
 }
 
@@ -4957,6 +4958,7 @@ func Convert_v1alpha3_KarpenterConfig_To_kops_KarpenterConfig(in *KarpenterConfi
 
 func autoConvert_kops_KarpenterConfig_To_v1alpha3_KarpenterConfig(in *kops.KarpenterConfig, out *KarpenterConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Version = in.Version
 	return nil
 }
 

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: b6cd8f0b7dcdf48fc658eb95d9948900665562de99e317c565fdfbfbdc4481bb
+    manifestHash: e66f31edcb3b66e7fc92336eef98d72e6979feaa68ec02fa329822b95acb4340
     name: karpenter.sh
     selector:
       k8s-addon: karpenter.sh

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -1444,6 +1444,23 @@ spec:
 
 ---
 
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: karpenter.sh
+  name: karpenter-nodes-default
+spec:
+  launchTemplate: karpenter-nodes-default.minimal.example.com
+  subnetSelector:
+    kops.k8s.io/instance-group/karpenter-nodes-default: '*'
+    kubernetes.io/cluster/minimal.example.com: '*'
+
+---
+
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
@@ -1464,11 +1481,8 @@ spec:
     systemReserved:
       cpu: 500m
       memory: 1G
-  provider:
-    launchTemplate: karpenter-nodes-default.minimal.example.com
-    subnetSelector:
-      kops.k8s.io/instance-group/karpenter-nodes-default: '*'
-      kubernetes.io/cluster/minimal.example.com: '*'
+  providerRef:
+    name: karpenter-nodes-default
   requirements:
   - key: karpenter.sh/capacity-type
     operator: In
@@ -1489,6 +1503,23 @@ spec:
 
 ---
 
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: karpenter.sh
+  name: karpenter-nodes-single-machinetype
+spec:
+  launchTemplate: karpenter-nodes-single-machinetype.minimal.example.com
+  subnetSelector:
+    kops.k8s.io/instance-group/karpenter-nodes-single-machinetype: '*'
+    kubernetes.io/cluster/minimal.example.com: '*'
+
+---
+
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
@@ -1501,11 +1532,8 @@ metadata:
 spec:
   consolidation:
     enabled: true
-  provider:
-    launchTemplate: karpenter-nodes-single-machinetype.minimal.example.com
-    subnetSelector:
-      kops.k8s.io/instance-group/karpenter-nodes-single-machinetype: '*'
-      kubernetes.io/cluster/minimal.example.com: '*'
+  providerRef:
+    name: karpenter-nodes-single-machinetype
   requirements:
   - key: karpenter.sh/capacity-type
     operator: In

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -1261,4 +1261,3 @@ spec:
     name: {{ $name }}
 {{ end }}
 {{ end }}
-{{ end }}

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -1185,6 +1185,16 @@ spec:
 {{ range $name, $spec := GetNodeInstanceGroups }}
 {{ if eq $spec.Manager "Karpenter" }}
 ---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: {{ $name }}
+spec:
+  subnetSelector:
+    kops.k8s.io/instance-group/{{ $name }}: "*"
+    kubernetes.io/cluster/{{ ClusterName }}: "*"
+  launchTemplate: {{ $name }}.{{ ClusterName }}
+---
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
@@ -1247,10 +1257,8 @@ spec:
     {{ $key }}: "{{ $value }}"
   {{ end }}
 {{ end }}
-  provider:
-    launchTemplate: {{ $name }}.{{ ClusterName }}
-    subnetSelector:
-      kops.k8s.io/instance-group/{{ $name }}: "*"
-      kubernetes.io/cluster/{{ ClusterName }}: "*"
+  providerRef:
+    name: {{ $name }}
+{{ end }}
 {{ end }}
 {{ end }}

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -874,7 +874,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: controller
-          image: public.ecr.aws/karpenter/controller:v0.16.3
+          image: public.ecr.aws/karpenter/controller:{{ or .Karpenter.Version "v0.16.3" }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -985,7 +985,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: webhook
-          image: public.ecr.aws/karpenter/webhook:v0.16.3
+          image: public.ecr.aws/karpenter/webhook:{{ or .Karpenter.Version "v0.16.3" }}
           imagePullPolicy: IfNotPresent
           args:
             - -port=8443


### PR DESCRIPTION
## [KARPENTER: Add possibility to set a tune image version](https://github.com/kubernetes/kops/commit/b090c164d04b14c38fe206cada7ebeb382ccdec0) 

Add the possibility into `Karpenter` to set a different image tag version.
It can help to have the last fixes if it's needed.

## [KARPENTER: Use AWSNodeTemplate for launchTemplate](https://github.com/kubernetes/kops/commit/e1e341f83fa73e1882716f8b7dcb21663b0aac03) 

To set Launch Templates is deprecated into the provisioner, it is recommended to use the `AWSNodeTemplate` to set it.
Ref:
 - https://karpenter.sh/v0.17.0/aws/launch-templates/