### PR TITLE
scaleway: list and delete resources

### DIFF
--- a/pkg/resources/ops/collector.go
+++ b/pkg/resources/ops/collector.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kops/pkg/resources/gce"
 	"k8s.io/kops/pkg/resources/hetzner"
 	"k8s.io/kops/pkg/resources/openstack"
+	"k8s.io/kops/pkg/resources/scaleway"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	cloudazure "k8s.io/kops/upup/pkg/fi/cloudup/azure"
@@ -34,6 +35,7 @@ import (
 	cloudgce "k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	cloudhetzner "k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
 	cloudopenstack "k8s.io/kops/upup/pkg/fi/cloudup/openstack"
+	cloudscaleway "k8s.io/kops/upup/pkg/fi/cloudup/scaleway"
 )
 
 // ListResources collects the resources from the specified cloud
@@ -60,6 +62,8 @@ func ListResources(cloud fi.Cloud, cluster *kops.Cluster) (map[string]*resources
 		clusterInfo.AzureNetworkShared = cluster.SharedVPC()
 		clusterInfo.AzureRouteTableShared = cluster.IsSharedAzureRouteTable()
 		return azure.ListResourcesAzure(cloud.(cloudazure.AzureCloud), clusterInfo)
+	case kops.CloudProviderScaleway:
+		return scaleway.ListResources(cloud.(cloudscaleway.ScwCloud), clusterInfo)
 	default:
 		return nil, fmt.Errorf("delete on clusters on %q not (yet) supported", cloud.ProviderID())
 	}

--- a/pkg/resources/scaleway/OWNERS
+++ b/pkg/resources/scaleway/OWNERS
@@ -1,0 +1,3 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+labels:
+- area/provider/scaleway

--- a/pkg/resources/scaleway/resources.go
+++ b/pkg/resources/scaleway/resources.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaleway
+
+import (
+	"k8s.io/kops/pkg/resources"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/scaleway"
+
+	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+)
+
+const (
+	resourceTypeServer = "server"
+	resourceTypeSSHKey = "ssh-key"
+	resourceTypeVolume = "volume"
+)
+
+type listFn func(fi.Cloud, string) ([]*resources.Resource, error)
+
+func ListResources(cloud scaleway.ScwCloud, clusterInfo resources.ClusterInfo) (map[string]*resources.Resource, error) {
+	resourceTrackers := make(map[string]*resources.Resource)
+	clusterName := clusterInfo.Name
+
+	listFunctions := []listFn{
+		listServers,
+		listSSHKeys,
+		listVolumes,
+	}
+
+	for _, fn := range listFunctions {
+		rt, err := fn(cloud, clusterName)
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range rt {
+			resourceTrackers[t.Type+":"+t.ID] = t
+		}
+	}
+
+	return resourceTrackers, nil
+}
+
+func listServers(cloud fi.Cloud, clusterName string) ([]*resources.Resource, error) {
+	c := cloud.(scaleway.ScwCloud)
+	servers, err := c.GetClusterServers(clusterName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceTrackers := []*resources.Resource(nil)
+	for _, server := range servers {
+		resourceTracker := &resources.Resource{
+			Name: server.Name,
+			ID:   server.ID,
+			Type: resourceTypeServer,
+			Deleter: func(cloud fi.Cloud, tracker *resources.Resource) error {
+				return deleteServer(cloud, tracker)
+			},
+			Obj: server,
+		}
+		resourceTrackers = append(resourceTrackers, resourceTracker)
+	}
+
+	return resourceTrackers, nil
+}
+
+func listSSHKeys(cloud fi.Cloud, clusterName string) ([]*resources.Resource, error) {
+	c := cloud.(scaleway.ScwCloud)
+	sshkeys, err := c.GetClusterSSHKeys(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceTrackers := []*resources.Resource(nil)
+	for _, sshkey := range sshkeys {
+		resourceTracker := &resources.Resource{
+			Name: sshkey.Name,
+			ID:   sshkey.ID,
+			Type: resourceTypeSSHKey,
+			Deleter: func(cloud fi.Cloud, tracker *resources.Resource) error {
+				return deleteSSHKey(cloud, tracker)
+			},
+			Obj: sshkey,
+		}
+		resourceTrackers = append(resourceTrackers, resourceTracker)
+	}
+
+	return resourceTrackers, nil
+}
+
+func listVolumes(cloud fi.Cloud, clusterName string) ([]*resources.Resource, error) {
+	c := cloud.(scaleway.ScwCloud)
+	volumes, err := c.GetClusterVolumes(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceTrackers := []*resources.Resource(nil)
+	for _, volume := range volumes {
+		resourceTracker := &resources.Resource{
+			Name: volume.Name,
+			ID:   volume.ID,
+			Type: resourceTypeVolume,
+			Deleter: func(cloud fi.Cloud, tracker *resources.Resource) error {
+				return deleteVolume(cloud, tracker)
+			},
+			Obj: volume,
+		}
+		if volume.Server != nil {
+			resourceTracker.Blocked = []string{resourceTypeServer + ":" + volume.Server.ID}
+		}
+		resourceTrackers = append(resourceTrackers, resourceTracker)
+	}
+
+	return resourceTrackers, nil
+}
+
+func deleteServer(cloud fi.Cloud, tracker *resources.Resource) error {
+	c := cloud.(scaleway.ScwCloud)
+	server := tracker.Obj.(*instance.Server)
+
+	return c.DeleteServer(server)
+}
+
+func deleteSSHKey(cloud fi.Cloud, tracker *resources.Resource) error {
+	c := cloud.(scaleway.ScwCloud)
+	sshkey := tracker.Obj.(*iam.SSHKey)
+
+	return c.DeleteSSHKey(sshkey)
+}
+
+func deleteVolume(cloud fi.Cloud, tracker *resources.Resource) error {
+	c := cloud.(scaleway.ScwCloud)
+	volume := tracker.Obj.(*instance.Volume)
+
+	return c.DeleteVolume(volume)
+}

--- a/upup/pkg/fi/cloudup/scalewaytasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/sshkey.go
@@ -122,7 +122,8 @@ func (*SSHKey) RenderScw(c *fi.Context, actual, expected, changes *SSHKey) error
 	klog.V(2).Infof("Creating keypair with name: %q", name)
 
 	keyArgs := &iam.CreateSSHKeyRequest{
-		Name: name}
+		Name: name,
+	}
 	if expected.PublicKey != nil {
 		d, err := fi.ResourceAsString(*expected.PublicKey)
 		if err != nil {


### PR DESCRIPTION
Now that the `kops create cluster` command actually creates a Scaleway cluster, this new PR should add everything that is needed for the `kops delete cluster` command to be able to destroy it, which will be useful to implement automated testing.