### PR TITLE
Automated cherry pick of #14442: Fix pdb for identity webhook

### DIFF
--- a/tests/e2e/templates/many-addons.yaml.tmpl
+++ b/tests/e2e/templates/many-addons.yaml.tmpl
@@ -50,6 +50,8 @@ spec:
     enabled: true
     enableSQSTerminationDraining: true
   nonMasqueradeCIDR: 100.64.0.0/10
+  podIdentityWebhook:
+    enabled: true
   sshAccess:
     - {{.publicIP}}
   topology:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7b8cee18c8828975bf34d41c10e2915777d63b5e14bae5272b003aafb439dc34
+    manifestHash: a1573fc78e0b9cc5a30570251082c6af7d5f44fc4e383d80a68a84f0be392922
     name: eks-pod-identity-webhook.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
@@ -205,7 +205,6 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: eks-pod-identity-webhook.addons.k8s.io
   name: pod-identity-webhook
-  namespace: kube-system
 webhooks:
 - admissionReviewVersions:
   - v1beta1

--- a/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
@@ -150,7 +150,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: pod-identity-webhook
-  namespace: kube-system
   annotations:
     cert-manager.io/inject-ca-from: kube-system/pod-identity-webhook
 webhooks:
@@ -208,7 +207,11 @@ metadata:
 data:
   config: {{ PodIdentityWebhookConfigMapData }}
 ---
+{{ if IsKubernetesGTE "1.23" }}
+apiVersion: policy/v1
+{{ else }}
 apiVersion: policy/v1beta1
+{{ end }}
 kind: PodDisruptionBudget
 metadata:
   name: pod-identity-webhook


### PR DESCRIPTION
Cherry pick of #14442 on release-1.25.

#14442: Fix pdb for identity webhook

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.