### PR TITLE
Add SELinuxMount feature gate

### DIFF
--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -25,6 +25,7 @@ limitations under the License.
 package featureflag
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -163,4 +164,16 @@ func ParseFlags(f string) {
 			klog.Infof("Unknown FeatureFlag %q", s)
 		}
 	}
+}
+
+// Get returns given FeatureFlag.
+func Get(flagName string) (*FeatureFlag, error) {
+	flagsMutex.Lock()
+	defer flagsMutex.Unlock()
+
+	flag, found := flags[flagName]
+	if !found {
+		return nil, fmt.Errorf("flag %s not found", flagName)
+	}
+	return flag, nil
 }

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -91,6 +91,13 @@ var (
 	ImageDigest = new("ImageDigest", Bool(true))
 	// Scaleway toggles the Scaleway Cloud support.
 	Scaleway = new("Scaleway", Bool(false))
+	// SELinuxMount configures AWS EBS CSI driver for SELinuxMount support.
+	// It expects than Kubernetes feature gate SELinuxMountReadWriteOncePod is
+	// enabled or GA in the API server, KCM and kubelet.
+	// OS with SELinux support on all nodes is recommended, but not required
+	// - the feature won't do anything when the node OS does not support SELinux.
+	// TODO(jsafrane): add to all CSI drivers installed by kops.
+	SELinuxMount = new("SELinuxMount", Bool(false))
 )
 
 // FeatureFlag defines a feature flag

--- a/pkg/featureflag/featureflag_test.go
+++ b/pkg/featureflag/featureflag_test.go
@@ -58,3 +58,25 @@ func TestSetenv(t *testing.T) {
 		t.Fatalf("Flag was not updated by ParseFlags")
 	}
 }
+
+func TestGetPositive(t *testing.T) {
+	// Find a random existing feature
+	var featureName string
+	for featureName = range flags {
+		break
+	}
+
+	f, err := Get(featureName)
+	if err != nil {
+		t.Errorf("Unexpected error when getting a feature: %s", err)
+	}
+	if f != flags[featureName] {
+		t.Errorf("Unexpected content when getting a feature: expected %+v, got %+v", flags[featureName], f)
+	}
+}
+
+func TestGetNegative(t *testing.T) {
+	if _, err := Get("NonExistingFeature"); err == nil {
+		t.Errorf("Expected Get error on NonExistingFeature, got nil")
+	}
+}

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -324,6 +324,12 @@ spec:
               mountPath: /csi
             - name: device-dir
               mountPath: /dev
+{{ if KopsFeatureEnabled "SELinuxMount" }}
+            - name: etc-selinux
+              mountPath: /etc/selinux
+            - name: sys-fs
+              mountPath: /sys/fs
+{{ end }}
           ports:
             - name: healthz
               containerPort: 9808
@@ -384,6 +390,16 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+{{ if KopsFeatureEnabled "SELinuxMount" }}
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
+            type: DirectoryOrCreate
+        - name: sys-fs
+          hostPath:
+            path: /sys/fs
+            type: Directory
+{{ end }}
 ---
 # Source: aws-ebs-csi-driver/templates/controller.yaml
 # Controller Service
@@ -622,6 +638,9 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+{{ if KopsFeatureEnabled "SELinuxMount" }}
+  seLinuxMount: true
+{{ end }}
 ---
 {{ if IsKubernetesGTE "1.23" }}
 apiVersion: policy/v1

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -346,6 +346,8 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["IsKubernetesGTE"] = tf.IsKubernetesGTE
 	dest["IsKubernetesLT"] = tf.IsKubernetesLT
 
+	dest["KopsFeatureEnabled"] = tf.kopsFeatureEnabled
+
 	return nil
 }
 
@@ -963,4 +965,12 @@ func karpenterInstanceTypes(cloud awsup.AWSCloud, ig kops.InstanceGroupSpec) ([]
 	}
 
 	return []string{ig.MachineType}, nil
+}
+
+func (tf *TemplateFunctions) kopsFeatureEnabled(featureName string) (bool, error) {
+	f, err := featureflag.Get(featureName)
+	if err != nil {
+		return false, err
+	}
+	return f.Enabled(), nil
 }


### PR DESCRIPTION
Add a new feature gate `SELinuxMount` that configures AWS EBS CSI driver installed by kOps  for SELinuxMount support.
* It projects necessary SELinux `/etc` and `/sys` directories from the host to the CSI driver (see [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling#volume-mounting) for details)
* It sets `CSIDriver.Spec.SELinuxMount: true`

I added `KopsFeatureEnabled` function to templates to have a nice `{{ if KopsFeatureEnabled "SELinuxMount" }}` there.