### PR TITLE
e2e: always upload to a versioned directory

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"strings"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kops/tests/e2e/pkg/util"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
@@ -36,9 +37,15 @@ func (d *deployer) Build() error {
 	if err := d.init(); err != nil {
 		return err
 	}
-	if err := d.BuildOptions.Build(); err != nil {
+	results, err := d.BuildOptions.Build()
+	if err != nil {
 		return err
 	}
+	if results.KopsBaseURL != "" {
+		klog.Infof("setting kops base url to %q from build results", results.KopsBaseURL)
+		d.KopsBaseURL = results.KopsBaseURL
+	}
+
 	// Copy the kops binary into the test's RunDir to be included in the tester's PATH
 	if d.KopsBinaryPath != "" {
 		return util.Copy(d.KopsBinaryPath, path.Join(d.commonOptions.RunDir(), "kops"))

--- a/upup/pkg/fi/nodeup/nodetasks/load_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/load_image.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -103,9 +104,10 @@ func (_ *LoadImageTask) RenderLocal(t *local.LocalTarget, a, e, changes *LoadIma
 		return fmt.Errorf("no sources specified: %v", err)
 	}
 
-	// We assume the first url is the "main" url, and download to that _name_, wherever we get it from
+	// We assume the first url is the "main" url, and download to a local file based on that _name_, wherever we get it from
 	primaryURL := urls[0]
-	localFile := path.Join(t.CacheDir, hash.String()+"_"+utils.SanitizeString(primaryURL))
+	key := path.Base(primaryURL)
+	localFile := filepath.Join(t.CacheDir, hash.String()+"_"+utils.SanitizeString(key))
 
 	for _, url := range urls {
 		_, err = fi.DownloadURL(url, localFile, hash)


### PR DESCRIPTION
Otherwise on our first upload we were truncating one level of the
upload path.

Issue #14639
