### PR TITLE
Automated cherry pick of #14704: Update OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,24 +8,20 @@ emeritus_approvers:
   - chrislovecnm
   - chrisz100
   - gambol99
-  - granular-ryanbonham
-approvers:
   - geojaz
+  - granular-ryanbonham
+  - kashifsaadat
+  - mikesplain
+  - rdrgmnzs
+approvers:
   - hakman
   - johngmyers
   - justinsb
-  - kashifsaadat
-  - mikesplain
   - olemarkus
-  - rdrgmnzs
   - rifelpet
   - zetaab
 reviewers:
   - hakman
   - johngmyers
-  - joshbranham
-  - kashifsaadat
-  - mikesplain
   - olemarkus
-  - rdrgmnzs
   - zetaab

--- a/pkg/model/openstackmodel/OWNERS
+++ b/pkg/model/openstackmodel/OWNERS
@@ -1,8 +1,2 @@
-approvers:
-- dims # just for bootstrapping the provider
-- zetaab
-reviewers:
-- drekle
-- zetaab
 labels:
 - area/provider/openstack

--- a/pkg/resources/openstack/OWNERS
+++ b/pkg/resources/openstack/OWNERS
@@ -1,9 +1,2 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-approvers:
-- dims # just for bootstrapping the provider
-- zetaab
-reviewers:
-- drekle
-- zetaab
 labels:
 - area/provider/openstack

--- a/pkg/resources/spotinst/OWNERS
+++ b/pkg/resources/spotinst/OWNERS
@@ -1,7 +1,2 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-approvers:
-- liranp
-reviewers:
-- liranp
 labels:
 - area/provider/spotinst

--- a/upup/pkg/fi/cloudup/openstack/OWNERS
+++ b/upup/pkg/fi/cloudup/openstack/OWNERS
@@ -1,9 +1,2 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-approvers:
-- dims # just for bootstrapping the provider
-- zetaab
-reviewers:
-- drekle
-- zetaab
 labels:
 - area/provider/openstack

--- a/upup/pkg/fi/cloudup/openstacktasks/OWNERS
+++ b/upup/pkg/fi/cloudup/openstacktasks/OWNERS
@@ -1,9 +1,2 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-approvers:
-- dims # just for bootstrapping the provider
-- zetaab
-reviewers:
-- drekle
-- zetaab
 labels:
 - area/provider/openstack

--- a/upup/pkg/fi/cloudup/spotinsttasks/OWNERS
+++ b/upup/pkg/fi/cloudup/spotinsttasks/OWNERS
@@ -1,7 +1,2 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-approvers:
-- liranp
-reviewers:
-- liranp
 labels:
 - area/provider/spotinst


### PR DESCRIPTION
Cherry pick of #14704 on release-1.25.

#14704: Update OWNERS files

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```