### PR TITLE
Make `--cloud` and `--zones` flags required

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -231,11 +231,13 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		sort.Strings(validClouds)
 	}
 	cmd.Flags().StringVar(&options.CloudProvider, "cloud", options.CloudProvider, fmt.Sprintf("Cloud provider to use - %s", strings.Join(validClouds, ", ")))
+	cmd.MarkFlagRequired("cloud")
 	cmd.RegisterFlagCompletionFunc("cloud", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return validClouds, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	cmd.Flags().StringSliceVar(&options.Zones, "zones", options.Zones, "Zones in which to run the cluster")
+	cmd.MarkFlagRequired("zones")
 	cmd.RegisterFlagCompletionFunc("zones", completeZone(options))
 	cmd.Flags().StringSliceVar(&options.ControlPlaneZones, "control-plane-zones", options.ControlPlaneZones, "Zones in which to run control-plane nodes. (must be an odd number)")
 	cmd.RegisterFlagCompletionFunc("control-plane-zones", completeZone(options))

--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -147,13 +147,12 @@ func NewCmdRoot(f *util.Factory, out io.Writer) *cobra.Command {
 		return []string{"yaml", "json"}, cobra.ShellCompDirectiveFilterFileExt
 	})
 
-	cmd.PersistentFlags().StringVar(&rootCommand.RegistryPath, "state", "", "Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable")
-	viper.BindPFlag("KOPS_STATE_STORE", cmd.PersistentFlags().Lookup("state"))
 	viper.BindEnv("KOPS_STATE_STORE")
+	cmd.PersistentFlags().StringVar(&rootCommand.RegistryPath, "state", viper.GetString("KOPS_STATE_STORE"), "Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable")
 	// TODO implement completion against VFS
 
-	defaultClusterName := os.Getenv("KOPS_CLUSTER_NAME")
-	cmd.PersistentFlags().StringVarP(&rootCommand.clusterName, "name", "", defaultClusterName, "Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable")
+	viper.BindEnv("KOPS_CLUSTER_NAME")
+	cmd.PersistentFlags().StringVar(&rootCommand.clusterName, "name", viper.GetString("KOPS_CLUSTER_NAME"), "Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable")
 	cmd.RegisterFlagCompletionFunc("name", commandutils.CompleteClusterName(rootCommand.factory, false, false))
 
 	// create subcommands

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/client/simple"
 	"k8s.io/kops/pkg/featureflag"
-	"k8s.io/kops/pkg/zones"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
@@ -288,24 +287,9 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 	allZones.Insert(opt.ControlPlaneZones...)
 
 	if opt.CloudProvider == "" {
-		for _, zone := range allZones.List() {
-			cloud, known := zones.GuessCloudForZone(zone)
-			if known {
-				klog.Infof("Inferred %q cloud provider from zone %q", cloud, zone)
-				opt.CloudProvider = string(cloud)
-				break
-			}
-		}
-		if opt.CloudProvider == "" {
-			if allZones.Len() == 0 {
-				return nil, fmt.Errorf("must specify --zones or --cloud")
-			}
-			return nil, fmt.Errorf("unable to infer cloud provider from zones. pass in the cloud provider explicitly using --cloud")
-		}
+		return nil, fmt.Errorf("must specify cloud provider for the cluster (use --cloud)")
 	}
-
 	var cloud fi.Cloud
-
 	switch api.CloudProviderID(opt.CloudProvider) {
 	case api.CloudProviderAWS:
 		cluster.Spec.CloudProvider.AWS = &api.AWSSpec{}


### PR DESCRIPTION
kOps has some logic that is inferring the cloud provider. This is done by matching the specified zones with cloud provider specific list of zones/regions. These lists are static and unlikely to be maintained over time. All this logic could be gone if the `--cloud` flag would be mandatory. As this flag is only passed during cluster creation, it seems to me a better approach than to rely on flaky guessing. Would also open the possibility to start initialising the cloud components earlier and do better validation in the future (like for AWS instance types).

/cc @johngmyers @olemarkus @rifelpet 