### PR TITLE
bump k8s versions and ubuntu ami version in alpha channel

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -58,11 +58,11 @@ spec:
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20221018
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20221206
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0"
@@ -88,13 +88,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.25.0"
-    recommendedVersion: 1.25.4
+    recommendedVersion: 1.25.5
     requiredVersion: 1.25.0
   - range: ">=1.24.0"
-    recommendedVersion: 1.24.8
+    recommendedVersion: 1.24.9
     requiredVersion: 1.24.0
   - range: ">=1.23.0"
-    recommendedVersion: 1.23.14
+    recommendedVersion: 1.23.15
     requiredVersion: 1.23.0
   - range: ">=1.22.0"
     recommendedVersion: 1.22.16
@@ -139,15 +139,15 @@ spec:
   - range: ">=1.25.0-alpha.1"
     recommendedVersion: "1.25.2"
     #requiredVersion: 1.25.0
-    kubernetesVersion: 1.25.4
+    kubernetesVersion: 1.25.5
   - range: ">=1.24.0-alpha.1"
     recommendedVersion: "1.25.2"
     #requiredVersion: 1.24.0
-    kubernetesVersion: 1.24.8
+    kubernetesVersion: 1.24.9
   - range: ">=1.23.0-alpha.1"
     recommendedVersion: "1.25.2"
     #requiredVersion: 1.23.0
-    kubernetesVersion: 1.23.14
+    kubernetesVersion: 1.23.15
   - range: ">=1.22.0-alpha.1"
     recommendedVersion: "1.25.2"
     #requiredVersion: 1.22.0


### PR DESCRIPTION
* https://github.com/kubernetes/kubernetes/releases/tag/v1.25.5
* https://github.com/kubernetes/kubernetes/releases/tag/v1.24.9
* https://github.com/kubernetes/kubernetes/releases/tag/v1.23.15