### PR TITLE
aws: Skip Route53 cleanup for clusters without DNS

### DIFF
--- a/pkg/resources/ops/collector.go
+++ b/pkg/resources/ops/collector.go
@@ -41,7 +41,7 @@ func ListResources(cloud fi.Cloud, cluster *kops.Cluster, region string) (map[st
 	clusterName := cluster.Name
 	switch cloud.ProviderID() {
 	case kops.CloudProviderAWS:
-		return aws.ListResourcesAWS(cloud.(awsup.AWSCloud), clusterName)
+		return aws.ListResourcesAWS(cloud.(awsup.AWSCloud), cluster)
 	case kops.CloudProviderDO:
 		return digitalocean.ListResources(cloud.(clouddo.DOCloud), clusterName)
 	case kops.CloudProviderGCE:


### PR DESCRIPTION
Small cleanup improvement to get tests passing again in https://github.com/kubernetes/cloud-provider-aws/pull/532:
```
Ginkgo ran 1 suite in 2m57.709627616s
Test Suite Passed
/home/prow/go/src/k8s.io/cloud-provider-aws
I1202 08:29:47.704238   27602 delete_cluster.go:128] Looking for cloud resources to delete
Error: error querying for route53 zones: AccessDenied:
	User: arn:aws:iam::607362164682:user/awstester is not authorized to perform: route53:ListHostedZones
	because no identity-based policy allows the route53:ListHostedZones action
		status code: 403, request id: 911b0c35-ba05-4950-880f-3d78acabfddb
make: *** [Makefile:133: test-e2e] Error 1
```

/cc @olemarkus @johngmyers @rifelpet 