### PR TITLE
Load etcd binaries dynamically from container images

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -180,7 +180,7 @@ metadata:
 spec:
   containers:
   - name: etcd-manager
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     resources:
       requests:
         cpu: 100m

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
@@ -195,6 +196,8 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
   hostNetwork: true
   hostPID: true # helps with mounting volumes from inside a container
   volumes:
@@ -210,6 +213,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager
       type: DirectoryOrCreate
     name: pki
+  - name: bin
+    emptyDir: {}
 `
 
 // buildPod creates the pod spec, based on the EtcdClusterSpec
@@ -236,7 +241,45 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 		} else {
 			pod = podObject
 		}
+	}
 
+	{
+		for _, etcdVersion := range etcdSupportedVersions() {
+			initContainer := v1.Container{
+				Name:    "init-etcd-" + strings.ReplaceAll(etcdVersion, ".", "-"),
+				Image:   etcdSupportedImages[etcdVersion],
+				Command: []string{"/bin/sh"},
+				Args: []string{
+					"-c",
+				},
+				VolumeMounts: []v1.VolumeMount{
+					{
+						MountPath: "/opt",
+						Name:      "bin",
+					},
+				},
+			}
+			// Add the command for copying the etcd binaries
+			var command string
+			if semver.MustParse(etcdVersion).GE(semver.MustParse("3.4.13")) {
+				// Newer images bundle a custom go based `cp` utility that recursively creates the necessary dirs
+				// https://github.com/kubernetes/kubernetes/pull/91171
+				command = "cp /usr/local/bin/etcd /opt/etcd-v" + etcdVersion + "/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v" + etcdVersion + "/etcdctl"
+			} else {
+				command = "mkdir -p /opt/etcd-v" + etcdVersion + "/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl /opt/etcd-v" + etcdVersion + "/"
+			}
+			initContainer.Args = append(initContainer.Args, command)
+			// Remap image via AssetBuilder
+			remapped, err := b.AssetBuilder.RemapImage(initContainer.Image)
+			if err != nil {
+				return nil, fmt.Errorf("unable to remap container image %q: %w", initContainer.Image, err)
+			}
+			initContainer.Image = remapped
+			pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
+		}
+	}
+
+	{
 		if len(pod.Spec.Containers) != 1 {
 			return nil, fmt.Errorf("expected exactly one container in etcd-manager Pod, found %d", len(pod.Spec.Containers))
 		}
@@ -246,13 +289,11 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 			klog.Warningf("overloading image in manifest %s with images %s", bundle, etcdCluster.Manager.Image)
 			container.Image = etcdCluster.Manager.Image
 		}
-	}
 
-	// Remap image via AssetBuilder
-	{
+		// Remap image via AssetBuilder
 		remapped, err := b.AssetBuilder.RemapImage(container.Image)
 		if err != nil {
-			return nil, fmt.Errorf("unable to remap container image %q: %v", container.Image, err)
+			return nil, fmt.Errorf("unable to remap container image %q: %w", container.Image, err)
 		}
 		container.Image = remapped
 	}

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -18,6 +18,7 @@ package etcdmanager
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -53,8 +54,10 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 			if featureflag.SkipEtcdVersionCheck.Enabled() {
 				klog.Warningf("etcd version %q is not known to be supported, but ignoring because of SkipEtcdVersionCheck feature flag", etcdCluster.Version)
 			} else {
-				klog.Warningf("unsupported etcd version %q detected; please update etcd version.  Use export KOPS_FEATURE_FLAGS=SkipEtcdVersionCheck to override this check", etcdCluster.Version)
-				return fmt.Errorf("etcd version %q is not supported with etcd-manager, please specify a supported version or remove the value to use the default version.  Supported versions: %s", etcdCluster.Version, strings.Join(supportedEtcdVersions, ", "))
+				klog.Warningf("Unsupported etcd version %q detected; please update etcd version.", etcdCluster.Version)
+				klog.Warningf("Use export KOPS_FEATURE_FLAGS=SkipEtcdVersionCheck to override this check.")
+				klog.Warningf("Supported etcd versions: %s", strings.Join(etcdSupportedVersions(), ", "))
+				return fmt.Errorf("etcd version %q is not supported with etcd-manager, please specify a supported version or remove the value to use the recommended version", etcdCluster.Version)
 			}
 		}
 	}
@@ -62,14 +65,32 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 	return nil
 }
 
-var supportedEtcdVersions = []string{"3.1.12", "3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.3.17", "3.4.3", "3.4.13", "3.5.0", "3.5.1", "3.5.3", "3.5.4", "3.5.6"}
+var etcdSupportedImages = map[string]string{
+	"3.2.24": "registry.k8s.io/etcd:3.2.24-1",
+	"3.3.10": "registry.k8s.io/etcd:3.3.10-0",
+	"3.3.17": "registry.k8s.io/etcd:3.3.17-0",
+	"3.4.3":  "registry.k8s.io/etcd:3.4.3-0",
+	"3.4.13": "registry.k8s.io/etcd:3.4.13-0",
+	"3.5.0":  "registry.k8s.io/etcd:3.5.0-0",
+	"3.5.1":  "registry.k8s.io/etcd:3.5.1-0",
+	"3.5.3":  "registry.k8s.io/etcd:3.5.3-0",
+	"3.5.4":  "registry.k8s.io/etcd:3.5.4-0",
+	"3.5.6":  "registry.k8s.io/etcd:3.5.6-0",
+}
+
+func etcdSupportedVersions() []string {
+	var versions []string
+	for etcdVersion := range etcdSupportedImages {
+		versions = append(versions, etcdVersion)
+	}
+	sort.Strings(versions)
+	return versions
+}
 
 func etcdVersionIsSupported(version string) bool {
 	version = strings.TrimPrefix(version, "v")
-	for _, v := range supportedEtcdVersions {
-		if v == version {
-			return true
-		}
+	if _, ok := etcdSupportedImages[version]; ok {
+		return true
 	}
 	return false
 }

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -101,10 +101,127 @@ Contents: |
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
+      - mountPath: /opt
+        name: bin
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
     hostPID: true
+    initContainers:
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.2.24/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.2.24-1
+      name: init-etcd-3-2-24
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.10/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.17/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.17-0
+      name: init-etcd-3-3-17
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.13-0
+      name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.4.3/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
     priorityClassName: system-cluster-critical
     tolerations:
     - key: CriticalAddonsOnly
@@ -122,6 +239,8 @@ Contents: |
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
       name: pki
+    - emptyDir: {}
+      name: bin
     - hostPath:
         path: /var/log/etcd-events.log
         type: FileOrCreate
@@ -170,10 +289,127 @@ Contents: |
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
+      - mountPath: /opt
+        name: bin
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
     hostPID: true
+    initContainers:
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.2.24/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.2.24-1
+      name: init-etcd-3-2-24
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.10/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.17/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.17-0
+      name: init-etcd-3-3-17
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.13-0
+      name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.4.3/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
     priorityClassName: system-cluster-critical
     tolerations:
     - key: CriticalAddonsOnly
@@ -191,6 +427,8 @@ Contents: |
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate
       name: pki
+    - emptyDir: {}
+      name: bin
     - hostPath:
         path: /var/log/etcd.log
         type: FileOrCreate

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -86,7 +86,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
         --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
       name: etcd-manager
       resources:
         requests:
@@ -274,7 +274,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
         --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -85,7 +85,7 @@ Contents: |
         --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
         --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
       name: etcd-manager
       resources:
         requests:
@@ -272,7 +272,7 @@ Contents: |
         --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
         --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -100,10 +100,127 @@ Contents: |
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
+      - mountPath: /opt
+        name: bin
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
     hostPID: true
+    initContainers:
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.2.24/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.2.24-1
+      name: init-etcd-3-2-24
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.10/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.17/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.17-0
+      name: init-etcd-3-3-17
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.13-0
+      name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.4.3/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
     priorityClassName: system-cluster-critical
     tolerations:
     - key: CriticalAddonsOnly
@@ -121,6 +238,8 @@ Contents: |
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
       name: pki
+    - emptyDir: {}
+      name: bin
     - hostPath:
         path: /var/log/etcd-events.log
         type: FileOrCreate
@@ -168,10 +287,127 @@ Contents: |
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
+      - mountPath: /opt
+        name: bin
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
     hostPID: true
+    initContainers:
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.2.24/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.2.24-1
+      name: init-etcd-3-2-24
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.10/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.17/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.17-0
+      name: init-etcd-3-3-17
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.13-0
+      name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.4.3/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
     priorityClassName: system-cluster-critical
     tolerations:
     - key: CriticalAddonsOnly
@@ -189,6 +425,8 @@ Contents: |
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate
       name: pki
+    - emptyDir: {}
+      name: bin
     - hostPath:
         path: /var/log/etcd.log
         type: FileOrCreate

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -88,7 +88,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
       name: etcd-manager
       resources:
         requests:
@@ -278,7 +278,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -103,10 +103,127 @@ Contents: |
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
+      - mountPath: /opt
+        name: bin
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
     hostPID: true
+    initContainers:
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.2.24/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.2.24-1
+      name: init-etcd-3-2-24
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.10/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.17/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.17-0
+      name: init-etcd-3-3-17
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.13-0
+      name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.4.3/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
     priorityClassName: system-cluster-critical
     tolerations:
     - key: CriticalAddonsOnly
@@ -124,6 +241,8 @@ Contents: |
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
       name: pki
+    - emptyDir: {}
+      name: bin
     - hostPath:
         path: /var/log/etcd-events.log
         type: FileOrCreate
@@ -174,10 +293,127 @@ Contents: |
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
+      - mountPath: /opt
+        name: bin
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
     hostPID: true
+    initContainers:
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.2.24/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.2.24-1
+      name: init-etcd-3-2-24
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.10/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.17/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.17-0
+      name: init-etcd-3-3-17
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.13-0
+      name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.4.3/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
     priorityClassName: system-cluster-critical
     tolerations:
     - key: CriticalAddonsOnly
@@ -195,6 +431,8 @@ Contents: |
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate
       name: pki
+    - emptyDir: {}
+      name: bin
     - hostPath:
         path: /var/log/etcd.log
         type: FileOrCreate

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -109,10 +109,127 @@ Contents: |
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
+      - mountPath: /opt
+        name: bin
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
     hostPID: true
+    initContainers:
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.2.24/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.2.24-1
+      name: init-etcd-3-2-24
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.10/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.17/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.17-0
+      name: init-etcd-3-3-17
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.13-0
+      name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.4.3/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
     priorityClassName: system-cluster-critical
     tolerations:
     - key: CriticalAddonsOnly
@@ -130,6 +247,8 @@ Contents: |
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
       name: pki
+    - emptyDir: {}
+      name: bin
     - hostPath:
         path: /var/log/etcd-events.log
         type: FileOrCreate
@@ -186,10 +305,127 @@ Contents: |
         name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
+      - mountPath: /opt
+        name: bin
       - mountPath: /var/log/etcd.log
         name: varlogetcd
     hostNetwork: true
     hostPID: true
+    initContainers:
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.2.24/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.2.24-1
+      name: init-etcd-3-2-24
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.10/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.3.17/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.3.17-0
+      name: init-etcd-3-3-17
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.13-0
+      name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+        /opt/etcd-v3.4.3/
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
+    - args:
+      - -c
+      - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+      command:
+      - /bin/sh
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: bin
     priorityClassName: system-cluster-critical
     tolerations:
     - key: CriticalAddonsOnly
@@ -207,6 +443,8 @@ Contents: |
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate
       name: pki
+    - emptyDir: {}
+      name: bin
     - hostPath:
         path: /var/log/etcd.log
         type: FileOrCreate

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -94,7 +94,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
       name: etcd-manager
       resources:
         requests:
@@ -290,7 +290,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
       name: etcd-manager
       resources:
         requests:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -36,10 +36,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -57,6 +174,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -36,10 +36,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -57,6 +174,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/cas-priority-expander-custom.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned >
       /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/cas-priority-expander.example.com=owned >
       /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/docker.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/docker.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -39,10 +39,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -60,6 +177,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.long.cluster-name.minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.long.cluster-name.minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-private-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-private-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: HCLOUD_TOKEN
       value: REDACTED
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -36,10 +36,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -57,6 +174,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -36,10 +36,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -57,6 +174,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: HCLOUD_TOKEN
       value: REDACTED
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/nthimdsprocessor.longclustername.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
       /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
       /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatecanal.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatecanal.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-cilium
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-cilium.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/cilium --volume-provider=aws --volume-tag=k8s.io/etcd/cilium
       --volume-tag=k8s.io/role/control-plane=1 --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
       /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
       /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privateweave.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/privateweave.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -34,10 +34,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -55,6 +172,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-events
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd-events.log
       type: FileOrCreate

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230119-slim
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -33,10 +33,127 @@ spec:
       name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
+    - mountPath: /opt
+      name: bin
     - mountPath: /var/log/etcd.log
       name: varlogetcd
   hostNetwork: true
   hostPID: true
+  initContainers:
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.2.24/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.2.24/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.2.24-1
+    name: init-etcd-3-2-24
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.10/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.10/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.3.17/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.3.17/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.3.17-0
+    name: init-etcd-3-3-17
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.4.13/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.4.13/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.13-0
+    name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - mkdir -p /opt/etcd-v3.4.3/ && cp /usr/local/bin/etcd /usr/local/bin/etcdctl
+      /opt/etcd-v3.4.3/
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.0/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.0/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.1/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.1/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.3/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.3/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.4/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.4/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
+  - args:
+    - -c
+    - cp /usr/local/bin/etcd /opt/etcd-v3.5.6/etcd && cp /usr/local/bin/etcdctl /opt/etcd-v3.5.6/etcdctl
+    command:
+    - /bin/sh
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: bin
   priorityClassName: system-cluster-critical
   tolerations:
   - key: CriticalAddonsOnly
@@ -54,6 +171,8 @@ spec:
       path: /etc/kubernetes/pki/etcd-manager-main
       type: DirectoryOrCreate
     name: pki
+  - emptyDir: {}
+    name: bin
   - hostPath:
       path: /var/log/etcd.log
       type: FileOrCreate

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/cluster.yaml
@@ -15,12 +15,12 @@ spec:
   - etcdMembers:
     - instanceGroup: master-us-test-1a
       name: master-us-test-1a
-    version: 3.1.12
+    version: 3.5.6
     name: main
   - etcdMembers:
     - instanceGroup: master-us-test-1a
       name: master-us-test-1a
-    version: 3.1.12
+    version: 3.5.6
     name: events
   iam: {}
   kubernetesVersion: 1.22.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/cluster.yaml
@@ -15,12 +15,12 @@ spec:
   - etcdMembers:
     - instanceGroup: master-us-test-1a
       name: master-us-test-1a
-    version: 3.1.12
+    version: 3.5.6
     name: main
   - etcdMembers:
     - instanceGroup: master-us-test-1a
       name: master-us-test-1a
-    version: 3.1.12
+    version: 3.5.6
     name: events
   iam: {}
   kubernetesVersion: 1.22.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/cluster.yaml
@@ -17,12 +17,12 @@ spec:
   - etcdMembers:
     - instanceGroup: master-us-test-1a
       name: master-us-test-1a
-    version: 3.1.12
+    version: 3.5.6
     name: main
   - etcdMembers:
     - instanceGroup: master-us-test-1a
       name: master-us-test-1a
-    version: 3.1.12
+    version: 3.5.6
     name: events
   iam: {}
   kubernetesVersion: 1.22.0


### PR DESCRIPTION
Based on the idea discussed during office hours about using init containers to populate the required `etcd` binaries, instead of having them bundled with the `etcd-manager` images. 

This could also easily be extended to use any version specified by the user.

/cc @justinsb @johngmyers