### PR TITLE
aws: Add `ec2:DescribeAvailabilityZones` to the AWS CCM permissions list

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -892,6 +892,7 @@ func AddCCMPermissions(p *Policy, cloudRoutes bool) {
 		"autoscaling:DescribeTags",
 		"ec2:DescribeInstances",
 		"ec2:DescribeRegions",
+		"ec2:DescribeAvailabilityZones",
 		"ec2:DescribeRouteTables",
 		"ec2:DescribeSecurityGroups",
 		"ec2:DescribeSubnets",

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -116,6 +116,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -116,6 +116,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -139,6 +139,7 @@
         "ec2:DeleteRoute",
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
@@ -171,6 +171,7 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/docker-custom/data/aws_iam_role_policy_masters.docker.example.com_policy
+++ b/tests/integration/update_cluster/docker-custom/data/aws_iam_role_policy_masters.docker.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -139,6 +139,7 @@
         "ec2:DeleteRoute",
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeTags",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -44,6 +44,7 @@
         "ec2:DeleteRoute",
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeTags",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeTags",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeTags",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeTags",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -171,6 +171,7 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -171,6 +171,7 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -171,6 +171,7 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -141,6 +141,7 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -172,6 +172,7 @@
         "autoscaling:DescribeTags",
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -172,6 +172,7 @@
         "autoscaling:DescribeTags",
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -172,6 +172,7 @@
         "autoscaling:DescribeTags",
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -172,6 +172,7 @@
         "autoscaling:DescribeTags",
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.long.cluster-name.m-kaamp9_policy
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.long.cluster-name.m-kaamp9_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -148,6 +148,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -109,6 +109,7 @@
         "ec2:DeleteRoute",
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_iam_role_policy_masters.nthsqsresources.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_iam_role_policy_masters.nthsqsresources.longclustername.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
@@ -171,6 +171,7 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
@@ -171,6 +171,7 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -182,6 +182,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -171,6 +171,7 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
@@ -192,6 +192,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
@@ -171,6 +171,7 @@
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_masters.privateweave.example.com_policy
+++ b/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_masters.privateweave.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeTags",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -172,6 +172,7 @@
         "autoscaling:DescribeTags",
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -178,6 +178,7 @@
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",


### PR DESCRIPTION
To workaround the issue with subnets auto-discovery [1] AWS ccm needs to have permission to retrieve information about availability zones (specifically to detect outpost, wavelength, and local zones [2]).

[1] https://github.com/kubernetes/cloud-provider-aws/issues/442 
[2] https://github.com/kubernetes/cloud-provider-aws/pull/499

/cc @olemarkus 