### PR TITLE
Automated cherry pick of #14667: We no longer release an images.tar.gz

### DIFF
--- a/.shipbot.yaml
+++ b/.shipbot.yaml
@@ -45,7 +45,3 @@ assets:
     githubName: channels-linux-arm64
   - source: linux/arm64/channels.sha256
     githubName: channels-linux-arm64.sha256
-  - source: images/images.tar.gz
-    githubName: images.tar.gz
-  - source: images/images.tar.gz.sha256
-    githubName: images.tar.gz.sha256


### PR DESCRIPTION
Cherry pick of #14667 on release-1.25.

#14667: We no longer release an images.tar.gz

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```