### PR TITLE
Refactor rendering Terraform functions into constructor

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -214,7 +214,7 @@ type terraformTargetGroup struct {
 	Name        string                          `cty:"name"`
 	Port        int64                           `cty:"port"`
 	Protocol    string                          `cty:"protocol"`
-	VPCID       terraformWriter.Literal         `cty:"vpc_id"`
+	VPCID       *terraformWriter.Literal        `cty:"vpc_id"`
 	Tags        map[string]string               `cty:"tags"`
 	HealthCheck terraformTargetGroupHealthCheck `cty:"health_check"`
 }
@@ -240,7 +240,7 @@ func (_ *TargetGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 		Name:     *e.Name,
 		Port:     *e.Port,
 		Protocol: *e.Protocol,
-		VPCID:    *e.VPC.TerraformLink(),
+		VPCID:    e.VPC.TerraformLink(),
 		Tags:     e.Tags,
 		HealthCheck: terraformTargetGroupHealthCheck{
 			Interval:           *e.Interval,
@@ -253,7 +253,7 @@ func (_ *TargetGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 	return t.RenderResource("aws_lb_target_group", *e.Name, tf)
 }
 
-func (e *TargetGroup) TerraformLink(params ...string) *terraformWriter.Literal {
+func (e *TargetGroup) TerraformLink() *terraformWriter.Literal {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		if e.ARN != nil {

--- a/upup/pkg/fi/cloudup/terraform/hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/hcl2.go
@@ -17,10 +17,8 @@ limitations under the License.
 package terraform
 
 import (
-	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -104,14 +102,13 @@ func writeValue(body *hclwrite.Body, key string, value cty.Value) {
 // key = res_type.res_name.res_prop
 // key = file("${module.path}/foo")
 func writeLiteral(body *hclwrite.Body, key string, literal *terraformWriter.Literal) {
-	if literal.FnName != "" {
-		tokens := hclwrite.Tokens{
+	if literal.String != "" {
+		body.SetAttributeRaw(key, hclwrite.Tokens{
 			{
 				Type:  hclsyntax.TokenIdent,
-				Bytes: []byte(fmt.Sprintf("%v(%v)", literal.FnName, strings.Join(literal.FnArgs, ", "))),
+				Bytes: []byte(literal.String),
 			},
-		}
-		body.SetAttributeRaw(key, tokens)
+		})
 	} else if literal.Index {
 		tokens := hclwrite.Tokens{
 			{
@@ -242,10 +239,10 @@ func writeMap(body *hclwrite.Body, key string, values map[string]cty.Value) {
 		errLiteralSlice := gocty.FromCtyValue(v, refLiteralSlice.Interface())
 		// If this is a map of literals then do not surround the value with quotes
 		if literal, ok := refLiteral.Interface().(*terraformWriter.Literal); errLiteral == nil && ok {
-			if literal.FnName != "" {
+			if literal.String != "" {
 				tokens = append(tokens, &hclwrite.Token{
 					Type:  hclsyntax.TokenIdent,
-					Bytes: []byte(fmt.Sprintf("%v(%v)", literal.FnName, strings.Join(literal.FnArgs, ", "))),
+					Bytes: []byte(literal.String),
 				})
 			} else if literal.Value != "" {
 				tokens = append(tokens, []*hclwrite.Token{

--- a/upup/pkg/fi/cloudup/terraformWriter/literal.go
+++ b/upup/pkg/fi/cloudup/terraformWriter/literal.go
@@ -27,6 +27,8 @@ import (
 
 // Literal represents a literal in terraform syntax
 type Literal struct {
+	// String is the Terraform representation.
+	String string `cty:"string"`
 	// Value is used to support Terraform's "${}" interpolation.
 	Value string `cty:"value"`
 	// Index to support the index of the count meta-argument.
@@ -36,8 +38,6 @@ type Literal struct {
 	// example: {"aws_vpc", "foo", "id"}
 	Tokens []string `cty:"tokens"`
 
-	// FnName represents the name of a terraform function.
-	FnName string `cty:"fn_name"`
 	// FnArgs contains string representations of arguments to the function call.
 	// Any string arguments must be quoted.
 	FnArgs []string `cty:"fn_arg"`
@@ -51,8 +51,8 @@ func (l *Literal) MarshalJSON() ([]byte, error) {
 
 func LiteralFunctionExpression(functionName string, args ...string) *Literal {
 	return &Literal{
+		String: fmt.Sprintf("%v(%v)", functionName, strings.Join(args, ", ")),
 		Value:  fmt.Sprintf("${%v(%v)}", functionName, strings.Join(args, ", ")),
-		FnName: functionName,
 		FnArgs: args,
 	}
 }


### PR DESCRIPTION
This is a first step in refactoring the rendering logic of `terraformWriter.Literal` into the respective constructors. This refactors `LiteralFunctionExpression()`; the other constructors would switch to using `String` in subsequent PRs.

What do you think @rifelpet ?
/assign @rifelpet 