### PR TITLE
metrics-server: Set preferred address type to `InternalIP` when non AWS

### DIFF
--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 2c50298a62f772220623daac250303f2757a9393c63a441acd89f077f1b4c2f7
+    manifestHash: 1b89be4bcb1ed917bbd82781eebceec127f2d30eb13f6e5477e3e42f0cafc1b6
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -170,7 +170,7 @@ spec:
         - --secure-port=4443
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=Hostname
+        - --kubelet-preferred-address-types=InternalIP
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
         image: registry.k8s.io/metrics-server/metrics-server:v0.6.1

--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -132,7 +132,7 @@ spec:
           - --secure-port=4443
           - --kubelet-use-node-status-port
           - --metric-resolution=15s
-          - --kubelet-preferred-address-types={{ if or IsIPv6Only (eq GetCloudProvider "hetzner")}}InternalIP{{ else }}Hostname{{ end }}
+          - --kubelet-preferred-address-types={{ if or IsIPv6Only (not (eq GetCloudProvider "aws"))}}InternalIP{{ else }}Hostname{{ end }}
 {{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
           - --tls-cert-file=/srv/tls.crt
           - --tls-private-key-file=/srv/tls.key


### PR DESCRIPTION
Closes #14708 

/cc @olemarkus 