### PR TITLE
Automated cherry pick of #14632: hetzner: Update CSI driver to v2.0.0

### DIFF
--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: hcloud-csi-driver.addons.k8s.io/k8s-1.22.yaml
-    manifestHash: 4c3eaaab2359e91bbd50ca60a3f84de376ecbd2e1bab32de4bce758e2184deed
+    manifestHash: 8e3f5a90da912e2ce39a53fbcfd76c39c1fa52cec43678cf1286e37690028c66
     name: hcloud-csi-driver.addons.k8s.io
     selector:
       k8s-addon: hcloud-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-hcloud-csi-driver.addons.k8s.io-k8s-1.22_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-hcloud-csi-driver.addons.k8s.io-k8s-1.22_content
@@ -25,7 +25,6 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: hcloud-csi-driver.addons.k8s.io
   name: hcloud-volumes
-  namespace: kube-system
 provisioner: csi.hetzner.cloud
 volumeBindingMode: WaitForFirstConsumer
 
@@ -309,7 +308,7 @@ spec:
             secretKeyRef:
               key: token
               name: hcloud-csi
-        image: hetznercloud/hcloud-csi-driver:latest
+        image: hetznercloud/hcloud-csi-driver:2.0.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
@@ -392,7 +391,7 @@ spec:
           value: 0.0.0.0:9189
         - name: ENABLE_METRICS
           value: "true"
-        image: hetznercloud/hcloud-csi-driver:latest
+        image: hetznercloud/hcloud-csi-driver:2.0.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5

--- a/upup/models/cloudup/resources/addons/hcloud-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/hcloud-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
@@ -15,7 +15,6 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
   name: hcloud-volumes
-  namespace: kube-system
 provisioner: csi.hetzner.cloud
 volumeBindingMode: WaitForFirstConsumer
 ---
@@ -257,7 +256,7 @@ spec:
             secretKeyRef:
               key: token
               name: hcloud-csi
-        image: hetznercloud/hcloud-csi-driver:latest
+        image: hetznercloud/hcloud-csi-driver:2.0.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
@@ -332,7 +331,7 @@ spec:
           value: 0.0.0.0:9189
         - name: ENABLE_METRICS
           value: "true"
-        image: hetznercloud/hcloud-csi-driver:latest
+        image: hetznercloud/hcloud-csi-driver:2.0.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
Cherry pick of #14632 on release-1.25.

#14632: hetzner: Update CSI driver to v2.0.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```