### PR TITLE
Stop trying to populate arbitrary cluster fields from the channel

### DIFF
--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -352,15 +352,6 @@ func RecommendedKubernetesVersion(c *Channel, kopsVersionString string) *semver.
 		}
 	}
 
-	if c.Spec.Cluster != nil {
-		sv, err := util.ParseKubernetesVersion(c.Spec.Cluster.KubernetesVersion)
-		if err != nil {
-			klog.Warningf("unable to parse kubernetes version %q", c.Spec.Cluster.KubernetesVersion)
-		} else {
-			return sv
-		}
-	}
-
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -202,16 +202,13 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 		},
 	}
 
-	if channel.Spec.Cluster != nil {
-		cluster.Spec = *channel.Spec.Cluster
-
+	cluster.Spec.Channel = opt.Channel
+	if opt.KubernetesVersion == "" {
 		kubernetesVersion := api.RecommendedKubernetesVersion(channel, kops.Version)
 		if kubernetesVersion != nil {
 			cluster.Spec.KubernetesVersion = kubernetesVersion.String()
 		}
-	}
-	cluster.Spec.Channel = opt.Channel
-	if opt.KubernetesVersion != "" {
+	} else {
 		cluster.Spec.KubernetesVersion = opt.KubernetesVersion
 	}
 


### PR DESCRIPTION
When I refactored `Spec.Networking` to be a non-pointer, this code started forcing new clusters to have Kubenet.

This seems to be an extremely dubious feature.