### PR TITLE
aws: Use EnsureTask to reference shared target groups

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -480,7 +480,9 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 				Shared:           fi.PtrTo(true),
 			}
 			t.LoadBalancers = append(t.LoadBalancers, lb)
-			c.EnsureTask(lb)
+			if err := c.EnsureTask(lb); err != nil {
+				return nil, err
+			}
 		}
 
 		if extLB.TargetGroupARN != nil {
@@ -489,13 +491,15 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 				return nil, err
 			}
 			tg := &awstasks.TargetGroup{
-				Name:      fi.PtrTo(name + "-" + targetGroupName),
+				Name:      fi.PtrTo(targetGroupName),
 				Lifecycle: b.Lifecycle,
 				ARN:       extLB.TargetGroupARN,
 				Shared:    fi.PtrTo(true),
 			}
 			t.TargetGroups = append(t.TargetGroups, tg)
-			c.AddTask(tg)
+			if err := c.EnsureTask(tg); err != nil {
+				return nil, err
+			}
 		}
 	}
 	sort.Stable(awstasks.OrderLoadBalancersByName(t.LoadBalancers))

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -188,11 +188,7 @@ func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
 			if err != nil {
 				return nil, err
 			}
-			if targetGroupName != awsup.GetResourceName32(c.Cluster.Name, "tcp") && targetGroupName != awsup.GetResourceName32(c.Cluster.Name, "tls") {
-				actual.TargetGroups = append(actual.TargetGroups, &TargetGroup{ARN: aws.String(*tg), Name: aws.String(targetGroupName)})
-			} else {
-				actual.TargetGroups = append(actual.TargetGroups, &TargetGroup{ARN: aws.String(*tg), Name: aws.String(fi.ValueOf(g.AutoScalingGroupName) + "-" + targetGroupName)})
-			}
+			actual.TargetGroups = append(actual.TargetGroups, &TargetGroup{ARN: aws.String(*tg), Name: aws.String(targetGroupName)})
 		}
 	}
 	sort.Stable(OrderTargetGroupsByName(actual.TargetGroups))


### PR DESCRIPTION
This optimises the way we reference shared (external) target groups by using `EnsureTask()` instead of pre-pending the autoscaling group name.

Ref: https://github.com/kubernetes/kops/pull/10335