### PR TITLE
Base OpenStack API resources on cluster name if public name is not set

### DIFF
--- a/pkg/model/openstackmodel/context.go
+++ b/pkg/model/openstackmodel/context.go
@@ -73,6 +73,13 @@ func (c *OpenstackModelContext) GetNetworkName() (string, error) {
 	return network.Name, nil
 }
 
+func (c *OpenstackModelContext) APIResourceName() string {
+	if c.Cluster.Spec.API.PublicName != "" {
+		return c.Cluster.Spec.API.PublicName
+	}
+	return "api." + c.ClusterName()
+}
+
 func (c *OpenstackModelContext) findSubnetClusterSpec(subnet string) (string, error) {
 	for _, sp := range c.Cluster.Spec.Networking.Subnets {
 		if sp.Name == subnet {

--- a/pkg/model/openstackmodel/firewall.go
+++ b/pkg/model/openstackmodel/firewall.go
@@ -233,7 +233,7 @@ func (b *FirewallModelBuilder) addNodePortRules(c *fi.ModelBuilderContext, sgMap
 func (b *FirewallModelBuilder) addHTTPSRules(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup, useVIPACL bool) error {
 	masterName := b.SecurityGroupName(kops.InstanceGroupRoleControlPlane)
 	nodeName := b.SecurityGroupName(kops.InstanceGroupRoleNode)
-	lbSGName := b.Cluster.Spec.API.PublicName
+	lbSGName := b.APIResourceName()
 	lbSG := sgMap[lbSGName]
 	masterSG := sgMap[masterName]
 	nodeSG := sgMap[nodeName]
@@ -579,7 +579,7 @@ func (b *FirewallModelBuilder) getExistingRules(sgMap map[string]*openstacktasks
 
 func (b *FirewallModelBuilder) addDefaultEgress(c *fi.ModelBuilderContext, sgMap map[string]*openstacktasks.SecurityGroup, useVIPACL bool) {
 	for name, sg := range sgMap {
-		if useVIPACL && name == b.Cluster.Spec.API.PublicName {
+		if useVIPACL && name == b.APIResourceName() {
 			continue
 		}
 		t := &openstacktasks.SecurityGroupRule{
@@ -616,7 +616,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		useVIPACL = true
 	}
 	sg := &openstacktasks.SecurityGroup{
-		Name:             s(b.Cluster.Spec.API.PublicName),
+		Name:             s(b.APIResourceName()),
 		Lifecycle:        b.Lifecycle,
 		RemoveExtraRules: []string{"port=443"},
 	}
@@ -624,7 +624,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		sg.RemoveGroup = true
 	}
 	c.AddTask(sg)
-	sgMap[b.Cluster.Spec.API.PublicName] = sg
+	sgMap[b.APIResourceName()] = sg
 	for _, role := range roles {
 
 		// Create Security Group for Role

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -106,7 +106,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 	securityGroups = append(securityGroups, b.LinkToSecurityGroup(securityGroupName))
 
 	if b.Cluster.Spec.CloudProvider.Openstack.Loadbalancer == nil && ig.Spec.Role == kops.InstanceGroupRoleControlPlane {
-		securityGroups = append(securityGroups, b.LinkToSecurityGroup(b.Cluster.Spec.API.PublicName))
+		securityGroups = append(securityGroups, b.LinkToSecurityGroup(b.APIResourceName()))
 	}
 
 	r := strings.NewReplacer("_", "-", ".", "-")
@@ -285,14 +285,14 @@ func (b *ServerGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			return fmt.Errorf("could not find subnet for Kubernetes API loadbalancer")
 		}
 		lbTask := &openstacktasks.LB{
-			Name:      fi.PtrTo(b.Cluster.Spec.API.PublicName),
+			Name:      fi.PtrTo(b.APIResourceName()),
 			Subnet:    fi.PtrTo(lbSubnetName),
 			Lifecycle: b.Lifecycle,
 		}
 
 		useVIPACL := b.UseVIPACL()
 		if !useVIPACL {
-			lbTask.SecurityGroup = b.LinkToSecurityGroup(b.Cluster.Spec.API.PublicName)
+			lbTask.SecurityGroup = b.LinkToSecurityGroup(b.APIResourceName())
 		}
 
 		c.AddTask(lbTask)

--- a/tests/integration/update_cluster/minimal_openstack/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal_openstack/in-v1alpha2.yaml
@@ -30,7 +30,6 @@ spec:
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: v1.21.0
-  masterPublicName: api.minimal-openstack.k8s.local
   networking:
     cni: {}
   networkCIDR: 192.168.0.0/16


### PR DESCRIPTION
We no longer expect the API's public name being set for gossip clusters as they don't really make sense. This fixes some incorrect assumptions in the OpenStack models.

Should get us one step further with #14546