### PR TITLE
The aws-iam-authenticator pod always fails from kops update cluster c…

### DIFF
--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
@@ -134,6 +134,26 @@ subjects:
 
 ---
 
+apiVersion: v1
+data:
+  config.yaml: |
+    # a unique-per-cluster identifier to prevent replay attacks
+    # (good choices are a random token or a domain name that will be unique to your cluster)
+
+    clusterID: complex.example.com
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    k8s-app: aws-iam-authenticator
+    role.kubernetes.io/authentication: "1"
+  name: aws-iam-authenticator
+  namespace: kube-system
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: e5087fe4df1676c9d497b29a8aee52c45ddb6e4352665c32417cec755c6ba012
+    manifestHash: c390bd8dcefed07b9a6aabaf9948c04dd4fe228c6c300f95db7e1f5226fe9578
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -110,6 +110,21 @@ subjects:
   namespace: kube-system
 
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: kube-system
+  name: aws-iam-authenticator
+  labels:
+    k8s-app: aws-iam-authenticator
+data:
+  config.yaml: |
+    # a unique-per-cluster identifier to prevent replay attacks
+    # (good choices are a random token or a domain name that will be unique to your cluster)
+
+    clusterID: {{ or .Authentication.AWS.ClusterID ClusterName }}
+
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
@@ -134,6 +134,26 @@ subjects:
 
 ---
 
+apiVersion: v1
+data:
+  config.yaml: |
+    # a unique-per-cluster identifier to prevent replay attacks
+    # (good choices are a random token or a domain name that will be unique to your cluster)
+
+    clusterID: custom-cluster-ID
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    k8s-app: aws-iam-authenticator
+    role.kubernetes.io/authentication: "1"
+  name: aws-iam-authenticator
+  namespace: kube-system
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 2930510e9956df164e98720c05f5022e494fa054b767390932bdba9bcdc99d93
+    manifestHash: 21788b58db9c2762f56ec40463139b344ebdb3fcd979b62bced49729d5827ab8
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
@@ -134,6 +134,26 @@ subjects:
 
 ---
 
+apiVersion: v1
+data:
+  config.yaml: |
+    # a unique-per-cluster identifier to prevent replay attacks
+    # (good choices are a random token or a domain name that will be unique to your cluster)
+
+    clusterID: minimal.example.com
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    k8s-app: aws-iam-authenticator
+    role.kubernetes.io/authentication: "1"
+  name: aws-iam-authenticator
+  namespace: kube-system
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 0af026b62ac6db270bb2d706f33445d29e9a27d557be62c9778d9c341450c329
+    manifestHash: ddce90993ef3eda1ca5681263a9b413c1977631a4313bb3b3cca75c8c05427fc
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"


### PR DESCRIPTION
The aws-iam-authenticator pod always fails from [kops update cluster ](https://kops.sigs.k8s.io/getting_started/aws/#build-the-cluster)complaining the following error. 
This PR fix the error by adding a config.

```
Events:
  Type     Reason       Age                   From     Message
  ----     ------       ----                  ----     -------
  Warning  FailedMount  44m                   kubelet  Unable to attach or mount volumes: unmounted volumes=[config], unattached volumes=[output kube-api-access-rkvtd config state]: timed out waiting for the condition
  Warning  FailedMount  31m (x5 over 60m)     kubelet  Unable to attach or mount volumes: unmounted volumes=[config], unattached volumes=[kube-api-access-rkvtd config state output]: timed out waiting for the condition
  Warning  FailedMount  26m (x2 over 56m)     kubelet  Unable to attach or mount volumes: unmounted volumes=[config], unattached volumes=[state output kube-api-access-rkvtd config]: timed out waiting for the condition
  Warning  FailedMount  6m19s (x16 over 65m)  kubelet  Unable to attach or mount volumes: unmounted volumes=[config], unattached volumes=[config state output kube-api-access-rkvtd]: timed out waiting for the condition
  Warning  FailedMount  2m7s (x40 over 67m)   kubelet  MountVolume.SetUp failed for volume "config" : configmap "aws-iam-authenticator" not found
```