### PR TITLE
WIP toolbox-dump: add support for --bastion-ssh-user flag

### DIFF
--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -60,9 +60,10 @@ type ToolboxDumpOptions struct {
 
 	ClusterName string
 
-	Dir        string
-	PrivateKey string
-	SSHUser    string
+	Dir            string
+	PrivateKey     string
+	SSHUser        string
+	BastionSSHUser string
 }
 
 func (o *ToolboxDumpOptions) InitDefaults() {
@@ -97,6 +98,8 @@ func NewCmdToolboxDump(f commandutils.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.PrivateKey, "private-key", options.PrivateKey, "File containing private key to use for SSH access to instances")
 	cmd.Flags().StringVar(&options.SSHUser, "ssh-user", options.SSHUser, "The remote user for SSH access to instances")
 	cmd.RegisterFlagCompletionFunc("ssh-user", cobra.NoFileCompletions)
+	cmd.Flags().StringVar(&options.BastionSSHUser, "bastion-ssh-user", options.BastionSSHUser, "The remote user for SSH access to bastions. Defaults to value of --ssh-user")
+	cmd.RegisterFlagCompletionFunc("bastion-ssh-user", cobra.NoFileCompletions)
 
 	return cmd
 }
@@ -195,7 +198,7 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 			return fmt.Errorf("adding key to SSH agent: %w", err)
 		}
 
-		dumper := dump.NewLogDumper(cluster.ObjectMeta.Name, sshConfig, keyRing, options.Dir)
+		dumper := dump.NewLogDumper(cluster.ObjectMeta.Name, sshConfig, options.BastionSSHUser, keyRing, options.Dir)
 
 		var additionalIPs []string
 		var additionalPrivateIPs []string

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -121,6 +121,9 @@ func (d *deployer) initialize() error {
 	if d.SSHUser == "" {
 		d.SSHUser = os.Getenv("KUBE_SSH_USER")
 	}
+	if d.BastionSSHUser == "" {
+		d.BastionSSHUser = os.Getenv("BASTION_SSH_USER")
+	}
 	if d.TerraformVersion != "" {
 		t, err := target.NewTerraform(d.TerraformVersion)
 		if err != nil {

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -69,6 +69,7 @@ type deployer struct {
 	SSHPrivateKeyPath string `flag:"ssh-private-key" desc:"The path to the private key used for SSH access to instances"`
 	SSHPublicKeyPath  string `flag:"ssh-public-key" desc:"The path to the public key passed to the cloud provider"`
 	SSHUser           string `flag:"ssh-user" desc:"The SSH user to use for SSH access to instances"`
+	BastionSSHUser    string `flag:"bastion-ssh-user" desc:"The SSH user to use for SSH access to bastions"`
 
 	TerraformVersion string `flag:"terraform-version" desc:"The version of terraform to use for applying the cluster"`
 

--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -42,6 +42,9 @@ func (d *deployer) DumpClusterLogs() error {
 		"--private-key", d.SSHPrivateKeyPath,
 		"--ssh-user", d.SSHUser,
 	}
+	if d.BastionSSHUser != "" {
+		args = append(args, "--bastion-ssh-user", d.BastionSSHUser)
+	}
 	klog.Info(strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(d.env()...)
@@ -184,6 +187,9 @@ func (d *deployer) dumpClusterInfoSSH() error {
 		"--private-key", d.SSHPrivateKeyPath,
 		"--ssh-user", d.SSHUser,
 		"-o", "yaml",
+	}
+	if d.BastionSSHUser != "" {
+		toolboxDumpArgs = append(toolboxDumpArgs, "--bastion-ssh-user", d.BastionSSHUser)
 	}
 	klog.Info(strings.Join(toolboxDumpArgs, " "))
 


### PR DESCRIPTION
Debian 11 doesn't forward authentication by default, so those clusters will need to use a bastion on Ubuntu or some other distro. But then the bastion will need to use a different SSH user than the cluster nodes.