### PR TITLE
Automated cherry pick of #14655: gce: Allow Cilium to connect to its etcd cluster

### DIFF
--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gcetasks"
@@ -124,6 +125,9 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 		if b.NetworkingIsCilium() {
 			t.Allowed = append(t.Allowed, fmt.Sprintf("udp:%d", wellknownports.VxlanUDP))
+			if model.UseCiliumEtcd(b.Cluster) {
+				t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.EtcdCiliumClientPort))
+			}
 		}
 		c.AddTask(t)
 	}

--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -56,10 +56,13 @@ const (
 	// ProtokubeGossipMemberlist is the port where protokube listens for the memberlist-backed gossip
 	ProtokubeGossipMemberlist = 4000
 
+	// 4001 is etcd main, 4002 is etcd events
+
+	// EtcdCiliumClientPort is the port were the Cilium etcd cluster listens
+	EtcdCiliumClientPort = 4003
+
 	// CiliumOperatorPrometheusPort is the port the Cilium Operator exposes metrics
 	CiliumPrometheusOperatorPort = 6942
-
-	// 4001 is etcd main, 4002 is etcd events, 4003 is etcd cilium
 
 	// CiliumPrometheusPort is the default port where Cilium exposes metrics
 	CiliumPrometheusPort = 9090


### PR DESCRIPTION
Cherry pick of #14655 on release-1.25.

#14655: gce: Allow Cilium to connect to its etcd cluster

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```