### PR TITLE
gce: Update default instance types

### DIFF
--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -13,7 +13,7 @@ with "control-plane-". The names of groups for existing clusters are unchanged.
 
 * The channels CLI that kOps use to manage addons is now bundled with the kOps binary. These commands are useful for addon diagnostics and troubleshooting. For example, to list installed addons, run `kops toolbox addons get addons`.
 
-## AWS only
+## AWS
 
 * Bastions are now fronted by a Network Load Balancer.
 
@@ -28,6 +28,10 @@ with "control-plane-". The names of groups for existing clusters are unchanged.
 * CapacityRebalance can be enabled/disabled on ASGs through a new `capacityRebalance` field in InstanceGroup specs.
 
 * New clusters can more easily be configured to use Cilium in ENI mode by setting `--networking=cilium-eni`.
+
+## GCP
+
+* The default instance type is now `e2-medium` for control-plane and worker nodes, and `e2-micro` for bastions.
 
 # Breaking changes
 

--- a/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
@@ -85,7 +85,7 @@ metadata:
   name: nodes-us-test1-a
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20221018
-  machineType: n1-standard-2
+  machineType: e2-medium
   maxSize: 1
   minSize: 1
   role: Node

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -132,7 +132,7 @@ metadata:
   name: nodes-us-test1-a
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20221018
-  machineType: n1-standard-2
+  machineType: e2-medium
   maxSize: 1
   minSize: 1
   role: Node
@@ -152,7 +152,7 @@ metadata:
   name: nodes-us-test1-b
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20221018
-  machineType: n1-standard-2
+  machineType: e2-medium
   maxSize: 1
   minSize: 1
   role: Node
@@ -172,7 +172,7 @@ metadata:
   name: nodes-us-test1-c
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20221018
-  machineType: n1-standard-2
+  machineType: e2-medium
   maxSize: 1
   minSize: 1
   role: Node

--- a/tests/integration/create_cluster/minimal-1.26-gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-gce/expected-v1alpha2.yaml
@@ -84,7 +84,7 @@ metadata:
   name: nodes-us-test1-a
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20221018
-  machineType: n1-standard-2
+  machineType: e2-medium
   maxSize: 1
   minSize: 1
   role: Node

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -72,7 +72,7 @@ metadata:
   name: bastions
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20221018
-  machineType: f1-micro
+  machineType: e2-micro
   maxSize: 1
   minSize: 1
   role: Bastion
@@ -118,7 +118,7 @@ spec:
   - sg-exampleid
   - sg-exampleid2
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20221018
-  machineType: n1-standard-2
+  machineType: e2-medium
   maxSize: 1
   minSize: 1
   role: Node

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -36,12 +36,12 @@ import (
 
 // Default Machine types for various types of instance group machine
 const (
-	defaultNodeMachineTypeGCE     = "n1-standard-2"
+	defaultNodeMachineTypeGCE     = "e2-medium"
 	defaultNodeMachineTypeDO      = "s-2vcpu-4gb"
 	defaultNodeMachineTypeAzure   = "Standard_B2s"
 	defaultNodeMachineTypeHetzner = "cx21"
 
-	defaultBastionMachineTypeGCE     = "f1-micro"
+	defaultBastionMachineTypeGCE     = "e2-micro"
 	defaultBastionMachineTypeAzure   = "Standard_B2s"
 	defaultBastionMachineTypeHetzner = "cx11"
 


### PR DESCRIPTION
These instance types seems newer and with better availability and cost/performance ratio (same type for masters and nodes).

/cc @justinsb 
/assign @justinsb 