### PR TITLE
Enable NTH capacity rebalance handling by default

### DIFF
--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -29,7 +29,7 @@ with "control-plane-". The names of groups for existing clusters are unchanged.
 
 * New clusters can more easily be configured to use Cilium in ENI mode by setting `--networking=cilium-eni`.
 
-* Node Termination Handler now defaults to Queue-Processor mode. It also now enables Scheduled Event Draining by default.
+* Node Termination Handler now defaults to Queue-Processor mode. It also now enables Scheduled Event Draining and Rebalance Draining by default.
 
 ## GCP
 

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5336,12 +5336,12 @@ spec:
                   enableRebalanceDraining:
                     description: 'EnableRebalanceDraining makes node termination handler
                       drain nodes when the rebalance recommendation notice is received
-                      Default: false'
+                      Default: true'
                     type: boolean
                   enableRebalanceMonitoring:
                     description: 'EnableRebalanceMonitoring makes node termination
                       handler cordon nodes when the rebalance recommendation notice
-                      is received Default: false'
+                      is received Default: true'
                     type: boolean
                   enableSQSTerminationDraining:
                     description: 'EnableSQSTerminationDraining enables queue-processor

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -930,10 +930,10 @@ type NodeTerminationHandlerConfig struct {
 	// Default: true
 	EnableScheduledEventDraining *bool `json:"enableScheduledEventDraining,omitempty"`
 	// EnableRebalanceMonitoring makes node termination handler cordon nodes when the rebalance recommendation notice is received
-	// Default: false
+	// Default: true
 	EnableRebalanceMonitoring *bool `json:"enableRebalanceMonitoring,omitempty"`
 	// EnableRebalanceDraining makes node termination handler drain nodes when the rebalance recommendation notice is received
-	// Default: false
+	// Default: true
 	EnableRebalanceDraining *bool `json:"enableRebalanceDraining,omitempty"`
 
 	// EnablePrometheusMetrics enables the "/metrics" endpoint.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -956,10 +956,10 @@ type NodeTerminationHandlerConfig struct {
 	// Default: true
 	EnableScheduledEventDraining *bool `json:"enableScheduledEventDraining,omitempty"`
 	// EnableRebalanceMonitoring makes node termination handler cordon nodes when the rebalance recommendation notice is received
-	// Default: false
+	// Default: true
 	EnableRebalanceMonitoring *bool `json:"enableRebalanceMonitoring,omitempty"`
 	// EnableRebalanceDraining makes node termination handler drain nodes when the rebalance recommendation notice is received
-	// Default: false
+	// Default: true
 	EnableRebalanceDraining *bool `json:"enableRebalanceDraining,omitempty"`
 
 	// EnablePrometheusMetrics enables the "/metrics" endpoint.

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -927,10 +927,10 @@ type NodeTerminationHandlerConfig struct {
 	// Default: true
 	EnableScheduledEventDraining *bool `json:"enableScheduledEventDraining,omitempty"`
 	// EnableRebalanceMonitoring makes node termination handler cordon nodes when the rebalance recommendation notice is received
-	// Default: false
+	// Default: true
 	EnableRebalanceMonitoring *bool `json:"enableRebalanceMonitoring,omitempty"`
 	// EnableRebalanceDraining makes node termination handler drain nodes when the rebalance recommendation notice is received
-	// Default: false
+	// Default: true
 	EnableRebalanceDraining *bool `json:"enableRebalanceDraining,omitempty"`
 
 	// EnablePrometheusMetrics enables the "/metrics" endpoint.

--- a/pkg/model/components/nodeterminationhandler.go
+++ b/pkg/model/components/nodeterminationhandler.go
@@ -46,10 +46,10 @@ func (b *NodeTerminationHandlerOptionsBuilder) BuildOptions(o interface{}) error
 		nth.EnableScheduledEventDraining = fi.PtrTo(true)
 	}
 	if nth.EnableRebalanceMonitoring == nil {
-		nth.EnableRebalanceMonitoring = fi.PtrTo(false)
+		nth.EnableRebalanceMonitoring = fi.PtrTo(true)
 	}
 	if nth.EnableRebalanceDraining == nil {
-		nth.EnableRebalanceDraining = fi.PtrTo(false)
+		nth.EnableRebalanceDraining = fi.PtrTo(true)
 	}
 
 	if nth.EnablePrometheusMetrics == nil {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -211,8 +211,8 @@ spec:
     amazonvpc: {}
   nodeTerminationHandler:
     cpuRequest: 50m
-    enableRebalanceDraining: false
-    enableRebalanceMonitoring: false
+    enableRebalanceDraining: true
+    enableRebalanceMonitoring: true
     enableScheduledEventDraining: true
     enableSpotInterruptionDraining: true
     enabled: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: bbecd97aee6cebe83a7f0910215d2bb43fb1243020c65ffa6427938c14b6f90b
+    manifestHash: b4feec0ab676e490055c253d12054138a212e5b502942ad557ab4329723bac75
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -194,9 +194,9 @@ spec:
         - name: ENABLE_SCHEDULED_EVENT_DRAINING
           value: "true"
         - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
+          value: "true"
         - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
+          value: "true"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
@@ -215,8 +215,8 @@ spec:
     amazonvpc: {}
   nodeTerminationHandler:
     cpuRequest: 50m
-    enableRebalanceDraining: false
-    enableRebalanceMonitoring: false
+    enableRebalanceDraining: true
+    enableRebalanceMonitoring: true
     enableScheduledEventDraining: true
     enableSpotInterruptionDraining: true
     enabled: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 48ffe0ff97ba1c0769c5ba1ad34e3bffc6b1b944f4d6b63a6ba1fd23cd229ebd
+    manifestHash: 9ea094fa6ad946e56b1df6fa03437d4943b95ca426fa9dcaca6b68ee460b7a80
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -194,9 +194,9 @@ spec:
         - name: ENABLE_SCHEDULED_EVENT_DRAINING
           value: "true"
         - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
+          value: "true"
         - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
+          value: "true"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
@@ -214,8 +214,8 @@ spec:
     amazonvpc: {}
   nodeTerminationHandler:
     cpuRequest: 50m
-    enableRebalanceDraining: false
-    enableRebalanceMonitoring: false
+    enableRebalanceDraining: true
+    enableRebalanceMonitoring: true
     enableScheduledEventDraining: true
     enableSpotInterruptionDraining: true
     enabled: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 48ffe0ff97ba1c0769c5ba1ad34e3bffc6b1b944f4d6b63a6ba1fd23cd229ebd
+    manifestHash: 9ea094fa6ad946e56b1df6fa03437d4943b95ca426fa9dcaca6b68ee460b7a80
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -194,9 +194,9 @@ spec:
         - name: ENABLE_SCHEDULED_EVENT_DRAINING
           value: "true"
         - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
+          value: "true"
         - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
+          value: "true"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
@@ -213,8 +213,8 @@ spec:
     amazonvpc: {}
   nodeTerminationHandler:
     cpuRequest: 50m
-    enableRebalanceDraining: false
-    enableRebalanceMonitoring: false
+    enableRebalanceDraining: true
+    enableRebalanceMonitoring: true
     enableScheduledEventDraining: true
     enableSpotInterruptionDraining: true
     enabled: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 48ffe0ff97ba1c0769c5ba1ad34e3bffc6b1b944f4d6b63a6ba1fd23cd229ebd
+    manifestHash: 9ea094fa6ad946e56b1df6fa03437d4943b95ca426fa9dcaca6b68ee460b7a80
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -194,9 +194,9 @@ spec:
         - name: ENABLE_SCHEDULED_EVENT_DRAINING
           value: "true"
         - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
+          value: "true"
         - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
+          value: "true"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
@@ -213,8 +213,8 @@ spec:
     amazonvpc: {}
   nodeTerminationHandler:
     cpuRequest: 50m
-    enableRebalanceDraining: false
-    enableRebalanceMonitoring: false
+    enableRebalanceDraining: true
+    enableRebalanceMonitoring: true
     enableScheduledEventDraining: true
     enableSpotInterruptionDraining: true
     enabled: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 48ffe0ff97ba1c0769c5ba1ad34e3bffc6b1b944f4d6b63a6ba1fd23cd229ebd
+    manifestHash: 9ea094fa6ad946e56b1df6fa03437d4943b95ca426fa9dcaca6b68ee460b7a80
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -194,9 +194,9 @@ spec:
         - name: ENABLE_SCHEDULED_EVENT_DRAINING
           value: "true"
         - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
+          value: "true"
         - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
+          value: "true"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -210,8 +210,8 @@ spec:
     amazonvpc: {}
   nodeTerminationHandler:
     cpuRequest: 50m
-    enableRebalanceDraining: false
-    enableRebalanceMonitoring: false
+    enableRebalanceDraining: true
+    enableRebalanceMonitoring: true
     enableScheduledEventDraining: true
     enableSpotInterruptionDraining: true
     enabled: true

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 031dd270cecb6247a363cebba3efb61ebb940315373f929a9ba2aee8e249ddfd
+    manifestHash: 4b7f3285c6133f95adbe8c8354c8ab311f6ea69c171e8a0186aa3de83aca273d
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -204,9 +204,9 @@ spec:
         - name: ENABLE_SCHEDULED_EVENT_DRAINING
           value: "true"
         - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
+          value: "true"
         - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
+          value: "true"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -203,8 +203,8 @@ spec:
     amazonvpc: {}
   nodeTerminationHandler:
     cpuRequest: 50m
-    enableRebalanceDraining: false
-    enableRebalanceMonitoring: false
+    enableRebalanceDraining: true
+    enableRebalanceMonitoring: true
     enableScheduledEventDraining: true
     enableSpotInterruptionDraining: true
     enabled: true

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 031dd270cecb6247a363cebba3efb61ebb940315373f929a9ba2aee8e249ddfd
+    manifestHash: 4b7f3285c6133f95adbe8c8354c8ab311f6ea69c171e8a0186aa3de83aca273d
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -204,9 +204,9 @@ spec:
         - name: ENABLE_SCHEDULED_EVENT_DRAINING
           value: "true"
         - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
+          value: "true"
         - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
+          value: "true"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -166,8 +166,8 @@ spec:
     cni: {}
   nodeTerminationHandler:
     cpuRequest: 50m
-    enableRebalanceDraining: false
-    enableRebalanceMonitoring: false
+    enableRebalanceDraining: true
+    enableRebalanceMonitoring: true
     enableSQSTerminationDraining: false
     enableScheduledEventDraining: true
     enableSpotInterruptionDraining: true

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 784285158b562b0c7c8a13808d902237a524406122f9d76b92fe036f8c0f9f2a
+    manifestHash: a945744b772fe547caae4735bd3d7d0e1360676a45ba7bb6b7f690cae7a41667
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -195,9 +195,9 @@ spec:
         - name: ENABLE_SCHEDULED_EVENT_DRAINING
           value: "true"
         - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
+          value: "true"
         - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
+          value: "true"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "false"
         - name: UPTIME_FROM_FILE

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
@@ -165,8 +165,8 @@ spec:
     cni: {}
   nodeTerminationHandler:
     cpuRequest: 50m
-    enableRebalanceDraining: false
-    enableRebalanceMonitoring: false
+    enableRebalanceDraining: true
+    enableRebalanceMonitoring: true
     enableSQSTerminationDraining: false
     enableScheduledEventDraining: true
     enableSpotInterruptionDraining: true

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: cc014009342e2acbb68675a1c9f3b2a21ba0468b929eb8f6c02b7a8c39e38b60
+    manifestHash: 1582efa3dde2bc1d661ea01f49f48fcefadffbd05ef3a9da9631aadeae428c28
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -195,9 +195,9 @@ spec:
         - name: ENABLE_SCHEDULED_EVENT_DRAINING
           value: "true"
         - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
+          value: "true"
         - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
+          value: "true"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "false"
         - name: UPTIME_FROM_FILE

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -211,9 +211,9 @@ spec:
             - name: ENABLE_SCHEDULED_EVENT_DRAINING
               value: "{{ WithDefaultBool .EnableScheduledEventDraining true }}"
             - name: ENABLE_REBALANCE_MONITORING
-              value: "{{ WithDefaultBool .EnableRebalanceMonitoring false }}"
+              value: "{{ WithDefaultBool .EnableRebalanceMonitoring true }}"
             - name: ENABLE_REBALANCE_DRAINING
-              value: "{{ WithDefaultBool .EnableRebalanceDraining false }}"
+              value: "{{ WithDefaultBool .EnableRebalanceDraining true }}"
             - name: ENABLE_SQS_TERMINATION_DRAINING
               value: "true"
             - name: QUEUE_URL
@@ -378,9 +378,9 @@ spec:
             - name: ENABLE_SCHEDULED_EVENT_DRAINING
               value: "{{ WithDefaultBool .EnableScheduledEventDraining true }}"
             - name: ENABLE_REBALANCE_MONITORING
-              value: "{{ WithDefaultBool .EnableRebalanceMonitoring false }}"
+              value: "{{ WithDefaultBool .EnableRebalanceMonitoring true }}"
             - name: ENABLE_REBALANCE_DRAINING
-              value: "{{ WithDefaultBool .EnableRebalanceDraining false }}"
+              value: "{{ WithDefaultBool .EnableRebalanceDraining true }}"
             - name: ENABLE_SQS_TERMINATION_DRAINING
               value: "false"
             - name: UPTIME_FROM_FILE


### PR DESCRIPTION
Since (I believe) capacity rebalance recommendations need to be explicitly enabled, this is a more sensible default. Why would someone enable rebalance recommendations if they don't want some sort of action taken on them?