### PR TITLE
Remove support for IPv6 on Debian

### DIFF
--- a/docs/networking/ipv6.md
+++ b/docs/networking/ipv6.md
@@ -39,6 +39,10 @@ the NAT Gateway will be placed in the first-listed public subnet in that zone.
 The managed private subnets route the rest of outbound IPv6 traffic to the VPC's Egress-only Internet Gateway.
 The managed public subnets route the rest of outbound IPv6 traffic to the VPC's Internet Gateway.
 
+## Distributions
+
+As Debian, as of Debian 11, does not support IPv6-only instances, kOps does not support IPv6 on Debian.
+
 ## CNI
 
 kOps currently supports IPv6 on Calico, Cilium, and bring-your-own CNI only.
@@ -47,7 +51,7 @@ CNIs must not masquerade IPv6 addresses.
 
 ### Calico
 
-Running IPv6 with Calico requires a Ubuntu 22.04, Debian 11, or Flatcar based AMI.
+Running IPv6 with Calico requires a Ubuntu 22.04 or Flatcar based AMI.
 
 ## Future work
 


### PR DESCRIPTION
```
Nov 21 03:39:18 debian dhclient[469]: DHCPREQUEST for 169.254.61.153 on ens5 to 169.254.0.1 port 67
Nov 21 03:39:18 debian dhclient[469]: send_packet: Network is unreachable
Nov 21 03:39:18 debian dhclient[469]: send_packet: please consult README file regarding broadcast address.
Nov 21 03:39:18 debian dhclient[469]: dhclient.c:2756: Failed to send 300 byte long packet over fallback inter>
```