### PR TITLE
Automated cherry pick of #14630: Add a create cluster integration test for openstack

### DIFF
--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -63,6 +63,11 @@ func TestCreateClusterHetzner(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/minimal_hetzner", "v1alpha2")
 }
 
+func TestCreateClusterOpenStack(t *testing.T) {
+	t.Setenv("OS_REGION_NAME", "us-test1")
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/ha_openstack", "v1alpha2")
+}
+
 // TestCreateClusterOverride tests the override flag
 func TestCreateClusterOverride(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/overrides", "v1alpha2")
@@ -180,6 +185,7 @@ func runCreateClusterIntegrationTest(t *testing.T, srcDir string, version string
 
 	h.SetupMockAWS()
 	h.SetupMockGCE()
+	testutils.SetupMockOpenstack()
 
 	cloudTags := map[string]string{}
 	awsCloud, _ := awsup.NewAWSCloud("us-test-1", cloudTags)

--- a/pkg/apis/kops/v1alpha2/defaults.go
+++ b/pkg/apis/kops/v1alpha2/defaults.go
@@ -72,10 +72,9 @@ func SetDefaults_ClusterSpec(obj *ClusterSpec) {
 			obj.API.LoadBalancer.Type = LoadBalancerTypePublic
 		}
 
-	}
-
-	if obj.API.LoadBalancer != nil && obj.API.LoadBalancer.Class == "" && obj.LegacyCloudProvider == "aws" {
-		obj.API.LoadBalancer.Class = LoadBalancerClassClassic
+		if obj.API.LoadBalancer != nil && obj.API.LoadBalancer.Class == "" && obj.LegacyCloudProvider == "aws" {
+			obj.API.LoadBalancer.Class = LoadBalancerClassClassic
+		}
 	}
 
 	if obj.Authorization == nil {

--- a/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
@@ -1,0 +1,143 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  name: minimal.k8s.local
+spec:
+  api: {}
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudConfig:
+    openstack:
+      blockStorage:
+        bs-version: v3
+        ignore-volume-az: false
+      monitor:
+        delay: 15s
+        maxRetries: 3
+        timeout: 10s
+      router:
+        externalNetwork: ""
+  cloudProvider: openstack
+  configBase: memfs://tests/minimal.k8s.local
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - instanceGroup: master-us-test1-1
+      name: etcd-1
+    - instanceGroup: master-us-test1-2
+      name: etcd-2
+    - instanceGroup: master-us-test1-3
+      name: etcd-3
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+    - instanceGroup: master-us-test1-1
+      name: etcd-1
+    - instanceGroup: master-us-test1-2
+      name: etcd-2
+    - instanceGroup: master-us-test1-3
+      name: etcd-3
+    memoryRequest: 100Mi
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubelet:
+    anonymousAuth: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  - ::/0
+  kubernetesVersion: v1.25.0
+  masterPublicName: api.minimal.k8s.local
+  networkCIDR: 10.0.0.0/16
+  networking:
+    cni: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  - ::/0
+  subnets:
+  - cidr: 10.0.32.0/19
+    name: us-test1
+    type: Public
+    zone: us-test1
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.k8s.local
+  name: master-us-test1-1
+spec:
+  image: ubuntu-20.04
+  machineType: n1-standard-2
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test1
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.k8s.local
+  name: master-us-test1-2
+spec:
+  image: ubuntu-20.04
+  machineType: n1-standard-2
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test1
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.k8s.local
+  name: master-us-test1-3
+spec:
+  image: ubuntu-20.04
+  machineType: n1-standard-2
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test1
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.k8s.local
+  name: nodes-us-test1
+spec:
+  image: ubuntu-20.04
+  machineType: n1-standard-2
+  maxSize: 1
+  minSize: 1
+  role: Node
+  subnets:
+  - us-test1

--- a/tests/integration/create_cluster/ha_openstack/options.yaml
+++ b/tests/integration/create_cluster/ha_openstack/options.yaml
@@ -1,0 +1,9 @@
+CloudProvider: openstack
+ClusterName: minimal.k8s.local
+Image: ubuntu-20.04
+KubernetesVersion: v1.25.0
+MasterCount: 3
+NetworkCIDR: 10.0.0.0/16
+Networking: cni
+Zones:
+  - us-test1

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -313,6 +313,14 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 				MaxRetries: fi.Int(3),
 			},
 		}
+		tags := make(map[string]string)
+		tags[openstack.TagClusterName] = cluster.GetName()
+		osCloud, err := openstack.NewOpenstackCloud(tags, &cluster.Spec, "openstackmodel")
+		if err != nil {
+			return nil, err
+		}
+		cloud = osCloud
+
 	default:
 		return nil, fmt.Errorf("unsupported cloud provider %s", opt.CloudProvider)
 	}


### PR DESCRIPTION
Cherry pick of #14630 on release-1.25.

#14630: Add a create cluster integration test for openstack

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```