### PR TITLE
OpenStack: Refactor Load Balancer builder

### DIFF
--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -69,6 +69,11 @@ func TestCreateClusterOpenStack(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/ha_openstack", "v1alpha2")
 }
 
+func TestCreateClusterOpenStackOctavia(t *testing.T) {
+	t.Setenv("OS_REGION_NAME", "us-test1")
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/ha_openstack_octavia", "v1alpha2")
+}
+
 // TestCreateClusterCilium runs kops with the cilium networking flags
 func TestCreateClusterCilium(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/cilium-eni", "v1alpha2")

--- a/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
@@ -1,0 +1,141 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  name: minimal.k8s.local
+spec:
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudConfig:
+    openstack:
+      blockStorage:
+        bs-version: v3
+        ignore-volume-az: false
+      monitor:
+        delay: 15s
+        maxRetries: 3
+        timeout: 10s
+      router:
+        externalNetwork: ""
+  cloudProvider: openstack
+  configBase: memfs://tests/minimal.k8s.local
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - instanceGroup: control-plane-us-test1-1
+      name: etcd-1
+    - instanceGroup: control-plane-us-test1-2
+      name: etcd-2
+    - instanceGroup: control-plane-us-test1-3
+      name: etcd-3
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+    - instanceGroup: control-plane-us-test1-1
+      name: etcd-1
+    - instanceGroup: control-plane-us-test1-2
+      name: etcd-2
+    - instanceGroup: control-plane-us-test1-3
+      name: etcd-3
+    memoryRequest: 100Mi
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubelet:
+    anonymousAuth: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  - ::/0
+  kubernetesVersion: v1.25.0
+  networkCIDR: 10.0.0.0/16
+  networking:
+    cni: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  - ::/0
+  subnets:
+  - cidr: 10.0.32.0/19
+    name: us-test1
+    type: Public
+    zone: us-test1
+  topology:
+    dns:
+      type: Private
+    masters: public
+    nodes: public
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.k8s.local
+  name: control-plane-us-test1-1
+spec:
+  image: ubuntu-20.04
+  machineType: n1-standard-1
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test1
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.k8s.local
+  name: control-plane-us-test1-2
+spec:
+  image: ubuntu-20.04
+  machineType: n1-standard-1
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test1
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.k8s.local
+  name: control-plane-us-test1-3
+spec:
+  image: ubuntu-20.04
+  machineType: n1-standard-1
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test1
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.k8s.local
+  name: nodes-us-test1
+spec:
+  image: ubuntu-20.04
+  machineType: n1-standard-1
+  maxSize: 1
+  minSize: 1
+  role: Node
+  subnets:
+  - us-test1

--- a/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   name: minimal.k8s.local
 spec:
+  api:
+    loadBalancer:
+      type: Public
   authorization:
     rbac: {}
   channel: stable
@@ -12,12 +15,18 @@ spec:
       blockStorage:
         bs-version: v3
         ignore-volume-az: false
+      loadbalancer:
+        floatingNetwork: vlan1
+        method: ROUND_ROBIN
+        provider: octavia
+        useOctavia: true
       monitor:
         delay: 15s
         maxRetries: 3
         timeout: 10s
       router:
-        externalNetwork: ""
+        dnsServers: 1.1.1.1
+        externalNetwork: vlan1
   cloudProvider: openstack
   configBase: memfs://tests/minimal.k8s.local
   etcdClusters:
@@ -60,13 +69,17 @@ spec:
   subnets:
   - cidr: 10.0.32.0/19
     name: us-test1
-    type: Public
+    type: Private
+    zone: us-test1
+  - cidr: 10.0.0.0/22
+    name: utility-us-test1
+    type: Utility
     zone: us-test1
   topology:
     dns:
       type: Private
-    masters: public
-    nodes: public
+    masters: private
+    nodes: private
 
 ---
 

--- a/tests/integration/create_cluster/ha_openstack_octavia/options.yaml
+++ b/tests/integration/create_cluster/ha_openstack_octavia/options.yaml
@@ -7,4 +7,8 @@ NetworkCIDR: 10.0.0.0/16
 Networking: cni
 Zones:
   - us-test1
-Octavia: true
+OpenstackLBOctavia: true
+OpenstackExternalNet: vlan1
+OpenstackDNSServers: 1.1.1.1
+APILoadBalancerType: public
+Topology: private

--- a/tests/integration/create_cluster/ha_openstack_octavia/options.yaml
+++ b/tests/integration/create_cluster/ha_openstack_octavia/options.yaml
@@ -1,0 +1,10 @@
+CloudProvider: openstack
+ClusterName: minimal.k8s.local
+Image: ubuntu-20.04
+KubernetesVersion: v1.25.0
+ControlPlaneCount: 3
+NetworkCIDR: 10.0.0.0/16
+Networking: cni
+Zones:
+  - us-test1
+Octavia: true


### PR DESCRIPTION
This should make the code more easier to reason about. It should also help uncover what breaks in #14546.

An additional error case is tested after this refactor. If octavia is configured, but no router is set, no LB client would be set on the cloud. Now we return error instead. This should be caught earlier by validation, but these additional tests doesn't hurt.

/cc @zetaab 