### PR TITLE
Fix the addons/authentication.aws startup failure

### DIFF
--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
@@ -134,6 +134,26 @@ subjects:
 
 ---
 
+apiVersion: v1
+data:
+  config.yaml: |
+    # a unique-per-cluster identifier to prevent replay attacks
+    # (good choices are a random token or a domain name that will be unique to your cluster)
+
+    clusterID: complex.example.com
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    k8s-app: aws-iam-authenticator
+    role.kubernetes.io/authentication: "1"
+  name: aws-iam-authenticator
+  namespace: kube-system
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 73a17cf8c3602388b0dc3a33d5df80c3384892fd86d7d58702aec434f1915a10
+    manifestHash: ce1f1344feccd0106242ecfca0c95750acf751f511fc03748471ec94041c6fb0
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -110,6 +110,21 @@ subjects:
   namespace: kube-system
 
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: kube-system
+  name: aws-iam-authenticator
+  labels:
+    k8s-app: aws-iam-authenticator
+data:
+  config.yaml: |
+    # a unique-per-cluster identifier to prevent replay attacks
+    # (good choices are a random token or a domain name that will be unique to your cluster)
+
+    clusterID: {{ or .Authentication.AWS.ClusterID ClusterName }}
+
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -158,7 +173,7 @@ spec:
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: aws-iam-authenticator
-        image: {{ or .Authentication.AWS.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.9" }}
+        image: {{ or .Authentication.AWS.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.12" }}
         args:
         - server
         {{- if or (not .Authentication.AWS.BackendMode) (contains "MountedFile" .Authentication.AWS.BackendMode) }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
@@ -134,6 +134,26 @@ subjects:
 
 ---
 
+apiVersion: v1
+data:
+  config.yaml: |
+    # a unique-per-cluster identifier to prevent replay attacks
+    # (good choices are a random token or a domain name that will be unique to your cluster)
+
+    clusterID: custom-cluster-ID
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    k8s-app: aws-iam-authenticator
+    role.kubernetes.io/authentication: "1"
+  name: aws-iam-authenticator
+  namespace: kube-system
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 6f65c3a4aefb968a74fadb7d957ca738687b85b21fcaadd5446822601921f86b
+    manifestHash: d06bf33ddf2675741cffefa4d0cf3141fa20d07c27b5890fde341aec94284187
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
@@ -134,6 +134,26 @@ subjects:
 
 ---
 
+apiVersion: v1
+data:
+  config.yaml: |
+    # a unique-per-cluster identifier to prevent replay attacks
+    # (good choices are a random token or a domain name that will be unique to your cluster)
+
+    clusterID: minimal.example.com
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    k8s-app: aws-iam-authenticator
+    role.kubernetes.io/authentication: "1"
+  name: aws-iam-authenticator
+  namespace: kube-system
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: e8c9ce3983b6a5c5ee7a4dd37a203a8c8c41a1a741b4be7188f6e2fda3a77cb5
+    manifestHash: c970483b8c3fb2059ec916e320c6b27e118e64a5bbccd9b4222f4d3c118a0139
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"


### PR DESCRIPTION
The aws-iam-authenticator pod always fails from [kops update cluster ](https://kops.sigs.k8s.io/getting_started/aws/#build-the-cluster) complaining the following error. This PR fix the error. 
The added configMap is only placeholder to avoid the mounting error as below. It still prevents unauthorized user/role from authenticating. 

```
Events:
  Type     Reason       Age                   From     Message
  ----     ------       ----                  ----     -------
  Warning  FailedMount  44m                   kubelet  Unable to attach or mount volumes: unmounted volumes=[config], unattached volumes=[output kube-api-access-rkvtd config state]: timed out waiting for the condition
  Warning  FailedMount  31m (x5 over 60m)     kubelet  Unable to attach or mount volumes: unmounted volumes=[config], unattached volumes=[kube-api-access-rkvtd config state output]: timed out waiting for the condition
  Warning  FailedMount  26m (x2 over 56m)     kubelet  Unable to attach or mount volumes: unmounted volumes=[config], unattached volumes=[state output kube-api-access-rkvtd config]: timed out waiting for the condition
  Warning  FailedMount  6m19s (x16 over 65m)  kubelet  Unable to attach or mount volumes: unmounted volumes=[config], unattached volumes=[config state output kube-api-access-rkvtd]: timed out waiting for the condition
  Warning  FailedMount  2m7s (x40 over 67m)   kubelet  MountVolume.SetUp failed for volume "config" : configmap "aws-iam-authenticator" not found
```
/cc @olemarkus
/assign @olemarkus