### PR TITLE
Fix edit.HasExtraFields()

### DIFF
--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -214,7 +214,7 @@ func RunEditCluster(ctx context.Context, f *util.Factory, out io.Writer, options
 			continue
 		}
 
-		extraFields, err := edit.HasExtraFields(string(edited), newObj)
+		extraFields, err := edit.HasExtraFields(string(edited))
 		if err != nil {
 			results = editResults{
 				file: file,

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -242,7 +242,7 @@ func RunEditInstanceGroup(ctx context.Context, f *util.Factory, out io.Writer, o
 			continue
 		}
 
-		extraFields, err := edit.HasExtraFields(string(edited), newObj)
+		extraFields, err := edit.HasExtraFields(string(edited))
 		if err != nil {
 			results = editResults{
 				file: file,


### PR DESCRIPTION
The current implementation assumes that the v1alpha1 form is the same as the internal form. There are a bunch of logic errors in both the implementation and test.

The new version is much simpler and does not rely on conversion to the internal API.