### PR TITLE
split key to resolve dependencies when deleting resources

### DIFF
--- a/pkg/resources/ops/delete.go
+++ b/pkg/resources/ops/delete.go
@@ -18,6 +18,7 @@ package ops
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -72,7 +73,8 @@ func DeleteResources(cloud fi.Cloud, resourceMap map[string]*resources.Resource)
 				}
 
 				ready := true
-				for _, dep := range depMap[k] {
+				resourceType := strings.Split(k, ":")
+				for _, dep := range depMap[resourceType[0]] {
 					if _, d := done[dep]; !d {
 						klog.V(4).Infof("dependency %q of %q not deleted; skipping", dep, k)
 						ready = false


### PR DESCRIPTION
When I was implementing the listing and deletion of Scaleway resources (#14731), I noticed that every cloud provider builds the key of the resourceTrackers map by concatenating the type and the ID of the resource `resourceTrackers[t.Type+":"+t.ID] = t`, then in `pkg/resources/ops/delete.go`, the way dependencies completion is checked is by comparing this key to just the type, which always fails and so dependencies are never complete.
Am I the only only experiencing this problem ? If not, here's a proposition on how to fix it.