### PR TITLE
OpenStack: allow no lbclient when checking for vipacl

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -672,6 +672,9 @@ func (c *openstackCloud) UseLoadBalancerVIPACL() (bool, error) {
 }
 
 func useLoadBalancerVIPACL(c OpenstackCloud) (bool, error) {
+	if c.LoadBalancerClient() == nil {
+		return false, nil
+	}
 	allPages, err := apiversions.List(c.LoadBalancerClient()).AllPages()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Since OS' client builder can build a cloud without load balancer client, we need to account for this here.