### PR TITLE
Bump karpenter to 0.19.x

### DIFF
--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,8 +69,58 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: b6cd8f0b7dcdf48fc658eb95d9948900665562de99e317c565fdfbfbdc4481bb
+    manifestHash: 48698a907d19d00706c7a400395ed771d1cabfd921288184975cb47d7d2a2fff
     name: karpenter.sh
+    prune:
+      kinds:
+      - kind: ConfigMap
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
+      - kind: Service
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
+      - kind: ServiceAccount
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: apps
+        kind: DaemonSet
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: apps
+        kind: Deployment
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
+      - group: apps
+        kind: StatefulSet
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: policy
+        kind: PodDisruptionBudget
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: rbac.authorization.k8s.io
+        kind: ClusterRole
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: rbac.authorization.k8s.io
+        kind: ClusterRoleBinding
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: rbac.authorization.k8s.io
+        kind: Role
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
+      - group: rbac.authorization.k8s.io
+        kind: RoleBinding
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
     selector:
       k8s-addon: karpenter.sh
     version: 9.99.0

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -590,23 +590,12 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
   name: karpenter
-  namespace: kube-system
-
----
-
-apiVersion: v1
-data: {}
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: karpenter.sh
-    app.kubernetes.io/managed-by: kops
-    k8s-addon: karpenter.sh
-  name: karpenter-webhook-cert
   namespace: kube-system
 
 ---
@@ -654,6 +643,15 @@ metadata:
 
 apiVersion: v1
 data:
+  aws.clusterEndpoint: https://api.internal.minimal.example.com
+  aws.clusterName: minimal.example.com
+  aws.defaultInstanceProfile: ""
+  aws.enableENILimitedPodDensity: "true"
+  aws.enablePodENI: "false"
+  aws.interruptionQueueName: ""
+  aws.isolatedVPC: "false"
+  aws.nodeNameConvention: resource-name
+  aws.vmMemoryOverheadPercent: "0.075"
   batchIdleDuration: 1s
   batchMaxDuration: 10s
 kind: ConfigMap
@@ -661,8 +659,10 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/part-of: karpenter
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
   name: karpenter-global-settings
   namespace: kube-system
@@ -675,9 +675,52 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
-  name: karpenter-controller
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: karpenter-admin
+rules:
+- apiGroups:
+  - karpenter.sh
+  resources:
+  - provisioners
+  - provisioners/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups:
+  - karpenter.k8s.aws
+  resources:
+  - awsnodetemplates
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
+    k8s-addon: karpenter.sh
+  name: karpenter-core
 rules:
 - apiGroups:
   - karpenter.sh
@@ -689,22 +732,14 @@ rules:
   - list
   - watch
 - apiGroups:
-  - karpenter.k8s.aws
-  resources:
-  - awsnodetemplates
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - pods
   - nodes
-  - namespaces
   - persistentvolumes
   - persistentvolumeclaims
   - replicationcontrollers
+  - namespaces
   verbs:
   - get
   - list
@@ -728,6 +763,15 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - watch
+  - list
 - apiGroups:
   - policy
   resources:
@@ -765,6 +809,23 @@ rules:
   - pods/eviction
   verbs:
   - create
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - validation.webhook.karpenter.sh
+  - validation.webhook.config.karpenter.sh
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - defaulting.webhook.karpenter.sh
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - update
 
 ---
 
@@ -774,24 +835,26 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
-  name: karpenter-webhook
+  name: karpenter
 rules:
 - apiGroups:
-  - admissionregistration.k8s.io
+  - karpenter.k8s.aws
   resources:
-  - validatingwebhookconfigurations
-  - mutatingwebhookconfigurations
+  - awsnodetemplates
   verbs:
   - get
-  - watch
   - list
+  - watch
+  - patch
 - apiGroups:
   - admissionregistration.k8s.io
   resourceNames:
-  - validation.webhook.provisioners.karpenter.sh
-  - validation.webhook.config.karpenter.sh
+  - validation.webhook.karpenter.k8s.aws
   resources:
   - validatingwebhookconfigurations
   verbs:
@@ -799,7 +862,7 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resourceNames:
-  - defaulting.webhook.provisioners.karpenter.sh
+  - defaulting.webhook.karpenter.k8s.aws
   resources:
   - mutatingwebhookconfigurations
   verbs:
@@ -813,13 +876,16 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
-  name: karpenter-controller
+  name: karpenter-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: karpenter-controller
+  name: karpenter-core
 subjects:
 - kind: ServiceAccount
   name: karpenter
@@ -833,13 +899,16 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
-  name: karpenter-webhook
+  name: karpenter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: karpenter-webhook
+  name: karpenter
 subjects:
 - kind: ServiceAccount
   name: karpenter
@@ -853,9 +922,12 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
-  name: karpenter-controller
+  name: karpenter
   namespace: kube-system
 rules:
 - apiGroups:
@@ -878,7 +950,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - karpenter-webhook-cert
+  - karpenter-cert
   resources:
   - secrets
   verbs:
@@ -887,7 +959,7 @@ rules:
   - ""
   resourceNames:
   - karpenter-global-settings
-  - karpenter-config-logging
+  - config-logging
   resources:
   - configmaps
   verbs:
@@ -928,37 +1000,22 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
-  name: karpenter-webhook
+  name: karpenter-dns
   namespace: kube-system
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - kube-dns
   resources:
-  - namespaces
+  - services
   verbs:
   - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - watch
-  - create
-  - update
 
 ---
 
@@ -968,14 +1025,17 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
-  name: karpenter-controller
+  name: karpenter
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: karpenter-controller
+  name: karpenter
 subjects:
 - kind: ServiceAccount
   name: karpenter
@@ -989,14 +1049,17 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
-  name: karpenter-webhook
+  name: karpenter-dns
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: karpenter-webhook
+  name: karpenter-dns
 subjects:
 - kind: ServiceAccount
   name: karpenter
@@ -1010,35 +1073,28 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
+    helm.sh/chart: karpenter-0.19.1
     k8s-addon: karpenter.sh
-  name: karpenter-metrics
+  name: karpenter
   namespace: kube-system
 spec:
   ports:
-  - port: 8080
+  - name: http-metrics
+    port: 8080
+    protocol: TCP
     targetPort: http-metrics
-  selector:
-    karpenter: controller
-
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: karpenter.sh
-    app.kubernetes.io/managed-by: kops
-    k8s-addon: karpenter.sh
-  name: karpenter-webhook
-  namespace: kube-system
-spec:
-  ports:
-  - port: 443
+  - name: https-webhook
+    port: 443
+    protocol: TCP
     targetPort: https-webhook
   selector:
-    karpenter: webhook
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/name: karpenter
+  type: ClusterIP
 
 ---
 
@@ -1048,23 +1104,29 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
-  name: karpenter-controller
+  name: karpenter
   namespace: kube-system
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
-      karpenter: controller
+      app.kubernetes.io/instance: karpenter
+      app.kubernetes.io/name: karpenter
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       creationTimestamp: null
       labels:
+        app.kubernetes.io/instance: karpenter
         app.kubernetes.io/name: karpenter
-        karpenter: controller
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -1072,28 +1134,19 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
-              - key: karpenter.sh/provisioner-name
-                operator: DoesNotExist
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - env:
-        - name: AWS_ENI_LIMITED_POD_DENSITY
-          value: "true"
-        - name: AWS_NODE_NAME_CONVENTION
-          value: resource-name
-        - name: AWS_REGION
-          value: us-test-1
-        - name: CLUSTER_NAME
-          value: minimal.example.com
-        - name: CLUSTER_ENDPOINT
-          value: https://api.internal.minimal.example.com
-        - name: CONFIG_LOGGING_NAME
-          value: karpenter-config-logging
+        - name: KUBERNETES_MIN_VERSION
+          value: 1.19.0-0
         - name: KARPENTER_SERVICE
-          value: karpenter-webhook
+          value: karpenter
+        - name: WEBHOOK_PORT
+          value: "8443"
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:
@@ -1108,7 +1161,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/karpenter.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/karpenter/controller:v0.16.3
+        image: public.ecr.aws/karpenter/controller:v0.19.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1124,6 +1177,9 @@ spec:
         - containerPort: 8081
           name: http
           protocol: TCP
+        - containerPort: 8443
+          name: https-webhook
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz
@@ -1133,18 +1189,22 @@ spec:
           limits:
             memory: 1Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 1Gi
         volumeMounts:
         - mountPath: /var/run/secrets/amazonaws.com/
           name: token-amazonaws-com
           readOnly: true
       dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       securityContext:
-        fsGroup: 10001
+        fsGroup: 1000
       serviceAccountName: karpenter
       tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
       - key: node-role.kubernetes.io/control-plane
@@ -1152,151 +1212,13 @@ spec:
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
-            karpenter: webhook
+            app.kubernetes.io/name: karpenter
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
         whenUnsatisfiable: ScheduleAnyway
       - labelSelector:
           matchLabels:
-            karpenter: webhook
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: DoNotSchedule
-      volumes:
-      - name: token-amazonaws-com
-        projected:
-          defaultMode: 420
-          sources:
-          - serviceAccountToken:
-              audience: amazonaws.com
-              expirationSeconds: 86400
-              path: token
-
----
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: karpenter.sh
-    app.kubernetes.io/managed-by: kops
-    k8s-addon: karpenter.sh
-  name: karpenter-webhook
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      karpenter: webhook
-  strategy:
-    type: Recreate
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
-        app.kubernetes.io/name: karpenter
-        karpenter: webhook
-        kops.k8s.io/managed-by: kops
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
-              - key: karpenter.sh/provisioner-name
-                operator: DoesNotExist
-              - key: node-role.kubernetes.io/control-plane
-                operator: Exists
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
-              - key: karpenter.sh/provisioner-name
-                operator: DoesNotExist
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-      containers:
-      - args:
-        - -port=8443
-        env:
-        - name: AWS_REGION
-          value: us-test-1
-        - name: CLUSTER_NAME
-          value: minimal.example.com
-        - name: KUBERNETES_MIN_VERSION
-          value: 1.19.0-0
-        - name: CLUSTER_ENDPOINT
-          value: https://api.internal.minimal.example.com
-        - name: CONFIG_LOGGING_NAME
-          value: karpenter-config-logging
-        - name: KARPENTER_SERVICE
-          value: karpenter-webhook
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: AWS_ROLE_ARN
-          value: arn:aws-test:iam::123456789012:role/karpenter.kube-system.sa.minimal.example.com
-        - name: AWS_WEB_IDENTITY_TOKEN_FILE
-          value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/karpenter/webhook:v0.16.3
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            port: https-webhook
-            scheme: HTTPS
-          initialDelaySeconds: 30
-        name: webhook
-        ports:
-        - containerPort: 8443
-          name: https-webhook
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            port: https-webhook
-            scheme: HTTPS
-        resources:
-          limits:
-            cpu: 100m
-            memory: 50Mi
-          requests:
-            cpu: 100m
-            memory: 50Mi
-        startupProbe:
-          failureThreshold: 6
-          httpGet:
-            port: https-webhook
-            scheme: HTTPS
-        volumeMounts:
-        - mountPath: /var/run/secrets/amazonaws.com/
-          name: token-amazonaws-com
-          readOnly: true
-      dnsPolicy: Default
-      priorityClassName: system-cluster-critical
-      securityContext:
-        fsGroup: 10001
-      serviceAccountName: karpenter
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            karpenter: webhook
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            karpenter: webhook
+            app.kubernetes.io/name: karpenter
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: DoNotSchedule
@@ -1318,18 +1240,21 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
-  name: defaulting.webhook.provisioners.karpenter.sh
+  name: defaulting.webhook.karpenter.k8s.aws
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: karpenter-webhook
+      name: karpenter
       namespace: kube-system
   failurePolicy: Fail
-  name: defaulting.webhook.provisioners.karpenter.sh
+  name: defaulting.webhook.karpenter.k8s.aws
   rules:
   - apiGroups:
     - karpenter.k8s.aws
@@ -1362,31 +1287,22 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
-  name: validation.webhook.provisioners.karpenter.sh
+  name: validation.webhook.karpenter.sh
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: karpenter-webhook
+      name: karpenter
       namespace: kube-system
   failurePolicy: Fail
-  name: validation.webhook.provisioners.karpenter.sh
+  name: validation.webhook.karpenter.sh
   rules:
-  - apiGroups:
-    - karpenter.k8s.aws
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - awsnodetemplates
-    - awsnodetemplates/status
-    scope: '*'
   - apiGroups:
     - karpenter.sh
     apiVersions:
@@ -1408,7 +1324,10 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
     k8s-addon: karpenter.sh
   name: validation.webhook.config.karpenter.sh
 webhooks:
@@ -1416,13 +1335,62 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: karpenter-webhook
+      name: karpenter
       namespace: kube-system
   failurePolicy: Fail
   name: validation.webhook.config.karpenter.sh
   objectSelector:
     matchLabels:
       app.kubernetes.io/part-of: karpenter
+  sideEffects: None
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.19.1
+    helm.sh/chart: karpenter-0.19.1
+    k8s-addon: karpenter.sh
+  name: validation.webhook.karpenter.k8s.aws
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: karpenter
+      namespace: kube-system
+  failurePolicy: Fail
+  name: validation.webhook.karpenter.k8s.aws
+  rules:
+  - apiGroups:
+    - karpenter.k8s.aws
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsnodetemplates
+    - awsnodetemplates/status
+    scope: '*'
+  - apiGroups:
+    - karpenter.sh
+    apiVersions:
+    - v1alpha5
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - provisioners
+    - provisioners/status
   sideEffects: None
 
 ---

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -66,6 +66,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -73,6 +73,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -73,6 +73,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -73,6 +73,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -66,6 +66,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -66,6 +66,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -66,6 +66,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -69,6 +69,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -53,6 +53,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=node-termination-handler.aws,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -69,6 +69,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -69,6 +69,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org.canal,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org.canal,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org.canal,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=networking.projectcalico.org.canal,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -69,6 +69,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=networking.flannel,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-flannel
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=networking.flannel,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=networking.flannel,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=networking.flannel,app.kubernetes.io/managed-by=kops

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -60,6 +60,12 @@ spec:
         labelSelector: addon.kops.k8s.io/name=networking.kope.io,app.kubernetes.io/managed-by=kops
         namespaces:
         - kube-system
+      - group: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=networking.kope.io,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=networking.kope.io,app.kubernetes.io/managed-by=kops
       - group: apps
         kind: DaemonSet
         labelSelector: addon.kops.k8s.io/name=networking.kope.io,app.kubernetes.io/managed-by=kops

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -580,13 +579,23 @@ kind: ServiceAccount
 metadata:
   name: karpenter
   namespace: kube-system
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 ---
-# Source: karpenter/templates/webhook/deployment.yaml
+# Source: karpenter/templates/secret-webhook-cert.yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: karpenter-webhook-cert
+  name: karpenter-cert
   namespace: kube-system
+  labels:
+    helm.sh/chart: karpenter-0.19.1
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
+    app.kubernetes.io/managed-by: Helm
 data: {} # Injected by karpenter-webhook
 ---
 # Source: karpenter/templates/100-config-logging.yaml
@@ -627,6 +636,7 @@ data:
   loglevel.controller: debug
   loglevel.webhook: debug
 ---
+
 # Source: karpenter/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -634,260 +644,347 @@ metadata:
   name: karpenter-global-settings
   namespace: kube-system
   labels:
-    app.kubernetes.io/part-of: karpenter
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 data:
-  "batchMaxDuration": "10s"
+  "aws.clusterEndpoint": "https://{{ APIInternalName }}"
+  "aws.clusterName": "{{ ClusterName }}"
+  "aws.defaultInstanceProfile": ""
+  {{ if not .Networking.AmazonVPC }}
+  "aws.enableENILimitedPodDensity": "true"
+  {{ else }}
+  "aws.enableENILimitedPodDensity": "false"
+  {{ end }}
+  "aws.enablePodENI": "false"
+  "aws.interruptionQueueName": ""
+  "aws.isolatedVPC": "false"
+  {{ if UsesInstanceIDForNodeName }}
+  "aws.nodeNameConvention": "resource-name"
+  {{ else }}
+  "aws.nodeNameConvention": "ip-name"
+  {{ end }}
+  "aws.vmMemoryOverheadPercent": "0.075"
   "batchIdleDuration": "1s"
+  "batchMaxDuration": "10s"
 ---
-# Source: karpenter/templates/controller/rbac.yaml
+# Source: karpenter/templates/aggregate-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: karpenter-controller
+  name: karpenter-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 rules:
-# Read
-- apiGroups: ["karpenter.sh"]
-  resources: ["provisioners", "provisioners/status"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["karpenter.k8s.aws"]
-  resources: ["awsnodetemplates"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["pods", "nodes", "namespaces", "persistentvolumes", "persistentvolumeclaims", "replicationcontrollers"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["storage.k8s.io"]
-  resources: ["storageclasses", "csinodes"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["apps"]
-  resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
-  verbs: ["list", "watch"]
-- apiGroups: [ "policy" ]
-  resources: [ "poddisruptionbudgets" ]
-  verbs: [ "get", "list", "watch" ]
-# Write
-- apiGroups: ["karpenter.sh"]
-  resources: ["provisioners/status"]
-  verbs: ["create", "delete", "patch"]
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create", "patch"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["create", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["pods/eviction"]
-  verbs: ["create"]
+  - apiGroups: ["karpenter.sh"]
+    resources: ["provisioners", "provisioners/status"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["awsnodetemplates"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
 ---
-# Source: karpenter/templates/webhook/rbac.yaml
+# Source: karpenter/templates/clusterrole-core.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: karpenter-webhook
+  name: karpenter-core
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 rules:
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations"]
-  verbs: ["update"]
-  resourceNames: ["validation.webhook.provisioners.karpenter.sh", "validation.webhook.config.karpenter.sh"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
-  verbs: ["update"]
-  resourceNames: ["defaulting.webhook.provisioners.karpenter.sh"]
+  # Read
+  - apiGroups: ["karpenter.sh"]
+    resources: ["provisioners", "provisioners/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "persistentvolumes", "persistentvolumeclaims", "replicationcontrollers", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: [ "policy" ]
+    resources: [ "poddisruptionbudgets" ]
+    verbs: [ "get", "list", "watch" ]
+  # Write
+  - apiGroups: ["karpenter.sh"]
+    resources: ["provisioners/status"]
+    verbs: ["create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["create", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["update"]
+    resourceNames: ["validation.webhook.karpenter.sh", "validation.webhook.config.karpenter.sh"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["update"]
+    resourceNames: ["defaulting.webhook.karpenter.sh"]
 ---
-# Source: karpenter/templates/controller/rbac.yaml
+# Source: karpenter/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karpenter
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
+rules:
+  # Read
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["awsnodetemplates"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["update"]
+    resourceNames: ["validation.webhook.karpenter.k8s.aws"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["update"]
+    resourceNames: ["defaulting.webhook.karpenter.k8s.aws"]
+---
+# Source: karpenter/templates/clusterrole-core.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: karpenter-controller
+  name: karpenter-core
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: karpenter-controller
+  name: karpenter-core
 subjects:
-- kind: ServiceAccount
-  name: karpenter
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: karpenter
+    namespace: kube-system
 ---
-# Source: karpenter/templates/webhook/rbac.yaml
+# Source: karpenter/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: karpenter-webhook
+  name: karpenter
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: karpenter-webhook
-subjects:
-- kind: ServiceAccount
   name: karpenter
-  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: karpenter
+    namespace: kube-system
 ---
-# Source: karpenter/templates/controller/rbac.yaml
+# Source: karpenter/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: karpenter-controller
+  name: karpenter
   namespace: kube-system
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 rules:
-# Read
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch"]
-- apiGroups: [""]
-  resources: ["configmaps", "namespaces", "secrets"]
-  verbs: ["get", "list", "watch"]
-# Write
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["update"]
-  resourceNames: ["karpenter-webhook-cert"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["update", "patch", "delete"]
-  resourceNames:
-    - karpenter-global-settings
-    - karpenter-config-logging
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["patch", "update"]
-  resourceNames:
-    - "karpenter-leader-election"
-    - "webhook.configmapwebhook.00-of-01"
-    - "webhook.defaultingwebhook.00-of-01"
-    - "webhook.validationwebhook.00-of-01"
-    - "webhook.webhookcertificates.00-of-01"
-# Cannot specify resourceNames on create
-# https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["create"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["create"]
+  # Read
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps", "namespaces", "secrets"]
+    verbs: ["get", "list", "watch"]
+  # Write
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["update"]
+    resourceNames: ["karpenter-cert"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["update", "patch", "delete"]
+    resourceNames:
+      - karpenter-global-settings
+      - config-logging
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["patch", "update"]
+    resourceNames:
+      - "karpenter-leader-election"
+      - "webhook.configmapwebhook.00-of-01"
+      - "webhook.defaultingwebhook.00-of-01"
+      - "webhook.validationwebhook.00-of-01"
+      - "webhook.webhookcertificates.00-of-01"
+  # Cannot specify resourceNames on create
+  # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
 ---
-# Source: karpenter/templates/webhook/rbac.yaml
+# Source: karpenter/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: karpenter-webhook
+  name: karpenter-dns
   namespace: kube-system
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 rules:
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "watch", "update"]
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "create", "update"]
+  # Read
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["kube-dns"]
+    verbs: ["get"]
 ---
-# Source: karpenter/templates/controller/rbac.yaml
+# Source: karpenter/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: karpenter-controller
+  name: karpenter
   namespace: kube-system
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: karpenter-controller
-subjects:
-- kind: ServiceAccount
   name: karpenter
-  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: karpenter
+    namespace: kube-system
 ---
-# Source: karpenter/templates/webhook/rbac.yaml
+# Source: karpenter/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: karpenter-webhook
+  name: karpenter-dns
   namespace: kube-system
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: karpenter-webhook
+  name: karpenter-dns
 subjects:
-- kind: ServiceAccount
-  name: karpenter
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: karpenter
+    namespace: kube-system
 ---
-# Source: karpenter/templates/controller/deployment.yaml
+# Source: karpenter/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: karpenter-metrics
+  name: karpenter
   namespace: kube-system
+  labels:
+    helm.sh/chart: karpenter-0.19.1
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
+    app.kubernetes.io/managed-by: Helm
 spec:
+  type: ClusterIP
   ports:
-    - port: 8080
+    - name: http-metrics
+      port: 8080
       targetPort: http-metrics
-  selector:
-    karpenter: controller
----
-# Source: karpenter/templates/webhook/deployment.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: karpenter-webhook
-  namespace: kube-system
-spec:
-  ports:
-    - port: 443
+      protocol: TCP
+    - name: https-webhook
+      port: 443
       targetPort: https-webhook
+      protocol: TCP
   selector:
-    karpenter: webhook
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
 ---
-# Source: karpenter/templates/controller/deployment.yaml
+# Source: karpenter/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: karpenter-controller
+  name: karpenter
   namespace: kube-system
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 spec:
   replicas: {{ ControlPlaneControllerReplicas false }}
+  revisionHistoryLimit: 10
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
-      karpenter: controller
+      app.kubernetes.io/name: karpenter
+      app.kubernetes.io/instance: karpenter
   template:
     metadata:
       labels:
-        karpenter: controller
         app.kubernetes.io/name: karpenter
+        app.kubernetes.io/instance: karpenter
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-      priorityClassName: system-cluster-critical
       serviceAccountName: karpenter
+      securityContext:
+        fsGroup: 1000
       dnsPolicy: Default
       containers:
         - name: controller
-          image: public.ecr.aws/karpenter/controller:v0.16.3
+          image: public.ecr.aws/karpenter/controller:v0.19.1
           imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 1Gi
+          env:
+            - name: KUBERNETES_MIN_VERSION
+              value: "1.19.0-0"
+            - name: KARPENTER_SERVICE
+              value: karpenter
+            - name: WEBHOOK_PORT
+              value: "8443"
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MEMORY_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: controller
+                  divisor: "0"
+                  resource: limits.memory
           ports:
             - name: http-metrics
               containerPort: 8080
               protocol: TCP
             - name: http
               containerPort: 8081
+              protocol: TCP
+            - name: https-webhook
+              containerPort: 8443
               protocol: TCP
           livenessProbe:
             initialDelaySeconds: 30
@@ -900,272 +997,182 @@ spec:
             httpGet:
               path: /readyz
               port: http
-          env:
-            {{ if not .Networking.AmazonVPC }}
-            - name: AWS_ENI_LIMITED_POD_DENSITY
-              value: "true"
-            {{ end }}
-            {{ if UsesInstanceIDForNodeName }}
-            - name: AWS_NODE_NAME_CONVENTION
-              value: "resource-name"
-            {{ end }}
-            - name: AWS_REGION
-              value: {{ Region }}
-            - name: CLUSTER_NAME
-              value: {{ ClusterName }}
-            - name: CLUSTER_ENDPOINT
-              value: https://{{ APIInternalName }}
-            - name: CONFIG_LOGGING_NAME
-              value: "karpenter-config-logging"
-            - name: KARPENTER_SERVICE
-              value: karpenter-webhook
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MEMORY_LIMIT
-              valueFrom:
-                resourceFieldRef:
-                  containerName: controller
-                  divisor: "0"
-                  resource: limits.memory
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 1Gi
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
-              - key: karpenter.sh/provisioner-name
-                operator: DoesNotExist
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      priorityClassName: system-cluster-critical
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: "topology.kubernetes.io/zone"
         whenUnsatisfiable: ScheduleAnyway
         labelSelector:
           matchLabels:
-            karpenter: webhook
+            app.kubernetes.io/name: karpenter
       - maxSkew: 1
         topologyKey: "kubernetes.io/hostname"
         whenUnsatisfiable: DoNotSchedule
         labelSelector:
           matchLabels:
-            karpenter: webhook
-      nodeSelector: null
-
+            app.kubernetes.io/name: karpenter
 ---
-# Source: karpenter/templates/webhook/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: karpenter-webhook
-  namespace: kube-system
-spec:
-  replicas: {{ ControlPlaneControllerReplicas false }}
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      karpenter: webhook
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: karpenter
-        karpenter: webhook
-    spec:
-      priorityClassName: system-cluster-critical
-      serviceAccountName: karpenter
-      dnsPolicy: Default
-      containers:
-        - name: webhook
-          image: public.ecr.aws/karpenter/webhook:v0.16.3
-          imagePullPolicy: IfNotPresent
-          args:
-            - -port=8443
-          resources: 
-            limits:
-              cpu: 100m
-              memory: 50Mi
-            requests:
-              cpu: 100m
-              memory: 50Mi
-          ports:
-            - name: https-webhook
-              containerPort: 8443
-              protocol: TCP
-          livenessProbe:
-            initialDelaySeconds: 30
-            httpGet:
-              scheme: HTTPS
-              port: https-webhook
-          readinessProbe:
-            httpGet:
-              scheme: HTTPS
-              port: https-webhook
-          startupProbe:
-            httpGet:
-              scheme: HTTPS
-              port: https-webhook
-            failureThreshold: 6
-          env:
-            - name: AWS_REGION
-              value: {{ Region }}
-            - name: CLUSTER_NAME
-              value: {{ ClusterName }}
-            - name: KUBERNETES_MIN_VERSION
-              value: "1.19.0-0"
-            - name: CLUSTER_ENDPOINT
-              value: https://{{ APIInternalName }}
-            - name: CONFIG_LOGGING_NAME
-              value: "karpenter-config-logging"
-            - name: KARPENTER_SERVICE
-              value: karpenter-webhook
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
-              - key: karpenter.sh/provisioner-name
-                operator: DoesNotExist
-              - key: node-role.kubernetes.io/control-plane
-                operator: Exists
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
-              - key: karpenter.sh/provisioner-name
-                operator: DoesNotExist
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-      topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            karpenter: webhook
-      - maxSkew: 1
-        topologyKey: "kubernetes.io/hostname"
-        whenUnsatisfiable: DoNotSchedule
-        labelSelector:
-          matchLabels:
-            karpenter: webhook
-      nodeSelector: null
----
-# Source: karpenter/templates/webhook/webhooks.yaml
+# Source: karpenter/templates/webhooks.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: defaulting.webhook.provisioners.karpenter.sh
+  name: defaulting.webhook.karpenter.k8s.aws
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 webhooks:
-- admissionReviewVersions: ["v1"]
-  clientConfig:
-    service:
-      name: karpenter-webhook
-      namespace: 'kube-system'
-  failurePolicy: Fail
-  sideEffects: None
-  name: defaulting.webhook.provisioners.karpenter.sh
-  rules:
-  - apiGroups:
-    - karpenter.k8s.aws
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - awsnodetemplates
-    - awsnodetemplates/status
-    scope: '*'
-  - apiGroups:
-    - karpenter.sh
-    apiVersions:
-    - v1alpha5
-    resources:
-    - provisioners
-    - provisioners/status
-    operations:
-    - CREATE
-    - UPDATE
+  - name: defaulting.webhook.karpenter.k8s.aws
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: karpenter
+        namespace: kube-system
+    failurePolicy: Fail
+    sideEffects: None
+    rules:
+      - apiGroups:
+          - karpenter.k8s.aws
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - awsnodetemplates
+          - awsnodetemplates/status
+        scope: '*'
+      - apiGroups:
+          - karpenter.sh
+        apiVersions:
+          - v1alpha5
+        resources:
+          - provisioners
+          - provisioners/status
+        operations:
+          - CREATE
+          - UPDATE
 ---
-# Source: karpenter/templates/webhook/webhooks.yaml
+# Source: karpenter/templates/webhooks-core.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validation.webhook.provisioners.karpenter.sh
+  name: validation.webhook.karpenter.sh
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 webhooks:
-- admissionReviewVersions: ["v1"]
-  clientConfig:
-    service:
-      name: karpenter-webhook
-      namespace: 'kube-system'
-  failurePolicy: Fail
-  sideEffects: None
-  name: validation.webhook.provisioners.karpenter.sh
-  rules:
-  - apiGroups:
-    - karpenter.k8s.aws
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - awsnodetemplates
-    - awsnodetemplates/status
-    scope: '*'
-  - apiGroups:
-    - karpenter.sh
-    apiVersions:
-    - v1alpha5
-    resources:
-    - provisioners
-    - provisioners/status
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
+  - name: validation.webhook.karpenter.sh
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: karpenter
+        namespace: kube-system
+    failurePolicy: Fail
+    sideEffects: None
+    rules:
+      - apiGroups:
+          - karpenter.sh
+        apiVersions:
+          - v1alpha5
+        resources:
+          - provisioners
+          - provisioners/status
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
 ---
-# Source: karpenter/templates/webhook/webhooks.yaml
+# Source: karpenter/templates/webhooks-core.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.config.karpenter.sh
+  labels:
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
 webhooks:
-- admissionReviewVersions: ["v1"]
-  clientConfig:
-    service:
-      name: karpenter-webhook
-      namespace: 'kube-system'
-  failurePolicy: Fail
-  sideEffects: None
-  name: validation.webhook.config.karpenter.sh
-  objectSelector:
-    matchLabels:
-      app.kubernetes.io/part-of: karpenter
+  - name: validation.webhook.config.karpenter.sh
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: karpenter
+        namespace: kube-system
+    failurePolicy: Fail
+    sideEffects: None
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/part-of: karpenter
+---
+# Source: karpenter/templates/webhooks.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.karpenter.k8s.aws
+  labels:
+    helm.sh/chart: karpenter-0.19.1
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.19.1"
+webhooks:
+  - name: validation.webhook.karpenter.k8s.aws
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: karpenter
+        namespace: kube-system
+    failurePolicy: Fail
+    sideEffects: None
+    rules:
+      - apiGroups:
+          - karpenter.k8s.aws
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - awsnodetemplates
+          - awsnodetemplates/status
+        scope: '*'
+      - apiGroups:
+          - karpenter.sh
+        apiVersions:
+          - v1alpha5
+        resources:
+          - provisioners
+          - provisioners/status
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
 ---
 # Source: karpenter/templates/poddisruptionbudget.yaml
 {{ if IsKubernetesGTE "1.23" }}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -1193,7 +1193,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*Addon
 		{
 			id := "k8s-1.19"
 			location := key + "/" + id + ".yaml"
-			addons.Add(&channelsapi.AddonSpec{
+			addon := addons.Add(&channelsapi.AddonSpec{
 				Name:     fi.String(key),
 				Manifest: fi.String(location),
 				Selector: map[string]string{"k8s-addon": key},
@@ -1202,6 +1202,9 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*Addon
 			if b.UseServiceAccountExternalPermissions() {
 				serviceAccountRoles = append(serviceAccountRoles, &karpenter.ServiceAccount{})
 			}
+
+			addon.BuildPrune = true
+
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/pruning.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/pruning.go
@@ -71,6 +71,8 @@ func (b *BootstrapChannelBuilder) addPruneDirectivesForAddon(addon *Addon) error
 		{Group: "rbac.authorization.k8s.io", Kind: "Role"},
 		{Group: "rbac.authorization.k8s.io", Kind: "RoleBinding"},
 		{Group: "policy", Kind: "PodDisruptionBudget"},
+		{Group: "admissionregistration.k8s.io/v1", Kind: "ValidatingWebhookConfiguration"},
+		{Group: "admissionregistration.k8s.io/v1", Kind: "MutatingWebhookConfiguration"},
 	}
 	pruneGroupKind := make(map[schema.GroupKind]bool)
 	for _, gk := range alwaysPruneGroupKinds {


### PR DESCRIPTION
Significant changes to the templates related to webhook and controller being compiled into a single binary.

Note that this is currently broken due to https://github.com/aws/karpenter/issues/2892