### PR TITLE
WIP: Add context to more places

### DIFF
--- a/channels/pkg/channels/addon.go
+++ b/channels/pkg/channels/addon.go
@@ -192,7 +192,7 @@ func (a *Addon) updateAddon(ctx context.Context, k8sClient kubernetes.Interface,
 	klog.Infof("Applying update from %q", manifestURL)
 
 	// We copy the manifest to a temp file because it is likely e.g. an s3 URL, which kubectl can't read
-	data, err := vfs.Context.ReadFile(manifestURL.String())
+	data, err := vfs.FromContext(ctx).ReadFile(manifestURL.String())
 	if err != nil {
 		return fmt.Errorf("error reading manifest: %w", err)
 	}

--- a/channels/pkg/channels/addons.go
+++ b/channels/pkg/channels/addons.go
@@ -17,6 +17,7 @@ limitations under the License.
 package channels
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -34,9 +35,9 @@ type Addons struct {
 	APIObject       *api.Addons
 }
 
-func LoadAddons(name string, location *url.URL) (*Addons, error) {
+func LoadAddons(ctx context.Context, name string, location *url.URL) (*Addons, error) {
 	klog.V(2).Infof("Loading addons channel from %q", location)
-	data, err := vfs.Context.ReadFile(location.String())
+	data, err := vfs.FromContext(ctx).ReadFile(location.String())
 	if err != nil {
 		return nil, fmt.Errorf("error reading addons from %q: %v", location, err)
 	}

--- a/channels/pkg/cmd/apply_channel.go
+++ b/channels/pkg/cmd/apply_channel.go
@@ -100,7 +100,7 @@ func RunApplyChannel(ctx context.Context, f Factory, out io.Writer, options *App
 	channelLocation := args[0]
 
 	// menu is the expected list of addons in the cluster and their configurations.
-	menu, err := buildMenu(kubernetesVersion, channelLocation)
+	menu, err := buildMenu(ctx, kubernetesVersion, channelLocation)
 	if err != nil {
 		return fmt.Errorf("cannot build the addon menu from args: %w", err)
 	}
@@ -219,7 +219,7 @@ func getChannelVersions(ctx context.Context, k8sClient kubernetes.Interface) (ma
 	return channelVersions, nil
 }
 
-func buildMenu(kubernetesVersion semver.Version, channelLocation string) (*channels.AddonMenu, error) {
+func buildMenu(ctx context.Context, kubernetesVersion semver.Version, channelLocation string) (*channels.AddonMenu, error) {
 	menu := channels.NewAddonMenu()
 
 	location, err := url.Parse(channelLocation)
@@ -245,7 +245,7 @@ func buildMenu(kubernetesVersion semver.Version, channelLocation string) (*chann
 			klog.Warningf("Legacy addons are deprecated and unmaintained, use managed addons instead of %s", expanded)
 		}
 	}
-	o, err := channels.LoadAddons(channelLocation, location)
+	o, err := channels.LoadAddons(ctx, channelLocation, location)
 	if err != nil {
 		return nil, fmt.Errorf("error loading channel %q: %v", location, err)
 	}

--- a/cmd/kops-controller/controllers/legacy_node_controller.go
+++ b/cmd/kops-controller/controllers/legacy_node_controller.go
@@ -39,7 +39,7 @@ import (
 )
 
 // NewLegacyNodeReconciler is the constructor for a LegacyNodeReconciler
-func NewLegacyNodeReconciler(mgr manager.Manager, configPath string, identifier nodeidentity.LegacyIdentifier) (*LegacyNodeReconciler, error) {
+func NewLegacyNodeReconciler(ctx context.Context, mgr manager.Manager, configPath string, identifier nodeidentity.LegacyIdentifier) (*LegacyNodeReconciler, error) {
 	r := &LegacyNodeReconciler{
 		client:     mgr.GetClient(),
 		log:        ctrl.Log.WithName("controllers").WithName("Node"),
@@ -53,7 +53,7 @@ func NewLegacyNodeReconciler(mgr manager.Manager, configPath string, identifier 
 	}
 	r.coreV1Client = coreClient
 
-	configBase, err := vfs.Context.BuildVfsPath(configPath)
+	configBase, err := vfs.FromContext(ctx).BuildVfsPath(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse ConfigBase %q: %v", configPath, err)
 	}

--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -58,6 +59,8 @@ func init() {
 }
 
 func main() {
+	ctx := context.Background()
+
 	klog.InitFlags(nil)
 
 	// Disable metrics by default (avoid port conflicts, also risky because we are host network)
@@ -130,7 +133,7 @@ func main() {
 			klog.Fatalf("server cloud provider config not provided")
 		}
 
-		srv, err := server.NewServer(&opt, verifier)
+		srv, err := server.NewServer(ctx, &opt, verifier)
 		if err != nil {
 			setupLog.Error(err, "unable to create server")
 			os.Exit(1)
@@ -155,7 +158,7 @@ func main() {
 		}
 	}
 
-	if err := addNodeController(mgr, &opt); err != nil {
+	if err := addNodeController(ctx, mgr, &opt); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NodeController")
 		os.Exit(1)
 	}
@@ -185,7 +188,7 @@ func buildScheme() error {
 	return nil
 }
 
-func addNodeController(mgr manager.Manager, opt *config.Options) error {
+func addNodeController(ctx context.Context, mgr manager.Manager, opt *config.Options) error {
 	var legacyIdentifier nodeidentity.LegacyIdentifier
 	var identifier nodeidentity.Identifier
 	var err error
@@ -249,7 +252,7 @@ func addNodeController(mgr manager.Manager, opt *config.Options) error {
 			return fmt.Errorf("must specify secretStore")
 		}
 
-		nodeController, err := controllers.NewLegacyNodeReconciler(mgr, opt.ConfigBase, legacyIdentifier)
+		nodeController, err := controllers.NewLegacyNodeReconciler(ctx, mgr, opt.ConfigBase, legacyIdentifier)
 		if err != nil {
 			return err
 		}

--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -55,7 +55,7 @@ type Server struct {
 	configBase vfs.Path
 }
 
-func NewServer(opt *config.Options, verifier bootstrap.Verifier) (*Server, error) {
+func NewServer(ctx context.Context, opt *config.Options, verifier bootstrap.Verifier) (*Server, error) {
 	server := &http.Server{
 		Addr: opt.Server.Listen,
 		TLSConfig: &tls.Config{
@@ -71,13 +71,13 @@ func NewServer(opt *config.Options, verifier bootstrap.Verifier) (*Server, error
 		verifier:  verifier,
 	}
 
-	configBase, err := vfs.Context.BuildVfsPath(opt.ConfigBase)
+	configBase, err := vfs.FromContext(ctx).BuildVfsPath(opt.ConfigBase)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse ConfigBase %q: %w", opt.ConfigBase, err)
 	}
 	s.configBase = configBase
 
-	p, err := vfs.Context.BuildVfsPath(opt.SecretStore)
+	p, err := vfs.FromContext(ctx).BuildVfsPath(opt.SecretStore)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse SecretStore %q: %w", opt.SecretStore, err)
 	}

--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -97,7 +97,7 @@ func NewCmdCreate(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunCreate(ctx context.Context, f *util.Factory, out io.Writer, c *CreateOptions) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func RunCreate(ctx context.Context, f *util.Factory, out io.Writer, c *CreateOpt
 				return err
 			}
 		} else {
-			contents, err = vfs.Context.ReadFile(f)
+			contents, err = vfs.FromContext(ctx).ReadFile(f)
 			if err != nil {
 				return fmt.Errorf("error reading file %q: %v", f, err)
 			}
@@ -192,7 +192,7 @@ func RunCreate(ctx context.Context, f *util.Factory, out io.Writer, c *CreateOpt
 					return err
 				}
 
-				sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
+				sshCredentialStore, err := clientset.SSHCredentialStore(ctx, cluster)
 				if err != nil {
 					return err
 				}

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -508,7 +508,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		}
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -536,7 +536,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		c.NetworkID = c.OpenstackNetworkID
 	}
 
-	clusterResult, err := cloudup.NewCluster(&c.NewClusterOptions, clientset)
+	clusterResult, err := cloudup.NewCluster(ctx, &c.NewClusterOptions, clientset)
 	if err != nil {
 		return err
 	}
@@ -643,13 +643,13 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 	}
 
 	strict := false
-	err = validation.DeepValidate(cluster, instanceGroups, strict, nil)
+	err = validation.DeepValidate(ctx, cluster, instanceGroups, strict, nil)
 	if err != nil {
 		return err
 	}
 
 	assetBuilder := assets.NewAssetBuilder(cluster, false)
-	fullCluster, err := cloudup.PopulateClusterSpec(clientset, cluster, cloud, assetBuilder)
+	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, cloud, assetBuilder)
 	if err != nil {
 		return err
 	}
@@ -665,7 +665,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 	}
 
 	for _, p := range c.AddonPaths {
-		addon, err := clusteraddons.LoadClusterAddon(p)
+		addon, err := clusteraddons.LoadClusterAddon(ctx, p)
 		if err != nil {
 			return fmt.Errorf("error loading cluster addon %s: %v", p, err)
 		}
@@ -683,7 +683,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 			fullInstanceGroups = append(fullInstanceGroups, fullGroup)
 		}
 
-		err = validation.DeepValidate(fullCluster, fullInstanceGroups, true, nil)
+		err = validation.DeepValidate(ctx, fullCluster, fullInstanceGroups, true, nil)
 		if err != nil {
 			return fmt.Errorf("validation of the full cluster and instance group specs failed: %w", err)
 		}
@@ -759,7 +759,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 	}
 
 	if len(c.SSHPublicKeys) != 0 {
-		sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
+		sshCredentialStore, err := clientset.SSHCredentialStore(ctx, cluster)
 		if err != nil {
 			return err
 		}

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -270,7 +270,7 @@ func runCreateClusterIntegrationTest(t *testing.T, srcDir string, version string
 		}
 	}
 
-	clientset, err := factory.KopsClient()
+	clientset, err := factory.KopsClient(ctx)
 	if err != nil {
 		t.Fatalf("error getting clientset: %v", err)
 	}

--- a/cmd/kops/create_instancegroup.go
+++ b/cmd/kops/create_instancegroup.go
@@ -154,12 +154,12 @@ func RunCreateInstanceGroup(ctx context.Context, f *util.Factory, out io.Writer,
 		return fmt.Errorf("error getting cluster: %q: %v", options.ClusterName, err)
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	channel, err := cloudup.ChannelForCluster(cluster)
+	channel, err := cloudup.ChannelForCluster(ctx, cluster)
 	if err != nil {
 		klog.Warningf("%v", err)
 	}

--- a/cmd/kops/create_keypair.go
+++ b/cmd/kops/create_keypair.go
@@ -153,12 +153,12 @@ func RunCreateKeypair(ctx context.Context, f *util.Factory, out io.Writer, optio
 		return fmt.Errorf("error getting cluster: %q: %v", options.ClusterName, err)
 	}
 
-	clientSet, err := f.KopsClient()
+	clientSet, err := f.KopsClient(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting clientset: %v", err)
 	}
 
-	keyStore, err := clientSet.KeyStore(cluster)
+	keyStore, err := clientSet.KeyStore(ctx, cluster)
 	if err != nil {
 		return fmt.Errorf("error getting keystore: %v", err)
 	}
@@ -267,8 +267,8 @@ func createKeypair(out io.Writer, options *CreateKeypairOptions, name string, ke
 	return nil
 }
 
-func completeKeyset(cluster *kopsapi.Cluster, clientSet simple.Clientset, args []string, filter func(name string, keyset *fi.Keyset) bool) (keyset *fi.Keyset, keyStore fi.CAStore, completions []string, directive cobra.ShellCompDirective) {
-	keyStore, err := clientSet.KeyStore(cluster)
+func completeKeyset(ctx context.Context, cluster *kopsapi.Cluster, clientSet simple.Clientset, args []string, filter func(name string, keyset *fi.Keyset) bool) (keyset *fi.Keyset, keyStore fi.CAStore, completions []string, directive cobra.ShellCompDirective) {
+	keyStore, err := clientSet.KeyStore(ctx, cluster)
 	if err != nil {
 		completions, directive := commandutils.CompletionError("getting keystore", err)
 		return nil, nil, completions, directive
@@ -313,7 +313,7 @@ func completeCreateKeypair(f commandutils.Factory, options *CreateKeypairOptions
 		return completions, directive
 	}
 
-	keyset, _, completions, directive := completeKeyset(cluster, clientSet, args, rotatableKeysetFilter)
+	keyset, _, completions, directive := completeKeyset(ctx, cluster, clientSet, args, rotatableKeysetFilter)
 	if keyset == nil {
 		return completions, directive
 	}

--- a/cmd/kops/create_secret_ciliumpassword.go
+++ b/cmd/kops/create_secret_ciliumpassword.go
@@ -91,12 +91,12 @@ func RunCreateSecretCiliumEncryptionConfig(ctx context.Context, f commandutils.F
 		return err
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	secretStore, err := clientset.SecretStore(cluster)
+	secretStore, err := clientset.SecretStore(ctx, cluster)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/create_secret_dockerconfig.go
+++ b/cmd/kops/create_secret_dockerconfig.go
@@ -96,12 +96,12 @@ func RunCreateSecretDockerConfig(ctx context.Context, f commandutils.Factory, ou
 		return err
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	secretStore, err := clientset.SecretStore(cluster)
+	secretStore, err := clientset.SecretStore(ctx, cluster)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/create_secret_encryptionconfig.go
+++ b/cmd/kops/create_secret_encryptionconfig.go
@@ -90,12 +90,12 @@ func RunCreateSecretEncryptionConfig(ctx context.Context, f commandutils.Factory
 		return err
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	secretStore, err := clientset.SecretStore(cluster)
+	secretStore, err := clientset.SecretStore(ctx, cluster)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/create_secret_weavepassword.go
+++ b/cmd/kops/create_secret_weavepassword.go
@@ -99,12 +99,12 @@ func RunCreateSecretWeavePassword(ctx context.Context, f commandutils.Factory, o
 		return err
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	secretStore, err := clientset.SecretStore(cluster)
+	secretStore, err := clientset.SecretStore(ctx, cluster)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/create_sshpublickey.go
+++ b/cmd/kops/create_sshpublickey.go
@@ -86,12 +86,12 @@ func RunCreateSSHPublicKey(ctx context.Context, f *util.Factory, out io.Writer, 
 		return err
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
+	sshCredentialStore, err := clientset.SSHCredentialStore(ctx, cluster)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -91,7 +91,7 @@ func RunDelete(ctx context.Context, factory *util.Factory, out io.Writer, d *Del
 				return fmt.Errorf("reading from stdin: %v", err)
 			}
 		} else {
-			contents, err = vfs.Context.ReadFile(f)
+			contents, err = vfs.FromContext(ctx).ReadFile(f)
 			if err != nil {
 				return fmt.Errorf("reading file %q: %v", f, err)
 			}

--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -187,7 +187,7 @@ func RunDeleteCluster(ctx context.Context, f *util.Factory, out io.Writer, optio
 			}
 			return nil
 		}
-		clientset, err := f.KopsClient()
+		clientset, err := f.KopsClient(ctx)
 		if err != nil {
 			return err
 		}

--- a/cmd/kops/delete_instance.go
+++ b/cmd/kops/delete_instance.go
@@ -153,7 +153,7 @@ func NewCmdDeleteInstance(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, options *DeleteInstanceOptions) error {
-	clientSet, err := f.KopsClient()
+	clientSet, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/delete_instancegroup.go
+++ b/cmd/kops/delete_instancegroup.go
@@ -132,7 +132,7 @@ func RunDeleteInstanceGroup(ctx context.Context, f *util.Factory, out io.Writer,
 		return err
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/delete_secret.go
+++ b/cmd/kops/delete_secret.go
@@ -93,7 +93,7 @@ func RunDeleteSecret(ctx context.Context, f *util.Factory, out io.Writer, option
 		})
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func RunDeleteSecret(ctx context.Context, f *util.Factory, out io.Writer, option
 		return err
 	}
 
-	secretStore, err := clientset.SecretStore(cluster)
+	secretStore, err := clientset.SecretStore(ctx, cluster)
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,7 @@ func completeSecretNames(f commandutils.Factory) func(cmd *cobra.Command, args [
 			return completions, directive
 		}
 
-		secretStore, err := clientSet.SecretStore(cluster)
+		secretStore, err := clientSet.SecretStore(ctx, cluster)
 		if err != nil {
 			return commandutils.CompletionError("constructing secret store", err)
 		}

--- a/cmd/kops/delete_sshpublickey.go
+++ b/cmd/kops/delete_sshpublickey.go
@@ -62,7 +62,7 @@ func NewCmdDeleteSSHPublicKey(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunDeleteSSHPublicKey(ctx context.Context, f *util.Factory, out io.Writer, options *DeleteSSHPublicKeyOptions) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func RunDeleteSSHPublicKey(ctx context.Context, f *util.Factory, out io.Writer, 
 		return err
 	}
 
-	sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
+	sshCredentialStore, err := clientset.SSHCredentialStore(ctx, cluster)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/distrust_keypair.go
+++ b/cmd/kops/distrust_keypair.go
@@ -109,7 +109,7 @@ func NewCmdDistrustKeypair(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunDistrustKeypair(ctx context.Context, f *util.Factory, out io.Writer, options *DistrustKeypairOptions) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func RunDistrustKeypair(ctx context.Context, f *util.Factory, out io.Writer, opt
 		return err
 	}
 
-	keyStore, err := clientset.KeyStore(cluster)
+	keyStore, err := clientset.KeyStore(ctx, cluster)
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func completeDistrustKeyset(f commandutils.Factory, options *DistrustKeypairOpti
 		return completions, directive
 	}
 
-	keyset, _, completions, directive := completeKeyset(cluster, clientSet, args, rotatableKeysetFilter)
+	keyset, _, completions, directive := completeKeyset(ctx, cluster, clientSet, args, rotatableKeysetFilter)
 	if keyset == nil {
 		return completions, directive
 	}

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -110,7 +110,7 @@ func RunEditCluster(ctx context.Context, f *util.Factory, out io.Writer, options
 		return err
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -264,12 +264,12 @@ func updateCluster(ctx context.Context, clientset simple.Clientset, oldCluster, 
 	}
 
 	assetBuilder := assets.NewAssetBuilder(newCluster, false)
-	fullCluster, err := cloudup.PopulateClusterSpec(clientset, newCluster, cloud, assetBuilder)
+	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, newCluster, cloud, assetBuilder)
 	if err != nil {
 		return fmt.Sprintf("error populating cluster spec: %s", err), nil
 	}
 
-	err = validation.DeepValidate(fullCluster, instanceGroups, true, cloud)
+	err = validation.DeepValidate(ctx, fullCluster, instanceGroups, true, cloud)
 	if err != nil {
 		return fmt.Sprintf("validation failed: %s", err), nil
 	}

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -130,12 +130,12 @@ func RunEditInstanceGroup(ctx context.Context, f *util.Factory, out io.Writer, o
 		return err
 	}
 
-	channel, err := cloudup.ChannelForCluster(cluster)
+	channel, err := cloudup.ChannelForCluster(ctx, cluster)
 	if err != nil {
 		klog.Warningf("%v", err)
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func updateInstanceGroup(ctx context.Context, clientset simple.Clientset, channe
 	}
 
 	assetBuilder := assets.NewAssetBuilder(cluster, false)
-	fullCluster, err := cloudup.PopulateClusterSpec(clientset, cluster, cloud, assetBuilder)
+	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, cloud, assetBuilder)
 	if err != nil {
 		return fmt.Sprintf("error populating cluster spec: %s", err), nil
 	}

--- a/cmd/kops/edit_instancegroup_test.go
+++ b/cmd/kops/edit_instancegroup_test.go
@@ -48,7 +48,7 @@ func TestEditInstanceGroup(t *testing.T) {
 	factoryOptions.RegistryPath = "memfs://tests"
 
 	factory := util.NewFactory(factoryOptions)
-	clientSet, err := factory.KopsClient()
+	clientSet, err := factory.KopsClient(ctx)
 	if err != nil {
 		t.Fatalf("could not create clientset: %v", err)
 	}

--- a/cmd/kops/export_kubeconfig.go
+++ b/cmd/kops/export_kubeconfig.go
@@ -107,7 +107,7 @@ func NewCmdExportKubeconfig(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunExportKubeconfig(ctx context.Context, f *util.Factory, out io.Writer, options *ExportKubeconfigOptions, args []string) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -130,12 +130,12 @@ func RunExportKubeconfig(ctx context.Context, f *util.Factory, out io.Writer, op
 	}
 
 	for _, cluster := range clusterList {
-		keyStore, err := clientset.KeyStore(cluster)
+		keyStore, err := clientset.KeyStore(ctx, cluster)
 		if err != nil {
 			return err
 		}
 
-		secretStore, err := clientset.SecretStore(cluster)
+		secretStore, err := clientset.SecretStore(ctx, cluster)
 		if err != nil {
 			return err
 		}

--- a/cmd/kops/get_all.go
+++ b/cmd/kops/get_all.go
@@ -73,7 +73,7 @@ func NewCmdGetAll(f *util.Factory, out io.Writer, getOptions *GetOptions) *cobra
 }
 
 func RunGetAll(ctx context.Context, f commandutils.Factory, out io.Writer, options *GetAllOptions) error {
-	client, err := f.KopsClient()
+	client, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/get_assets.go
+++ b/cmd/kops/get_assets.go
@@ -141,7 +141,7 @@ func RunGetAssets(ctx context.Context, f *util.Factory, out io.Writer, options *
 	}
 
 	if options.Copy {
-		err := assets.Copy(updateClusterResults.ImageAssets, updateClusterResults.FileAssets, updateClusterResults.Cluster)
+		err := assets.Copy(ctx, updateClusterResults.ImageAssets, updateClusterResults.FileAssets, updateClusterResults.Cluster)
 		if err != nil {
 			return err
 		}

--- a/cmd/kops/get_cluster.go
+++ b/cmd/kops/get_cluster.go
@@ -118,7 +118,7 @@ func NewCmdGetCluster(f *util.Factory, out io.Writer, getOptions *GetOptions) *c
 }
 
 func RunGetClusters(ctx context.Context, f commandutils.Factory, out io.Writer, options *GetClusterOptions) error {
-	client, err := f.KopsClient()
+	client, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func RunGetClusters(ctx context.Context, f commandutils.Factory, out io.Writer, 
 
 	if options.FullSpec {
 		var err error
-		clusters, err = fullClusterSpecs(clusters)
+		clusters, err = fullClusterSpecs(ctx, clusters)
 		if err != nil {
 			return err
 		}
@@ -278,10 +278,10 @@ func fullOutputYAML(out io.Writer, args ...runtime.Object) error {
 	return nil
 }
 
-func fullClusterSpecs(clusters []*kopsapi.Cluster) ([]*kopsapi.Cluster, error) {
+func fullClusterSpecs(ctx context.Context, clusters []*kopsapi.Cluster) ([]*kopsapi.Cluster, error) {
 	var fullSpecs []*kopsapi.Cluster
 	for _, cluster := range clusters {
-		configBase, err := registry.ConfigBase(cluster)
+		configBase, err := registry.ConfigBase(ctx, cluster)
 		if err != nil {
 			return nil, fmt.Errorf("error reading full cluster spec for %q: %v", cluster.ObjectMeta.Name, err)
 		}

--- a/cmd/kops/get_instancegroups.go
+++ b/cmd/kops/get_instancegroups.go
@@ -89,7 +89,7 @@ func NewCmdGetInstanceGroups(f *util.Factory, out io.Writer, getOptions *GetOpti
 }
 
 func RunGetInstanceGroups(ctx context.Context, f commandutils.Factory, out io.Writer, options *GetInstanceGroupsOptions) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/get_instances.go
+++ b/cmd/kops/get_instances.go
@@ -81,7 +81,7 @@ func NewCmdGetInstances(f *util.Factory, out io.Writer, options *GetOptions) *co
 }
 
 func RunGetInstances(ctx context.Context, f *util.Factory, out io.Writer, options *GetOptions) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/get_keypairs.go
+++ b/cmd/kops/get_keypairs.go
@@ -165,7 +165,7 @@ func listKeypairs(keyStore fi.CAStore, names []string, includeDistrusted bool) (
 }
 
 func RunGetKeypairs(ctx context.Context, f commandutils.Factory, out io.Writer, options *GetKeypairsOptions) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func RunGetKeypairs(ctx context.Context, f commandutils.Factory, out io.Writer, 
 		return err
 	}
 
-	keyStore, err := clientset.KeyStore(cluster)
+	keyStore, err := clientset.KeyStore(ctx, cluster)
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func completeGetKeypairs(f commandutils.Factory, options *GetKeypairsOptions, ar
 	}
 
 	alreadySelected := sets.NewString(args...).Insert("all")
-	_, _, completions, directive = completeKeyset(cluster, clientSet, nil, func(name string, keyset *fi.Keyset) bool {
+	_, _, completions, directive = completeKeyset(ctx, cluster, clientSet, nil, func(name string, keyset *fi.Keyset) bool {
 		return !alreadySelected.Has(name)
 	})
 

--- a/cmd/kops/get_secrets.go
+++ b/cmd/kops/get_secrets.go
@@ -110,7 +110,7 @@ func RunGetSecrets(ctx context.Context, f *util.Factory, out io.Writer, options 
 		return fmt.Errorf("unknown secret type %q", options.Type)
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func RunGetSecrets(ctx context.Context, f *util.Factory, out io.Writer, options 
 	if err != nil {
 		return err
 	}
-	secretStore, err := clientset.SecretStore(cluster)
+	secretStore, err := clientset.SecretStore(ctx, cluster)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/get_sshpublickeys.go
+++ b/cmd/kops/get_sshpublickeys.go
@@ -70,7 +70,7 @@ type SSHKeyItem struct {
 }
 
 func RunGetSSHPublicKeys(ctx context.Context, f *util.Factory, out io.Writer, options *GetSSHPublicKeysOptions) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func RunGetSSHPublicKeys(ctx context.Context, f *util.Factory, out io.Writer, op
 		return err
 	}
 
-	sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
+	sshCredentialStore, err := clientset.SSHCredentialStore(ctx, cluster)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -981,9 +981,7 @@ func TestClusterNameDigit(t *testing.T) {
 		runTestTerraformAWS(t)
 }
 
-func (i *integrationTest) runTest(t *testing.T, h *testutils.IntegrationTestHarness, expectedDataFilenames []string, tfFileName string, expectedTfFileName string, phase *cloudup.Phase) {
-	ctx := context.Background()
-
+func (i *integrationTest) runTest(t *testing.T, ctx context.Context, h *testutils.IntegrationTestHarness, expectedDataFilenames []string, tfFileName string, expectedTfFileName string, phase *cloudup.Phase) {
 	var stdout bytes.Buffer
 
 	i.srcDir = updateClusterTestBase + i.srcDir
@@ -1156,12 +1154,12 @@ func (i *integrationTest) setupCluster(t *testing.T, inputYAML string, ctx conte
 		t.Fatalf("error getting cluster: %v", err)
 	}
 
-	clientSet, err := factory.KopsClient()
+	clientSet, err := factory.KopsClient(ctx)
 	if err != nil {
 		t.Fatalf("error getting clientset: %v", err)
 	}
 
-	keyStore, err := clientSet.KeyStore(cluster)
+	keyStore, err := clientSet.KeyStore(ctx, cluster)
 	if err != nil {
 		t.Fatalf("error getting keystore: %v", err)
 	}
@@ -1298,6 +1296,8 @@ func storeKeyset(t *testing.T, keyStore fi.Keystore, name string, testingKeyset 
 }
 
 func (i *integrationTest) runTestTerraformAWS(t *testing.T) {
+	ctx := context.TODO()
+
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -1379,10 +1379,12 @@ func (i *integrationTest) runTestTerraformAWS(t *testing.T) {
 	}
 	expectedFilenames = append(expectedFilenames, i.expectServiceAccountRolePolicies...)
 
-	i.runTest(t, h, expectedFilenames, "", "", nil)
+	i.runTest(t, ctx, h, expectedFilenames, "", "", nil)
 }
 
 func (i *integrationTest) runTestPhase(t *testing.T, phase cloudup.Phase) {
+	ctx := context.TODO()
+
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -1423,10 +1425,12 @@ func (i *integrationTest) runTestPhase(t *testing.T, phase cloudup.Phase) {
 		}
 	}
 
-	i.runTest(t, h, expectedFilenames, tfFileName, "", &phase)
+	i.runTest(t, ctx, h, expectedFilenames, tfFileName, "", &phase)
 }
 
 func (i *integrationTest) runTestTerraformGCE(t *testing.T) {
+	ctx := context.TODO()
+
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -1461,10 +1465,12 @@ func (i *integrationTest) runTestTerraformGCE(t *testing.T) {
 		expectedFilenames = append(expectedFilenames, prefix+"startup-script")
 	}
 
-	i.runTest(t, h, expectedFilenames, "", "", nil)
+	i.runTest(t, ctx, h, expectedFilenames, "", "", nil)
 }
 
 func (i *integrationTest) runTestTerraformHetzner(t *testing.T) {
+	ctx := context.TODO()
+
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -1493,7 +1499,7 @@ func (i *integrationTest) runTestTerraformHetzner(t *testing.T) {
 		"hcloud_server_nodes-fsn1_user_data",
 	)
 
-	i.runTest(t, h, expectedFilenames, "", "", nil)
+	i.runTest(t, ctx, h, expectedFilenames, "", "", nil)
 }
 
 func MakeSSHKeyPair(publicKeyPath string, privateKeyPath string) error {

--- a/cmd/kops/lifecycle_integration_test.go
+++ b/cmd/kops/lifecycle_integration_test.go
@@ -210,7 +210,7 @@ func runLifecycleTest(h *testutils.IntegrationTestHarness, o *LifecycleTestOptio
 		if err != nil {
 			t.Fatalf("error getting cluster: %v", err)
 		}
-		clientset, err := factory.KopsClient()
+		clientset, err := factory.KopsClient(ctx)
 		if err != nil {
 			t.Fatalf("error getting clientset: %v", err)
 		}
@@ -548,7 +548,7 @@ func updateEnsureNoChanges(ctx context.Context, t *testing.T, factory *util.Fact
 	target := results.Target.(*fi.DryRunTarget)
 	if target.HasChanges() {
 		var b bytes.Buffer
-		if err := target.PrintReport(results.TaskMap, &b); err != nil {
+		if err := target.PrintReport(ctx, results.TaskMap, &b); err != nil {
 			t.Fatalf("error building report: %v", err)
 		}
 		t.Fatalf("Target had changes after executing: %v", b.String())

--- a/cmd/kops/promote_keypair.go
+++ b/cmd/kops/promote_keypair.go
@@ -123,12 +123,12 @@ func RunPromoteKeypair(ctx context.Context, f *util.Factory, out io.Writer, opti
 		return fmt.Errorf("getting cluster: %q: %v", options.ClusterName, err)
 	}
 
-	clientSet, err := f.KopsClient()
+	clientSet, err := f.KopsClient(ctx)
 	if err != nil {
 		return fmt.Errorf("getting clientset: %v", err)
 	}
 
-	keyStore, err := clientSet.KeyStore(cluster)
+	keyStore, err := clientSet.KeyStore(ctx, cluster)
 	if err != nil {
 		return fmt.Errorf("getting keystore: %v", err)
 	}
@@ -210,7 +210,7 @@ func completePromoteKeyset(f commandutils.Factory, options *PromoteKeypairOption
 		return completions, directive
 	}
 
-	keyset, _, completions, directive := completeKeyset(cluster, clientSet, args, rotatableKeysetFilter)
+	keyset, _, completions, directive := completeKeyset(ctx, cluster, clientSet, args, rotatableKeysetFilter)
 	if keyset == nil {
 		return completions, directive
 	}

--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -85,7 +85,7 @@ func NewCmdReplace(f *util.Factory, out io.Writer) *cobra.Command {
 
 // RunReplace processes the replace command
 func RunReplace(ctx context.Context, f *util.Factory, out io.Writer, c *ReplaceOptions) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func RunReplace(ctx context.Context, f *util.Factory, out io.Writer, c *ReplaceO
 				return err
 			}
 		} else {
-			contents, err = vfs.Context.ReadFile(f)
+			contents, err = vfs.FromContext(ctx).ReadFile(f)
 			if err != nil {
 				return fmt.Errorf("error reading file %q: %v", f, err)
 			}
@@ -201,7 +201,7 @@ func RunReplace(ctx context.Context, f *util.Factory, out io.Writer, c *ReplaceO
 					return err
 				}
 
-				sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
+				sshCredentialStore, err := clientset.SSHCredentialStore(ctx, cluster)
 				if err != nil {
 					return err
 				}

--- a/cmd/kops/rolling-update_cluster.go
+++ b/cmd/kops/rolling-update_cluster.go
@@ -225,7 +225,7 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer, options *RollingUpdateOptions) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -329,7 +329,7 @@ func GetCluster(ctx context.Context, factory commandutils.Factory, clusterName s
 		return nil, field.Required(field.NewPath("clusterName"), "Cluster name is required")
 	}
 
-	clientset, err := factory.KopsClient()
+	clientset, err := factory.KopsClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +379,7 @@ func GetClusterForCompletion(ctx context.Context, factory commandutils.Factory, 
 		return nil, nil, completions, directive
 	}
 
-	clientSet, err = factory.KopsClient()
+	clientSet, err = factory.KopsClient(ctx)
 	if err != nil {
 		completions, directive := commandutils.CompletionError("getting clientset", err)
 		return nil, nil, completions, directive

--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -102,7 +102,7 @@ func NewCmdToolboxDump(f commandutils.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, options *ToolboxDumpOptions) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/toolbox_instance-selector.go
+++ b/cmd/kops/toolbox_instance-selector.go
@@ -374,7 +374,7 @@ func processAndValidateFlags(commandline *cli.CommandLineInterface) error {
 }
 
 func retrieveClusterRefs(ctx context.Context, f commandutils.Factory, clusterName string) (simple.Clientset, *kops.Cluster, *kops.Channel, error) {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -384,7 +384,7 @@ func retrieveClusterRefs(ctx context.Context, f commandutils.Factory, clusterNam
 		return nil, nil, nil, err
 	}
 
-	channel, err := cloudup.ChannelForCluster(cluster)
+	channel, err := cloudup.ChannelForCluster(ctx, cluster)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/kops/toolbox_template.go
+++ b/cmd/kops/toolbox_template.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -86,7 +87,8 @@ func NewCmdToolboxTemplate(f commandutils.Factory, out io.Writer) *cobra.Command
 		Args:              rootCommand.clusterNameArgs(&options.ClusterName),
 		ValidArgsFunction: commandutils.CompleteClusterName(f, true, false),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return RunToolBoxTemplate(f, out, options)
+			ctx := cmd.Context()
+			return RunToolBoxTemplate(ctx, f, out, options)
 		},
 	}
 
@@ -120,7 +122,7 @@ func NewCmdToolboxTemplate(f commandutils.Factory, out io.Writer) *cobra.Command
 }
 
 // RunToolBoxTemplate is the action for the command
-func RunToolBoxTemplate(f commandutils.Factory, out io.Writer, options *ToolboxTemplateOptions) error {
+func RunToolBoxTemplate(ctx context.Context, f commandutils.Factory, out io.Writer, options *ToolboxTemplateOptions) error {
 	// @step: read in the configuration if any
 	context, err := newTemplateContext(options.configPath, options.values, options.stringValues)
 	if err != nil {
@@ -173,7 +175,7 @@ func RunToolBoxTemplate(f commandutils.Factory, out io.Writer, options *ToolboxT
 		}
 	}
 
-	channel, err := kopsapi.LoadChannel(options.channel)
+	channel, err := kopsapi.LoadChannel(ctx, options.channel)
 	if err != nil {
 		return fmt.Errorf("error loading channel %q: %v", options.channel, err)
 	}

--- a/cmd/kops/trust_keypair.go
+++ b/cmd/kops/trust_keypair.go
@@ -93,7 +93,7 @@ func NewCmdTrustKeypair(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunTrustKeypair(ctx context.Context, f *util.Factory, out io.Writer, options *TrustKeypairOptions) error {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func RunTrustKeypair(ctx context.Context, f *util.Factory, out io.Writer, option
 		return err
 	}
 
-	keyStore, err := clientset.KeyStore(cluster)
+	keyStore, err := clientset.KeyStore(ctx, cluster)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func completeTrustKeyset(f commandutils.Factory, options *TrustKeypairOptions, a
 		return completions, directive
 	}
 
-	keyset, _, completions, directive := completeKeyset(cluster, clientSet, args, func(name string, keyset *fi.Keyset) bool {
+	keyset, _, completions, directive := completeKeyset(ctx, cluster, clientSet, args, func(name string, keyset *fi.Keyset) bool {
 		if name == "all" {
 			return false
 		}

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -202,22 +202,22 @@ func RunUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Up
 		return results, err
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return results, err
 	}
 
-	keyStore, err := clientset.KeyStore(cluster)
+	keyStore, err := clientset.KeyStore(ctx, cluster)
 	if err != nil {
 		return results, err
 	}
 
-	sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
+	sshCredentialStore, err := clientset.SSHCredentialStore(ctx, cluster)
 	if err != nil {
 		return results, err
 	}
 
-	secretStore, err := clientset.SecretStore(cluster)
+	secretStore, err := clientset.SecretStore(ctx, cluster)
 	if err != nil {
 		return results, err
 	}

--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -103,7 +103,7 @@ func RunUpgradeCluster(ctx context.Context, f *util.Factory, out io.Writer, opti
 		return err
 	}
 
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func RunUpgradeCluster(ctx context.Context, f *util.Factory, out io.Writer, opti
 		})
 	}
 
-	channel, err := kopsapi.LoadChannel(channelLocation)
+	channel, err := kopsapi.LoadChannel(ctx, channelLocation)
 	if err != nil {
 		return fmt.Errorf("error loading channel %q: %v", channelLocation, err)
 	}

--- a/cmd/kops/util/factory.go
+++ b/cmd/kops/util/factory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -77,7 +78,7 @@ For example, a valid value follows the format s3://<bucket>.
 Trailing slash will be trimmed.`
 )
 
-func (f *Factory) KopsClient() (simple.Clientset, error) {
+func (f *Factory) KopsClient(ctx context.Context) (simple.Clientset, error) {
 	if f.clientset == nil {
 		registryPath := f.options.RegistryPath
 		klog.V(2).Infof("state store %s", registryPath)
@@ -119,7 +120,7 @@ func (f *Factory) KopsClient() (simple.Clientset, error) {
 				KopsClient: kopsClient.Kops(),
 			}
 		} else {
-			basePath, err := vfs.Context.BuildVfsPath(registryPath)
+			basePath, err := vfs.FromContext(ctx).BuildVfsPath(registryPath)
 			if err != nil {
 				return nil, fmt.Errorf("error building path for %q: %v", registryPath, err)
 			}

--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -111,7 +111,7 @@ func NewCmdValidateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunValidateCluster(ctx context.Context, f *util.Factory, out io.Writer, options *ValidateClusterOptions) (*validation.ValidationCluster, error) {
-	clientSet, err := f.KopsClient()
+	clientSet, err := f.KopsClient(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-apiserver-healthcheck/main.go
+++ b/cmd/kube-apiserver-healthcheck/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
@@ -128,7 +129,7 @@ func (s *healthCheckServer) proxyRequest(w http.ResponseWriter, forwardRequest *
 	}
 }
 
-func run() error {
+func run(ctx context.Context) error {
 	listen := fmt.Sprintf(":%d", wellknownports.KubeAPIServerHealthCheck)
 
 	clientCert := ""
@@ -184,7 +185,9 @@ func run() error {
 }
 
 func main() {
-	if err := run(); err != nil {
+	ctx := context.Background()
+
+	if err := run(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/nodeup/main.go
+++ b/cmd/nodeup/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main // import "k8s.io/kops/cmd/nodeup"
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -34,6 +35,8 @@ const (
 )
 
 func main() {
+	ctx := context.Background()
+
 	klog.InitFlags(nil)
 
 	var flagConf, flagCacheDir, gitVersion string
@@ -103,7 +106,7 @@ func main() {
 			}
 			i.RunTasksOptions.InitDefaults()
 			i.RunTasksOptions.MaxTaskDuration = 5 * time.Minute
-			err = i.Run()
+			err = i.Run(ctx)
 			if err == nil {
 				fmt.Printf("service installed")
 				os.Exit(0)

--- a/examples/kops-api-example/main.go
+++ b/examples/kops-api-example/main.go
@@ -47,15 +47,15 @@ var (
 )
 
 func main() {
+	ctx := context.Background()
+
 	flag.Parse()
 
-	err := parseFlags()
+	err := parseFlags(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-
-	ctx := context.TODO()
 
 	err = up(ctx)
 	if err != nil {
@@ -70,10 +70,10 @@ func main() {
 	}
 }
 
-func parseFlags() error {
+func parseFlags(ctx context.Context) error {
 	var err error
 
-	registryBase, err = vfs.Context.BuildVfsPath(*flagRegistryBase)
+	registryBase, err = vfs.FromContext(ctx).BuildVfsPath(*flagRegistryBase)
 	if err != nil {
 		return fmt.Errorf("error parsing registry path %q: %v", *flagRegistryBase, err)
 	}

--- a/examples/kops-api-example/up.go
+++ b/examples/kops-api-example/up.go
@@ -113,7 +113,7 @@ func up(ctx context.Context) error {
 		}
 	}
 
-	sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
+	sshCredentialStore, err := clientset.SSHCredentialStore(ctx, cluster)
 	if err != nil {
 		return err
 	}

--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -17,6 +17,7 @@ limitations under the License.
 package bootstrap
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -36,7 +37,7 @@ type Installation struct {
 	Command         []string
 }
 
-func (i *Installation) Run() error {
+func (i *Installation) Run(ctx context.Context) error {
 	_, err := distributions.FindDistribution("/")
 	if err != nil {
 		return fmt.Errorf("error determining OS distribution: %v", err)
@@ -72,7 +73,7 @@ func (i *Installation) Run() error {
 	}
 
 	checkExisting := true
-	context, err := fi.NewContext(target, nil, cloud, keyStore, secretStore, configBase, checkExisting, tasks)
+	context, err := fi.NewContext(ctx, target, nil, cloud, keyStore, secretStore, configBase, checkExisting, tasks)
 	if err != nil {
 		return fmt.Errorf("error building context: %v", err)
 	}
@@ -83,7 +84,7 @@ func (i *Installation) Run() error {
 		return fmt.Errorf("error running tasks: %v", err)
 	}
 
-	err = target.Finish(tasks)
+	err = target.Finish(ctx, tasks)
 	if err != nil {
 		return fmt.Errorf("error finishing target: %v", err)
 	}

--- a/nodeup/pkg/model/cloudconfig_test.go
+++ b/nodeup/pkg/model/cloudconfig_test.go
@@ -84,9 +84,9 @@ func TestBuildAzure(t *testing.T) {
 	if task == nil {
 		t.Fatalf("no File task found")
 	}
-	r, err := task.Contents.Open()
+	r, err := task.Contents.Open(ctx.Context())
 	if err != nil {
-		t.Fatalf("unexpected error from task.Contents.Open(): %v", err)
+		t.Fatalf("unexpected error from task.Contents.Open(ctx): %v", err)
 	}
 	data, err := io.ReadAll(r)
 	if err != nil {
@@ -157,9 +157,9 @@ func TestBuildAWSCustomNodeIPFamilies(t *testing.T) {
 	if task == nil {
 		t.Fatalf("no File task found")
 	}
-	r, err := task.Contents.Open()
+	r, err := task.Contents.Open(ctx.Context())
 	if err != nil {
-		t.Fatalf("unexpected error from task.Contents.Open(): %v", err)
+		t.Fatalf("unexpected error from task.Contents.Open(ctx): %v", err)
 	}
 	awsCloudConfig, err := io.ReadAll(r)
 	if err != nil {

--- a/nodeup/pkg/model/containerd_test.go
+++ b/nodeup/pkg/model/containerd_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -132,6 +133,8 @@ func TestContainerdBuilder_BuildFlags(t *testing.T) {
 }
 
 func runContainerdBuilderTest(t *testing.T, key string, distro distributions.Distribution) {
+	ctx := context.TODO()
+
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -145,7 +148,7 @@ func runContainerdBuilderTest(t *testing.T, key string, distro distributions.Dis
 		t.Fatal(err)
 	}
 
-	nodeUpModelContext, err := BuildNodeupModelContext(model)
+	nodeUpModelContext, err := BuildNodeupModelContext(ctx, model)
 	if err != nil {
 		t.Fatalf("error parsing cluster yaml %q: %v", basedir, err)
 		return

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -331,7 +331,7 @@ func (c *NodeupModelContext) BuildBootstrapKubeconfig(name string, ctx *fi.Model
 			return nil, err
 		}
 
-		config, err := fi.ResourceAsBytes(kubeConfig.GetConfig())
+		config, err := fi.ResourceAsBytes(ctx.Context(), kubeConfig.GetConfig())
 		if err != nil {
 			return nil, err
 		}

--- a/nodeup/pkg/model/docker_test.go
+++ b/nodeup/pkg/model/docker_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"context"
 	"path"
 	"path/filepath"
 	"testing"
@@ -124,6 +125,8 @@ func TestDockerBuilder_BuildFlags(t *testing.T) {
 }
 
 func runDockerBuilderTest(t *testing.T, key string) {
+	ctx := context.TODO()
+
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -137,7 +140,7 @@ func runDockerBuilderTest(t *testing.T, key string) {
 		t.Fatal(err)
 	}
 
-	nodeUpModelContext, err := BuildNodeupModelContext(model)
+	nodeUpModelContext, err := BuildNodeupModelContext(ctx, model)
 	if err != nil {
 		t.Fatalf("error parsing cluster yaml %q: %v", basedir, err)
 		return

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -355,6 +355,8 @@ func (b *KubeAPIServerBuilder) writeAuthenticationConfig(c *fi.ModelBuilderConte
 }
 
 func (b *KubeAPIServerBuilder) writeServerCertificate(c *fi.ModelBuilderContext, kubeAPIServer *kops.KubeAPIServerConfig) error {
+	ctx := c.Context()
+
 	pathSrvKAPI := filepath.Join(b.PathSrvKubernetes(), "kube-apiserver")
 
 	{
@@ -399,7 +401,7 @@ func (b *KubeAPIServerBuilder) writeServerCertificate(c *fi.ModelBuilderContext,
 		}
 		if b.CloudProvider == kops.CloudProviderOpenstack {
 			if b.Cluster.Spec.Networking.Topology != nil && b.Cluster.Spec.Networking.Topology.ControlPlane == kops.TopologyPrivate {
-				instanceAddress, err := getInstanceAddress()
+				instanceAddress, err := getInstanceAddress(ctx)
 				if err != nil {
 					return err
 				}

--- a/nodeup/pkg/model/manifests.go
+++ b/nodeup/pkg/model/manifests.go
@@ -35,10 +35,12 @@ var _ fi.ModelBuilder = &ManifestsBuilder{}
 
 // Build creates tasks for copying the manifests
 func (b *ManifestsBuilder) Build(c *fi.ModelBuilderContext) error {
+	ctx := c.Context()
+
 	// Write etcd manifests (currently etcd <=> master)
 	if b.IsMaster {
 		for _, manifest := range b.NodeupConfig.EtcdManifests {
-			p, err := vfs.Context.BuildVfsPath(manifest)
+			p, err := vfs.FromContext(ctx).BuildVfsPath(manifest)
 			if err != nil {
 				return fmt.Errorf("error parsing path for etcd manifest %s: %v", manifest, err)
 			}

--- a/nodeup/pkg/model/secrets.go
+++ b/nodeup/pkg/model/secrets.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"context"
 	"path/filepath"
 
 	"k8s.io/kops/upup/pkg/fi"
@@ -64,8 +65,8 @@ func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
 	return nil
 }
 
-func getInstanceAddress() (string, error) {
-	addrBytes, err := vfs.Context.ReadFile("metadata://openstack/local-ipv4")
+func getInstanceAddress(ctx context.Context) (string, error) {
+	addrBytes, err := vfs.FromContext(ctx).ReadFile("metadata://openstack/local-ipv4")
 	if err != nil {
 		return "", nil
 	}

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kops
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -128,7 +129,7 @@ func ResolveChannel(location string) (*url.URL, error) {
 }
 
 // LoadChannel loads a Channel object from the specified VFS location
-func LoadChannel(location string) (*Channel, error) {
+func LoadChannel(ctx context.Context, location string) (*Channel, error) {
 	resolvedURL, err := ResolveChannel(location)
 	if err != nil {
 		return nil, err
@@ -141,7 +142,7 @@ func LoadChannel(location string) (*Channel, error) {
 	resolved := resolvedURL.String()
 
 	klog.V(2).Infof("Loading channel from %q", resolved)
-	channelBytes, err := vfs.Context.ReadFile(resolved)
+	channelBytes, err := vfs.FromContext(ctx).ReadFile(resolved)
 	if err != nil {
 		return nil, fmt.Errorf("error reading channel %q: %v", resolved, err)
 	}

--- a/pkg/apis/kops/registry/registry.go
+++ b/pkg/apis/kops/registry/registry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package registry
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -33,11 +34,11 @@ const (
 	PathKopsVersionUpdated = "kops-version.txt"
 )
 
-func ConfigBase(c *api.Cluster) (vfs.Path, error) {
+func ConfigBase(ctx context.Context, c *api.Cluster) (vfs.Path, error) {
 	if c.Spec.ConfigBase == "" {
 		return nil, field.Required(field.NewPath("spec", "configBase"), "")
 	}
-	configBase, err := vfs.Context.BuildVfsPath(c.Spec.ConfigBase)
+	configBase, err := vfs.FromContext(ctx).BuildVfsPath(c.Spec.ConfigBase)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing ConfigBase %q: %v", c.Spec.ConfigBase, err)
 	}

--- a/pkg/apis/kops/validation/cluster.go
+++ b/pkg/apis/kops/validation/cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -25,8 +26,8 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 )
 
-func ValidateClusterUpdate(obj *kops.Cluster, status *kops.ClusterStatus, old *kops.Cluster) field.ErrorList {
-	allErrs := ValidateCluster(obj, false)
+func ValidateClusterUpdate(ctx context.Context, obj *kops.Cluster, status *kops.ClusterStatus, old *kops.Cluster) field.ErrorList {
+	allErrs := ValidateCluster(ctx, obj, false)
 
 	// Validate etcd cluster changes
 	{

--- a/pkg/assets/copy.go
+++ b/pkg/assets/copy.go
@@ -17,6 +17,7 @@ limitations under the License.
 package assets
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -25,10 +26,10 @@ import (
 )
 
 type assetTask interface {
-	Run() error
+	Run(ctx context.Context) error
 }
 
-func Copy(imageAssets []*ImageAsset, fileAssets []*FileAsset, cluster *kops.Cluster) error {
+func Copy(ctx context.Context, imageAssets []*ImageAsset, fileAssets []*FileAsset, cluster *kops.Cluster) error {
 	tasks := map[string]assetTask{}
 
 	for _, imageAsset := range imageAssets {
@@ -95,7 +96,7 @@ func Copy(imageAssets []*ImageAsset, fileAssets []*FileAsset, cluster *kops.Clus
 			gotError = true
 		}
 		go func(n string, t assetTask) {
-			err := t.Run()
+			err := t.Run(ctx)
 			if err != nil {
 				err = fmt.Errorf("%s: %v", n, err)
 			}

--- a/pkg/assets/copyimage.go
+++ b/pkg/assets/copyimage.go
@@ -17,6 +17,7 @@ limitations under the License.
 package assets
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -34,7 +35,7 @@ type CopyImage struct {
 	TargetImage string
 }
 
-func (e *CopyImage) Run() error {
+func (e *CopyImage) Run(ctx context.Context) error {
 	source := e.SourceImage
 	target := e.TargetImage
 
@@ -49,6 +50,7 @@ func (e *CopyImage) Run() error {
 	}
 
 	options := []remote.Option{remote.WithAuthFromKeychain(authn.DefaultKeychain)}
+	options = append(options, remote.WithContext(ctx))
 
 	desc, err := remote.Get(sourceRef, options...)
 	if err != nil {

--- a/pkg/client/simple/clientset.go
+++ b/pkg/client/simple/clientset.go
@@ -41,7 +41,7 @@ type Clientset interface {
 	ListClusters(ctx context.Context, options metav1.ListOptions) (*kops.ClusterList, error)
 
 	// ConfigBaseFor returns the vfs path where we will read configuration information from
-	ConfigBaseFor(cluster *kops.Cluster) (vfs.Path, error)
+	ConfigBaseFor(ctx context.Context, cluster *kops.Cluster) (vfs.Path, error)
 
 	// InstanceGroupsFor returns the InstanceGroupInterface bound to the namespace for a particular Cluster
 	InstanceGroupsFor(cluster *kops.Cluster) kopsinternalversion.InstanceGroupInterface
@@ -50,13 +50,13 @@ type Clientset interface {
 	AddonsFor(cluster *kops.Cluster) AddonsClient
 
 	// SecretStore builds the secret store for the specified cluster
-	SecretStore(cluster *kops.Cluster) (fi.SecretStore, error)
+	SecretStore(ctx context.Context, cluster *kops.Cluster) (fi.SecretStore, error)
 
 	// KeyStore builds the key store for the specified cluster
-	KeyStore(cluster *kops.Cluster) (fi.CAStore, error)
+	KeyStore(ctx context.Context, cluster *kops.Cluster) (fi.CAStore, error)
 
 	// SSHCredentialStore builds the SSHCredential store for the specified cluster
-	SSHCredentialStore(cluster *kops.Cluster) (fi.SSHCredentialStore, error)
+	SSHCredentialStore(ctx context.Context, cluster *kops.Cluster) (fi.SSHCredentialStore, error)
 
 	// DeleteCluster deletes all the state for the specified cluster
 	DeleteCluster(ctx context.Context, cluster *kops.Cluster) error

--- a/pkg/client/simple/vfsclientset/clientset_test.go
+++ b/pkg/client/simple/vfsclientset/clientset_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vfsclientset
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -24,7 +25,9 @@ import (
 )
 
 func TestSSHCredentialStoreOnConfigBase(t *testing.T) {
-	vfs.Context.ResetMemfsContext(true)
+	ctx := context.TODO()
+
+	vfs.FromContext(ctx).ResetMemfsContext(true)
 	configBase := "memfs://some/config/base"
 	cluster := &kops.Cluster{
 		Spec: kops.ClusterSpec{
@@ -32,7 +35,7 @@ func TestSSHCredentialStoreOnConfigBase(t *testing.T) {
 		},
 	}
 
-	p, err := pkiPath(cluster)
+	p, err := pkiPath(ctx, cluster)
 	if err != nil {
 		t.Errorf("Failed to create ssh path: %v", err)
 	}
@@ -46,7 +49,9 @@ func TestSSHCredentialStoreOnConfigBase(t *testing.T) {
 }
 
 func TestSSHCredentialStoreOnOwnCFS(t *testing.T) {
-	vfs.Context.ResetMemfsContext(true)
+	ctx := context.TODO()
+
+	vfs.FromContext(ctx).ResetMemfsContext(true)
 	configBase := "memfs://some/config/base"
 	keyPath := "memfs://keys/some/config/base/pki"
 	cluster := &kops.Cluster{
@@ -56,7 +61,7 @@ func TestSSHCredentialStoreOnOwnCFS(t *testing.T) {
 		},
 	}
 
-	p, err := pkiPath(cluster)
+	p, err := pkiPath(ctx, cluster)
 	if err != nil {
 		t.Errorf("Failed to create ssh path: %v", err)
 	}

--- a/pkg/client/simple/vfsclientset/cluster.go
+++ b/pkg/client/simple/vfsclientset/cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vfsclientset
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -95,8 +96,8 @@ func (c *ClusterVFS) List(options metav1.ListOptions) (*api.ClusterList, error) 
 	return &api.ClusterList{Items: items}, nil
 }
 
-func (r *ClusterVFS) Create(c *api.Cluster) (*api.Cluster, error) {
-	if errs := validation.ValidateCluster(c, false); len(errs) != 0 {
+func (r *ClusterVFS) Create(ctx context.Context, c *api.Cluster) (*api.Cluster, error) {
+	if errs := validation.ValidateCluster(ctx, c, false); len(errs) != 0 {
 		return nil, errs.ToAggregate()
 	}
 
@@ -119,7 +120,7 @@ func (r *ClusterVFS) Create(c *api.Cluster) (*api.Cluster, error) {
 	return c, nil
 }
 
-func (r *ClusterVFS) Update(c *api.Cluster, status *api.ClusterStatus) (*api.Cluster, error) {
+func (r *ClusterVFS) Update(ctx context.Context, c *api.Cluster, status *api.ClusterStatus) (*api.Cluster, error) {
 	clusterName := c.ObjectMeta.Name
 	if clusterName == "" {
 		return nil, field.Required(field.NewPath("objectMeta", "name"), "clusterName is required")
@@ -134,7 +135,7 @@ func (r *ClusterVFS) Update(c *api.Cluster, status *api.ClusterStatus) (*api.Clu
 		return nil, errors.NewNotFound(schema.GroupResource{Group: api.GroupName, Resource: "Cluster"}, clusterName)
 	}
 
-	if err := validation.ValidateClusterUpdate(c, status, old).ToAggregate(); err != nil {
+	if err := validation.ValidateClusterUpdate(ctx, c, status, old).ToAggregate(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/clusteraddons/load.go
+++ b/pkg/clusteraddons/load.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clusteraddons
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -31,7 +32,7 @@ type ClusterAddon struct {
 }
 
 // LoadClusterAddon loads a set of objects from the specified VFS location
-func LoadClusterAddon(location string) (*ClusterAddon, error) {
+func LoadClusterAddon(ctx context.Context, location string) (*ClusterAddon, error) {
 	u, err := url.Parse(location)
 	if err != nil {
 		return nil, fmt.Errorf("invalid addon location: %q", location)
@@ -41,7 +42,7 @@ func LoadClusterAddon(location string) (*ClusterAddon, error) {
 
 	resolved := u.String()
 	klog.V(2).Infof("Loading addon from %q", resolved)
-	addonBytes, err := vfs.Context.ReadFile(resolved)
+	addonBytes, err := vfs.FromContext(ctx).ReadFile(resolved)
 	if err != nil {
 		return nil, fmt.Errorf("error reading addon %q: %v", resolved, err)
 	}

--- a/pkg/commands/commandutils/cluster.go
+++ b/pkg/commands/commandutils/cluster.go
@@ -27,13 +27,15 @@ import (
 // CompleteClusterName returns a Cobra completion function for cluster names.
 func CompleteClusterName(f Factory, suppressIfArgs bool, suppressArgs bool) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ctx := cmd.Context()
+
 		if suppressIfArgs && len(args) > 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		ConfigureKlogForCompletion()
 
-		client, err := f.KopsClient()
+		client, err := f.KopsClient(ctx)
 		if err != nil {
 			return CompletionError("getting clientset", err)
 		}

--- a/pkg/commands/commandutils/factory.go
+++ b/pkg/commands/commandutils/factory.go
@@ -16,8 +16,12 @@ limitations under the License.
 
 package commandutils
 
-import "k8s.io/kops/pkg/client/simple"
+import (
+	"context"
+
+	"k8s.io/kops/pkg/client/simple"
+)
 
 type Factory interface {
-	KopsClient() (simple.Clientset, error)
+	KopsClient(ctx context.Context) (simple.Clientset, error)
 }

--- a/pkg/commands/helpers/kubectl_auth.go
+++ b/pkg/commands/helpers/kubectl_auth.go
@@ -218,7 +218,7 @@ func loadCachedExecCredential(cacheFilePath string) (*ExecCredential, error) {
 }
 
 func buildCredentials(ctx context.Context, f *util.Factory, options *HelperKubectlAuthOptions) (*ExecCredentialStatus, error) {
-	clientset, err := f.KopsClient()
+	clientset, err := f.KopsClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func buildCredentials(ctx context.Context, f *util.Factory, options *HelperKubec
 		return nil, fmt.Errorf("cluster not found %q", options.ClusterName)
 	}
 
-	keyStore, err := clientset.KeyStore(cluster)
+	keyStore, err := clientset.KeyStore(ctx, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get cluster keystore: %v", err)
 	}

--- a/pkg/commands/helpers_readwrite.go
+++ b/pkg/commands/helpers_readwrite.go
@@ -41,12 +41,12 @@ func UpdateCluster(ctx context.Context, clientset simple.Clientset, cluster *kop
 	}
 
 	assetBuilder := assets.NewAssetBuilder(cluster, false)
-	fullCluster, err := cloudup.PopulateClusterSpec(clientset, cluster, cloud, assetBuilder)
+	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, cloud, assetBuilder)
 	if err != nil {
 		return err
 	}
 
-	err = validation.DeepValidate(fullCluster, instanceGroups, true, nil)
+	err = validation.DeepValidate(ctx, fullCluster, instanceGroups, true, nil)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func UpdateInstanceGroup(ctx context.Context, clientset simple.Clientset, cluste
 	}
 
 	assetBuilder := assets.NewAssetBuilder(cluster, false)
-	fullCluster, err := cloudup.PopulateClusterSpec(clientset, cluster, cloud, assetBuilder)
+	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, cloud, assetBuilder)
 	if err != nil {
 		return err
 	}

--- a/pkg/instancegroups/rollingupdate_os_test.go
+++ b/pkg/instancegroups/rollingupdate_os_test.go
@@ -39,7 +39,9 @@ import (
 )
 
 func getTestSetupOS(t *testing.T) (*RollingUpdateCluster, *openstack.MockCloud) {
-	vfs.Context.ResetMemfsContext(true)
+	ctx := context.TODO()
+
+	vfs.FromContext(ctx).ResetMemfsContext(true)
 
 	k8sClient := fake.NewSimpleClientset()
 
@@ -59,15 +61,15 @@ func getTestSetupOS(t *testing.T) (*RollingUpdateCluster, *openstack.MockCloud) 
 	}
 
 	assetBuilder := assets.NewAssetBuilder(inCluster, false)
-	basePath, _ := vfs.Context.BuildVfsPath(inCluster.Spec.ConfigBase)
+	basePath, _ := vfs.FromContext(ctx).BuildVfsPath(inCluster.Spec.ConfigBase)
 	clientset := vfsclientset.NewVFSClientset(basePath)
-	cluster, err := cloudup.PopulateClusterSpec(clientset, inCluster, mockcloud, assetBuilder)
+	cluster, err := cloudup.PopulateClusterSpec(ctx, clientset, inCluster, mockcloud, assetBuilder)
 	if err != nil {
 		t.Fatalf("Failed to populate cluster spec: %v", err)
 	}
 
 	sshPublicKey := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDF2sghZsClUBXJB4mBMIw8rb0hJWjg1Vz4eUeXwYmTdi92Gf1zNc5xISSip9Y+PWX/jJokPB7tgPnMD/2JOAKhG1bi4ZqB15pYRmbbBekVpM4o4E0dx+czbqjiAm6wlccTrINK5LYenbucAAQt19eH+D0gJwzYUK9SYz1hWnlGS+qurt2bz7rrsG73lN8E2eiNvGtIXqv3GabW/Hea3acOBgCUJQWUDTRu0OmmwxzKbFN/UpNKeRaHlCqwZWjVAsmqA8TX8LIocq7Np7MmIBwt7EpEeZJxThcmC8DEJs9ClAjD+jlLIvMPXKC3JWCPgwCLGxHjy7ckSGFCSzbyPduh")
-	sshCredentialStore, err := clientset.SSHCredentialStore(cluster)
+	sshCredentialStore, err := clientset.SSHCredentialStore(ctx, cluster)
 	if err != nil {
 		t.Fatalf("Failed to get credential store: %v", err)
 	}

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -335,6 +335,8 @@ func (b *BootstrapScript) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 }
 
 func (b *BootstrapScript) Run(c *fi.Context) error {
+	ctx := c.Context()
+
 	if b.Lifecycle == fi.LifecycleIgnore {
 		return nil
 	}
@@ -441,7 +443,7 @@ func (b *BootstrapScript) Run(c *fi.Context) error {
 	}
 
 	b.resource.Resource = fi.FunctionToResource(func() ([]byte, error) {
-		nodeupScript, err := fi.ResourceAsString(nodeupScriptResource)
+		nodeupScript, err := fi.ResourceAsString(ctx, nodeupScriptResource)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/model/bootstrapscript_test.go
+++ b/pkg/model/bootstrapscript_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -78,6 +79,8 @@ func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 }
 
 func TestBootstrapUserData(t *testing.T) {
+	ctx := context.TODO()
+
 	cs := []struct {
 		Role               kops.InstanceGroupRole
 		ExpectedFileIndex  int
@@ -193,7 +196,7 @@ func TestBootstrapUserData(t *testing.T) {
 		err = c.Tasks["BootstrapScript/testIG"].Run(&fi.Context{Cluster: cluster})
 		require.NoError(t, err, "running task")
 
-		actual, err := fi.ResourceAsString(res)
+		actual, err := fi.ResourceAsString(ctx, res)
 		if err != nil {
 			t.Errorf("case %d failed to render nodeup resource. error: %s", i, err)
 			continue
@@ -202,7 +205,7 @@ func TestBootstrapUserData(t *testing.T) {
 		golden.AssertMatchesFile(t, actual, fmt.Sprintf("tests/data/bootstrapscript_%d.txt", x.ExpectedFileIndex))
 
 		require.Contains(t, c.Tasks, "ManagedFile/nodeupconfig-testIG")
-		actual, err = fi.ResourceAsString(c.Tasks["ManagedFile/nodeupconfig-testIG"].(*fitasks.ManagedFile).Contents)
+		actual, err = fi.ResourceAsString(ctx, c.Tasks["ManagedFile/nodeupconfig-testIG"].(*fitasks.ManagedFile).Contents)
 		if err != nil {
 			t.Errorf("case %d failed to render nodeupconfig resource. error: %s", i, err)
 			continue

--- a/pkg/model/components/addonmanifests/awscloudcontrollermanager/iam.go
+++ b/pkg/model/components/addonmanifests/awscloudcontrollermanager/iam.go
@@ -17,6 +17,8 @@ limitations under the License.
 package awscloudcontrollermanager
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/kops/pkg/model/iam"
@@ -29,7 +31,7 @@ type ServiceAccount struct{}
 var _ iam.Subject = &ServiceAccount{}
 
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
-func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
+func (r *ServiceAccount) BuildAWSPolicy(ctx context.Context, b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName, b.Partition)
 	iam.AddCCMPermissions(p, b.Cluster.Spec.Networking.Kubenet != nil)

--- a/pkg/model/components/addonmanifests/awsebscsidriver/iam.go
+++ b/pkg/model/components/addonmanifests/awsebscsidriver/iam.go
@@ -17,6 +17,8 @@ limitations under the License.
 package awsebscsidriver
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kops/pkg/model/iam"
 	"k8s.io/kops/upup/pkg/fi"
@@ -29,7 +31,7 @@ type ServiceAccount struct{}
 var _ iam.Subject = &ServiceAccount{}
 
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
-func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
+func (r *ServiceAccount) BuildAWSPolicy(ctx context.Context, b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName, b.Partition)
 

--- a/pkg/model/components/addonmanifests/awsloadbalancercontroller/iam.go
+++ b/pkg/model/components/addonmanifests/awsloadbalancercontroller/iam.go
@@ -17,6 +17,8 @@ limitations under the License.
 package awsloadbalancercontroller
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kops/pkg/model/iam"
 )
@@ -28,7 +30,7 @@ type ServiceAccount struct{}
 var _ iam.Subject = &ServiceAccount{}
 
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
-func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
+func (r *ServiceAccount) BuildAWSPolicy(ctx context.Context, b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName, b.Partition)
 

--- a/pkg/model/components/addonmanifests/certmanager/iam.go
+++ b/pkg/model/components/addonmanifests/certmanager/iam.go
@@ -17,6 +17,7 @@ limitations under the License.
 package certmanager
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -32,7 +33,7 @@ type ServiceAccount struct{}
 var _ iam.Subject = &ServiceAccount{}
 
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
-func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
+func (r *ServiceAccount) BuildAWSPolicy(ctx context.Context, b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName, b.Partition)
 

--- a/pkg/model/components/addonmanifests/clusterautoscaler/iam.go
+++ b/pkg/model/components/addonmanifests/clusterautoscaler/iam.go
@@ -17,6 +17,8 @@ limitations under the License.
 package clusterautoscaler
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kops/pkg/model/iam"
 	"k8s.io/kops/upup/pkg/fi"
@@ -29,7 +31,7 @@ type ServiceAccount struct{}
 var _ iam.Subject = &ServiceAccount{}
 
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
-func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
+func (r *ServiceAccount) BuildAWSPolicy(ctx context.Context, b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName, b.Partition)
 

--- a/pkg/model/components/addonmanifests/dnscontroller/iam.go
+++ b/pkg/model/components/addonmanifests/dnscontroller/iam.go
@@ -17,6 +17,8 @@ limitations under the License.
 package dnscontroller
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kops/pkg/model/iam"
 )
@@ -28,7 +30,7 @@ type ServiceAccount struct{}
 var _ iam.Subject = &ServiceAccount{}
 
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
-func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
+func (r *ServiceAccount) BuildAWSPolicy(ctx context.Context, b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName, b.Partition)
 

--- a/pkg/model/components/addonmanifests/externaldns/iam.go
+++ b/pkg/model/components/addonmanifests/externaldns/iam.go
@@ -17,6 +17,8 @@ limitations under the License.
 package externaldns
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kops/pkg/model/iam"
 )
@@ -28,7 +30,7 @@ type ServiceAccount struct{}
 var _ iam.Subject = &ServiceAccount{}
 
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
-func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
+func (r *ServiceAccount) BuildAWSPolicy(ctx context.Context, b *iam.PolicyBuilder) (*iam.Policy, error) {
 	p := &iam.Policy{
 		Version: iam.PolicyDefaultVersion,
 	}

--- a/pkg/model/components/addonmanifests/karpenter/iam.go
+++ b/pkg/model/components/addonmanifests/karpenter/iam.go
@@ -17,6 +17,8 @@ limitations under the License.
 package karpenter
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/kops/pkg/model/iam"
@@ -29,7 +31,7 @@ type ServiceAccount struct{}
 var _ iam.Subject = &ServiceAccount{}
 
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
-func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
+func (r *ServiceAccount) BuildAWSPolicy(ctx context.Context, b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName, b.Partition)
 

--- a/pkg/model/components/addonmanifests/kuberouter/iam.go
+++ b/pkg/model/components/addonmanifests/kuberouter/iam.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kuberouter
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/kops/pkg/model/iam"
@@ -29,7 +31,7 @@ type ServiceAccount struct{}
 var _ iam.Subject = &ServiceAccount{}
 
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
-func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
+func (r *ServiceAccount) BuildAWSPolicy(ctx context.Context, b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName, b.Partition)
 	iam.AddKubeRouterPermissions(b, p)

--- a/pkg/model/components/addonmanifests/nodeterminationhandler/iam.go
+++ b/pkg/model/components/addonmanifests/nodeterminationhandler/iam.go
@@ -17,6 +17,8 @@ limitations under the License.
 package nodeterminationhandler
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kops/pkg/model/iam"
 )
@@ -28,7 +30,7 @@ type ServiceAccount struct{}
 var _ iam.Subject = &ServiceAccount{}
 
 // BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
-func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
+func (r *ServiceAccount) BuildAWSPolicy(ctx context.Context, b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName, b.Partition)
 

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -37,7 +38,7 @@ type KubeAPIServerOptionsBuilder struct {
 var _ loader.OptionsBuilder = &KubeAPIServerOptionsBuilder{}
 
 // BuildOptions is responsible for filling in the default settings for the kube apiserver
-func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *KubeAPIServerOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	if clusterSpec.KubeAPIServer == nil {
 		clusterSpec.KubeAPIServer = &kops.KubeAPIServerConfig{}
@@ -91,7 +92,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 		return nil
 	}
 
-	image, err := Image("kube-apiserver", clusterSpec, b.AssetBuilder)
+	image, err := Image(ctx, "kube-apiserver", clusterSpec, b.AssetBuilder)
 	if err != nil {
 		return err
 	}

--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -32,7 +33,7 @@ type AWSCloudControllerManagerOptionsBuilder struct {
 var _ loader.OptionsBuilder = &AWSCloudControllerManagerOptionsBuilder{}
 
 // BuildOptions generates the configurations used for the AWS cloud controller manager manifest
-func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 
 	if clusterSpec.GetCloudProvider() != kops.CloudProviderAWS {

--- a/pkg/model/components/awsebscsidriver.go
+++ b/pkg/model/components/awsebscsidriver.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
@@ -29,7 +31,7 @@ type AWSEBSCSIDriverOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &AWSEBSCSIDriverOptionsBuilder{}
 
-func (b *AWSEBSCSIDriverOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *AWSEBSCSIDriverOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	if clusterSpec.GetCloudProvider() != kops.CloudProviderAWS {
 		return nil

--- a/pkg/model/components/calico.go
+++ b/pkg/model/components/calico.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
@@ -28,7 +30,7 @@ type CalicoOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &CalicoOptionsBuilder{}
 
-func (b *CalicoOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *CalicoOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	c := clusterSpec.Networking.Calico
 	if c == nil {

--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -32,7 +34,7 @@ type CiliumOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &CiliumOptionsBuilder{}
 
-func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *CiliumOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	c := clusterSpec.Networking.Cilium
 	if c == nil {

--- a/pkg/model/components/cloudconfiguration.go
+++ b/pkg/model/components/cloudconfiguration.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
@@ -29,7 +31,7 @@ type CloudConfigurationOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &CloudConfigurationOptionsBuilder{}
 
-func (b *CloudConfigurationOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *CloudConfigurationOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	c := clusterSpec.CloudConfig
 	if c == nil {

--- a/pkg/model/components/cloudconfiguration_test.go
+++ b/pkg/model/components/cloudconfiguration_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"testing"
 
 	kopsapi "k8s.io/kops/pkg/apis/kops"
@@ -24,6 +25,8 @@ import (
 )
 
 func TestCloudConfigurationOptionsBuilder(t *testing.T) {
+	ctx := context.TODO()
+
 	ob := &CloudConfigurationOptionsBuilder{
 		Context: nil,
 	}
@@ -107,7 +110,7 @@ func TestCloudConfigurationOptionsBuilder(t *testing.T) {
 			if p := test.openStackManageSCs; p != nil {
 				spec.CloudProvider.Openstack.BlockStorage.CreateStorageClass = p
 			}
-			if err := ob.BuildOptions(&spec); err != nil {
+			if err := ob.BuildOptions(ctx, &spec); err != nil {
 				t.Fatalf("failed to build options: %v", err)
 			}
 			if want, got := test.expectedGeneralManageSCs, spec.CloudConfig.ManageStorageClasses; (want == nil) != (got == nil) || (got != nil && *got != *want) {

--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/upup/pkg/fi"
@@ -30,7 +32,7 @@ type ClusterAutoscalerOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &ClusterAutoscalerOptionsBuilder{}
 
-func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	cas := clusterSpec.ClusterAutoscaler
 	if cas == nil || !fi.ValueOf(cas.Enabled) {

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/blang/semver/v4"
@@ -34,7 +35,7 @@ type ContainerdOptionsBuilder struct {
 var _ loader.OptionsBuilder = &ContainerdOptionsBuilder{}
 
 // BuildOptions is responsible for filling in the default setting for containerd daemon
-func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *ContainerdOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 
 	if clusterSpec.Containerd == nil {

--- a/pkg/model/components/containerd_test.go
+++ b/pkg/model/components/containerd_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"testing"
 
 	kopsapi "k8s.io/kops/pkg/apis/kops"
@@ -39,6 +40,7 @@ func buildContainerdCluster(version string) *kopsapi.Cluster {
 }
 
 func Test_Build_Containerd_Supported_Version(t *testing.T) {
+	ctx := context.TODO()
 	kubernetesVersions := []string{"1.18.0", "1.18.3"}
 
 	for _, v := range kubernetesVersions {
@@ -59,7 +61,7 @@ func Test_Build_Containerd_Supported_Version(t *testing.T) {
 			},
 		}
 
-		err = ob.BuildOptions(&c.Spec)
+		err = ob.BuildOptions(ctx, &c.Spec)
 		if err != nil {
 			t.Fatalf("unexpected error from BuildOptions: %v", err)
 		}
@@ -71,6 +73,8 @@ func Test_Build_Containerd_Supported_Version(t *testing.T) {
 }
 
 func Test_Build_Containerd_Unneeded_Runtime(t *testing.T) {
+	ctx := context.TODO()
+
 	dockerVersions := []string{"1.13.1", "17.03.2", "18.06.3"}
 
 	for _, v := range dockerVersions {
@@ -88,7 +92,7 @@ func Test_Build_Containerd_Unneeded_Runtime(t *testing.T) {
 			},
 		}
 
-		err := ob.BuildOptions(&c.Spec)
+		err := ob.BuildOptions(ctx, &c.Spec)
 		if err != nil {
 			t.Fatalf("unexpected error from BuildOptions: %v", err)
 		}
@@ -100,6 +104,7 @@ func Test_Build_Containerd_Unneeded_Runtime(t *testing.T) {
 }
 
 func Test_Build_Containerd_Needed_Runtime(t *testing.T) {
+	ctx := context.TODO()
 	dockerVersions := []string{"18.09.3", "18.09.9", "19.03.4"}
 
 	for _, v := range dockerVersions {
@@ -117,7 +122,7 @@ func Test_Build_Containerd_Needed_Runtime(t *testing.T) {
 			},
 		}
 
-		err := ob.BuildOptions(&c.Spec)
+		err := ob.BuildOptions(ctx, &c.Spec)
 		if err != nil {
 			t.Fatalf("unexpected error from BuildOptions: %v", err)
 		}

--- a/pkg/model/components/context.go
+++ b/pkg/model/components/context.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"math/big"
@@ -115,7 +116,7 @@ func IsBaseURL(kubernetesVersion string) bool {
 }
 
 // Image returns the docker image name for the specified component
-func Image(component string, clusterSpec *kops.ClusterSpec, assetsBuilder *assets.AssetBuilder) (string, error) {
+func Image(ctx context.Context, component string, clusterSpec *kops.ClusterSpec, assetsBuilder *assets.AssetBuilder) (string, error) {
 	if assetsBuilder == nil {
 		return "", fmt.Errorf("unable to parse assets as assetBuilder is not defined")
 	}
@@ -155,7 +156,7 @@ func Image(component string, clusterSpec *kops.ClusterSpec, assetsBuilder *asset
 	tagURL := baseURL + "/bin/linux/amd64/" + component + ".docker_tag"
 	klog.V(2).Infof("Downloading docker tag for %s from: %s", component, tagURL)
 
-	b, err := vfs.Context.ReadFile(tagURL)
+	b, err := vfs.FromContext(ctx).ReadFile(tagURL)
 	if err != nil {
 		return "", fmt.Errorf("error reading tag file %q: %v", tagURL, err)
 	}

--- a/pkg/model/components/defaults.go
+++ b/pkg/model/components/defaults.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
@@ -29,7 +31,7 @@ type DefaultsOptionsBuilder struct {
 var _ loader.OptionsBuilder = &DefaultsOptionsBuilder{}
 
 // BuildOptions is responsible for cluster options
-func (b *DefaultsOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *DefaultsOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	options := o.(*kops.ClusterSpec)
 
 	if options.ClusterDNSDomain == "" {

--- a/pkg/model/components/discovery.go
+++ b/pkg/model/components/discovery.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -33,7 +34,7 @@ type DiscoveryOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &DiscoveryOptionsBuilder{}
 
-func (b *DiscoveryOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *DiscoveryOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 
 	if clusterSpec.KubeAPIServer == nil {
@@ -51,7 +52,7 @@ func (b *DiscoveryOptionsBuilder) BuildOptions(o interface{}) error {
 		var serviceAccountIssuer string
 		if said != nil && said.DiscoveryStore != "" {
 			store := said.DiscoveryStore
-			base, err := vfs.Context.BuildVfsPath(store)
+			base, err := vfs.FromContext(ctx).BuildVfsPath(store)
 			if err != nil {
 				return fmt.Errorf("error parsing locationStore=%q: %w", store, err)
 			}

--- a/pkg/model/components/docker.go
+++ b/pkg/model/components/docker.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
@@ -30,7 +32,7 @@ type DockerOptionsBuilder struct {
 var _ loader.OptionsBuilder = &DockerOptionsBuilder{}
 
 // BuildOptions is responsible for filling in the default setting for docker daemon
-func (b *DockerOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *DockerOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 
 	if clusterSpec.Docker == nil {

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
@@ -34,7 +36,7 @@ const (
 )
 
 // BuildOptions is responsible for filling in the defaults for the etcd cluster model
-func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *EtcdOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	spec := o.(*kops.ClusterSpec)
 
 	for i := range spec.EtcdClusters {

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package etcdmanager
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -36,7 +37,7 @@ type EtcdManagerOptionsBuilder struct {
 var _ loader.OptionsBuilder = &EtcdManagerOptionsBuilder{}
 
 // BuildOptions generates the configurations used to create etcd manager manifest
-func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *EtcdManagerOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 
 	for i := range clusterSpec.EtcdClusters {

--- a/pkg/model/components/gcpcloudcontrollermanager.go
+++ b/pkg/model/components/gcpcloudcontrollermanager.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
@@ -29,7 +31,7 @@ type GCPCloudControllerManagerOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = (*GCPCloudControllerManagerOptionsBuilder)(nil)
 
-func (b *GCPCloudControllerManagerOptionsBuilder) BuildOptions(options interface{}) error {
+func (b *GCPCloudControllerManagerOptionsBuilder) BuildOptions(ctx context.Context, options interface{}) error {
 	clusterSpec := options.(*kops.ClusterSpec)
 
 	if clusterSpec.GetCloudProvider() != kops.CloudProviderGCE {

--- a/pkg/model/components/gcppdcsidriver.go
+++ b/pkg/model/components/gcppdcsidriver.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
@@ -29,7 +31,7 @@ type GCPPDCSIDriverOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &GCPPDCSIDriverOptionsBuilder{}
 
-func (b *GCPPDCSIDriverOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *GCPPDCSIDriverOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	if clusterSpec.GetCloudProvider() != kops.CloudProviderGCE {
 		return nil

--- a/pkg/model/components/hetznercloudcontrollermanager.go
+++ b/pkg/model/components/hetznercloudcontrollermanager.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
@@ -30,7 +32,7 @@ type HetznerCloudControllerManagerOptionsBuilder struct {
 var _ loader.OptionsBuilder = &HetznerCloudControllerManagerOptionsBuilder{}
 
 // BuildOptions generates the configurations used for the Hetzner cloud controller manager manifest
-func (b *HetznerCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *HetznerCloudControllerManagerOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 
 	if clusterSpec.GetCloudProvider() != kops.CloudProviderHetzner {

--- a/pkg/model/components/image_test.go
+++ b/pkg/model/components/image_test.go
@@ -18,6 +18,7 @@ package components
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -27,6 +28,7 @@ import (
 )
 
 func TestImage(t *testing.T) {
+	ctx := context.TODO()
 	featureflag.ParseFlags("-ImageDigest")
 	grid := []struct {
 		Component string
@@ -61,11 +63,11 @@ func TestImage(t *testing.T) {
 	}
 
 	for _, g := range grid {
-		vfs.Context.ResetMemfsContext(true)
+		vfs.FromContext(ctx).ResetMemfsContext(true)
 
 		// Populate VFS files
 		for k, v := range g.VFS {
-			p, err := vfs.Context.BuildVfsPath(k)
+			p, err := vfs.FromContext(ctx).BuildVfsPath(k)
 			if err != nil {
 				t.Errorf("error building vfs path for %s: %v", k, err)
 				continue
@@ -77,7 +79,7 @@ func TestImage(t *testing.T) {
 		}
 
 		assetBuilder := assets.NewAssetBuilder(g.Cluster, false)
-		actual, err := Image(g.Component, &g.Cluster.Spec, assetBuilder)
+		actual, err := Image(ctx, g.Component, &g.Cluster.Spec, assetBuilder)
 		if err != nil {
 			t.Errorf("unexpected error from image %q %v: %v",
 				g.Component, g.Cluster.Spec.KubernetesVersion, err)

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -42,7 +43,7 @@ type KubeControllerManagerOptionsBuilder struct {
 var _ loader.OptionsBuilder = &KubeControllerManagerOptionsBuilder{}
 
 // BuildOptions generates the configurations used to create kubernetes controller manager manifest
-func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *KubeControllerManagerOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	if clusterSpec.KubeControllerManager == nil {
 		clusterSpec.KubeControllerManager = &kops.KubeControllerManagerConfig{}
@@ -119,7 +120,7 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 		kcm.LogLevel = 2
 	}
 
-	image, err := Image("kube-controller-manager", clusterSpec, b.AssetBuilder)
+	image, err := Image(ctx, "kube-controller-manager", clusterSpec, b.AssetBuilder)
 	if err != nil {
 		return err
 	}

--- a/pkg/model/components/kubecontrollermanager_test.go
+++ b/pkg/model/components/kubecontrollermanager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -41,6 +42,7 @@ func buildCluster() *api.Cluster {
 }
 
 func Test_Build_KCM_Builder(t *testing.T) {
+	ctx := context.TODO()
 	versions := []string{"v1.11.0", "v2.4.0"}
 	for _, v := range versions {
 
@@ -54,7 +56,7 @@ func Test_Build_KCM_Builder(t *testing.T) {
 			},
 		}
 
-		err := kcm.BuildOptions(&c.Spec)
+		err := kcm.BuildOptions(ctx, &c.Spec)
 		if err != nil {
 			t.Fatalf("unexpected error from BuildOptions %s", err)
 		}
@@ -66,6 +68,7 @@ func Test_Build_KCM_Builder(t *testing.T) {
 }
 
 func Test_Build_KCM_Builder_Change_Duration(t *testing.T) {
+	ctx := context.TODO()
 	c := buildCluster()
 	b := assets.NewAssetBuilder(c, false)
 
@@ -81,7 +84,7 @@ func Test_Build_KCM_Builder_Change_Duration(t *testing.T) {
 
 	c.Spec.KubeControllerManager.AttachDetachReconcileSyncPeriod.Duration = time.Minute * 5
 
-	err := kcm.BuildOptions(&c.Spec)
+	err := kcm.BuildOptions(ctx, &c.Spec)
 	if err != nil {
 		t.Fatalf("unexpected error from BuildOptions %s", err)
 	}
@@ -92,6 +95,7 @@ func Test_Build_KCM_Builder_Change_Duration(t *testing.T) {
 }
 
 func Test_Build_KCM_Builder_CIDR_Mask_Size(t *testing.T) {
+	ctx := context.TODO()
 	grid := []struct {
 		PodCIDR          string
 		ClusterCIDR      string
@@ -155,7 +159,7 @@ func Test_Build_KCM_Builder_CIDR_Mask_Size(t *testing.T) {
 				ClusterCIDR: tc.ClusterCIDR,
 			}
 
-			err := kcm.BuildOptions(&c.Spec)
+			err := kcm.BuildOptions(ctx, &c.Spec)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.ExpectedMaskSize, c.Spec.KubeControllerManager.NodeCIDRMaskSize)

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -32,7 +34,7 @@ type KubeDnsOptionsBuilder struct {
 var _ loader.OptionsBuilder = &KubeDnsOptionsBuilder{}
 
 // BuildOptions fills in the kubedns model
-func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *KubeDnsOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 
 	if clusterSpec.KubeDNS == nil {

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -37,7 +38,7 @@ type KubeletOptionsBuilder struct {
 var _ loader.OptionsBuilder = &KubeletOptionsBuilder{}
 
 // BuildOptions is responsible for filling the defaults for the kubelet
-func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *KubeletOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 
 	if clusterSpec.Kubelet == nil {

--- a/pkg/model/components/kubelet_test.go
+++ b/pkg/model/components/kubelet_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -36,7 +37,7 @@ func buildKubeletTestCluster() *kops.Cluster {
 	}
 }
 
-func buildOptions(cluster *kops.Cluster) error {
+func buildOptions(ctx context.Context, cluster *kops.Cluster) error {
 	ab := assets.NewAssetBuilder(cluster, false)
 
 	ver, err := util.ParseKubernetesVersion(cluster.Spec.KubernetesVersion)
@@ -51,7 +52,7 @@ func buildOptions(cluster *kops.Cluster) error {
 		},
 	}
 
-	err = builder.BuildOptions(&cluster.Spec)
+	err = builder.BuildOptions(ctx, &cluster.Spec)
 	if err != nil {
 		return nil
 	}
@@ -60,9 +61,10 @@ func buildOptions(cluster *kops.Cluster) error {
 }
 
 func TestFeatureGatesKubernetesVersion(t *testing.T) {
+	ctx := context.TODO()
 	cluster := buildKubeletTestCluster()
 	cluster.Spec.KubernetesVersion = "1.17.0"
-	err := buildOptions(cluster)
+	err := buildOptions(ctx, cluster)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,12 +76,13 @@ func TestFeatureGatesKubernetesVersion(t *testing.T) {
 }
 
 func TestFeatureGatesOverride(t *testing.T) {
+	ctx := context.TODO()
 	cluster := buildKubeletTestCluster()
 	cluster.Spec.Kubelet.FeatureGates = map[string]string{
 		"ExperimentalCriticalPodAnnotation": "false",
 	}
 
-	err := buildOptions(cluster)
+	err := buildOptions(ctx, cluster)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/model/components/kubeproxy.go
+++ b/pkg/model/components/kubeproxy.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -31,7 +33,7 @@ type KubeProxyOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &KubeProxyOptionsBuilder{}
 
-func (b *KubeProxyOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *KubeProxyOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	if clusterSpec.KubeProxy == nil {
 		clusterSpec.KubeProxy = &kops.KubeProxyConfig{}
@@ -50,7 +52,7 @@ func (b *KubeProxyOptionsBuilder) BuildOptions(o interface{}) error {
 		config.CPURequest = resource.NewScaledQuantity(100, resource.Milli)
 	}
 
-	image, err := Image("kube-proxy", clusterSpec, b.Context.AssetBuilder)
+	image, err := Image(ctx, "kube-proxy", clusterSpec, b.Context.AssetBuilder)
 	if err != nil {
 		return err
 	}

--- a/pkg/model/components/kubescheduler.go
+++ b/pkg/model/components/kubescheduler.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
@@ -29,7 +31,7 @@ type KubeSchedulerOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &KubeSchedulerOptionsBuilder{}
 
-func (b *KubeSchedulerOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *KubeSchedulerOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	if clusterSpec.KubeScheduler == nil {
 		clusterSpec.KubeScheduler = &kops.KubeSchedulerConfig{}
@@ -43,7 +45,7 @@ func (b *KubeSchedulerOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if config.Image == "" {
-		image, err := Image("kube-scheduler", clusterSpec, b.AssetBuilder)
+		image, err := Image(ctx, "kube-scheduler", clusterSpec, b.AssetBuilder)
 		if err != nil {
 			return err
 		}

--- a/pkg/model/components/kubescheduler_test.go
+++ b/pkg/model/components/kubescheduler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"testing"
 
 	api "k8s.io/kops/pkg/apis/kops"
@@ -41,6 +42,7 @@ func buildSchedulerConfigMapCluster(version string) *api.Cluster {
 }
 
 func Test_Build_Scheduler_Without_PolicyConfigMap(t *testing.T) {
+	ctx := context.TODO()
 	versions := []string{"v1.6.0", "v1.6.4", "v1.7.0", "v1.7.4"}
 
 	for _, v := range versions {
@@ -61,7 +63,7 @@ func Test_Build_Scheduler_Without_PolicyConfigMap(t *testing.T) {
 			},
 		}
 
-		err = ks.BuildOptions(&c.Spec)
+		err = ks.BuildOptions(ctx, &c.Spec)
 
 		if err != nil {
 			t.Fatalf("unexpected error from BuildOptions: %v", err)
@@ -70,6 +72,7 @@ func Test_Build_Scheduler_Without_PolicyConfigMap(t *testing.T) {
 }
 
 func Test_Build_Scheduler_PolicyConfigMap_Supported_Version(t *testing.T) {
+	ctx := context.TODO()
 	versions := []string{"v1.9.0", "v1.10.5", "v1.18.0"}
 
 	for _, v := range versions {
@@ -89,7 +92,7 @@ func Test_Build_Scheduler_PolicyConfigMap_Supported_Version(t *testing.T) {
 			},
 		}
 
-		err = ks.BuildOptions(&c.Spec)
+		err = ks.BuildOptions(ctx, &c.Spec)
 		if err != nil {
 			t.Fatalf("unexpected error from BuildOptions %s: %v", v, err)
 		}

--- a/pkg/model/components/networking.go
+++ b/pkg/model/components/networking.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -31,7 +32,7 @@ type NetworkingOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &NetworkingOptionsBuilder{}
 
-func (b *NetworkingOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *NetworkingOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 
 	options := o.(*kops.ClusterSpec)

--- a/pkg/model/components/nodeproblemdetector.go
+++ b/pkg/model/components/nodeproblemdetector.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
@@ -30,7 +32,7 @@ type NodeProblemDetectorOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &NodeProblemDetectorOptionsBuilder{}
 
-func (b *NodeProblemDetectorOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *NodeProblemDetectorOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	if clusterSpec.NodeProblemDetector == nil {
 		return nil

--- a/pkg/model/components/nodeterminationhandler.go
+++ b/pkg/model/components/nodeterminationhandler.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
@@ -30,7 +32,7 @@ type NodeTerminationHandlerOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &NodeTerminationHandlerOptionsBuilder{}
 
-func (b *NodeTerminationHandlerOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *NodeTerminationHandlerOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	if clusterSpec.NodeTerminationHandler == nil {
 		return nil

--- a/pkg/model/components/openstack.go
+++ b/pkg/model/components/openstack.go
@@ -17,6 +17,8 @@ limitations under the License.
 package components
 
 import (
+	"context"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
@@ -29,7 +31,7 @@ type OpenStackOptionsBuilder struct {
 
 var _ loader.OptionsBuilder = &OpenStackOptionsBuilder{}
 
-func (b *OpenStackOptionsBuilder) BuildOptions(o interface{}) error {
+func (b *OpenStackOptionsBuilder) BuildOptions(ctx context.Context, o interface{}) error {
 	clusterSpec := o.(*kops.ClusterSpec)
 	openstack := clusterSpec.CloudProvider.Openstack
 

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -50,6 +50,8 @@ var _ fi.ModelBuilder = &AutoscalingGroupModelBuilder{}
 // Build the GCE instance template object for an InstanceGroup
 // We are then able to extract out the fields when running with the clusterapi.
 func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.ModelBuilderContext, ig *kops.InstanceGroup, subnet *kops.ClusterSubnetSpec) (*gcetasks.InstanceTemplate, error) {
+	ctx := c.Context()
+
 	// Indented to keep diff manageable
 	// TODO: Remove spurious indent
 	{
@@ -120,7 +122,7 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.ModelBuilderC
 				return nil, err
 			}
 
-			storagePaths, err := iam.WriteableVFSPaths(b.Cluster, nodeRole)
+			storagePaths, err := iam.WriteableVFSPaths(ctx, b.Cluster, nodeRole)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/model/gcemodel/storageacl.go
+++ b/pkg/model/gcemodel/storageacl.go
@@ -43,6 +43,8 @@ var _ fi.ModelBuilder = &NetworkModelBuilder{}
 // Build creates the tasks that set up storage acls
 
 func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
+	ctx := c.Context()
+
 	if featureflag.GoogleCloudBucketACL.Enabled() {
 		if b.Cluster.Spec.CloudConfig.GCEServiceAccount == "" {
 			return fmt.Errorf("featureflag GoogleCloudBucketACL not supported with per-instancegroup GCEServiceAccount")
@@ -56,7 +58,7 @@ func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 
 		clusterPath := b.Cluster.Spec.ConfigBase
-		p, err := vfs.Context.BuildVfsPath(clusterPath)
+		p, err := vfs.FromContext(ctx).BuildVfsPath(clusterPath)
 		if err != nil {
 			return fmt.Errorf("cannot parse cluster path %q: %w", clusterPath, err)
 		}
@@ -81,7 +83,7 @@ func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
 			return err
 		}
 
-		writeablePaths, err := iam.WriteableVFSPaths(b.Cluster, nodeRole)
+		writeablePaths, err := iam.WriteableVFSPaths(ctx, b.Cluster, nodeRole)
 		if err != nil {
 			return err
 		}
@@ -143,7 +145,7 @@ func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
 
 		buckets := sets.NewString()
 
-		writeablePaths, err := iam.WriteableVFSPaths(b.Cluster, nodeRole)
+		writeablePaths, err := iam.WriteableVFSPaths(ctx, b.Cluster, nodeRole)
 		if err != nil {
 			return err
 		}
@@ -179,7 +181,7 @@ func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
 			return err
 		}
 		if len(readablePaths) != 0 {
-			p, err := vfs.Context.BuildVfsPath(b.Cluster.Spec.ConfigStore)
+			p, err := vfs.FromContext(ctx).BuildVfsPath(b.Cluster.Spec.ConfigStore)
 			if err != nil {
 				return fmt.Errorf("cannot parse VFS path %q: %v", b.Cluster.Spec.ConfigStore, err)
 			}

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package iam
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -96,6 +97,7 @@ func TestRoundTrip(t *testing.T) {
 }
 
 func TestPolicyGeneration(t *testing.T) {
+	ctx := context.TODO()
 	grid := []struct {
 		Role                   Subject
 		AllowContainerRegistry bool
@@ -181,7 +183,7 @@ func TestPolicyGeneration(t *testing.T) {
 		}
 		b.Cluster.SetName("iam-builder-test.k8s.local")
 
-		p, err := b.BuildAWSPolicy()
+		p, err := b.BuildAWSPolicy(ctx)
 		if err != nil {
 			t.Errorf("case %d failed to build an AWS IAM policy. Error: %v", i, err)
 			continue
@@ -198,6 +200,7 @@ func TestPolicyGeneration(t *testing.T) {
 }
 
 func TestEmptyPolicy(t *testing.T) {
+	ctx := context.TODO()
 	role := &GenericServiceAccount{
 		NamespacedName: types.NamespacedName{
 			Name:      "myaccount",
@@ -216,7 +219,7 @@ func TestEmptyPolicy(t *testing.T) {
 		Builder: b,
 	}
 
-	policy, err := fi.ResourceAsString(pr)
+	policy, err := fi.ResourceAsString(ctx, pr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/model/iam/subject.go
+++ b/pkg/model/iam/subject.go
@@ -17,6 +17,7 @@ limitations under the License.
 package iam
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +30,7 @@ import (
 // It is implemented by NodeRole objects and per-ServiceAccount objects.
 type Subject interface {
 	// BuildAWSPolicy builds the AWS permissions for the given subject.
-	BuildAWSPolicy(*PolicyBuilder) (*Policy, error)
+	BuildAWSPolicy(context.Context, *PolicyBuilder) (*Policy, error)
 
 	// ServiceAccount returns the kubernetes service account used by pods with this specified role.
 	// For node roles, it returns an empty NamespacedName and false.
@@ -81,7 +82,7 @@ func (g *GenericServiceAccount) ServiceAccount() (types.NamespacedName, bool) {
 	return g.NamespacedName, true
 }
 
-func (g *GenericServiceAccount) BuildAWSPolicy(*PolicyBuilder) (*Policy, error) {
+func (g *GenericServiceAccount) BuildAWSPolicy(context.Context, *PolicyBuilder) (*Policy, error) {
 	return g.Policy, nil
 }
 

--- a/pkg/model/issuerdiscovery.go
+++ b/pkg/model/issuerdiscovery.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/x509"
 	"encoding/base64"
@@ -122,7 +123,7 @@ func (o *OIDCKeys) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 	}
 }
 
-func (o *OIDCKeys) Open() (io.Reader, error) {
+func (o *OIDCKeys) Open(ctx context.Context) (io.Reader, error) {
 	keyset := o.SigningKey.Keyset()
 	var keys []jose.JSONWebKey
 

--- a/pkg/model/pki.go
+++ b/pkg/model/pki.go
@@ -36,6 +36,8 @@ var _ fi.ModelBuilder = &PKIModelBuilder{}
 
 // Build is responsible for generating the various pki assets.
 func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
+	ctx := c.Context()
+
 	// TODO: Only create the CA via this task
 	defaultCA := &fitasks.Keypair{
 		Name:      fi.PtrTo(fi.CertificateIDCA),
@@ -144,7 +146,7 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	{
-		mirrorPath, err := vfs.Context.BuildVfsPath(b.Cluster.Spec.SecretStore)
+		mirrorPath, err := vfs.FromContext(ctx).BuildVfsPath(b.Cluster.Spec.SecretStore)
 		if err != nil {
 			return err
 		}
@@ -158,7 +160,7 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	{
-		mirrorPath, err := vfs.Context.BuildVfsPath(b.Cluster.Spec.KeyStore)
+		mirrorPath, err := vfs.FromContext(ctx).BuildVfsPath(b.Cluster.Spec.KeyStore)
 		if err != nil {
 			return err
 		}

--- a/pkg/model/resources/template_resource.go
+++ b/pkg/model/resources/template_resource.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"text/template"
@@ -57,7 +58,7 @@ func newTemplateResource(key string, definition string, functions template.FuncM
 	return r, nil
 }
 
-func (r *templateResource) Open() (io.Reader, error) {
+func (r *templateResource) Open(ctx context.Context) (io.Reader, error) {
 	buffer := &bytes.Buffer{}
 
 	err := r.parsed.ExecuteTemplate(buffer, r.key, r.context)

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -18,6 +18,7 @@ package templates
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -136,7 +137,7 @@ type templateResource struct {
 
 var _ fi.Resource = &templateResource{}
 
-func (a *templateResource) Open() (io.Reader, error) {
+func (a *templateResource) Open(ctx context.Context) (io.Reader, error) {
 	var err error
 	result, err := a.loader.executeTemplate(a.key, a.template)
 	if err != nil {

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testutils
 
 import (
+	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -76,6 +77,8 @@ type IntegrationTestHarness struct {
 }
 
 func NewIntegrationTestHarness(t *testing.T) *IntegrationTestHarness {
+	ctx := context.TODO()
+
 	featureflag.ParseFlags("-ImageDigest")
 	h := &IntegrationTestHarness{}
 	tempDir, err := os.MkdirTemp("", "test")
@@ -84,7 +87,7 @@ func NewIntegrationTestHarness(t *testing.T) *IntegrationTestHarness {
 	}
 	h.TempDir = tempDir
 
-	vfs.Context.ResetMemfsContext(true)
+	vfs.FromContext(ctx).ResetMemfsContext(true)
 
 	// Generate much smaller keys, as this is often the bottleneck for tests
 	h.originalPKIDefaultPrivateKeySize = pki.DefaultPrivateKeySize

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -40,11 +41,13 @@ var (
 )
 
 func main() {
+	ctx := context.Background()
+
 	klog.InitFlags(nil)
 
 	fmt.Printf("protokube version %s\n", BuildVersion)
 
-	if err := run(); err != nil {
+	if err := run(ctx); err != nil {
 		klog.Errorf("Error: %v", err)
 		os.Exit(1)
 	}
@@ -52,7 +55,7 @@ func main() {
 }
 
 // run is responsible for running the protokube service controller
-func run() error {
+func run(ctx context.Context) error {
 	var zones []string
 	var containerized, master, gossip bool
 	var cloud, clusterID, dnsInternalSuffix, gossipSecret, gossipListen, gossipProtocol, gossipSecretSecondary, gossipListenSecondary, gossipProtocolSecondary string

--- a/tests/e2e/pkg/util/zip.go
+++ b/tests/e2e/pkg/util/zip.go
@@ -57,7 +57,7 @@ func UnzipToTempDir(data []byte) (string, error) {
 			return "", err
 		}
 
-		fileReader, err := r.Open()
+		fileReader, err := r.Open(ctx)
 		if err != nil {
 			return "", err
 		}

--- a/upup/pkg/fi/assetstore.go
+++ b/upup/pkg/fi/assetstore.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fi
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -82,8 +83,8 @@ var (
 	_ HasSource = &assetResource{}
 )
 
-func (r *assetResource) Open() (io.Reader, error) {
-	return r.Asset.resource.Open()
+func (r *assetResource) Open(ctx context.Context) (io.Reader, error) {
+	return r.Asset.resource.Open(ctx)
 }
 
 func (r *assetResource) GetSource() *Source {

--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awstasks
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -28,6 +29,8 @@ import (
 )
 
 func TestSharedEgressOnlyInternetGatewayDoesNotRename(t *testing.T) {
+	ctx := context.TODO()
+
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
 	c := &mockec2.MockEC2{}
 	cloud.MockEC2 = c
@@ -95,7 +98,7 @@ func TestSharedEgressOnlyInternetGatewayDoesNotRename(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -139,6 +142,6 @@ func TestSharedEgressOnlyInternetGatewayDoesNotRename(t *testing.T) {
 
 	{
 		allTasks := buildTasks()
-		checkNoChanges(t, cloud, allTasks)
+		checkNoChanges(t, ctx, cloud, allTasks)
 	}
 }

--- a/upup/pkg/fi/cloudup/awstasks/instance.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awstasks
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -208,6 +209,8 @@ func (_ *Instance) CheckChanges(a, e, changes *Instance) error {
 }
 
 func (_ *Instance) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Instance) error {
+	ctx := context.TODO()
+
 	if a == nil {
 
 		if fi.ValueOf(e.Shared) {
@@ -263,7 +266,7 @@ func (_ *Instance) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Instance) err
 		}
 
 		if e.UserData != nil {
-			d, err := fi.ResourceAsBytes(e.UserData)
+			d, err := fi.ResourceAsBytes(ctx, e.UserData)
 			if err != nil {
 				return fmt.Errorf("error rendering Instance UserData: %v", err)
 			}

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awstasks
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -28,6 +29,8 @@ import (
 )
 
 func TestSharedInternetGatewayDoesNotRename(t *testing.T) {
+	ctx := context.TODO()
+
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
 	c := &mockec2.MockEC2{}
 	cloud.MockEC2 = c
@@ -111,7 +114,7 @@ func TestSharedInternetGatewayDoesNotRename(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -155,6 +158,6 @@ func TestSharedInternetGatewayDoesNotRename(t *testing.T) {
 
 	{
 		allTasks := buildTasks()
-		checkNoChanges(t, cloud, allTasks)
+		checkNoChanges(t, ctx, cloud, allTasks)
 	}
 }

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awstasks
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"sort"
@@ -32,6 +33,8 @@ import (
 
 // RenderAWS is responsible for performing creating / updating the launch template
 func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchTemplate) error {
+	ctx := context.TODO()
+
 	// @step: resolve the image id to an AMI for us
 	image, err := c.Cloud.ResolveImage(fi.ValueOf(t.ImageID))
 	if err != nil {
@@ -121,7 +124,7 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchT
 	}
 	// @step: add the userdata
 	if t.UserData != nil {
-		d, err := fi.ResourceAsBytes(t.UserData)
+		d, err := fi.ResourceAsBytes(ctx, t.UserData)
 		if err != nil {
 			return fmt.Errorf("error rendering LaunchTemplate UserData: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -17,6 +17,8 @@ limitations under the License.
 package awstasks
 
 import (
+	"context"
+
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
@@ -177,6 +179,8 @@ func (t *LaunchTemplate) VersionLink() *terraformWriter.Literal {
 
 // RenderTerraform is responsible for rendering the terraform json
 func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e, changes *LaunchTemplate) error {
+	ctx := context.TODO()
+
 	var err error
 
 	cloud := target.Cloud.(awsup.AWSCloud)
@@ -252,7 +256,7 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 		}
 	}
 	if e.UserData != nil {
-		d, err := fi.ResourceAsBytes(e.UserData)
+		d, err := fi.ResourceAsBytes(ctx, e.UserData)
 		if err != nil {
 			return err
 		}

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awstasks
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -94,6 +95,8 @@ func testNotMatches(t *testing.T, rule *PortRemovalRule, permission *ec2.Securit
 }
 
 func TestSecurityGroupCreate(t *testing.T) {
+	ctx := context.TODO()
+
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
 	c := &mockec2.MockEC2{}
 	cloud.MockEC2 = c
@@ -129,7 +132,7 @@ func TestSecurityGroupCreate(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -167,6 +170,6 @@ func TestSecurityGroupCreate(t *testing.T) {
 
 	{
 		allTasks := buildTasks()
-		checkNoChanges(t, cloud, allTasks)
+		checkNoChanges(t, ctx, cloud, allTasks)
 	}
 }

--- a/upup/pkg/fi/cloudup/awstasks/sqs.go
+++ b/upup/pkg/fi/cloudup/awstasks/sqs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awstasks
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -53,6 +54,7 @@ func (q *SQS) CompareWithID() *string {
 }
 
 func (q *SQS) Find(c *fi.Context) (*SQS, error) {
+	ctx := context.TODO()
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	if q.Name == nil {
@@ -97,7 +99,7 @@ func (q *SQS) Find(c *fi.Context) (*SQS, error) {
 
 	// We parse both as JSON; if the json forms are equal we pretend the actual value is the expected value
 	if q.Policy != nil {
-		expectedPolicy, err := fi.ResourceAsString(q.Policy)
+		expectedPolicy, err := fi.ResourceAsString(ctx, q.Policy)
 		if err != nil {
 			return nil, fmt.Errorf("error reading expected Policy for SQS %q: %v", aws.StringValue(q.Name), err)
 		}
@@ -155,7 +157,9 @@ func (q *SQS) CheckChanges(a, e, changes *SQS) error {
 }
 
 func (q *SQS) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *SQS) error {
-	policy, err := fi.ResourceAsString(e.Policy)
+	ctx := context.TODO()
+
+	policy, err := fi.ResourceAsString(ctx, e.Policy)
 	if err != nil {
 		return fmt.Errorf("error rendering RolePolicyDocument: %v", err)
 	}
@@ -196,7 +200,7 @@ type terraformSQSQueue struct {
 }
 
 func (_ *SQS) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SQS) error {
-	p, err := t.AddFileResource("aws_sqs_queue", *e.Name, "policy", e.Policy, false)
+	p, err := t.AddFileResource(ctx, "aws_sqs_queue", *e.Name, "policy", e.Policy, false)
 	if err != nil {
 		return err
 	}

--- a/upup/pkg/fi/cloudup/awstasks/subnet_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awstasks
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -29,11 +30,13 @@ import (
 )
 
 func Test_Subnet_ValidateRequired(t *testing.T) {
+	ctx := context.TODO()
+
 	var a *Subnet
 	e := &Subnet{}
 
 	changes := &Subnet{}
-	fi.BuildChanges(a, e, changes)
+	fi.BuildChanges(ctx, a, e, changes)
 
 	err := e.CheckChanges(a, e, changes)
 	if err == nil {
@@ -45,6 +48,8 @@ func Test_Subnet_ValidateRequired(t *testing.T) {
 }
 
 func Test_Subnet_CannotChangeSubnet(t *testing.T) {
+	ctx := context.TODO()
+
 	a := &Subnet{VPC: &VPC{Name: s("defaultvpc")}, CIDR: s("192.168.0.0/16")}
 	e := &Subnet{}
 	*e = *a
@@ -52,7 +57,7 @@ func Test_Subnet_CannotChangeSubnet(t *testing.T) {
 	e.CIDR = s("192.168.0.1/16")
 
 	changes := &Subnet{}
-	fi.BuildChanges(a, e, changes)
+	fi.BuildChanges(ctx, a, e, changes)
 
 	err := e.CheckChanges(a, e, changes)
 	if err == nil {
@@ -64,6 +69,8 @@ func Test_Subnet_CannotChangeSubnet(t *testing.T) {
 }
 
 func TestSubnetCreate(t *testing.T) {
+	ctx := context.TODO()
+
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
 	c := &mockec2.MockEC2{}
 	cloud.MockEC2 = c
@@ -99,7 +106,7 @@ func TestSubnetCreate(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -142,11 +149,13 @@ func TestSubnetCreate(t *testing.T) {
 
 	{
 		allTasks := buildTasks()
-		checkNoChanges(t, cloud, allTasks)
+		checkNoChanges(t, ctx, cloud, allTasks)
 	}
 }
 
 func TestSubnetCreateIPv6(t *testing.T) {
+	ctx := context.TODO()
+
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
 	c := &mockec2.MockEC2{}
 	cloud.MockEC2 = c
@@ -190,7 +199,7 @@ func TestSubnetCreateIPv6(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -242,11 +251,13 @@ func TestSubnetCreateIPv6(t *testing.T) {
 
 	{
 		allTasks := buildTasks()
-		checkNoChanges(t, cloud, allTasks)
+		checkNoChanges(t, ctx, cloud, allTasks)
 	}
 }
 
 func TestSubnetCreateIPv6NetNum(t *testing.T) {
+	ctx := context.TODO()
+
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
 	c := &mockec2.MockEC2{}
 	cloud.MockEC2 = c
@@ -289,7 +300,7 @@ func TestSubnetCreateIPv6NetNum(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -341,11 +352,13 @@ func TestSubnetCreateIPv6NetNum(t *testing.T) {
 
 	{
 		allTasks := buildTasks()
-		checkNoChanges(t, cloud, allTasks)
+		checkNoChanges(t, ctx, cloud, allTasks)
 	}
 }
 
 func TestSharedSubnetCreateDoesNotCreateNew(t *testing.T) {
+	ctx := context.TODO()
+
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
 	c := &mockec2.MockEC2{}
 	cloud.MockEC2 = c
@@ -422,7 +435,7 @@ func TestSharedSubnetCreateDoesNotCreateNew(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -470,6 +483,6 @@ func TestSharedSubnetCreateDoesNotCreateNew(t *testing.T) {
 
 	{
 		allTasks := buildTasks()
-		checkNoChanges(t, cloud, allTasks)
+		checkNoChanges(t, ctx, cloud, allTasks)
 	}
 }

--- a/upup/pkg/fi/cloudup/awstasks/vpc_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awstasks
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -28,6 +29,8 @@ import (
 )
 
 func TestVPCCreate(t *testing.T) {
+	ctx := context.TODO()
+
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
 	c := &mockec2.MockEC2{}
 	cloud.MockEC2 = c
@@ -53,7 +56,7 @@ func TestVPCCreate(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}
@@ -91,7 +94,7 @@ func TestVPCCreate(t *testing.T) {
 	{
 		allTasks := buildTasks()
 
-		checkNoChanges(t, cloud, allTasks)
+		checkNoChanges(t, ctx, cloud, allTasks)
 	}
 }
 
@@ -108,6 +111,8 @@ func buildTags(tags map[string]string) []*ec2.Tag {
 
 // Test4758 is a sanity check for https://github.com/kubernetes/kops/issues/4758
 func Test4758(t *testing.T) {
+	ctx := context.TODO()
+
 	a := &VPC{
 		Name: s("cluster2.example.com"),
 		Tags: map[string]string{},
@@ -119,7 +124,7 @@ func Test4758(t *testing.T) {
 	}
 
 	changes := &VPC{}
-	changed := fi.BuildChanges(a, e, changes)
+	changed := fi.BuildChanges(ctx, a, e, changes)
 
 	if changed {
 		t.Errorf("expected changed=false")
@@ -132,6 +137,8 @@ func Test4758(t *testing.T) {
 }
 
 func TestSharedVPCAdditionalCIDR(t *testing.T) {
+	ctx := context.TODO()
+
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
 	c := &mockec2.MockEC2{}
 	c.CreateVpcWithId(&ec2.CreateVpcInput{
@@ -177,7 +184,7 @@ func TestSharedVPCAdditionalCIDR(t *testing.T) {
 			Cloud: cloud,
 		}
 
-		context, err := fi.NewContext(target, nil, cloud, nil, nil, nil, true, allTasks)
+		context, err := fi.NewContext(ctx, target, nil, cloud, nil, nil, nil, true, allTasks)
 		if err != nil {
 			t.Fatalf("error building context: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awsup
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -42,7 +43,7 @@ func (t *AWSAPITarget) ProcessDeletions() bool {
 	return true
 }
 
-func (t *AWSAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *AWSAPITarget) Finish(ctx context.Context, taskMap map[string]fi.Task) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/azure/azure_apitarget.go
+++ b/upup/pkg/fi/cloudup/azure/azure_apitarget.go
@@ -17,6 +17,8 @@ limitations under the License.
 package azure
 
 import (
+	"context"
+
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -36,7 +38,7 @@ func NewAzureAPITarget(cloud AzureCloud) *AzureAPITarget {
 
 // Finish is called by a lifecycle drive to finish the lifecycle of
 // the target.
-func (t *AzureAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *AzureAPITarget) Finish(ctx context.Context, taskMap map[string]fi.Task) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
@@ -268,6 +268,7 @@ func (s *VMScaleSet) CheckChanges(a, e, changes *VMScaleSet) error {
 
 // RenderAzure creates or updates a VM Scale Set.
 func (s *VMScaleSet) RenderAzure(t *azure.AzureAPITarget, a, e, changes *VMScaleSet) error {
+	ctx := context.TODO()
 	if a == nil {
 		klog.Infof("Creating a new VM Scale Set with name: %s", fi.ValueOf(e.Name))
 	} else {
@@ -278,7 +279,7 @@ func (s *VMScaleSet) RenderAzure(t *azure.AzureAPITarget, a, e, changes *VMScale
 
 	var customData *string
 	if e.UserData != nil {
-		d, err := fi.ResourceAsBytes(e.UserData)
+		d, err := fi.ResourceAsBytes(ctx, e.UserData)
 		if err != nil {
 			return fmt.Errorf("error rendering UserData: %s", err)
 		}

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
@@ -91,6 +91,8 @@ func newTestVMScaleSet() *VMScaleSet {
 }
 
 func TestVMScaleSetRenderAzure(t *testing.T) {
+	ctx := context.TODO()
+
 	cloud := NewMockAzureCloud("eastus")
 	apiTarget := azure.NewAzureAPITarget(cloud)
 	vmss := &VMScaleSet{}
@@ -118,7 +120,7 @@ func TestVMScaleSetRenderAzure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to decode user data: %s", err)
 	}
-	expectedUserData, err := fi.ResourceAsBytes(expected.UserData)
+	expectedUserData, err := fi.ResourceAsBytes(ctx, expected.UserData)
 	if err != nil {
 		t.Fatalf("failed to get user data: %s", err)
 	}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -100,6 +100,8 @@ func NewBootstrapChannelBuilder(modelContext *model.KopsModelContext,
 
 // Build is responsible for adding the addons to the channel
 func (b *BootstrapChannelBuilder) Build(c *fi.ModelBuilderContext) error {
+	ctx := c.Context()
+
 	addons, serviceAccounts, err := b.buildAddons(c)
 	if err != nil {
 		return err
@@ -124,7 +126,7 @@ func (b *BootstrapChannelBuilder) Build(c *fi.ModelBuilderContext) error {
 			return fmt.Errorf("unable to find manifest %s", manifestPath)
 		}
 
-		manifestBytes, err := fi.ResourceAsBytes(manifestResource)
+		manifestBytes, err := fi.ResourceAsBytes(ctx, manifestResource)
 		if err != nil {
 			return fmt.Errorf("error reading manifest %s: %v", manifestPath, err)
 		}
@@ -165,7 +167,7 @@ func (b *BootstrapChannelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Cluster: b.Cluster,
 		}
 
-		addonPackages, clusterAddons, err := ob.Build(b.ClusterAddons)
+		addonPackages, clusterAddons, err := ob.Build(ctx, b.ClusterAddons)
 		if err != nil {
 			return fmt.Errorf("error building well-known operators: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/do/api_target.go
+++ b/upup/pkg/fi/cloudup/do/api_target.go
@@ -17,6 +17,8 @@ limitations under the License.
 package do
 
 import (
+	"context"
+
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -32,7 +34,7 @@ func NewDOAPITarget(cloud DOCloud) *DOAPITarget {
 	}
 }
 
-func (t *DOAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *DOAPITarget) Finish(ctx context.Context, taskMap map[string]fi.Task) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -125,7 +125,9 @@ func (d *Droplet) Run(c *fi.Context) error {
 }
 
 func (_ *Droplet) RenderDO(t *do.DOAPITarget, a, e, changes *Droplet) error {
-	userData, err := fi.ResourceAsString(e.UserData)
+	ctx := context.TODO()
+
+	userData, err := fi.ResourceAsString(ctx, e.UserData)
 	if err != nil {
 		return err
 	}

--- a/upup/pkg/fi/cloudup/gce/gce_apitarget.go
+++ b/upup/pkg/fi/cloudup/gce/gce_apitarget.go
@@ -17,6 +17,8 @@ limitations under the License.
 package gce
 
 import (
+	"context"
+
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -32,7 +34,7 @@ func NewGCEAPITarget(cloud GCECloud) *GCEAPITarget {
 	}
 }
 
-func (t *GCEAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *GCEAPITarget) Finish(ctx context.Context, taskMap map[string]fi.Task) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -90,6 +90,8 @@ func (e *InstanceTemplate) CompareWithID() *string {
 }
 
 func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
+	ctx := c.Context()
+
 	cloud := c.Cloud.(gce.GCECloud)
 
 	templates, err := cloud.Compute().InstanceTemplates().List(context.Background(), cloud.Project())
@@ -100,7 +102,7 @@ func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
 		return nil, fmt.Errorf("error listing InstanceTemplates: %v", err)
 	}
 
-	expected, err := e.mapToGCE(cloud.Project(), cloud.Region())
+	expected, err := e.mapToGCE(ctx, cloud.Project(), cloud.Region())
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +245,7 @@ func (_ *InstanceTemplate) CheckChanges(a, e, changes *InstanceTemplate) error {
 	return nil
 }
 
-func (e *InstanceTemplate) mapToGCE(project string, region string) (*compute.InstanceTemplate, error) {
+func (e *InstanceTemplate) mapToGCE(ctx context.Context, project string, region string) (*compute.InstanceTemplate, error) {
 	// TODO: This is similar to Instance...
 	var scheduling *compute.Scheduling
 
@@ -344,7 +346,7 @@ func (e *InstanceTemplate) mapToGCE(project string, region string) (*compute.Ins
 
 	var metadataItems []*compute.MetadataItems
 	for key, r := range e.Metadata {
-		v, err := fi.ResourceAsString(r)
+		v, err := fi.ResourceAsString(ctx, r)
 		if err != nil {
 			return nil, fmt.Errorf("error rendering InstanceTemplate metadata %q: %v", key, err)
 		}
@@ -449,10 +451,11 @@ func (e *InstanceTemplate) URL(project string) (string, error) {
 }
 
 func (_ *InstanceTemplate) RenderGCE(t *gce.GCEAPITarget, a, e, changes *InstanceTemplate) error {
+	ctx := context.TODO()
 	project := t.Cloud.Project()
 	region := t.Cloud.Region()
 
-	i, err := e.mapToGCE(project, region)
+	i, err := e.mapToGCE(ctx, project, region)
 	if err != nil {
 		return err
 	}
@@ -602,9 +605,11 @@ func mapServiceAccountsToTerraform(serviceAccounts []*ServiceAccount, saScopes [
 }
 
 func (_ *InstanceTemplate) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *InstanceTemplate) error {
+	ctx := context.TODO()
+
 	project := t.Project
 
-	i, err := e.mapToGCE(project, t.Cloud.Region())
+	i, err := e.mapToGCE(ctx, project, t.Cloud.Region())
 	if err != nil {
 		return err
 	}

--- a/upup/pkg/fi/cloudup/gcetasks/projectiambinding_test.go
+++ b/upup/pkg/fi/cloudup/gcetasks/projectiambinding_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gcetasks
 
 import (
+	"context"
 	"testing"
 
 	gcemock "k8s.io/kops/cloudmock/gce"
@@ -24,6 +25,8 @@ import (
 )
 
 func TestProjectIAMBinding(t *testing.T) {
+	ctx := context.TODO()
+
 	project := "testproject"
 	region := "us-test1"
 
@@ -46,16 +49,16 @@ func TestProjectIAMBinding(t *testing.T) {
 
 	{
 		allTasks := buildTasks()
-		checkHasChanges(t, cloud, allTasks)
+		checkHasChanges(t, ctx, cloud, allTasks)
 	}
 
 	{
 		allTasks := buildTasks()
-		runTasks(t, cloud, allTasks)
+		runTasks(t, ctx, cloud, allTasks)
 	}
 
 	{
 		allTasks := buildTasks()
-		checkNoChanges(t, cloud, allTasks)
+		checkNoChanges(t, ctx, cloud, allTasks)
 	}
 }

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketiam_test.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketiam_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gcetasks
 
 import (
+	"context"
 	"testing"
 
 	gcemock "k8s.io/kops/cloudmock/gce"
@@ -24,6 +25,8 @@ import (
 )
 
 func TestStorageBucketIAM(t *testing.T) {
+	ctx := context.TODO()
+
 	project := "testproject"
 	region := "us-test1"
 
@@ -46,16 +49,16 @@ func TestStorageBucketIAM(t *testing.T) {
 
 	{
 		allTasks := buildTasks()
-		checkHasChanges(t, cloud, allTasks)
+		checkHasChanges(t, ctx, cloud, allTasks)
 	}
 
 	{
 		allTasks := buildTasks()
-		runTasks(t, cloud, allTasks)
+		runTasks(t, ctx, cloud, allTasks)
 	}
 
 	{
 		allTasks := buildTasks()
-		checkNoChanges(t, cloud, allTasks)
+		checkNoChanges(t, ctx, cloud, allTasks)
 	}
 }

--- a/upup/pkg/fi/cloudup/hetzner/api_target.go
+++ b/upup/pkg/fi/cloudup/hetzner/api_target.go
@@ -17,6 +17,8 @@ limitations under the License.
 package hetzner
 
 import (
+	"context"
+
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -32,7 +34,7 @@ func NewHetznerAPITarget(cloud HetznerCloud) *HetznerAPITarget {
 	}
 }
 
-func (t *HetznerAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *HetznerAPITarget) Finish(ctx context.Context, taskMap map[string]fi.Task) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/hetznertasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/servergroup.go
@@ -55,6 +55,8 @@ type ServerGroup struct {
 }
 
 func (v *ServerGroup) Find(c *fi.Context) (*ServerGroup, error) {
+	ctx := c.Context()
+
 	cloud := c.Cloud.(hetzner.HetznerCloud)
 	client := cloud.ServerClient()
 
@@ -76,7 +78,7 @@ func (v *ServerGroup) Find(c *fi.Context) (*ServerGroup, error) {
 	}
 
 	// Calculate the user-data hash
-	userDataBytes, err := fi.ResourceAsBytes(v.UserData)
+	userDataBytes, err := fi.ResourceAsBytes(ctx, v.UserData)
 	if err != nil {
 		return nil, err
 	}
@@ -155,6 +157,7 @@ func (_ *ServerGroup) CheckChanges(a, e, changes *ServerGroup) error {
 }
 
 func (_ *ServerGroup) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *ServerGroup) error {
+	ctx := context.TODO()
 	client := t.Cloud.ServerClient()
 
 	if a != nil {
@@ -196,11 +199,11 @@ func (_ *ServerGroup) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *
 		return fmt.Errorf("failed to find network for server group %q", fi.ValueOf(e.Name))
 	}
 
-	userData, err := fi.ResourceAsString(e.UserData)
+	userData, err := fi.ResourceAsString(ctx, e.UserData)
 	if err != nil {
 		return err
 	}
-	userDataBytes, err := fi.ResourceAsBytes(e.UserData)
+	userDataBytes, err := fi.ResourceAsBytes(ctx, e.UserData)
 	if err != nil {
 		return err
 	}
@@ -298,6 +301,8 @@ type terraformServerPublicNet struct {
 }
 
 func (_ *ServerGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ServerGroup) error {
+	ctx := context.TODO()
+
 	name := terraformWriter.LiteralWithIndex(fi.ValueOf(e.Name))
 	tf := &terraformServer{
 		Count:      fi.PtrTo(e.Count),
@@ -322,7 +327,7 @@ func (_ *ServerGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 	}
 
 	if e.UserData != nil {
-		data, err := fi.ResourceAsBytes(e.UserData)
+		data, err := fi.ResourceAsBytes(ctx, e.UserData)
 		if err != nil {
 			return err
 		}

--- a/upup/pkg/fi/cloudup/loader.go
+++ b/upup/pkg/fi/cloudup/loader.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudup
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -36,12 +37,13 @@ func (l *Loader) Init() {
 	l.tasks = make(map[string]fi.Task)
 }
 
-func (l *Loader) BuildTasks(lifecycleOverrides map[string]fi.Lifecycle) (map[string]fi.Task, error) {
+func (l *Loader) BuildTasks(ctx context.Context, lifecycleOverrides map[string]fi.Lifecycle) (map[string]fi.Task, error) {
 	for _, builder := range l.Builders {
 		context := &fi.ModelBuilderContext{
 			Tasks:              l.tasks,
 			LifecycleOverrides: lifecycleOverrides,
 		}
+		context = context.WithContext(ctx)
 		err := builder.Build(context)
 		if err != nil {
 			return nil, err

--- a/upup/pkg/fi/cloudup/networking.go
+++ b/upup/pkg/fi/cloudup/networking.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudup
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -46,7 +47,7 @@ const (
 	ENV_VAR_CNI_ASSET_HASH = "CNI_ASSET_HASH_STRING"
 )
 
-func findCNIAssets(c *kopsapi.Cluster, assetBuilder *assets.AssetBuilder, arch architectures.Architecture) (*url.URL, *hashing.Hash, error) {
+func findCNIAssets(ctx context.Context, c *kopsapi.Cluster, assetBuilder *assets.AssetBuilder, arch architectures.Architecture) (*url.URL, *hashing.Hash, error) {
 	// Override CNI packages from env vars
 	cniAssetURL := os.Getenv(ENV_VAR_CNI_ASSET_URL)
 	cniAssetHash := os.Getenv(ENV_VAR_CNI_ASSET_HASH)
@@ -97,7 +98,7 @@ func findCNIAssets(c *kopsapi.Cluster, assetBuilder *assets.AssetBuilder, arch a
 		return nil, nil, fmt.Errorf("unable to parse CNI plugin binaries asset URL %q: %v", cniAssetURL, err)
 	}
 
-	u, h, err := assetBuilder.RemapFileAndSHA(u)
+	u, h, err := assetBuilder.RemapFileAndSHA(ctx, u)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to remap CNI plugin binaries asset: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/networking_test.go
+++ b/upup/pkg/fi/cloudup/networking_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudup
 
 import (
+	"context"
 	"testing"
 
 	api "k8s.io/kops/pkg/apis/kops"
@@ -25,6 +26,8 @@ import (
 )
 
 func Test_FindCNIAssetFromEnvironmentVariable(t *testing.T) {
+	ctx := context.TODO()
+
 	desiredCNIVersion := "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-TEST-VERSION.tar.gz"
 	desiredCNIVersionHash := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 
@@ -35,7 +38,7 @@ func Test_FindCNIAssetFromEnvironmentVariable(t *testing.T) {
 	cluster.Spec.KubernetesVersion = "v1.18.0"
 
 	assetBuilder := assets.NewAssetBuilder(cluster, false)
-	cniAsset, cniAssetHash, err := findCNIAssets(cluster, assetBuilder, architectures.ArchitectureAmd64)
+	cniAsset, cniAssetHash, err := findCNIAssets(ctx, cluster, assetBuilder, architectures.ArchitectureAmd64)
 	if err != nil {
 		t.Errorf("Unable to parse CNI version %s", err)
 	}
@@ -50,6 +53,8 @@ func Test_FindCNIAssetFromEnvironmentVariable(t *testing.T) {
 }
 
 func Test_FindCNIAssetFromDefaults118(t *testing.T) {
+	ctx := context.TODO()
+
 	desiredCNIVersionURL := "https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz"
 	desiredCNIVersionHash := "sha256:977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8"
 
@@ -57,7 +62,7 @@ func Test_FindCNIAssetFromDefaults118(t *testing.T) {
 	cluster.Spec.KubernetesVersion = "v1.18.0"
 
 	assetBuilder := assets.NewAssetBuilder(cluster, false)
-	cniAsset, cniAssetHash, err := findCNIAssets(cluster, assetBuilder, architectures.ArchitectureAmd64)
+	cniAsset, cniAssetHash, err := findCNIAssets(ctx, cluster, assetBuilder, architectures.ArchitectureAmd64)
 	if err != nil {
 		t.Errorf("Unable to parse CNI version %s", err)
 	}
@@ -72,6 +77,8 @@ func Test_FindCNIAssetFromDefaults118(t *testing.T) {
 }
 
 func Test_FindCNIAssetFromDefaults122(t *testing.T) {
+	ctx := context.TODO()
+
 	desiredCNIVersionURL := "https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz"
 	desiredCNIVersionHash := "sha256:962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7"
 
@@ -79,7 +86,7 @@ func Test_FindCNIAssetFromDefaults122(t *testing.T) {
 	cluster.Spec.KubernetesVersion = "v1.22.0"
 
 	assetBuilder := assets.NewAssetBuilder(cluster, false)
-	cniAsset, cniAssetHash, err := findCNIAssets(cluster, assetBuilder, architectures.ArchitectureAmd64)
+	cniAsset, cniAssetHash, err := findCNIAssets(ctx, cluster, assetBuilder, architectures.ArchitectureAmd64)
 	if err != nil {
 		t.Errorf("Unable to parse CNI version %s", err)
 	}

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudup
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -183,7 +184,7 @@ type NewClusterResult struct {
 // intended for newly created clusters.
 // It is the responsibility of the caller to call cloudup.PerformAssignments() on
 // the returned cluster spec.
-func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewClusterResult, error) {
+func NewCluster(ctx context.Context, opt *NewClusterOptions, clientset simple.Clientset) (*NewClusterResult, error) {
 	if opt.ClusterName == "" {
 		return nil, fmt.Errorf("name is required")
 	}
@@ -191,7 +192,7 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 	if opt.Channel == "" {
 		opt.Channel = api.DefaultChannel
 	}
-	channel, err := api.LoadChannel(opt.Channel)
+	channel, err := api.LoadChannel(ctx, opt.Channel)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 	}
 
 	cluster.Spec.ConfigBase = opt.ConfigBase
-	configBase, err := clientset.ConfigBaseFor(&cluster)
+	configBase, err := clientset.ConfigBaseFor(ctx, &cluster)
 	if err != nil {
 		return nil, fmt.Errorf("error building ConfigBase for cluster: %v", err)
 	}
@@ -356,7 +357,7 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 	}
 
 	if opt.DiscoveryStore != "" {
-		discoveryPath, err := vfs.Context.BuildVfsPath(opt.DiscoveryStore)
+		discoveryPath, err := vfs.FromContext(ctx).BuildVfsPath(opt.DiscoveryStore)
 		if err != nil {
 			return nil, fmt.Errorf("error building DiscoveryStore for cluster: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/new_cluster_test.go
+++ b/upup/pkg/fi/cloudup/new_cluster_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudup
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -337,6 +338,8 @@ func TestSetupNetworking(t *testing.T) {
 }
 
 func TestDefaultImage(t *testing.T) {
+	ctx := context.TODO()
+
 	tests := []struct {
 		cluster      *api.Cluster
 		architecture architectures.Architecture
@@ -428,7 +431,7 @@ func TestDefaultImage(t *testing.T) {
 		},
 	}
 
-	channel, err := api.LoadChannel("file://tests/channels/channel.yaml")
+	channel, err := api.LoadChannel(ctx, "file://tests/channels/channel.yaml")
 	if err != nil {
 		t.Fatalf("unable to load test channel: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/openstack/apitarget.go
+++ b/upup/pkg/fi/cloudup/openstack/apitarget.go
@@ -17,6 +17,8 @@ limitations under the License.
 package openstack
 
 import (
+	"context"
+
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -32,7 +34,7 @@ func NewOpenstackAPITarget(cloud OpenstackCloud) *OpenstackAPITarget {
 	}
 }
 
-func (t *OpenstackAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (t *OpenstackAPITarget) Finish(ctx context.Context, taskMap map[string]fi.Task) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openstacktasks
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -312,6 +313,8 @@ func generateInstanceName(e *Instance) (string, error) {
 }
 
 func (_ *Instance) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *Instance) error {
+	ctx := context.TODO()
+
 	cloud := t.Cloud
 	if a == nil {
 		serverName, err := generateInstanceName(e)
@@ -346,7 +349,7 @@ func (_ *Instance) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, change
 			ConfigDrive:    e.ConfigDrive,
 		}
 		if e.UserData != nil {
-			bytes, err := fi.ResourceAsBytes(e.UserData)
+			bytes, err := fi.ResourceAsBytes(ctx, e.UserData)
 			if err != nil {
 				return err
 			}

--- a/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openstacktasks
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -71,8 +72,10 @@ func (e *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
 }
 
 func (e *SSHKey) Normalize(c *fi.Context) error {
+	ctx := c.Context()
+
 	if e.KeyFingerprint == nil && e.PublicKey != nil {
-		publicKey, err := fi.ResourceAsString(e.PublicKey)
+		publicKey, err := fi.ResourceAsString(ctx, e.PublicKey)
 		if err != nil {
 			return fmt.Errorf("error reading SSH public key: %v", err)
 		}
@@ -114,6 +117,8 @@ func openstackKeyPairName(org string) string {
 }
 
 func (_ *SSHKey) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *SSHKey) error {
+	ctx := context.TODO()
+
 	if a == nil {
 		klog.V(2).Infof("Creating Keypair with name:%q", fi.ValueOf(e.Name))
 
@@ -122,7 +127,7 @@ func (_ *SSHKey) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes 
 		}
 
 		if e.PublicKey != nil {
-			d, err := fi.ResourceAsString(e.PublicKey)
+			d, err := fi.ResourceAsString(ctx, e.PublicKey)
 			if err != nil {
 				return fmt.Errorf("error rendering SSHKey PublicKey: %v", err)
 			}

--- a/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudup
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -42,6 +43,7 @@ func buildMinimalCluster() (*awsup.MockAWSCloud, *kopsapi.Cluster) {
 }
 
 func TestPopulateCluster_Default_NoError(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 
 	err := PerformAssignments(c, cloud)
@@ -49,7 +51,7 @@ func TestPopulateCluster_Default_NoError(t *testing.T) {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
 
-	_, err = mockedPopulateClusterSpec(c, cloud)
+	_, err = mockedPopulateClusterSpec(ctx, c, cloud)
 	if err != nil {
 		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
 	}
@@ -83,6 +85,7 @@ func TestPopulateCluster_Subnets(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.NonMasqueradeCIDR, func(t *testing.T) {
+			ctx := context.TODO()
 			cloud, c := buildMinimalCluster()
 			c.Spec.Networking.NonMasqueradeCIDR = tc.NonMasqueradeCIDR
 			c.Spec.Networking.Kubenet = nil
@@ -97,7 +100,7 @@ func TestPopulateCluster_Subnets(t *testing.T) {
 			err := PerformAssignments(c, cloud)
 			require.NoError(t, err, "PerformAssignments")
 
-			full, err := mockedPopulateClusterSpec(c, cloud)
+			full, err := mockedPopulateClusterSpec(ctx, c, cloud)
 			require.NoError(t, err, "PopulateClusterSpec")
 
 			assert.Equal(t, tc.ExpectedClusterCIDR, full.Spec.KubeControllerManager.ClusterCIDR, "ClusterCIDR")
@@ -106,19 +109,20 @@ func TestPopulateCluster_Subnets(t *testing.T) {
 	}
 }
 
-func mockedPopulateClusterSpec(c *kopsapi.Cluster, cloud fi.Cloud) (*kopsapi.Cluster, error) {
-	vfs.Context.ResetMemfsContext(true)
+func mockedPopulateClusterSpec(ctx context.Context, c *kopsapi.Cluster, cloud fi.Cloud) (*kopsapi.Cluster, error) {
+	vfs.FromContext(ctx).ResetMemfsContext(true)
 
 	assetBuilder := assets.NewAssetBuilder(c, false)
-	basePath, err := vfs.Context.BuildVfsPath("memfs://tests")
+	basePath, err := vfs.FromContext(ctx).BuildVfsPath("memfs://tests")
 	if err != nil {
 		return nil, fmt.Errorf("error building vfspath: %v", err)
 	}
 	clientset := vfsclientset.NewVFSClientset(basePath)
-	return PopulateClusterSpec(clientset, c, cloud, assetBuilder)
+	return PopulateClusterSpec(ctx, clientset, c, cloud, assetBuilder)
 }
 
 func TestPopulateCluster_Docker_Spec(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.Spec.Docker = &kopsapi.DockerConfig{
 		MTU:                fi.PtrTo(int32(5678)),
@@ -133,7 +137,7 @@ func TestPopulateCluster_Docker_Spec(t *testing.T) {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
 
-	full, err := mockedPopulateClusterSpec(c, cloud)
+	full, err := mockedPopulateClusterSpec(ctx, c, cloud)
 	if err != nil {
 		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
 	}
@@ -160,6 +164,7 @@ func TestPopulateCluster_Docker_Spec(t *testing.T) {
 }
 
 func TestPopulateCluster_StorageDefault(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 
 	err := PerformAssignments(c, cloud)
@@ -167,7 +172,7 @@ func TestPopulateCluster_StorageDefault(t *testing.T) {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
 
-	full, err := mockedPopulateClusterSpec(c, cloud)
+	full, err := mockedPopulateClusterSpec(ctx, c, cloud)
 	if err != nil {
 		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
 	}
@@ -178,6 +183,7 @@ func TestPopulateCluster_StorageDefault(t *testing.T) {
 }
 
 func TestPopulateCluster_EvictionHard(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 
 	err := PerformAssignments(c, cloud)
@@ -189,7 +195,7 @@ func TestPopulateCluster_EvictionHard(t *testing.T) {
 		EvictionHard: fi.PtrTo("memory.available<250Mi"),
 	}
 
-	full, err := mockedPopulateClusterSpec(c, cloud)
+	full, err := mockedPopulateClusterSpec(ctx, c, cloud)
 	if err != nil {
 		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
 	}
@@ -200,6 +206,7 @@ func TestPopulateCluster_EvictionHard(t *testing.T) {
 }
 
 func build(c *kopsapi.Cluster) (*kopsapi.Cluster, error) {
+	ctx := context.TODO()
 	cloud, err := BuildCloud(c)
 	if err != nil {
 		return nil, fmt.Errorf("error from BuildCloud: %v", err)
@@ -210,7 +217,7 @@ func build(c *kopsapi.Cluster) (*kopsapi.Cluster, error) {
 		return nil, fmt.Errorf("error from PerformAssignments: %v", err)
 	}
 
-	full, err := mockedPopulateClusterSpec(c, cloud)
+	full, err := mockedPopulateClusterSpec(ctx, c, cloud)
 	if err != nil {
 		return nil, fmt.Errorf("Unexpected error from PopulateCluster: %v", err)
 	}
@@ -218,6 +225,7 @@ func build(c *kopsapi.Cluster) (*kopsapi.Cluster, error) {
 }
 
 func TestPopulateCluster_Custom_CIDR(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.Spec.Networking.NetworkCIDR = "172.20.2.0/24"
 	c.Spec.Networking.Subnets = []kopsapi.ClusterSubnetSpec{
@@ -231,7 +239,7 @@ func TestPopulateCluster_Custom_CIDR(t *testing.T) {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
 
-	full, err := mockedPopulateClusterSpec(c, cloud)
+	full, err := mockedPopulateClusterSpec(ctx, c, cloud)
 	if err != nil {
 		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
 	}
@@ -241,6 +249,7 @@ func TestPopulateCluster_Custom_CIDR(t *testing.T) {
 }
 
 func TestPopulateCluster_IsolateMasters(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.Spec.Networking.IsolateControlPlane = fi.PtrTo(true)
 
@@ -249,7 +258,7 @@ func TestPopulateCluster_IsolateMasters(t *testing.T) {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
 
-	full, err := mockedPopulateClusterSpec(c, cloud)
+	full, err := mockedPopulateClusterSpec(ctx, c, cloud)
 	if err != nil {
 		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
 	}
@@ -262,6 +271,7 @@ func TestPopulateCluster_IsolateMasters(t *testing.T) {
 }
 
 func TestPopulateCluster_IsolateMastersFalse(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	// default: c.Spec.IsolateControlPlane = fi.PtrTo(false)
 
@@ -270,7 +280,7 @@ func TestPopulateCluster_IsolateMastersFalse(t *testing.T) {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
 
-	full, err := mockedPopulateClusterSpec(c, cloud)
+	full, err := mockedPopulateClusterSpec(ctx, c, cloud)
 	if err != nil {
 		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
 	}
@@ -280,52 +290,59 @@ func TestPopulateCluster_IsolateMastersFalse(t *testing.T) {
 }
 
 func TestPopulateCluster_Name_Required(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.ObjectMeta.Name = ""
 
-	expectErrorFromPopulateCluster(t, c, cloud, "Name")
+	expectErrorFromPopulateCluster(t, ctx, c, cloud, "Name")
 }
 
 func TestPopulateCluster_Zone_Required(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.Spec.Networking.Subnets = nil
 
-	expectErrorFromPopulateCluster(t, c, cloud, "subnet")
+	expectErrorFromPopulateCluster(t, ctx, c, cloud, "subnet")
 }
 
 func TestPopulateCluster_NetworkCIDR_Required(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.Spec.Networking.NetworkCIDR = ""
 
-	expectErrorFromPopulateCluster(t, c, cloud, "networkCIDR")
+	expectErrorFromPopulateCluster(t, ctx, c, cloud, "networkCIDR")
 }
 
 func TestPopulateCluster_NonMasqueradeCIDR_Required(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.Spec.Networking.NonMasqueradeCIDR = ""
 
-	expectErrorFromPopulateCluster(t, c, cloud, "nonMasqueradeCIDR")
+	expectErrorFromPopulateCluster(t, ctx, c, cloud, "nonMasqueradeCIDR")
 }
 
 func TestPopulateCluster_CloudProvider_Required(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.Spec.CloudProvider = kopsapi.CloudProviderSpec{}
 
-	expectErrorFromPopulateCluster(t, c, cloud, "cloudProvider")
+	expectErrorFromPopulateCluster(t, ctx, c, cloud, "cloudProvider")
 }
 
 func TestPopulateCluster_TopologyInvalidNil_Required(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.Spec.Networking.Topology.ControlPlane = ""
 	c.Spec.Networking.Topology.Nodes = ""
-	expectErrorFromPopulateCluster(t, c, cloud, "topology")
+	expectErrorFromPopulateCluster(t, ctx, c, cloud, "topology")
 }
 
 func TestPopulateCluster_TopologyInvalidValue_Required(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.Spec.Networking.Topology.ControlPlane = "123"
 	c.Spec.Networking.Topology.Nodes = "abc"
-	expectErrorFromPopulateCluster(t, c, cloud, "topology")
+	expectErrorFromPopulateCluster(t, ctx, c, cloud, "topology")
 }
 
 //func TestPopulateCluster_TopologyInvalidMatchingValues_Required(t *testing.T) {
@@ -337,16 +354,17 @@ func TestPopulateCluster_TopologyInvalidValue_Required(t *testing.T) {
 //}
 
 func TestPopulateCluster_BastionInvalidMatchingValues_Required(t *testing.T) {
+	ctx := context.TODO()
 	// We can't have a bastion with public masters / nodes
 	cloud, c := buildMinimalCluster()
 	c.Spec.Networking.Topology.ControlPlane = kopsapi.TopologyPublic
 	c.Spec.Networking.Topology.Nodes = kopsapi.TopologyPublic
 	c.Spec.Networking.Topology.Bastion = &kopsapi.BastionSpec{}
-	expectErrorFromPopulateCluster(t, c, cloud, "bastion")
+	expectErrorFromPopulateCluster(t, ctx, c, cloud, "bastion")
 }
 
-func expectErrorFromPopulateCluster(t *testing.T, c *kopsapi.Cluster, cloud fi.Cloud, message string) {
-	_, err := mockedPopulateClusterSpec(c, cloud)
+func expectErrorFromPopulateCluster(t *testing.T, ctx context.Context, c *kopsapi.Cluster, cloud fi.Cloud, message string) {
+	_, err := mockedPopulateClusterSpec(ctx, c, cloud)
 	if err == nil {
 		t.Fatalf("Expected error from PopulateCluster")
 	}
@@ -370,6 +388,7 @@ func TestPopulateCluster_APIServerCount(t *testing.T) {
 }
 
 func TestPopulateCluster_AnonymousAuth(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.Spec.KubernetesVersion = "1.20.0"
 
@@ -378,7 +397,7 @@ func TestPopulateCluster_AnonymousAuth(t *testing.T) {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
 
-	full, err := mockedPopulateClusterSpec(c, cloud)
+	full, err := mockedPopulateClusterSpec(ctx, c, cloud)
 	if err != nil {
 		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
 	}
@@ -420,6 +439,7 @@ func TestPopulateCluster_DockerVersion(t *testing.T) {
 }
 
 func TestPopulateCluster_KubeController_High_Enough_Version(t *testing.T) {
+	ctx := context.TODO()
 	cloud, c := buildMinimalCluster()
 	c.Spec.KubernetesVersion = "v1.9.0"
 
@@ -428,7 +448,7 @@ func TestPopulateCluster_KubeController_High_Enough_Version(t *testing.T) {
 		t.Fatalf("error from PerformAssignments: %v", err)
 	}
 
-	full, err := mockedPopulateClusterSpec(c, cloud)
+	full, err := mockedPopulateClusterSpec(ctx, c, cloud)
 	if err != nil {
 		t.Fatalf("Unexpected error from PopulateCluster: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/scaleway/api_target.go
+++ b/upup/pkg/fi/cloudup/scaleway/api_target.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package scaleway
 
-import "k8s.io/kops/upup/pkg/fi"
+import (
+	"context"
+
+	"k8s.io/kops/upup/pkg/fi"
+)
 
 type ScwAPITarget struct {
 	Cloud ScwCloud
@@ -30,7 +34,7 @@ func NewScwAPITarget(cloud ScwCloud) *ScwAPITarget {
 	}
 }
 
-func (s ScwAPITarget) Finish(taskMap map[string]fi.Task) error {
+func (s ScwAPITarget) Finish(ctx context.Context, taskMap map[string]fi.Task) error {
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/scalewaytasks/instance.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/instance.go
@@ -107,11 +107,13 @@ func (_ *Instance) CheckChanges(actual, expected, changes *Instance) error {
 }
 
 func (_ *Instance) RenderScw(c *fi.Context, actual, expected, changes *Instance) error {
+	ctx := c.Context()
+
 	cloud := c.Cloud.(scaleway.ScwCloud)
 	instanceService := cloud.InstanceService()
 	zone := scw.Zone(fi.ValueOf(expected.Zone))
 
-	userData, err := fi.ResourceAsBytes(*expected.UserData)
+	userData, err := fi.ResourceAsBytes(ctx, *expected.UserData)
 	if err != nil {
 		return fmt.Errorf("error rendering instances: %w", err)
 	}

--- a/upup/pkg/fi/cloudup/scalewaytasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/sshkey.go
@@ -82,8 +82,10 @@ func (s *SSHKey) Find(c *fi.Context) (*SSHKey, error) {
 }
 
 func (s *SSHKey) Run(c *fi.Context) error {
+	ctx := c.Context()
+
 	if s.KeyPairFingerPrint == nil && s.PublicKey != nil {
-		publicKey, err := fi.ResourceAsString(*s.PublicKey)
+		publicKey, err := fi.ResourceAsString(ctx, *s.PublicKey)
 		if err != nil {
 			return fmt.Errorf("error reading SSH public key: %w", err)
 		}
@@ -108,6 +110,8 @@ func (s *SSHKey) CheckChanges(actual, expected, changes *SSHKey) error {
 }
 
 func (*SSHKey) RenderScw(c *fi.Context, actual, expected, changes *SSHKey) error {
+	ctx := c.Context()
+
 	if actual != nil {
 		klog.Infof("Scaleway does not support changes to ssh keys for the moment")
 		return nil
@@ -124,7 +128,7 @@ func (*SSHKey) RenderScw(c *fi.Context, actual, expected, changes *SSHKey) error
 	keyArgs := &iam.CreateSSHKeyRequest{
 		Name: name}
 	if expected.PublicKey != nil {
-		d, err := fi.ResourceAsString(*expected.PublicKey)
+		d, err := fi.ResourceAsString(ctx, *expected.PublicKey)
 		if err != nil {
 			return fmt.Errorf("error rendering SSH public key: %w", err)
 		}

--- a/upup/pkg/fi/cloudup/spec_builder.go
+++ b/upup/pkg/fi/cloudup/spec_builder.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cloudup
 
 import (
+	"context"
+
 	"k8s.io/klog/v2"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
@@ -28,8 +30,8 @@ type SpecBuilder struct {
 	OptionsLoader *loader.OptionsLoader
 }
 
-func (l *SpecBuilder) BuildCompleteSpec(clusterSpec *kopsapi.ClusterSpec) (*kopsapi.ClusterSpec, error) {
-	loaded, err := l.OptionsLoader.Build(clusterSpec)
+func (l *SpecBuilder) BuildCompleteSpec(ctx context.Context, clusterSpec *kopsapi.ClusterSpec) (*kopsapi.ClusterSpec, error) {
+	loaded, err := l.OptionsLoader.Build(ctx, clusterSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -509,6 +509,8 @@ func (eg *Elastigroup) createOrUpdate(cloud awsup.AWSCloud, a, e, changes *Elast
 }
 
 func (_ *Elastigroup) create(cloud awsup.AWSCloud, a, e, changes *Elastigroup) error {
+	ctx := context.TODO()
+
 	klog.V(2).Infof("Creating Elastigroup %q", *e.Name)
 	e.applyDefaults()
 
@@ -611,7 +613,7 @@ func (_ *Elastigroup) create(cloud awsup.AWSCloud, a, e, changes *Elastigroup) e
 			// User data.
 			{
 				if e.UserData != nil {
-					userData, err := fi.ResourceAsString(e.UserData)
+					userData, err := fi.ResourceAsString(ctx, e.UserData)
 					if err != nil {
 						return err
 					}
@@ -974,7 +976,7 @@ func (_ *Elastigroup) update(cloud awsup.AWSCloud, a, e, changes *Elastigroup) e
 			// User data.
 			{
 				if changes.UserData != nil {
-					userData, err := fi.ResourceAsString(e.UserData)
+					userData, err := fi.ResourceAsString(ctx, e.UserData)
 					if err != nil {
 						return err
 					}
@@ -1461,6 +1463,7 @@ type terraformTaint struct {
 }
 
 func (_ *Elastigroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Elastigroup) error {
+	ctx := context.TODO()
 	cloud := t.Cloud.(awsup.AWSCloud)
 	e.applyDefaults()
 
@@ -1524,7 +1527,7 @@ func (_ *Elastigroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 	// User data.
 	if e.UserData != nil {
 		var err error
-		tf.UserData, err = t.AddFileResource("spotinst_elastigroup_aws", *e.Name, "user_data", e.UserData, false)
+		tf.UserData, err = t.AddFileResource(ctx, "spotinst_elastigroup_aws", *e.Name, "user_data", e.UserData, false)
 		if err != nil {
 			return err
 		}

--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -362,6 +362,7 @@ func (o *LaunchSpec) createOrUpdate(cloud awsup.AWSCloud, a, e, changes *LaunchS
 }
 
 func (_ *LaunchSpec) create(cloud awsup.AWSCloud, a, e, changes *LaunchSpec) error {
+	ctx := context.TODO()
 	ocean, err := e.Ocean.find(cloud.Spotinst().Ocean())
 	if err != nil {
 		return err
@@ -399,7 +400,7 @@ func (_ *LaunchSpec) create(cloud awsup.AWSCloud, a, e, changes *LaunchSpec) err
 	// User data.
 	{
 		if e.UserData != nil {
-			userData, err := fi.ResourceAsString(e.UserData)
+			userData, err := fi.ResourceAsString(ctx, e.UserData)
 			if err != nil {
 				return err
 			}
@@ -551,6 +552,7 @@ func (_ *LaunchSpec) create(cloud awsup.AWSCloud, a, e, changes *LaunchSpec) err
 }
 
 func (_ *LaunchSpec) update(cloud awsup.AWSCloud, a, e, changes *LaunchSpec) error {
+	ctx := context.TODO()
 	klog.V(2).Infof("Updating Launch Spec for Ocean %q", *a.Ocean.Name)
 
 	ocean, err := a.Ocean.find(cloud.Spotinst().Ocean())
@@ -611,7 +613,7 @@ func (_ *LaunchSpec) update(cloud awsup.AWSCloud, a, e, changes *LaunchSpec) err
 	// User data.
 	{
 		if changes.UserData != nil {
-			userData, err := fi.ResourceAsString(e.UserData)
+			userData, err := fi.ResourceAsString(ctx, e.UserData)
 			if err != nil {
 				return err
 			}
@@ -799,7 +801,6 @@ func (_ *LaunchSpec) update(cloud awsup.AWSCloud, a, e, changes *LaunchSpec) err
 	}
 
 	klog.V(2).Infof("Updating Launch Spec %q (config: %s)", *e.Name, stringutil.Stringify(spec))
-	ctx := context.Background()
 
 	// Reset the Spot percentage on the Cluster level.
 	if spec.Strategy != nil && spec.Strategy.SpotPercentage != nil &&
@@ -884,6 +885,7 @@ type terraformBlockDeviceMappingEBS struct {
 }
 
 func (_ *LaunchSpec) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *LaunchSpec) error {
+	ctx := context.TODO()
 	cloud := t.Cloud.(awsup.AWSCloud)
 
 	tf := &terraformLaunchSpec{
@@ -960,7 +962,7 @@ func (_ *LaunchSpec) RenderTerraform(t *terraform.TerraformTarget, a, e, changes
 	{
 		if e.UserData != nil {
 			var err error
-			tf.UserData, err = t.AddFileResource("spotinst_ocean_aws_launch_spec", *e.Name, "user_data", e.UserData, false)
+			tf.UserData, err = t.AddFileResource(ctx, "spotinst_ocean_aws_launch_spec", *e.Name, "user_data", e.UserData, false)
 			if err != nil {
 				return err
 			}

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -356,6 +356,7 @@ func (o *Ocean) createOrUpdate(cloud awsup.AWSCloud, a, e, changes *Ocean) error
 }
 
 func (_ *Ocean) create(cloud awsup.AWSCloud, a, e, changes *Ocean) error {
+	ctx := context.TODO()
 	klog.V(2).Infof("Creating Ocean %q", *e.Name)
 
 	ocean := &aws.Cluster{
@@ -460,7 +461,7 @@ func (_ *Ocean) create(cloud awsup.AWSCloud, a, e, changes *Ocean) error {
 				// User data.
 				{
 					if e.UserData != nil {
-						userData, err := fi.ResourceAsString(e.UserData)
+						userData, err := fi.ResourceAsString(ctx, e.UserData)
 						if err != nil {
 							return err
 						}
@@ -593,6 +594,7 @@ readyLoop:
 }
 
 func (_ *Ocean) update(cloud awsup.AWSCloud, a, e, changes *Ocean) error {
+	ctx := context.TODO()
 	klog.V(2).Infof("Updating Ocean %q", *e.Name)
 
 	actual, err := e.find(cloud.Spotinst().Ocean())
@@ -817,7 +819,7 @@ func (_ *Ocean) update(cloud awsup.AWSCloud, a, e, changes *Ocean) error {
 				// User data.
 				{
 					if changes.UserData != nil {
-						userData, err := fi.ResourceAsString(e.UserData)
+						userData, err := fi.ResourceAsString(ctx, e.UserData)
 						if err != nil {
 							return err
 						}
@@ -1053,6 +1055,7 @@ type terraformOcean struct {
 }
 
 func (_ *Ocean) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Ocean) error {
+	ctx := context.TODO()
 	cloud := t.Cloud.(awsup.AWSCloud)
 
 	tf := &terraformOcean{
@@ -1196,7 +1199,7 @@ func (_ *Ocean) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Oce
 		// User data.
 		if e.UserData != nil {
 			var err error
-			tf.UserData, err = t.AddFileResource("spotinst_ocean_aws", *e.Name, "user_data", e.UserData, false)
+			tf.UserData, err = t.AddFileResource(ctx, "spotinst_ocean_aws", *e.Name, "user_data", e.UserData, false)
 			if err != nil {
 				return err
 			}

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -17,6 +17,7 @@ limitations under the License.
 package terraform
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -56,8 +57,8 @@ func NewTerraformTarget(cloud fi.Cloud, project string, filesProvider *vfs.Terra
 
 var _ fi.Target = &TerraformTarget{}
 
-func (t *TerraformTarget) AddFileResource(resourceType string, resourceName string, key string, r fi.Resource, base64 bool) (*terraformWriter.Literal, error) {
-	d, err := fi.ResourceAsBytes(r)
+func (t *TerraformTarget) AddFileResource(ctx context.Context, resourceType string, resourceName string, key string, r fi.Resource, base64 bool) (*terraformWriter.Literal, error) {
+	d, err := fi.ResourceAsBytes(ctx, r)
 	if err != nil {
 		id := resourceType + "_" + resourceName + "_" + key
 		return nil, fmt.Errorf("error rending resource %s %v", id, err)
@@ -91,7 +92,7 @@ func tfGetFilesProviderExtraConfig(c *kops.TargetSpec) map[string]string {
 	return nil
 }
 
-func (t *TerraformTarget) Finish(taskMap map[string]fi.Task) error {
+func (t *TerraformTarget) Finish(ctx context.Context, taskMap map[string]fi.Task) error {
 	if err := t.finishHCL2(); err != nil {
 		return err
 	}

--- a/upup/pkg/fi/cloudup/urls.go
+++ b/upup/pkg/fi/cloudup/urls.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudup
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -84,7 +85,7 @@ func copyBaseURL(base *url.URL) (*url.URL, error) {
 }
 
 // NodeUpAsset returns the asset for where nodeup should be downloaded
-func NodeUpAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Architecture) (*mirrors.MirroredAsset, error) {
+func NodeUpAsset(ctx context.Context, assetsBuilder *assets.AssetBuilder, arch architectures.Architecture) (*mirrors.MirroredAsset, error) {
 	if nodeUpAsset == nil {
 		nodeUpAsset = make(map[architectures.Architecture]*mirrors.MirroredAsset)
 	}
@@ -94,7 +95,7 @@ func NodeUpAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Architec
 		return nodeUpAsset[arch], nil
 	}
 
-	u, hash, err := KopsFileURL(fmt.Sprintf("linux/%s/nodeup", arch), assetsBuilder)
+	u, hash, err := KopsFileURL(ctx, fmt.Sprintf("linux/%s/nodeup", arch), assetsBuilder)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func NodeUpAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Architec
 }
 
 // ProtokubeAsset returns the url and hash of the protokube binary
-func ProtokubeAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Architecture) (*mirrors.MirroredAsset, error) {
+func ProtokubeAsset(ctx context.Context, assetsBuilder *assets.AssetBuilder, arch architectures.Architecture) (*mirrors.MirroredAsset, error) {
 	if protokubeAsset == nil {
 		protokubeAsset = make(map[architectures.Architecture]*mirrors.MirroredAsset)
 	}
@@ -114,7 +115,7 @@ func ProtokubeAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Archi
 		return protokubeAsset[arch], nil
 	}
 
-	u, hash, err := KopsFileURL(fmt.Sprintf("linux/%s/protokube", arch), assetsBuilder)
+	u, hash, err := KopsFileURL(ctx, fmt.Sprintf("linux/%s/protokube", arch), assetsBuilder)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +126,7 @@ func ProtokubeAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Archi
 }
 
 // ChannelsAsset returns the url and hash of the channels binary
-func ChannelsAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Architecture) (*mirrors.MirroredAsset, error) {
+func ChannelsAsset(ctx context.Context, assetsBuilder *assets.AssetBuilder, arch architectures.Architecture) (*mirrors.MirroredAsset, error) {
 	if channelsAsset == nil {
 		channelsAsset = make(map[architectures.Architecture]*mirrors.MirroredAsset)
 	}
@@ -134,7 +135,7 @@ func ChannelsAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Archit
 		return channelsAsset[arch], nil
 	}
 
-	u, hash, err := KopsFileURL(fmt.Sprintf("linux/%s/channels", arch), assetsBuilder)
+	u, hash, err := KopsFileURL(ctx, fmt.Sprintf("linux/%s/channels", arch), assetsBuilder)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +146,7 @@ func ChannelsAsset(assetsBuilder *assets.AssetBuilder, arch architectures.Archit
 }
 
 // KopsFileURL returns the base url for the distribution of kops - in particular for nodeup & docker images
-func KopsFileURL(file string, assetBuilder *assets.AssetBuilder) (*url.URL, *hashing.Hash, error) {
+func KopsFileURL(ctx context.Context, file string, assetBuilder *assets.AssetBuilder) (*url.URL, *hashing.Hash, error) {
 	base, err := BaseURL()
 	if err != nil {
 		return nil, nil, err
@@ -153,7 +154,7 @@ func KopsFileURL(file string, assetBuilder *assets.AssetBuilder) (*url.URL, *has
 
 	base.Path = path.Join(base.Path, file)
 
-	fileURL, hash, err := assetBuilder.RemapFileAndSHA(base)
+	fileURL, hash, err := assetBuilder.RemapFileAndSHA(ctx, base)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/upup/pkg/fi/default_methods.go
+++ b/upup/pkg/fi/default_methods.go
@@ -26,6 +26,8 @@ import (
 // DefaultDeltaRunMethod implements the standard change-based run procedure:
 // find the existing item; compare properties; call render with (actual, expected, changes)
 func DefaultDeltaRunMethod(e Task, c *Context) error {
+	ctx := c.Context()
+
 	var a Task
 	var err error
 
@@ -65,7 +67,7 @@ func DefaultDeltaRunMethod(e Task, c *Context) error {
 	}
 
 	changes := reflect.New(reflect.TypeOf(e).Elem()).Interface().(Task)
-	changed := BuildChanges(a, e, changes)
+	changed := BuildChanges(ctx, a, e, changes)
 
 	if changed {
 		err = invokeCheckChanges(a, e, changes)

--- a/upup/pkg/fi/dryruntarget_test.go
+++ b/upup/pkg/fi/dryruntarget_test.go
@@ -18,6 +18,7 @@ package fi
 
 import (
 	"bytes"
+	"context"
 	"reflect"
 	"testing"
 
@@ -27,6 +28,8 @@ import (
 )
 
 func Test_tryResourceAsString(t *testing.T) {
+	ctx := context.TODO()
+
 	var sr *StringResource
 	grid := []struct {
 		Resource interface{}
@@ -47,7 +50,7 @@ func Test_tryResourceAsString(t *testing.T) {
 	}
 	for i, g := range grid {
 		v := reflect.ValueOf(g.Resource)
-		actual, _ := tryResourceAsString(v)
+		actual, _ := tryResourceAsString(ctx, v)
 		if actual != g.Expected {
 			t.Errorf("unexpected result from %d.  Expected=%q, got %q", i, g.Expected, actual)
 		}
@@ -67,6 +70,8 @@ func (*testTask) Run(_ *Context) error {
 }
 
 func Test_DryrunTarget_PrintReport(t *testing.T) {
+	ctx := context.TODO()
+
 	builder := assets.NewAssetBuilder(&api.Cluster{
 		Spec: api.ClusterSpec{
 			KubernetesVersion: "1.17.3",
@@ -86,12 +91,12 @@ func Test_DryrunTarget_PrintReport(t *testing.T) {
 		Tags:      map[string]string{"key": "value"},
 	}
 	changes := reflect.New(reflect.TypeOf(e).Elem()).Interface().(Task)
-	_ = BuildChanges(a, e, changes)
+	_ = BuildChanges(ctx, a, e, changes)
 	err := target.Render(a, e, changes)
 	tasks[*e.Name] = e
 	assert.NoError(t, err, "target.Render()")
 
 	var out bytes.Buffer
-	err = target.PrintReport(tasks, &out)
+	err = target.PrintReport(ctx, tasks, &out)
 	assert.NoError(t, err, "target.PrintReport()")
 }

--- a/upup/pkg/fi/files.go
+++ b/upup/pkg/fi/files.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fi
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -29,13 +30,13 @@ import (
 )
 
 // WriteFile writes a file to the specified path, setting the mode, owner & group.
-func WriteFile(destPath string, contents Resource, fileMode os.FileMode, dirMode os.FileMode, owner string, group string) error {
+func WriteFile(ctx context.Context, destPath string, contents Resource, fileMode os.FileMode, dirMode os.FileMode, owner string, group string) error {
 	err := os.MkdirAll(path.Dir(destPath), dirMode)
 	if err != nil {
 		return fmt.Errorf("error creating directories for destination file %q: %v", destPath, err)
 	}
 
-	err = writeFileContents(destPath, contents, fileMode)
+	err = writeFileContents(ctx, destPath, contents, fileMode)
 	if err != nil {
 		return err
 	}
@@ -53,10 +54,10 @@ func WriteFile(destPath string, contents Resource, fileMode os.FileMode, dirMode
 	return nil
 }
 
-func writeFileContents(destPath string, src Resource, fileMode os.FileMode) error {
+func writeFileContents(ctx context.Context, destPath string, src Resource, fileMode os.FileMode) error {
 	klog.Infof("Writing file %q", destPath)
 
-	in, err := src.Open()
+	in, err := src.Open(ctx)
 	if err != nil {
 		return fmt.Errorf("error opening source resource for file %q: %v", destPath, err)
 	}

--- a/upup/pkg/fi/files_test.go
+++ b/upup/pkg/fi/files_test.go
@@ -21,6 +21,7 @@ package fi
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path"
 	"syscall"
@@ -28,6 +29,8 @@ import (
 )
 
 func TestWriteFile(t *testing.T) {
+	ctx := context.TODO()
+
 	// Clear the umask so an unusual umask doesn't break our test (for directory mode)
 	syscall.Umask(0)
 
@@ -47,7 +50,7 @@ func TestWriteFile(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		err := WriteFile(test.path, NewBytesResource(test.data), test.fileMode, test.dirMode, "", "")
+		err := WriteFile(ctx, test.path, NewBytesResource(test.data), test.fileMode, test.dirMode, "", "")
 		if err != nil {
 			t.Errorf("Error writing file {%s}, error: {%v}", test.path, err)
 			continue

--- a/upup/pkg/fi/nodeup/cloudinit/cloud_init_target.go
+++ b/upup/pkg/fi/nodeup/cloudinit/cloud_init_target.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudinit
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -108,7 +109,7 @@ func (t *CloudInitTarget) fetch(p *fi.Source, destPath string) {
 	}
 }
 
-func (t *CloudInitTarget) WriteFile(destPath string, contents fi.Resource, fileMode os.FileMode, dirMode os.FileMode) error {
+func (t *CloudInitTarget) WriteFile(ctx context.Context, destPath string, contents fi.Resource, fileMode os.FileMode, dirMode os.FileMode) error {
 	var p *fi.Source
 
 	if hs, ok := contents.(fi.HasSource); ok {
@@ -127,7 +128,7 @@ func (t *CloudInitTarget) WriteFile(destPath string, contents fi.Resource, fileM
 			Path:        destPath,
 		}
 
-		d, err := fi.ResourceAsBytes(contents)
+		d, err := fi.ResourceAsBytes(ctx, contents)
 		if err != nil {
 			return err
 		}
@@ -168,7 +169,7 @@ func (t *CloudInitTarget) AddCommand(addBehaviour AddBehaviour, args ...string) 
 	t.Config.RunCommmands = append(t.Config.RunCommmands, args)
 }
 
-func (t *CloudInitTarget) Finish(taskMap map[string]fi.Task) error {
+func (t *CloudInitTarget) Finish(ctx context.Context, taskMap map[string]fi.Task) error {
 	d, err := utils.YamlMarshal(t.Config)
 	if err != nil {
 		return fmt.Errorf("error serializing config to yaml: %v", err)

--- a/upup/pkg/fi/nodeup/local/local_target.go
+++ b/upup/pkg/fi/nodeup/local/local_target.go
@@ -17,6 +17,7 @@ limitations under the License.
 package local
 
 import (
+	"context"
 	"os/exec"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -32,7 +33,7 @@ type LocalTarget struct {
 
 var _ fi.Target = &LocalTarget{}
 
-func (t *LocalTarget) Finish(taskMap map[string]fi.Task) error {
+func (t *LocalTarget) Finish(ctx context.Context, taskMap map[string]fi.Task) error {
 	return nil
 }
 

--- a/upup/pkg/fi/nodeup/nodetasks/file.go
+++ b/upup/pkg/fi/nodeup/nodetasks/file.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodetasks
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -195,6 +196,8 @@ func (s *File) CheckChanges(a, e, changes *File) error {
 }
 
 func (_ *File) RenderLocal(t *local.LocalTarget, a, e, changes *File) error {
+	ctx := context.TODO()
+
 	dirMode := os.FileMode(0o755)
 	fileMode, err := fi.ParseFileMode(fi.ValueOf(e.Mode), 0o644)
 	if err != nil {
@@ -236,7 +239,7 @@ func (_ *File) RenderLocal(t *local.LocalTarget, a, e, changes *File) error {
 		}
 	} else if e.Type == FileType_File {
 		if changes.Contents != nil {
-			err = fi.WriteFile(e.Path, e.Contents, fileMode, dirMode, fi.ValueOf(e.Owner), fi.ValueOf(e.Group))
+			err = fi.WriteFile(ctx, e.Path, e.Contents, fileMode, dirMode, fi.ValueOf(e.Owner), fi.ValueOf(e.Group))
 			if err != nil {
 				return fmt.Errorf("error copying file %q: %v", e.Path, err)
 			}
@@ -280,6 +283,8 @@ func (_ *File) RenderLocal(t *local.LocalTarget, a, e, changes *File) error {
 }
 
 func (_ *File) RenderCloudInit(t *cloudinit.CloudInitTarget, a, e, changes *File) error {
+	ctx := context.TODO()
+
 	dirMode := os.FileMode(0o755)
 	fileMode, err := fi.ParseFileMode(fi.ValueOf(e.Mode), 0o644)
 	if err != nil {
@@ -293,7 +298,7 @@ func (_ *File) RenderCloudInit(t *cloudinit.CloudInitTarget, a, e, changes *File
 		t.AddCommand(cloudinit.Once, "mkdir", "-p", "-m", fi.FileModeToString(dirMode), parent)
 		t.AddCommand(cloudinit.Once, "mkdir", "-m", fi.FileModeToString(dirMode), e.Path)
 	} else if e.Type == FileType_File {
-		err = t.WriteFile(e.Path, e.Contents, fileMode, dirMode)
+		err = t.WriteFile(ctx, e.Path, e.Contents, fileMode, dirMode)
 		if err != nil {
 			return err
 		}

--- a/upup/pkg/fi/nodeup/nodetasks/issue_cert.go
+++ b/upup/pkg/fi/nodeup/nodetasks/issue_cert.go
@@ -18,6 +18,7 @@ package nodetasks
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509/pkix"
 	"fmt"
 	"hash/fnv"
@@ -194,7 +195,7 @@ type asBytesResource struct {
 	hasAsBytes
 }
 
-func (a asBytesResource) Open() (io.Reader, error) {
+func (a asBytesResource) Open(ctx context.Context) (io.Reader, error) {
 	data, err := a.AsBytes()
 	if err != nil {
 		return nil, err

--- a/upup/pkg/fi/nodeup/nodetasks/kubeconfig.go
+++ b/upup/pkg/fi/nodeup/nodetasks/kubeconfig.go
@@ -72,16 +72,18 @@ func (k *KubeConfig) GetConfig() *fi.TaskDependentResource {
 	return k.config
 }
 
-func (k *KubeConfig) Run(_ *fi.Context) error {
-	cert, err := fi.ResourceAsBytes(k.Cert)
+func (k *KubeConfig) Run(c *fi.Context) error {
+	ctx := c.Context()
+
+	cert, err := fi.ResourceAsBytes(ctx, k.Cert)
 	if err != nil {
 		return err
 	}
-	key, err := fi.ResourceAsBytes(k.Key)
+	key, err := fi.ResourceAsBytes(ctx, k.Key)
 	if err != nil {
 		return err
 	}
-	ca, err := fi.ResourceAsBytes(k.CA)
+	ca, err := fi.ResourceAsBytes(ctx, k.CA)
 	if err != nil {
 		return err
 	}

--- a/upup/pkg/fi/nodeup/nodetasks/service.go
+++ b/upup/pkg/fi/nodeup/nodetasks/service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodetasks
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -262,6 +263,8 @@ func (s *Service) CheckChanges(a, e, changes *Service) error {
 }
 
 func (_ *Service) RenderLocal(t *local.LocalTarget, a, e, changes *Service) error {
+	ctx := context.TODO()
+
 	systemdSystemPath, err := e.systemdSystemPath()
 	if err != nil {
 		return err
@@ -281,7 +284,7 @@ func (_ *Service) RenderLocal(t *local.LocalTarget, a, e, changes *Service) erro
 
 	if changes.Definition != nil {
 		servicePath := path.Join(systemdSystemPath, serviceName)
-		err := fi.WriteFile(servicePath, fi.NewStringResource(*e.Definition), 0o644, 0o755, "", "")
+		err := fi.WriteFile(ctx, servicePath, fi.NewStringResource(*e.Definition), 0o644, 0o755, "", "")
 		if err != nil {
 			return fmt.Errorf("error writing systemd service file: %v", err)
 		}
@@ -378,6 +381,7 @@ func (_ *Service) RenderLocal(t *local.LocalTarget, a, e, changes *Service) erro
 }
 
 func (_ *Service) RenderCloudInit(t *cloudinit.CloudInitTarget, a, e, changes *Service) error {
+	ctx := context.TODO()
 	systemdSystemPath, err := e.systemdSystemPath()
 	if err != nil {
 		return err
@@ -386,7 +390,7 @@ func (_ *Service) RenderCloudInit(t *cloudinit.CloudInitTarget, a, e, changes *S
 	serviceName := e.Name
 
 	servicePath := path.Join(systemdSystemPath, serviceName)
-	err = t.WriteFile(servicePath, fi.NewStringResource(*e.Definition), 0o644, 0o755)
+	err = t.WriteFile(ctx, servicePath, fi.NewStringResource(*e.Definition), 0o644, 0o755)
 	if err != nil {
 		return err
 	}

--- a/upup/pkg/fi/target.go
+++ b/upup/pkg/fi/target.go
@@ -16,9 +16,11 @@ limitations under the License.
 
 package fi
 
+import "context"
+
 type Target interface {
 	// Lifecycle methods, called by the driver
-	Finish(taskMap map[string]Task) error
+	Finish(ctx context.Context, taskMap map[string]Task) error
 
 	// ProcessDeletions returns true if we should delete resources
 	// Some providers (e.g. Terraform) actively keep state, and will delete resources automatically

--- a/upup/pkg/fi/task.go
+++ b/upup/pkg/fi/task.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fi
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -71,8 +72,26 @@ type HasDeletions interface {
 
 // ModelBuilderContext is a context object that holds state we want to pass to ModelBuilder
 type ModelBuilderContext struct {
+	// ctx holds the go Context object.
+	// While the general advice is not to embed context objects, it is done where the lifecycles are aligned.
+	ctx context.Context
+
 	Tasks              map[string]Task
 	LifecycleOverrides map[string]Lifecycle
+}
+
+func (c *ModelBuilderContext) WithContext(ctx context.Context) *ModelBuilderContext {
+	c2 := *c
+	c2.ctx = ctx
+	return &c2
+}
+
+func (c *ModelBuilderContext) Context() context.Context {
+	ctx := c.ctx
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+	return ctx
 }
 
 func (c *ModelBuilderContext) AddTask(task Task) {

--- a/upup/pkg/fi/values.go
+++ b/upup/pkg/fi/values.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fi
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -73,7 +74,7 @@ func ArrayContains(array []string, word string) bool {
 	return false
 }
 
-func DebugPrint(o interface{}) string {
+func DebugPrint(ctx context.Context, o interface{}) string {
 	if o == nil {
 		return "<nil>"
 	}
@@ -83,7 +84,7 @@ func DebugPrint(o interface{}) string {
 			return "<nil>"
 		}
 
-		s, err := ResourceAsString(resource)
+		s, err := ResourceAsString(ctx, resource)
 		if err != nil {
 			return fmt.Sprintf("error converting resource to string: %v", err)
 		}

--- a/upup/pkg/fi/vfs_castore_test.go
+++ b/upup/pkg/fi/vfs_castore_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fi
 
 import (
+	"context"
 	"math/big"
 	"math/rand"
 	"strings"
@@ -46,9 +47,11 @@ func TestBigInt_Format(t *testing.T) {
 }
 
 func TestVFSCAStoreRoundTrip(t *testing.T) {
-	vfs.Context.ResetMemfsContext(true)
+	ctx := context.TODO()
 
-	basePath, err := vfs.Context.BuildVfsPath("memfs://tests")
+	vfs.FromContext(ctx).ResetMemfsContext(true)
+
+	basePath, err := vfs.FromContext(ctx).BuildVfsPath("memfs://tests")
 	if err != nil {
 		t.Fatalf("error building vfspath: %v", err)
 	}

--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -52,9 +52,29 @@ type VFSContext struct {
 	azureClient *azureClient
 }
 
+// Context holds the global VFS state.
+// Deprecated: prefer FromContext.
 var Context = VFSContext{
 	s3Context:  NewS3Context(),
 	k8sContext: NewKubernetesContext(),
+}
+
+type contextKeyType int
+
+var contextKey contextKeyType
+
+// FromContext returns the vfs Context from the given context.Context.
+func FromContext(ctx context.Context) *VFSContext {
+	o := ctx.Value(contextKey)
+	if o != nil {
+		return o.(*VFSContext)
+	}
+	return &Context
+}
+
+// WithContext returns a context.Context with the given VFS context added.
+func WithContext(parent context.Context, vfsContext *VFSContext) context.Context {
+	return context.WithValue(parent, contextKey, vfsContext)
 }
 
 type vfsOptions struct {

--- a/util/pkg/vfs/tests/gsfs_test.go
+++ b/util/pkg/vfs/tests/gsfs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tests
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -33,6 +34,8 @@ import (
 var credsFile = "./mock_gcp_credentials.json"
 
 func TestGSRenderTerraform(t *testing.T) {
+	ctx := context.TODO()
+
 	creds, err := filepath.Abs(credsFile)
 	if err != nil {
 		t.Fatalf("failed to prepare mock gcp credentials: %v", err)
@@ -76,7 +79,7 @@ func TestGSRenderTerraform(t *testing.T) {
 
 		t.Run(tc.gsPath, func(t *testing.T) {
 			cloud := gce.InstallMockGCECloud("us-central1", "project")
-			path, err := vfs.Context.BuildVfsPath(tc.gsPath)
+			path, err := vfs.FromContext(ctx).BuildVfsPath(tc.gsPath)
 			if err != nil {
 				t.Fatalf("error building VFS path: %v", err)
 			}

--- a/util/pkg/vfs/tests/s3fs_test.go
+++ b/util/pkg/vfs/tests/s3fs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tests
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -57,8 +58,10 @@ func TestS3RenderTerraform(t *testing.T) {
 	for _, tc := range grid {
 
 		t.Run(tc.s3Path, func(t *testing.T) {
+			ctx := context.TODO()
+
 			cloud := awsup.BuildMockAWSCloud("us-east-1", "a")
-			path, err := vfs.Context.BuildVfsPath(tc.s3Path)
+			path, err := vfs.FromContext(ctx).BuildVfsPath(tc.s3Path)
 			if err != nil {
 				t.Fatalf("error building VFS path: %v", err)
 			}


### PR DESCRIPTION
This is to add context to all callsites for vfs.Context

Note: I don't think we should do this yet ... I think at the least we need to:
1) figure out how to get a context in the RenderAWS / RenderTerraform / etc methods.
2) do something better for tests, like maybe `ContextForTest` that puts the testing.T into the context, maybe in future sets up a logger that goes to the test output.  That could be quite handy, but this is more of a nice-to-have that would be nice to introduce at the same time.
