### PR TITLE
Details around Cilium Encryption risks & limits

### DIFF
--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -137,6 +137,8 @@ Also note that this feature has only been tested on the default kOps AMIs.
 
 #### Enabling Encryption in Cilium
 
+Encryption in Cilium is an area under active development seeking maintainers for several feature areas. There are varying levels of support for encryption features. Specifically, use caution when enabling encryption alongside enabling Cilium NodePort support, as this combination has been noted to result in broken deployments. Understand the [limitations](https://github.com/cilium/cilium/issues/13663) and state of the features before enabling IPSec or Wireguard.
+
 ##### ipsec
 {{ kops_feature_table(kops_added_default='1.19', k8s_min='1.17') }}
 


### PR DESCRIPTION
Ciilium encryption is not currently in a very compatible or complete state and frequently can result in broken deployments, especially when used in conjunction with other Cilium features supported by kOps (ex: NodePort and IPSec simply do not work together currently and there is no path or estimate for this). This PR simply highlights this risk and links to a relevant open issue in the Cilium repo regarding details. 