### PR TITLE
aws: Add support for managing target group attributes

### DIFF
--- a/cloudmock/aws/mockelbv2/api.go
+++ b/cloudmock/aws/mockelbv2/api.go
@@ -48,6 +48,7 @@ type loadBalancer struct {
 
 type targetGroup struct {
 	description elbv2.TargetGroup
+	attributes  []*elbv2.TargetGroupAttribute
 }
 
 type listener struct {

--- a/cloudmock/aws/mockelbv2/targetgroups.go
+++ b/cloudmock/aws/mockelbv2/targetgroups.go
@@ -131,3 +131,24 @@ func (m *MockELBV2) DeleteTargetGroup(request *elbv2.DeleteTargetGroupInput) (*e
 	delete(m.TargetGroups, arn)
 	return &elbv2.DeleteTargetGroupOutput{}, nil
 }
+
+func (m *MockELBV2) DescribeTargetGroupAttributes(request *elbv2.DescribeTargetGroupAttributesInput) (*elbv2.DescribeTargetGroupAttributesOutput, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	klog.Infof("DescribeTargetGroupAttributes %v", request)
+
+	arn := aws.StringValue(request.TargetGroupArn)
+	return &elbv2.DescribeTargetGroupAttributesOutput{Attributes: m.TargetGroups[arn].attributes}, nil
+}
+
+func (m *MockELBV2) ModifyTargetGroupAttributes(request *elbv2.ModifyTargetGroupAttributesInput) (*elbv2.ModifyTargetGroupAttributesOutput, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	klog.Infof("ModifyTargetGroupAttributes %v", request)
+
+	arn := aws.StringValue(request.TargetGroupArn)
+	m.TargetGroups[arn].attributes = request.Attributes
+	return &elbv2.ModifyTargetGroupAttributesOutput{Attributes: request.Attributes}, nil
+}

--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -274,6 +274,10 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 		if b.APILoadBalancerClass() == kops.LoadBalancerClassClassic {
 			c.AddTask(clb)
 		} else if b.APILoadBalancerClass() == kops.LoadBalancerClassNetwork {
+			groupAttrs := map[string]string{
+				awstasks.TargetGroupAttributeDeregistrationDelayConnectionTerminationEnabled: "true",
+				awstasks.TargetGroupAttributeDeregistrationDelayTimeoutSeconds:               "30",
+			}
 
 			{
 				groupName := b.NLBTargetGroupName("tcp")
@@ -289,6 +293,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 					Tags:               groupTags,
 					Protocol:           fi.PtrTo("TCP"),
 					Port:               fi.PtrTo(int64(443)),
+					Attributes:         groupAttrs,
 					Interval:           fi.PtrTo(int64(10)),
 					HealthyThreshold:   fi.PtrTo(int64(2)),
 					UnhealthyThreshold: fi.PtrTo(int64(2)),
@@ -314,6 +319,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 					Tags:               groupTags,
 					Protocol:           fi.PtrTo("TCP"),
 					Port:               fi.PtrTo(int64(wellknownports.KopsControllerPort)),
+					Attributes:         groupAttrs,
 					Interval:           fi.PtrTo(int64(10)),
 					HealthyThreshold:   fi.PtrTo(int64(2)),
 					UnhealthyThreshold: fi.PtrTo(int64(2)),
@@ -338,6 +344,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 					Tags:               tlsGroupTags,
 					Protocol:           fi.PtrTo("TLS"),
 					Port:               fi.PtrTo(int64(443)),
+					Attributes:         groupAttrs,
 					Interval:           fi.PtrTo(int64(10)),
 					HealthyThreshold:   fi.PtrTo(int64(2)),
 					UnhealthyThreshold: fi.PtrTo(int64(2)),

--- a/pkg/model/awsmodel/bastion.go
+++ b/pkg/model/awsmodel/bastion.go
@@ -289,6 +289,11 @@ func (b *BastionModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		// Override the returned name to be the expected NLB TG name
 		sshGroupTags["Name"] = sshGroupName
 
+		groupAttrs := map[string]string{
+			awstasks.TargetGroupAttributeDeregistrationDelayConnectionTerminationEnabled: "true",
+			awstasks.TargetGroupAttributeDeregistrationDelayTimeoutSeconds:               "30",
+		}
+
 		tg := &awstasks.TargetGroup{
 			Name:               fi.PtrTo(sshGroupName),
 			Lifecycle:          b.Lifecycle,
@@ -296,6 +301,7 @@ func (b *BastionModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Tags:               sshGroupTags,
 			Protocol:           fi.PtrTo("TCP"),
 			Port:               fi.PtrTo(int64(22)),
+			Attributes:         groupAttrs,
 			Interval:           fi.PtrTo(int64(10)),
 			HealthyThreshold:   fi.PtrTo(int64(2)),
 			UnhealthyThreshold: fi.PtrTo(int64(2)),

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -726,6 +726,8 @@ resource "aws_lb_listener" "bastion-bastionuserdata-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-bastionuserdata-e-4grhsv" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -574,6 +574,8 @@ resource "aws_lb_listener" "api-complex-example-com-8443" {
 }
 
 resource "aws_lb_target_group" "tcp-complex-example-com-vpjolq" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10
@@ -594,6 +596,8 @@ resource "aws_lb_target_group" "tcp-complex-example-com-vpjolq" {
 }
 
 resource "aws_lb_target_group" "tls-complex-example-com-5nursn" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
@@ -511,6 +511,8 @@ resource "aws_lb_listener" "api-minimal-example-com-443" {
 }
 
 resource "aws_lb_target_group" "kops-controller-minimal-e-uvauf3" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10
@@ -529,6 +531,8 @@ resource "aws_lb_target_group" "kops-controller-minimal-e-uvauf3" {
 }
 
 resource "aws_lb_target_group" "tcp-minimal-example-com-5905t8" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
@@ -550,6 +550,8 @@ resource "aws_lb_listener" "api-minimal-ipv6-example-com-443" {
 }
 
 resource "aws_lb_target_group" "tcp-minimal-ipv6-example--bne5ih" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
@@ -550,6 +550,8 @@ resource "aws_lb_listener" "api-minimal-ipv6-example-com-443" {
 }
 
 resource "aws_lb_target_group" "tcp-minimal-ipv6-example--bne5ih" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
@@ -550,6 +550,8 @@ resource "aws_lb_listener" "api-minimal-ipv6-example-com-443" {
 }
 
 resource "aws_lb_target_group" "tcp-minimal-ipv6-example--bne5ih" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
@@ -550,6 +550,8 @@ resource "aws_lb_listener" "api-minimal-ipv6-example-com-443" {
 }
 
 resource "aws_lb_target_group" "tcp-minimal-ipv6-example--bne5ih" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -707,6 +707,8 @@ resource "aws_lb_listener" "bastion-private-shared-ip-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-private-shared-ip-eepmph" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -702,6 +702,8 @@ resource "aws_lb_listener" "bastion-private-shared-subnet-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-private-shared-su-5ol32q" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -689,6 +689,8 @@ resource "aws_lb_listener" "bastion-privatecalico-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-privatecalico-exa-hocohm" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -693,6 +693,8 @@ resource "aws_lb_listener" "bastion-privatecanal-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-privatecanal-exam-hmhsp5" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
@@ -725,6 +725,8 @@ resource "aws_lb_listener" "bastion-privatecilium-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-privatecilium-exa-l2ms01" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -725,6 +725,8 @@ resource "aws_lb_listener" "bastion-privatecilium-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-privatecilium-exa-l2ms01" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -693,6 +693,8 @@ resource "aws_lb_listener" "bastion-privatecilium-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-privatecilium-exa-l2ms01" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -742,6 +742,8 @@ resource "aws_lb_listener" "bastion-privateciliumadvanced-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-privateciliumadva-0jni40" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -799,6 +799,8 @@ resource "aws_lb_listener" "bastion-privatedns1-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-privatedns1-examp-mbgbef" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -716,6 +716,8 @@ resource "aws_lb_listener" "bastion-privatedns2-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-privatedns2-examp-e704o2" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -693,6 +693,8 @@ resource "aws_lb_listener" "bastion-privateflannel-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-privateflannel-ex-753531" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -734,6 +734,8 @@ resource "aws_lb_listener" "bastion-privatekopeio-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-privatekopeio-exa-d8ef8e" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -725,6 +725,8 @@ resource "aws_lb_listener" "bastion-privateweave-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-privateweave-exam-fdb6ge" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
@@ -532,6 +532,8 @@ resource "aws_lb_listener" "api-minimal-ipv6-example-com-443" {
 }
 
 resource "aws_lb_target_group" "tcp-minimal-ipv6-example--bne5ih" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -710,6 +710,8 @@ resource "aws_lb_listener" "bastion-unmanaged-example-com-22" {
 }
 
 resource "aws_lb_target_group" "bastion-unmanaged-example-d7bn3d" {
+  connection_termination = "true"
+  deregistration_delay   = "30"
   health_check {
     healthy_threshold   = 2
     interval            = 10


### PR DESCRIPTION
With this change, kOps now sets the following [NLB TG attributes](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#deregistration-delay):
* `deregistration_delay.connection_termination.enabled` with value `true`, instead of `false`
* `deregistration_delay.timeout_seconds` with value `30`, instead of `300`