### PR TITLE
Announce deprecation of the Kube-router CNI

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -24,7 +24,7 @@ As of kOps 1.26 the default network provider is Cilium. Prior to that the defaul
 | Flannel udp      |        1.5.2 |      - |          - |               - |
 | Flannel vxlan    |        1.8.0 |      - |          - |               - |
 | Kopeio           |          1.5 |      - |          - |               - |
-| Kube-router      |        1.6.2 |      - |          - |               - |
+| Kube-router      |        1.6.2 |      - |       1.26 |               - |
 | Kubenet          |          1.5 |    1.5 |          - |               - |
 | Lyft VPC         |         1.11 |      - |       1.22 |            1.23 |
 | Romana           |          1.8 |      - |       1.18 |            1.19 |

--- a/docs/networking/kube-router.md
+++ b/docs/networking/kube-router.md
@@ -1,5 +1,7 @@
 # Kube-router
 
+&#9888; The Kube-router CNI is deprecated due to lack of a kOps maintainer.
+
 [Kube-router](https://github.com/cloudnativelabs/kube-router) is project that provides one cohesive solution that provides CNI networking for pods, an IPVS based network service proxy and iptables based network policy enforcement.
 
 Kube-router also provides a service proxy, so kube-proxy will not be deployed in to the cluster.

--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -52,12 +52,14 @@ CNIs, use the "cni" networking option instead.
 
 * The "kops get [CLUSTER]" command is deprecated. It is replaced by "kops get all [CLUSTER]".
 
+* Due to lack of a kOps maintainer, the Kube-router CNI is deprecated.
+
 * Support for Kubernetes version 1.21 is deprecated and will be removed in kOps 1.27.
 
 * Support for Kubernetes version 1.22 is deprecated and will be removed in kOps 1.28.
 
 * Support for Ubuntu 18.04 is deprecated and will be removed in kOps 1.28.
 
-* Support for AWS Classic Load Balancer for API is deprecated and should not be used for newly created clusters.
+* Support for AWS Classic Load Balancer for the Kubernetes API is deprecated and should not be used for newly created clusters.
 
 * All legacy addons are deprecated in favor of managed addons, including the [metrics server addon](https://github.com/kubernetes/kops/tree/master/addons/metrics-server) and the [autoscaler addon](https://github.com/kubernetes/kops/tree/master/addons/cluster-autoscaler).


### PR DESCRIPTION
While upstream has made releases, we have not upgraded Kube-router in over a year and a half.

It has a presubmit and is in the CNI e2e suite, but is not in the grid.

At the very least, we need a maintainer to keep it up to date.