### PR TITLE
NTH: Remove unnecessary configuration in Queue Processor mode

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: bbecd97aee6cebe83a7f0910215d2bb43fb1243020c65ffa6427938c14b6f90b
+    manifestHash: 76165f5029c21038f9470db4def5a1aeef4cf378ef88693c353c941ddf0f6f84
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -189,14 +189,6 @@ spec:
           value: "true"
         - name: COMPLETE_LIFECYCLE_ACTION_DELAY_SECONDS
           value: "-1"
-        - name: ENABLE_SPOT_INTERRUPTION_DRAINING
-          value: "true"
-        - name: ENABLE_SCHEDULED_EVENT_DRAINING
-          value: "true"
-        - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
-        - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 48ffe0ff97ba1c0769c5ba1ad34e3bffc6b1b944f4d6b63a6ba1fd23cd229ebd
+    manifestHash: c2bf3ef23db2c89345ffbd50db5a0b02610eb224346a27b091cb4e1220ff89cb
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -189,14 +189,6 @@ spec:
           value: "true"
         - name: COMPLETE_LIFECYCLE_ACTION_DELAY_SECONDS
           value: "-1"
-        - name: ENABLE_SPOT_INTERRUPTION_DRAINING
-          value: "true"
-        - name: ENABLE_SCHEDULED_EVENT_DRAINING
-          value: "true"
-        - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
-        - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 48ffe0ff97ba1c0769c5ba1ad34e3bffc6b1b944f4d6b63a6ba1fd23cd229ebd
+    manifestHash: c2bf3ef23db2c89345ffbd50db5a0b02610eb224346a27b091cb4e1220ff89cb
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -189,14 +189,6 @@ spec:
           value: "true"
         - name: COMPLETE_LIFECYCLE_ACTION_DELAY_SECONDS
           value: "-1"
-        - name: ENABLE_SPOT_INTERRUPTION_DRAINING
-          value: "true"
-        - name: ENABLE_SCHEDULED_EVENT_DRAINING
-          value: "true"
-        - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
-        - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 48ffe0ff97ba1c0769c5ba1ad34e3bffc6b1b944f4d6b63a6ba1fd23cd229ebd
+    manifestHash: c2bf3ef23db2c89345ffbd50db5a0b02610eb224346a27b091cb4e1220ff89cb
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -189,14 +189,6 @@ spec:
           value: "true"
         - name: COMPLETE_LIFECYCLE_ACTION_DELAY_SECONDS
           value: "-1"
-        - name: ENABLE_SPOT_INTERRUPTION_DRAINING
-          value: "true"
-        - name: ENABLE_SCHEDULED_EVENT_DRAINING
-          value: "true"
-        - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
-        - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 48ffe0ff97ba1c0769c5ba1ad34e3bffc6b1b944f4d6b63a6ba1fd23cd229ebd
+    manifestHash: c2bf3ef23db2c89345ffbd50db5a0b02610eb224346a27b091cb4e1220ff89cb
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -189,14 +189,6 @@ spec:
           value: "true"
         - name: COMPLETE_LIFECYCLE_ACTION_DELAY_SECONDS
           value: "-1"
-        - name: ENABLE_SPOT_INTERRUPTION_DRAINING
-          value: "true"
-        - name: ENABLE_SCHEDULED_EVENT_DRAINING
-          value: "true"
-        - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
-        - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 7cd05c5a73220c7db013f0c2e6322b23c989affed13804a221e98b82c11a60c6
+    manifestHash: 8680e60478dc97128d24a22cfcdbafd280b0c32f59e5d9d59d3c688a7202d612
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -199,14 +199,6 @@ spec:
           value: "true"
         - name: COMPLETE_LIFECYCLE_ACTION_DELAY_SECONDS
           value: "-1"
-        - name: ENABLE_SPOT_INTERRUPTION_DRAINING
-          value: "true"
-        - name: ENABLE_SCHEDULED_EVENT_DRAINING
-          value: "true"
-        - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
-        - name: ENABLE_REBALANCE_DRAINING
-          value: "true"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 031dd270cecb6247a363cebba3efb61ebb940315373f929a9ba2aee8e249ddfd
+    manifestHash: 8680e60478dc97128d24a22cfcdbafd280b0c32f59e5d9d59d3c688a7202d612
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -199,14 +199,6 @@ spec:
           value: "true"
         - name: COMPLETE_LIFECYCLE_ACTION_DELAY_SECONDS
           value: "-1"
-        - name: ENABLE_SPOT_INTERRUPTION_DRAINING
-          value: "true"
-        - name: ENABLE_SCHEDULED_EVENT_DRAINING
-          value: "true"
-        - name: ENABLE_REBALANCE_MONITORING
-          value: "false"
-        - name: ENABLE_REBALANCE_DRAINING
-          value: "false"
         - name: ENABLE_SQS_TERMINATION_DRAINING
           value: "true"
         - name: QUEUE_URL

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -206,14 +206,6 @@ spec:
               value: "true"
             - name: COMPLETE_LIFECYCLE_ACTION_DELAY_SECONDS
               value: "-1"
-            - name: ENABLE_SPOT_INTERRUPTION_DRAINING
-              value: "{{ WithDefaultBool .EnableSpotInterruptionDraining true }}"
-            - name: ENABLE_SCHEDULED_EVENT_DRAINING
-              value: "{{ WithDefaultBool .EnableScheduledEventDraining true }}"
-            - name: ENABLE_REBALANCE_MONITORING
-              value: "{{ WithDefaultBool .EnableRebalanceMonitoring false }}"
-            - name: ENABLE_REBALANCE_DRAINING
-              value: "{{ WithDefaultBool .EnableRebalanceDraining false }}"
             - name: ENABLE_SQS_TERMINATION_DRAINING
               value: "true"
             - name: QUEUE_URL


### PR DESCRIPTION
Remove configuration settings that don't affect Queue Processor mode (modulo bugs) from the Deployment template, so that they don't act as red herrings.

Works around aws/node-termination-handler#735 and aws/node-termination-handler#743.

Corresponds to aws/node-termination-handler#745.