### PR TITLE
Context injection: Add to Render methods

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -100,6 +100,8 @@ type AutoscalingGroup struct {
 	CapacityRebalance *bool
 }
 
+var _ awsup.AWSTask[AutoscalingGroup] = &AutoscalingGroup{}
+
 var _ fi.CompareWithID = &AutoscalingGroup{}
 var _ fi.CloudupTaskNormalize = &AutoscalingGroup{}
 

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -340,7 +340,7 @@ func (e *AutoscalingGroup) CheckChanges(a, ex, changes *AutoscalingGroup) error 
 }
 
 // RenderAWS is responsible for building the autoscaling group via AWS API
-func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *AutoscalingGroup) error {
+func (v *AutoscalingGroup) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *AutoscalingGroup) error {
 	// @step: did we find an autoscaling group?
 	if a == nil {
 		klog.V(2).Infof("Creating autoscaling group with name: %s", fi.ValueOf(e.Name))
@@ -949,7 +949,7 @@ type terraformAutoscalingGroup struct {
 }
 
 // RenderTerraform is responsible for rendering the terraform codebase
-func (_ *AutoscalingGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *AutoscalingGroup) error {
+func (_ *AutoscalingGroup) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *AutoscalingGroup) error {
 	tf := &terraformAutoscalingGroup{
 		Name:                e.Name,
 		MinSize:             e.MinSize,

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/kops/pkg/diff"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -199,6 +200,8 @@ func TestProcessCompare(t *testing.T) {
 }
 
 func TestAutoscalingGroupTerraformRender(t *testing.T) {
+	ctx := testcontext.ForTest(t)
+
 	cases := []*renderTest{
 		{
 			Resource: &AutoscalingGroup{
@@ -335,7 +338,7 @@ terraform {
 		},
 	}
 
-	doRenderTests(t, "RenderTerraform", cases)
+	doRenderTests(ctx, t, "RenderTerraform", cases)
 }
 
 func TestTGsARNsChunks(t *testing.T) {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
@@ -108,7 +108,7 @@ func (_ *AutoscalingLifecycleHook) CheckChanges(a, e, changes *AutoscalingLifecy
 	return nil
 }
 
-func (*AutoscalingLifecycleHook) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *AutoscalingLifecycleHook) error {
+func (*AutoscalingLifecycleHook) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *AutoscalingLifecycleHook) error {
 	if changes != nil {
 		if fi.ValueOf(e.Enabled) {
 			request := &autoscaling.PutLifecycleHookInput{
@@ -145,7 +145,7 @@ type terraformASGLifecycleHook struct {
 	LifecycleTransition  *string                  `cty:"lifecycle_transition"`
 }
 
-func (_ *AutoscalingLifecycleHook) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *AutoscalingLifecycleHook) error {
+func (_ *AutoscalingLifecycleHook) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *AutoscalingLifecycleHook) error {
 	if !fi.ValueOf(e.Enabled) {
 		return nil
 	}

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
@@ -46,6 +46,8 @@ type AutoscalingLifecycleHook struct {
 	Enabled *bool
 }
 
+var _ awsup.AWSTask[AutoscalingLifecycleHook] = &AutoscalingLifecycleHook{}
+
 var _ fi.CompareWithID = &AutoscalingLifecycleHook{}
 
 func (h *AutoscalingLifecycleHook) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
@@ -74,6 +74,8 @@ type ClassicLoadBalancer struct {
 	Shared *bool
 }
 
+var _ awsup.AWSTask[ClassicLoadBalancer] = &ClassicLoadBalancer{}
+
 var _ fi.CompareWithID = &ClassicLoadBalancer{}
 var _ fi.CloudupTaskNormalize = &ClassicLoadBalancer{}
 

--- a/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
@@ -423,7 +423,7 @@ func (s *ClassicLoadBalancer) CheckChanges(a, e, changes *ClassicLoadBalancer) e
 	return nil
 }
 
-func (_ *ClassicLoadBalancer) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *ClassicLoadBalancer) error {
+func (_ *ClassicLoadBalancer) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *ClassicLoadBalancer) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		return nil
@@ -646,7 +646,7 @@ type terraformLoadBalancerHealthCheck struct {
 	Timeout            *int64  `cty:"timeout"`
 }
 
-func (_ *ClassicLoadBalancer) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ClassicLoadBalancer) error {
+func (_ *ClassicLoadBalancer) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *ClassicLoadBalancer) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		return nil

--- a/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
@@ -45,6 +45,8 @@ type DHCPOptions struct {
 	Tags map[string]string
 }
 
+var _ awsup.AWSTask[DHCPOptions] = &DHCPOptions{}
+
 var _ fi.CompareWithID = &DHCPOptions{}
 
 func (e *DHCPOptions) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
@@ -136,7 +136,7 @@ func (s *DHCPOptions) CheckChanges(a, e, changes *DHCPOptions) error {
 	return nil
 }
 
-func (_ *DHCPOptions) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *DHCPOptions) error {
+func (_ *DHCPOptions) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *DHCPOptions) error {
 	if a == nil {
 		klog.V(2).Infof("Creating DHCPOptions with Name:%q", *e.Name)
 
@@ -175,7 +175,7 @@ type terraformDHCPOptions struct {
 	Tags              map[string]string `cty:"tags"`
 }
 
-func (_ *DHCPOptions) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *DHCPOptions) error {
+func (_ *DHCPOptions) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *DHCPOptions) error {
 	tf := &terraformDHCPOptions{
 		DomainName: e.DomainName,
 		Tags:       e.Tags,

--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -42,6 +42,8 @@ type DNSName struct {
 	TargetLoadBalancer DNSTarget
 }
 
+var _ awsup.AWSTask[DNSName] = &DNSName{}
+
 type DNSTarget interface {
 	fi.CloudupTask
 	getDNSName() *string

--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -209,7 +209,7 @@ func (s *DNSName) CheckChanges(a, e, changes *DNSName) error {
 	return nil
 }
 
-func (_ *DNSName) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *DNSName) error {
+func (_ *DNSName) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *DNSName) error {
 	rrs := &route53.ResourceRecordSet{
 		Name: e.ResourceName,
 		Type: e.ResourceType,
@@ -264,7 +264,7 @@ type terraformAlias struct {
 	EvaluateTargetHealth *bool                    `cty:"evaluate_target_health"`
 }
 
-func (_ *DNSName) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *DNSName) error {
+func (_ *DNSName) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *DNSName) error {
 	tf := &terraformRoute53Record{
 		Name:   e.ResourceName,
 		ZoneID: e.Zone.TerraformLink(),

--- a/upup/pkg/fi/cloudup/awstasks/dnszone.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnszone.go
@@ -45,6 +45,8 @@ type DNSZone struct {
 	PrivateVPC *VPC
 }
 
+var _ awsup.AWSTask[DNSZone] = &DNSZone{}
+
 var _ fi.CompareWithID = &DNSZone{}
 
 func (e *DNSZone) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/dnszone.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnszone.go
@@ -171,7 +171,7 @@ func (s *DNSZone) CheckChanges(a, e, changes *DNSZone) error {
 	return nil
 }
 
-func (_ *DNSZone) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *DNSZone) error {
+func (_ *DNSZone) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *DNSZone) error {
 	name := aws.StringValue(e.DNSName)
 	if a == nil {
 		request := &route53.CreateHostedZoneInput{}
@@ -230,7 +230,7 @@ type terraformRoute53ZoneAssociation struct {
 	Lifecycle *terraform.Lifecycle     `cty:"lifecycle"`
 }
 
-func (_ *DNSZone) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *DNSZone) error {
+func (_ *DNSZone) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *DNSZone) error {
 	cloud := t.Cloud.(awsup.AWSCloud)
 
 	dnsName := fi.ValueOf(e.DNSName)

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
@@ -45,6 +45,8 @@ type EBSVolume struct {
 	VolumeType       *string
 }
 
+var _ awsup.AWSTask[EBSVolume] = &EBSVolume{}
+
 var _ fi.CompareWithID = &EBSVolume{}
 var _ fi.CloudupTaskNormalize = &EBSVolume{}
 

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
@@ -128,7 +128,7 @@ func (_ *EBSVolume) CheckChanges(a, e, changes *EBSVolume) error {
 	return nil
 }
 
-func (_ *EBSVolume) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *EBSVolume) error {
+func (_ *EBSVolume) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *EBSVolume) error {
 	if a == nil {
 		klog.V(2).Infof("Creating PersistentVolume with Name:%q", *e.Name)
 
@@ -209,7 +209,7 @@ type terraformVolume struct {
 	Tags             map[string]string `cty:"tags"`
 }
 
-func (_ *EBSVolume) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *EBSVolume) error {
+func (_ *EBSVolume) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *EBSVolume) error {
 	tf := &terraformVolume{
 		AvailabilityZone: e.AvailabilityZone,
 		Size:             e.SizeGB,

--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway.go
@@ -41,6 +41,8 @@ type EgressOnlyInternetGateway struct {
 	Tags map[string]string
 }
 
+var _ awsup.AWSTask[EgressOnlyInternetGateway] = &EgressOnlyInternetGateway{}
+
 var _ fi.CompareWithID = &EgressOnlyInternetGateway{}
 
 func (e *EgressOnlyInternetGateway) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway.go
@@ -134,7 +134,7 @@ func (s *EgressOnlyInternetGateway) CheckChanges(a, e, changes *EgressOnlyIntern
 	return nil
 }
 
-func (_ *EgressOnlyInternetGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *EgressOnlyInternetGateway) error {
+func (_ *EgressOnlyInternetGateway) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *EgressOnlyInternetGateway) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Verify the EgressOnlyInternetGateway was found and matches our required settings
@@ -170,7 +170,7 @@ type terraformEgressOnlyInternetGateway struct {
 	Tags  map[string]string        `cty:"tags"`
 }
 
-func (_ *EgressOnlyInternetGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *EgressOnlyInternetGateway) error {
+func (_ *EgressOnlyInternetGateway) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *EgressOnlyInternetGateway) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Not terraform owned / managed

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -52,6 +52,8 @@ type ElasticIP struct {
 	AssociatedNatGatewayRouteTable *RouteTable
 }
 
+var _ awsup.AWSTask[ElasticIP] = &ElasticIP{}
+
 var _ fi.CompareWithID = &ElasticIP{}
 
 func (e *ElasticIP) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -219,7 +219,7 @@ func (_ *ElasticIP) CheckChanges(a, e, changes *ElasticIP) error {
 }
 
 // RenderAWS is where we actually apply changes to AWS
-func (_ *ElasticIP) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *ElasticIP) error {
+func (_ *ElasticIP) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *ElasticIP) error {
 	var publicIp *string
 	var eipId *string
 
@@ -275,7 +275,7 @@ type terraformElasticIP struct {
 	Tags map[string]string `cty:"tags"`
 }
 
-func (_ *ElasticIP) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ElasticIP) error {
+func (_ *ElasticIP) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *ElasticIP) error {
 	if fi.ValueOf(e.Shared) {
 		if e.ID == nil {
 			return fmt.Errorf("ID must be set, if ElasticIP is shared: %v", e)

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
@@ -41,6 +41,8 @@ type EventBridgeRule struct {
 	Tags map[string]string
 }
 
+var _ awsup.AWSTask[EventBridgeRule] = &EventBridgeRule{}
+
 var _ fi.CompareWithID = &EventBridgeRule{}
 
 func (eb *EventBridgeRule) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
@@ -100,7 +100,7 @@ func (_ *EventBridgeRule) CheckChanges(a, e, changes *EventBridgeRule) error {
 	return nil
 }
 
-func (eb *EventBridgeRule) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *EventBridgeRule) error {
+func (eb *EventBridgeRule) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *EventBridgeRule) error {
 	if e.EventPattern == nil {
 		return awsResources.DeleteEventBridgeRule(t.Cloud, *e.Name)
 	}
@@ -135,7 +135,7 @@ type terraformEventBridgeRule struct {
 	Tags         map[string]string        `cty:"tags"`
 }
 
-func (_ *EventBridgeRule) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *EventBridgeRule) error {
+func (_ *EventBridgeRule) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *EventBridgeRule) error {
 	m, err := t.AddFileBytes("aws_cloudwatch_event_rule", *e.Name, "event_pattern", []byte(*e.EventPattern), false)
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
@@ -105,7 +105,7 @@ func (_ *EventBridgeTarget) CheckChanges(a, e, changes *EventBridgeTarget) error
 	return nil
 }
 
-func (eb *EventBridgeTarget) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *EventBridgeTarget) error {
+func (eb *EventBridgeTarget) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *EventBridgeTarget) error {
 	if a == nil {
 		target := &eventbridge.Target{
 			Arn: eb.SQSQueue.ARN,
@@ -131,7 +131,7 @@ type terraformEventBridgeTarget struct {
 	TargetArn *terraformWriter.Literal `cty:"arn"`
 }
 
-func (_ *EventBridgeTarget) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *EventBridgeTarget) error {
+func (_ *EventBridgeTarget) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *EventBridgeTarget) error {
 	tf := &terraformEventBridgeTarget{
 		RuleName:  e.Rule.TerraformLink(),
 		TargetArn: e.SQSQueue.TerraformLink(),

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
@@ -39,6 +39,8 @@ type EventBridgeTarget struct {
 	SQSQueue *SQS
 }
 
+var _ awsup.AWSTask[EventBridgeTarget] = &EventBridgeTarget{}
+
 var _ fi.CompareWithID = &EventBridgeTarget{}
 
 func (eb *EventBridgeTarget) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
@@ -107,7 +107,7 @@ func (s *IAMInstanceProfile) CheckChanges(a, e, changes *IAMInstanceProfile) err
 	return nil
 }
 
-func (_ *IAMInstanceProfile) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMInstanceProfile) error {
+func (_ *IAMInstanceProfile) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *IAMInstanceProfile) error {
 	if fi.ValueOf(e.Shared) {
 		if a == nil {
 			return fmt.Errorf("instance role profile with id %q not found", fi.ValueOf(e.ID))
@@ -175,7 +175,7 @@ func (_ *IAMInstanceProfile) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAM
 	return nil
 }
 
-func (_ *IAMInstanceProfile) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMInstanceProfile) error {
+func (_ *IAMInstanceProfile) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *IAMInstanceProfile) error {
 	// Done on IAMInstanceProfileRole
 	return nil
 }

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
@@ -41,6 +41,8 @@ type IAMInstanceProfile struct {
 	Shared *bool
 }
 
+var _ awsup.AWSTask[IAMInstanceProfile] = &IAMInstanceProfile{}
+
 var _ fi.CompareWithID = &IAMInstanceProfile{}
 
 func (e *IAMInstanceProfile) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
@@ -38,6 +38,8 @@ type IAMInstanceProfileRole struct {
 	Role            *IAMRole
 }
 
+var _ awsup.AWSTask[IAMInstanceProfileRole] = &IAMInstanceProfileRole{}
+
 func (e *IAMInstanceProfileRole) Find(c *fi.CloudupContext) (*IAMInstanceProfileRole, error) {
 	cloud := c.T.Cloud.(awsup.AWSCloud)
 

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
@@ -94,7 +94,7 @@ func (s *IAMInstanceProfileRole) CheckChanges(a, e, changes *IAMInstanceProfileR
 	return nil
 }
 
-func (_ *IAMInstanceProfileRole) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMInstanceProfileRole) error {
+func (_ *IAMInstanceProfileRole) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *IAMInstanceProfileRole) error {
 	if a == nil {
 		request := &iam.AddRoleToInstanceProfileInput{
 			InstanceProfileName: e.InstanceProfile.Name,
@@ -115,7 +115,7 @@ type terraformIAMInstanceProfile struct {
 	Tags map[string]string        `cty:"tags"`
 }
 
-func (_ *IAMInstanceProfileRole) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMInstanceProfileRole) error {
+func (_ *IAMInstanceProfileRole) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *IAMInstanceProfileRole) error {
 	tf := &terraformIAMInstanceProfile{
 		Name: e.InstanceProfile.Name,
 		Role: e.Role.TerraformLink(),

--- a/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
@@ -44,6 +44,8 @@ type IAMOIDCProvider struct {
 	arn *string
 }
 
+var _ awsup.AWSTask[IAMOIDCProvider] = &IAMOIDCProvider{}
+
 var _ fi.CompareWithID = &IAMOIDCProvider{}
 
 func (e *IAMOIDCProvider) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
@@ -116,7 +116,7 @@ func (s *IAMOIDCProvider) CheckChanges(a, e, changes *IAMOIDCProvider) error {
 	return nil
 }
 
-func (p *IAMOIDCProvider) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMOIDCProvider) error {
+func (p *IAMOIDCProvider) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *IAMOIDCProvider) error {
 	thumbprints := e.Thumbprints
 
 	if a == nil {
@@ -219,7 +219,7 @@ type terraformIAMOIDCProvider struct {
 	Tags             map[string]string        `cty:"tags"`
 }
 
-func (p *IAMOIDCProvider) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMOIDCProvider) error {
+func (p *IAMOIDCProvider) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *IAMOIDCProvider) error {
 	err := t.AddOutputVariable("iam_openid_connect_provider_arn", e.TerraformLink())
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/awstasks/iamrole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole.go
@@ -54,6 +54,8 @@ type IAMRole struct {
 	ExportWithID *string
 }
 
+var _ awsup.AWSTask[IAMRole] = &IAMRole{}
+
 var _ fi.CompareWithID = &IAMRole{}
 
 func (e *IAMRole) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/iamrole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole.go
@@ -152,7 +152,7 @@ func (s *IAMRole) CheckChanges(a, e, changes *IAMRole) error {
 	return nil
 }
 
-func (_ *IAMRole) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMRole) error {
+func (_ *IAMRole) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *IAMRole) error {
 	if e.RolePolicyDocument == nil {
 		klog.V(2).Infof("Deleting IAM role %q", a.Name)
 
@@ -343,7 +343,7 @@ type terraformIAMRole struct {
 	Tags                map[string]string        `cty:"tags"`
 }
 
-func (_ *IAMRole) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMRole) error {
+func (_ *IAMRole) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *IAMRole) error {
 	policy, err := t.AddFileResource("aws_iam_role", *e.Name, "policy", e.RolePolicyDocument, false)
 	if err != nil {
 		return fmt.Errorf("error rendering RolePolicyDocument: %v", err)

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -168,7 +168,7 @@ func (_ *IAMRolePolicy) ShouldCreate(a, e, changes *IAMRolePolicy) (bool, error)
 	return true, nil
 }
 
-func (_ *IAMRolePolicy) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMRolePolicy) error {
+func (_ *IAMRolePolicy) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *IAMRolePolicy) error {
 	policy, err := e.policyDocumentString()
 	if err != nil {
 		return fmt.Errorf("error rendering PolicyDocument: %v", err)
@@ -310,7 +310,7 @@ type terraformIAMRolePolicy struct {
 	PolicyArn      *string                  `cty:"policy_arn"`
 }
 
-func (_ *IAMRolePolicy) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMRolePolicy) error {
+func (_ *IAMRolePolicy) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *IAMRolePolicy) error {
 	if e.ExternalPolicies != nil && len(*e.ExternalPolicies) > 0 {
 		for _, policy := range *e.ExternalPolicies {
 			// create a hash of the arn

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -52,9 +52,10 @@ type IAMRolePolicy struct {
 	Managed bool
 }
 
+var _ awsup.AWSTask[IAMRolePolicy] = &IAMRolePolicy{}
+
 func (e *IAMRolePolicy) Find(c *fi.CloudupContext) (*IAMRolePolicy, error) {
 	var actual IAMRolePolicy
-
 	cloud := c.T.Cloud.(awsup.AWSCloud)
 
 	// Handle policy overrides

--- a/upup/pkg/fi/cloudup/awstasks/instance.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
@@ -55,6 +56,8 @@ type Instance struct {
 	AssociatePublicIP  *bool
 	IAMInstanceProfile *IAMInstanceProfile
 }
+
+var _ awsup.AWSTask[Instance] = &Instance{}
 
 var _ fi.CompareWithID = &Instance{}
 
@@ -205,6 +208,11 @@ func (_ *Instance) CheckChanges(a, e, changes *Instance) error {
 		}
 	}
 	return nil
+}
+
+func (_ *Instance) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Instance) error {
+	// There's (likely) no barrier to implementing this, we simply haven't needed it
+	return fmt.Errorf("terraform rendering of Instances is not currently implemented")
 }
 
 func (_ *Instance) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *Instance) error {

--- a/upup/pkg/fi/cloudup/awstasks/instance.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance.go
@@ -207,7 +207,7 @@ func (_ *Instance) CheckChanges(a, e, changes *Instance) error {
 	return nil
 }
 
-func (_ *Instance) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Instance) error {
+func (_ *Instance) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *Instance) error {
 	if a == nil {
 
 		if fi.ValueOf(e.Shared) {

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway.go
@@ -41,6 +41,8 @@ type InternetGateway struct {
 	Tags map[string]string
 }
 
+var _ awsup.AWSTask[InternetGateway] = &InternetGateway{}
+
 var _ fi.CompareWithID = &InternetGateway{}
 
 func (e *InternetGateway) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway.go
@@ -135,7 +135,7 @@ func (s *InternetGateway) CheckChanges(a, e, changes *InternetGateway) error {
 	return nil
 }
 
-func (_ *InternetGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *InternetGateway) error {
+func (_ *InternetGateway) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *InternetGateway) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Verify the InternetGateway was found and matches our required settings
@@ -183,7 +183,7 @@ type terraformInternetGateway struct {
 	Tags  map[string]string        `cty:"tags"`
 }
 
-func (_ *InternetGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *InternetGateway) error {
+func (_ *InternetGateway) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *InternetGateway) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Not terraform owned / managed

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -95,6 +95,8 @@ var (
 	_ fi.CloudupProducesDeletions = &LaunchTemplate{}
 	_ fi.CloudupTaskNormalize     = &LaunchTemplate{}
 	_ fi.CloudupDeletion          = &deleteLaunchTemplate{}
+
+	_ awsup.AWSTask[LaunchTemplate] = &LaunchTemplate{}
 )
 
 // CompareWithID implements the comparable interface

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -31,7 +31,7 @@ import (
 )
 
 // RenderAWS is responsible for performing creating / updating the launch template
-func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchTemplate) error {
+func (t *LaunchTemplate) RenderAWS(ctx *fi.CloudupContext, c *awsup.AWSAPITarget, a, e, changes *LaunchTemplate) error {
 	// @step: resolve the image id to an AMI for us
 	image, err := c.Cloud.ResolveImage(fi.ValueOf(t.ImageID))
 	if err != nil {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -176,7 +176,7 @@ func (t *LaunchTemplate) VersionLink() *terraformWriter.Literal {
 }
 
 // RenderTerraform is responsible for rendering the terraform json
-func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e, changes *LaunchTemplate) error {
+func (t *LaunchTemplate) RenderTerraform(ctx *fi.CloudupContext, target *terraform.TerraformTarget, a, e, changes *LaunchTemplate) error {
 	var err error
 
 	cloud := target.Cloud.(awsup.AWSCloud)

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
@@ -19,10 +19,13 @@ package awstasks
 import (
 	"testing"
 
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 )
 
 func TestLaunchTemplateTerraformRender(t *testing.T) {
+	ctx := testcontext.ForTest(t)
+
 	cases := []*renderTest{
 		{
 			Resource: &LaunchTemplate{
@@ -193,5 +196,5 @@ terraform {
 `,
 		},
 	}
-	doRenderTests(t, "RenderTerraform", cases)
+	doRenderTests(ctx, t, "RenderTerraform", cases)
 }

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -51,6 +51,8 @@ type NatGateway struct {
 	AssociatedRouteTable *RouteTable
 }
 
+var _ awsup.AWSTask[NatGateway] = &NatGateway{}
+
 var _ fi.CompareWithID = &NatGateway{}
 
 func (e *NatGateway) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -295,7 +295,7 @@ func (e *NatGateway) Run(c *fi.CloudupContext) error {
 	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
-func (_ *NatGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *NatGateway) error {
+func (_ *NatGateway) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *NatGateway) error {
 	// New NGW
 
 	var id *string
@@ -367,7 +367,7 @@ type terraformNATGateway struct {
 	Tag          map[string]string        `cty:"tags"`
 }
 
-func (_ *NatGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *NatGateway) error {
+func (_ *NatGateway) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *NatGateway) error {
 	if fi.ValueOf(e.Shared) {
 		if e.ID == nil {
 			return fmt.Errorf("ID must be set, if NatGateway is shared: %s", e)

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -534,7 +534,7 @@ func (*NetworkLoadBalancer) CheckChanges(a, e, changes *NetworkLoadBalancer) err
 	return nil
 }
 
-func (_ *NetworkLoadBalancer) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *NetworkLoadBalancer) error {
+func (_ *NetworkLoadBalancer) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *NetworkLoadBalancer) error {
 	var loadBalancerName string
 	var loadBalancerArn string
 
@@ -760,7 +760,7 @@ type terraformNetworkLoadBalancerListenerAction struct {
 	TargetGroupARN *terraformWriter.Literal `cty:"target_group_arn"`
 }
 
-func (_ *NetworkLoadBalancer) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *NetworkLoadBalancer) error {
+func (_ *NetworkLoadBalancer) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *NetworkLoadBalancer) error {
 	nlbTF := &terraformNetworkLoadBalancer{
 		Name:                   *e.LoadBalancerName,
 		Internal:               fi.ValueOf(e.Scheme) == elbv2.LoadBalancerSchemeEnumInternal,

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -73,6 +73,8 @@ type NetworkLoadBalancer struct {
 	AccessLog    *NetworkLoadBalancerAccessLog
 }
 
+var _ awsup.AWSTask[NetworkLoadBalancer] = &NetworkLoadBalancer{}
+
 var _ fi.CompareWithID = &NetworkLoadBalancer{}
 var _ fi.CloudupTaskNormalize = &NetworkLoadBalancer{}
 var _ fi.CloudupProducesDeletions = &NetworkLoadBalancer{}

--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -47,6 +47,8 @@ type Route struct {
 	VPCPeeringConnectionID    *string
 }
 
+var _ awsup.AWSTask[Route] = &Route{}
+
 func (e *Route) Find(c *fi.CloudupContext) (*Route, error) {
 	cloud := c.T.Cloud.(awsup.AWSCloud)
 

--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -183,7 +183,7 @@ func (s *Route) CheckChanges(a, e, changes *Route) error {
 	return nil
 }
 
-func (_ *Route) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Route) error {
+func (_ *Route) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *Route) error {
 	if a == nil {
 		request := &ec2.CreateRouteInput{}
 		request.RouteTableId = checkNotNil(e.RouteTable.ID)
@@ -292,7 +292,7 @@ type terraformRoute struct {
 	VPCPeeringConnectionID      *string                  `cty:"vpc_peering_connection_id"`
 }
 
-func (_ *Route) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Route) error {
+func (_ *Route) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Route) error {
 	tf := &terraformRoute{
 		RouteTableID: e.RouteTable.TerraformLink(),
 		CIDR:         e.CIDR,

--- a/upup/pkg/fi/cloudup/awstasks/routetable.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable.go
@@ -42,6 +42,8 @@ type RouteTable struct {
 	Tags map[string]string
 }
 
+var _ awsup.AWSTask[RouteTable] = &RouteTable{}
+
 var _ fi.CompareWithID = &RouteTable{}
 
 func (e *RouteTable) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/routetable.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable.go
@@ -164,7 +164,7 @@ func (s *RouteTable) CheckChanges(a, e, changes *RouteTable) error {
 	return nil
 }
 
-func (_ *RouteTable) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *RouteTable) error {
+func (_ *RouteTable) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *RouteTable) error {
 	if a == nil {
 		vpcID := e.VPC.ID
 		if vpcID == nil {
@@ -195,7 +195,7 @@ type terraformRouteTable struct {
 	Tags  map[string]string        `cty:"tags"`
 }
 
-func (_ *RouteTable) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *RouteTable) error {
+func (_ *RouteTable) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *RouteTable) error {
 	// We use the role tag as a concise and stable identifier
 	tag := e.Tags[awsup.TagNameKopsRole]
 	if tag != "" {

--- a/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
@@ -38,6 +38,8 @@ type RouteTableAssociation struct {
 	Subnet     *Subnet
 }
 
+var _ awsup.AWSTask[RouteTableAssociation] = &RouteTableAssociation{}
+
 func (s *RouteTableAssociation) CompareWithID() *string {
 	return s.ID
 }

--- a/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
@@ -142,7 +142,7 @@ func findExistingRouteTableForSubnet(cloud awsup.AWSCloud, subnet *Subnet) (*ec2
 	return rt, nil
 }
 
-func (_ *RouteTableAssociation) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *RouteTableAssociation) error {
+func (_ *RouteTableAssociation) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *RouteTableAssociation) error {
 	if a == nil {
 		// TODO: We might do better just to make the subnet the primary key here
 
@@ -191,7 +191,7 @@ type terraformRouteTableAssociation struct {
 	RouteTableID *terraformWriter.Literal `cty:"route_table_id"`
 }
 
-func (_ *RouteTableAssociation) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *RouteTableAssociation) error {
+func (_ *RouteTableAssociation) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *RouteTableAssociation) error {
 	tf := &terraformRouteTableAssociation{
 		SubnetID:     e.Subnet.TerraformLink(),
 		RouteTableID: e.RouteTable.TerraformLink(),

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -48,6 +48,8 @@ type SecurityGroup struct {
 }
 
 var (
+	_ awsup.AWSTask[SecurityGroup] = &SecurityGroup{}
+
 	_ fi.CompareWithID            = &SecurityGroup{}
 	_ fi.CloudupProducesDeletions = &SecurityGroup{}
 )

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -156,7 +156,7 @@ func (_ *SecurityGroup) CheckChanges(a, e, changes *SecurityGroup) error {
 	return nil
 }
 
-func (_ *SecurityGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *SecurityGroup) error {
+func (_ *SecurityGroup) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *SecurityGroup) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Do we want to do any verification of the security group?
@@ -191,7 +191,7 @@ type terraformSecurityGroup struct {
 	Tags        map[string]string        `cty:"tags"`
 }
 
-func (_ *SecurityGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SecurityGroup) error {
+func (_ *SecurityGroup) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *SecurityGroup) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Not terraform owned / managed

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
@@ -54,6 +54,8 @@ type SecurityGroupRule struct {
 	Tags map[string]string
 }
 
+var _ awsup.AWSTask[SecurityGroupRule] = &SecurityGroupRule{}
+
 func (e *SecurityGroupRule) Find(c *fi.CloudupContext) (*SecurityGroupRule, error) {
 	cloud := c.T.Cloud.(awsup.AWSCloud)
 

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
@@ -259,7 +259,7 @@ func (e *SecurityGroupRule) Description() string {
 	return strings.Join(description, " ")
 }
 
-func (_ *SecurityGroupRule) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *SecurityGroupRule) error {
+func (_ *SecurityGroupRule) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *SecurityGroupRule) error {
 	name := fi.ValueOf(e.Name)
 
 	if a == nil {
@@ -353,7 +353,7 @@ type terraformSecurityGroupIngress struct {
 	PrefixListIDs  []string `cty:"prefix_list_ids"`
 }
 
-func (_ *SecurityGroupRule) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SecurityGroupRule) error {
+func (_ *SecurityGroupRule) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *SecurityGroupRule) error {
 	tf := &terraformSecurityGroupIngress{
 		Type:          fi.PtrTo("ingress"),
 		SecurityGroup: e.SecurityGroup.TerraformLink(),

--- a/upup/pkg/fi/cloudup/awstasks/sqs.go
+++ b/upup/pkg/fi/cloudup/awstasks/sqs.go
@@ -154,7 +154,7 @@ func (q *SQS) CheckChanges(a, e, changes *SQS) error {
 	return nil
 }
 
-func (q *SQS) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *SQS) error {
+func (q *SQS) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *SQS) error {
 	policy, err := fi.ResourceAsString(e.Policy)
 	if err != nil {
 		return fmt.Errorf("error rendering RolePolicyDocument: %v", err)
@@ -195,7 +195,7 @@ type terraformSQSQueue struct {
 	Tags                    map[string]string        `cty:"tags"`
 }
 
-func (_ *SQS) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SQS) error {
+func (_ *SQS) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *SQS) error {
 	p, err := t.AddFileResource("aws_sqs_queue", *e.Name, "policy", e.Policy, false)
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/awstasks/sqs.go
+++ b/upup/pkg/fi/cloudup/awstasks/sqs.go
@@ -46,6 +46,8 @@ type SQS struct {
 	Tags map[string]string
 }
 
+var _ awsup.AWSTask[SQS] = &SQS{}
+
 var _ fi.CompareWithID = &SQS{}
 
 func (q *SQS) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey.go
@@ -45,6 +45,8 @@ type SSHKey struct {
 	Tags map[string]string
 }
 
+var _ awsup.AWSTask[SSHKey] = &SSHKey{}
+
 var _ fi.CompareWithID = &SSHKey{}
 var _ fi.CloudupTaskNormalize = &SSHKey{}
 

--- a/upup/pkg/fi/cloudup/awstasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey.go
@@ -178,7 +178,7 @@ func (e *SSHKey) createKeypair(cloud awsup.AWSCloud) error {
 	return nil
 }
 
-func (_ *SSHKey) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *SSHKey) error {
+func (_ *SSHKey) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *SSHKey) error {
 	if a == nil {
 		return e.createKeypair(t.Cloud)
 	}
@@ -195,7 +195,7 @@ type terraformSSHKey struct {
 	Tags      map[string]string        `cty:"tags"`
 }
 
-func (_ *SSHKey) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SSHKey) error {
+func (_ *SSHKey) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *SSHKey) error {
 	// We don't want to render a key definition when we're using one that already exists
 	if e.IsExistingKey() {
 		return nil

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -55,6 +55,8 @@ type Subnet struct {
 	Tags map[string]string
 }
 
+var _ awsup.AWSTask[Subnet] = &Subnet{}
+
 var _ fi.CompareWithID = &Subnet{}
 
 func (e *Subnet) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -229,7 +229,7 @@ func (_ *Subnet) ShouldCreate(a, e, changes *Subnet) (bool, error) {
 	return true, nil
 }
 
-func (_ *Subnet) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Subnet) error {
+func (_ *Subnet) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *Subnet) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Verify the subnet was found
@@ -383,7 +383,7 @@ type terraformSubnet struct {
 	Tags                                    map[string]string        `cty:"tags"`
 }
 
-func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Subnet) error {
+func (_ *Subnet) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Subnet) error {
 	if fi.ValueOf(e.ShortName) != "" {
 		name := fi.ValueOf(e.ShortName)
 		if err := t.AddOutputVariable("subnet_"+name+"_id", e.TerraformLink()); err != nil {

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -162,7 +162,7 @@ func (s *TargetGroup) CheckChanges(a, e, changes *TargetGroup) error {
 	return nil
 }
 
-func (_ *TargetGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *TargetGroup) error {
+func (_ *TargetGroup) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *TargetGroup) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		return nil
@@ -255,7 +255,7 @@ type terraformTargetGroupHealthCheck struct {
 	Protocol           string `cty:"protocol"`
 }
 
-func (_ *TargetGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *TargetGroup) error {
+func (_ *TargetGroup) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *TargetGroup) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		return nil

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -61,6 +61,8 @@ type TargetGroup struct {
 	UnhealthyThreshold *int64
 }
 
+var _ awsup.AWSTask[TargetGroup] = &TargetGroup{}
+
 var _ fi.CompareWithID = &TargetGroup{}
 
 func (e *TargetGroup) CompareWithID() *string {

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -171,7 +171,7 @@ func (e *VPC) Run(c *fi.CloudupContext) error {
 	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
-func (_ *VPC) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPC) error {
+func (_ *VPC) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *VPC) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Verify the VPC was found and matches our required settings
@@ -291,7 +291,7 @@ type terraformVPC struct {
 	Tags               map[string]string `cty:"tags"`
 }
 
-func (_ *VPC) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPC) error {
+func (_ *VPC) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *VPC) error {
 	if err := t.AddOutputVariable("vpc_id", e.TerraformLink()); err != nil {
 		return err
 	}

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -58,6 +58,8 @@ type VPC struct {
 }
 
 var (
+	_ awsup.AWSTask[VPC] = &VPC{}
+
 	_ fi.CompareWithID            = &VPC{}
 	_ fi.CloudupProducesDeletions = &VPC{}
 )

--- a/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
@@ -84,7 +84,7 @@ func (s *VPCDHCPOptionsAssociation) CheckChanges(a, e, changes *VPCDHCPOptionsAs
 	return nil
 }
 
-func (_ *VPCDHCPOptionsAssociation) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPCDHCPOptionsAssociation) error {
+func (_ *VPCDHCPOptionsAssociation) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *VPCDHCPOptionsAssociation) error {
 	if changes.DHCPOptions != nil {
 		klog.V(2).Infof("calling EC2 AssociateDhcpOptions")
 		request := &ec2.AssociateDhcpOptionsInput{
@@ -106,7 +106,7 @@ type terraformVPCDHCPOptionsAssociation struct {
 	DHCPOptionsID *terraformWriter.Literal `cty:"dhcp_options_id"`
 }
 
-func (_ *VPCDHCPOptionsAssociation) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPCDHCPOptionsAssociation) error {
+func (_ *VPCDHCPOptionsAssociation) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *VPCDHCPOptionsAssociation) error {
 	tf := &terraformVPCDHCPOptionsAssociation{
 		VPCID:         e.VPC.TerraformLink(),
 		DHCPOptionsID: e.DHCPOptions.TerraformLink(),

--- a/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
@@ -36,6 +36,8 @@ type VPCDHCPOptionsAssociation struct {
 	DHCPOptions *DHCPOptions
 }
 
+var _ awsup.AWSTask[VPCDHCPOptionsAssociation] = &VPCDHCPOptionsAssociation{}
+
 func (e *VPCDHCPOptionsAssociation) Find(c *fi.CloudupContext) (*VPCDHCPOptionsAssociation, error) {
 	cloud := c.T.Cloud.(awsup.AWSCloud)
 

--- a/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
@@ -37,6 +37,8 @@ type VPCAmazonIPv6CIDRBlock struct {
 	Shared *bool
 }
 
+var _ awsup.AWSTask[VPCAmazonIPv6CIDRBlock] = &VPCAmazonIPv6CIDRBlock{}
+
 func (e *VPCAmazonIPv6CIDRBlock) Find(c *fi.CloudupContext) (*VPCAmazonIPv6CIDRBlock, error) {
 	cloud := c.T.Cloud.(awsup.AWSCloud)
 

--- a/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
@@ -83,7 +83,7 @@ func (s *VPCAmazonIPv6CIDRBlock) CheckChanges(a, e, changes *VPCAmazonIPv6CIDRBl
 	return nil
 }
 
-func (_ *VPCAmazonIPv6CIDRBlock) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPCAmazonIPv6CIDRBlock) error {
+func (_ *VPCAmazonIPv6CIDRBlock) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *VPCAmazonIPv6CIDRBlock) error {
 	shared := aws.BoolValue(e.Shared)
 	if shared && a == nil {
 		// VPC not owned by kOps, no changes will be applied
@@ -105,7 +105,7 @@ func (_ *VPCAmazonIPv6CIDRBlock) RenderAWS(t *awsup.AWSAPITarget, a, e, changes 
 	return nil // no tags
 }
 
-func (_ *VPCAmazonIPv6CIDRBlock) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPCAmazonIPv6CIDRBlock) error {
+func (_ *VPCAmazonIPv6CIDRBlock) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *VPCAmazonIPv6CIDRBlock) error {
 	// At the moment, this can only be done via the aws_vpc resource
 	return nil
 }

--- a/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
@@ -39,6 +39,8 @@ type VPCCIDRBlock struct {
 	Shared *bool
 }
 
+var _ awsup.AWSTask[VPCCIDRBlock] = &VPCCIDRBlock{}
+
 func (e *VPCCIDRBlock) Find(c *fi.CloudupContext) (*VPCCIDRBlock, error) {
 	cloud := c.T.Cloud.(awsup.AWSCloud)
 

--- a/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
@@ -115,7 +115,7 @@ func (s *VPCCIDRBlock) CheckChanges(a, e, changes *VPCCIDRBlock) error {
 	return nil
 }
 
-func (_ *VPCCIDRBlock) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPCCIDRBlock) error {
+func (_ *VPCCIDRBlock) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *VPCCIDRBlock) error {
 	shared := aws.BoolValue(e.Shared)
 	if shared && a == nil {
 		// VPC not owned by kOps, no changes will be applied
@@ -143,7 +143,7 @@ type terraformVPCCIDRBlock struct {
 	CIDRBlock *string                  `cty:"cidr_block"`
 }
 
-func (_ *VPCCIDRBlock) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPCCIDRBlock) error {
+func (_ *VPCCIDRBlock) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *VPCCIDRBlock) error {
 	shared := aws.BoolValue(e.Shared)
 	if shared && a == nil {
 		// VPC not owned by kOps, no changes will be applied

--- a/upup/pkg/fi/cloudup/awstasks/warmpool.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool.go
@@ -43,6 +43,8 @@ type WarmPool struct {
 	AutoscalingGroup *AutoscalingGroup
 }
 
+var _ awsup.AWSTask[WarmPool] = &WarmPool{}
+
 // Find is used to discover the ASG in the cloud provider.
 func (e *WarmPool) Find(c *fi.CloudupContext) (*WarmPool, error) {
 	cloud := c.T.Cloud.(awsup.AWSCloud)

--- a/upup/pkg/fi/cloudup/awstasks/warmpool.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool.go
@@ -82,7 +82,7 @@ func (*WarmPool) CheckChanges(a, e, changes *WarmPool) error {
 	return nil
 }
 
-func (*WarmPool) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *WarmPool) error {
+func (*WarmPool) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *WarmPool) error {
 	svc := t.Cloud.Autoscaling()
 	if changes != nil {
 		if fi.ValueOf(e.Enabled) {
@@ -118,7 +118,7 @@ func (*WarmPool) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *WarmPool) error
 	return nil
 }
 
-func (_ *WarmPool) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *WarmPool) error {
+func (_ *WarmPool) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *WarmPool) error {
 	if changes != nil {
 		klog.Warning("ASG warm pool is not supported by the terraform target")
 	}

--- a/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
 type AWSAPITarget struct {
@@ -31,6 +32,14 @@ type AWSAPITarget struct {
 }
 
 var _ fi.CloudupTarget = &AWSAPITarget{}
+
+// AWS tasks should this function common signature; even though we currently invoke by reflection.
+// This lets us catch common mistakes, and we may be able to use this instead of reflection in future.
+type AWSTask[T any] interface {
+	fi.CloudupTask
+	RenderAWS(ctx *fi.CloudupContext, t *AWSAPITarget, a, e, changes *T) error
+	RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *T) error
+}
 
 func NewAWSAPITarget(cloud AWSCloud) *AWSAPITarget {
 	return &AWSAPITarget{

--- a/upup/pkg/fi/cloudup/azuretasks/disk.go
+++ b/upup/pkg/fi/cloudup/azuretasks/disk.go
@@ -107,7 +107,7 @@ func (*Disk) CheckChanges(a, e, changes *Disk) error {
 }
 
 // RenderAzure creates or updates a Disk.
-func (*Disk) RenderAzure(t *azure.AzureAPITarget, a, e, changes *Disk) error {
+func (*Disk) RenderAzure(c *fi.CloudupContext, t *azure.AzureAPITarget, a, e, changes *Disk) error {
 	if a == nil {
 		klog.Infof("Creating a new Disk with name: %s", fi.ValueOf(e.Name))
 	} else {

--- a/upup/pkg/fi/cloudup/azuretasks/disk_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/disk_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 )
@@ -48,11 +49,17 @@ func newTestDisk() *Disk {
 }
 
 func TestDiskRenderAzure(t *testing.T) {
+	ctx := testcontext.ForTest(t)
 	cloud := NewMockAzureCloud("eastus")
 	apiTarget := azure.NewAzureAPITarget(cloud)
+	context, err := fi.NewCloudupContext(ctx, apiTarget, nil, cloud, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("error from NewCloudupContext: %v", err)
+	}
+
 	disk := &Disk{}
 	expected := newTestDisk()
-	if err := disk.RenderAzure(apiTarget, nil, expected, nil); err != nil {
+	if err := disk.RenderAzure(context, apiTarget, nil, expected, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 

--- a/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
@@ -127,7 +127,7 @@ func (*LoadBalancer) CheckChanges(a, e, changes *LoadBalancer) error {
 }
 
 // RenderAzure creates or updates a Loadbalancer.
-func (*LoadBalancer) RenderAzure(t *azure.AzureAPITarget, a, e, changes *LoadBalancer) error {
+func (*LoadBalancer) RenderAzure(c *fi.CloudupContext, t *azure.AzureAPITarget, a, e, changes *LoadBalancer) error {
 	if a == nil {
 		klog.Infof("Creating a new Loadbalancer with name: %s", fi.ValueOf(e.Name))
 	} else {

--- a/upup/pkg/fi/cloudup/azuretasks/loadbalancer_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/loadbalancer_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-05-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 )
@@ -51,11 +52,17 @@ func newTestLoadBalancer() *LoadBalancer {
 }
 
 func TestLoadBalancerRenderAzure(t *testing.T) {
+	ctx := testcontext.ForTest(t)
 	cloud := NewMockAzureCloud("eastus")
 	apiTarget := azure.NewAzureAPITarget(cloud)
+	context, err := fi.NewCloudupContext(ctx, apiTarget, nil, cloud, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("error from NewCloudupContext: %v", err)
+	}
+
 	loadbalancer := &LoadBalancer{}
 	expected := newTestLoadBalancer()
-	if err := loadbalancer.RenderAzure(apiTarget, nil, expected, nil); err != nil {
+	if err := loadbalancer.RenderAzure(context, apiTarget, nil, expected, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 

--- a/upup/pkg/fi/cloudup/azuretasks/publicipaddress.go
+++ b/upup/pkg/fi/cloudup/azuretasks/publicipaddress.go
@@ -104,7 +104,7 @@ func (*PublicIPAddress) CheckChanges(a, e, changes *PublicIPAddress) error {
 }
 
 // RenderAzure creates or updates a Public IP Address.
-func (*PublicIPAddress) RenderAzure(t *azure.AzureAPITarget, a, e, changes *PublicIPAddress) error {
+func (*PublicIPAddress) RenderAzure(c *fi.CloudupContext, t *azure.AzureAPITarget, a, e, changes *PublicIPAddress) error {
 	if a == nil {
 		klog.Infof("Creating a new Public IP Address with name: %s", fi.ValueOf(e.Name))
 	} else {

--- a/upup/pkg/fi/cloudup/azuretasks/publicipaddress_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/publicipaddress_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-05-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 )
@@ -42,11 +43,17 @@ func newTestPublicIPAddress() *PublicIPAddress {
 }
 
 func TestPublicIPAddressRenderAzure(t *testing.T) {
+	ctx := testcontext.ForTest(t)
 	cloud := NewMockAzureCloud("eastus")
 	apiTarget := azure.NewAzureAPITarget(cloud)
+	context, err := fi.NewCloudupContext(ctx, apiTarget, nil, cloud, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("error from NewCloudupContext: %v", err)
+	}
+
 	publicIPAddress := &PublicIPAddress{}
 	expected := newTestPublicIPAddress()
-	if err := publicIPAddress.RenderAzure(apiTarget, nil, expected, nil); err != nil {
+	if err := publicIPAddress.RenderAzure(context, apiTarget, nil, expected, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -139,6 +146,7 @@ func TestPublicIPAddressRun(t *testing.T) {
 }
 
 func TestPublicIPAddressCheckChanges(t *testing.T) {
+
 	testCases := []struct {
 		a, e, changes *PublicIPAddress
 		success       bool

--- a/upup/pkg/fi/cloudup/azuretasks/resourcegroup.go
+++ b/upup/pkg/fi/cloudup/azuretasks/resourcegroup.go
@@ -103,7 +103,7 @@ func (*ResourceGroup) CheckChanges(a, e, changes *ResourceGroup) error {
 }
 
 // RenderAzure creates or updates a resource group.
-func (*ResourceGroup) RenderAzure(t *azure.AzureAPITarget, a, e, changes *ResourceGroup) error {
+func (*ResourceGroup) RenderAzure(c *fi.CloudupContext, t *azure.AzureAPITarget, a, e, changes *ResourceGroup) error {
 	if a == nil {
 		klog.Infof("Creating a new Resource Group with name: %s", fi.ValueOf(e.Name))
 	} else {

--- a/upup/pkg/fi/cloudup/azuretasks/resourcegroup_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/resourcegroup_test.go
@@ -24,13 +24,20 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2021-04-01/resources"
 	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 )
 
 func TestResourceGroupRenderAzure(t *testing.T) {
+	ctx := testcontext.ForTest(t)
 	cloud := NewMockAzureCloud("eastus")
 	apiTarget := azure.NewAzureAPITarget(cloud)
+	context, err := fi.NewCloudupContext(ctx, apiTarget, nil, cloud, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("error from NewCloudupContext: %v", err)
+	}
+
 	rg := &ResourceGroup{}
 	expected := &ResourceGroup{
 		Name: to.StringPtr("rg"),
@@ -38,7 +45,7 @@ func TestResourceGroupRenderAzure(t *testing.T) {
 			"key": to.StringPtr("value"),
 		},
 	}
-	if err := rg.RenderAzure(apiTarget, nil, expected, nil); err != nil {
+	if err := rg.RenderAzure(context, apiTarget, nil, expected, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -66,7 +73,7 @@ func TestResourceGroupRenderAzure(t *testing.T) {
 			"key2": to.StringPtr("value2"),
 		},
 	}
-	if err := rg.RenderAzure(apiTarget, current, expected, changes); err != nil {
+	if err := rg.RenderAzure(context, apiTarget, current, expected, changes); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	actual = cloud.ResourceGroupsClient.RGs[*expected.Name]

--- a/upup/pkg/fi/cloudup/azuretasks/roleassignment.go
+++ b/upup/pkg/fi/cloudup/azuretasks/roleassignment.go
@@ -151,7 +151,7 @@ func (r *RoleAssignment) CheckChanges(a, e, changes *RoleAssignment) error {
 }
 
 // RenderAzure creates or updates a Role Assignment.
-func (*RoleAssignment) RenderAzure(t *azure.AzureAPITarget, a, e, changes *RoleAssignment) error {
+func (*RoleAssignment) RenderAzure(c *fi.CloudupContext, t *azure.AzureAPITarget, a, e, changes *RoleAssignment) error {
 	if a == nil {
 		return createNewRoleAssignment(t, e)
 	}

--- a/upup/pkg/fi/cloudup/azuretasks/roleassignment_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/roleassignment_test.go
@@ -26,13 +26,20 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/uuid"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 )
 
 func TestRoleAssignmentRenderAzure(t *testing.T) {
+	ctx := testcontext.ForTest(t)
 	cloud := NewMockAzureCloud("eastus")
 	apiTarget := azure.NewAzureAPITarget(cloud)
+	context, err := fi.NewCloudupContext(ctx, apiTarget, nil, cloud, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("error from NewCloudupContext: %v", err)
+	}
+
 	ra := &RoleAssignment{}
 	expected := &RoleAssignment{
 		Name: to.StringPtr("ra"),
@@ -46,7 +53,7 @@ func TestRoleAssignmentRenderAzure(t *testing.T) {
 		RoleDefID: to.StringPtr("rdid0"),
 	}
 
-	if err := ra.RenderAzure(apiTarget, nil, expected, nil); err != nil {
+	if err := ra.RenderAzure(context, apiTarget, nil, expected, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 

--- a/upup/pkg/fi/cloudup/azuretasks/routetable.go
+++ b/upup/pkg/fi/cloudup/azuretasks/routetable.go
@@ -103,7 +103,7 @@ func (*RouteTable) CheckChanges(a, e, changes *RouteTable) error {
 }
 
 // RenderAzure creates or updates a Route Table.
-func (*RouteTable) RenderAzure(t *azure.AzureAPITarget, a, e, changes *RouteTable) error {
+func (*RouteTable) RenderAzure(c *fi.CloudupContext, t *azure.AzureAPITarget, a, e, changes *RouteTable) error {
 	if a == nil {
 		klog.Infof("Creating a new Route Table with name: %s", fi.ValueOf(e.Name))
 	} else {

--- a/upup/pkg/fi/cloudup/azuretasks/subnet.go
+++ b/upup/pkg/fi/cloudup/azuretasks/subnet.go
@@ -102,7 +102,7 @@ func (*Subnet) CheckChanges(a, e, changes *Subnet) error {
 }
 
 // RenderAzure creates or updates a subnet.
-func (*Subnet) RenderAzure(t *azure.AzureAPITarget, a, e, changes *Subnet) error {
+func (*Subnet) RenderAzure(c *fi.CloudupContext, t *azure.AzureAPITarget, a, e, changes *Subnet) error {
 	if a == nil {
 		klog.Infof("Creating a new Subnet with name: %s", fi.ValueOf(e.Name))
 	} else {

--- a/upup/pkg/fi/cloudup/azuretasks/subnet_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/subnet_test.go
@@ -23,13 +23,20 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-05-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 )
 
 func TestSubnetRenderAzure(t *testing.T) {
+	ctx := testcontext.ForTest(t)
 	cloud := NewMockAzureCloud("eastus")
 	apiTarget := azure.NewAzureAPITarget(cloud)
+	context, err := fi.NewCloudupContext(ctx, apiTarget, nil, cloud, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("error from NewCloudupContext: %v", err)
+	}
+
 	subnet := &Subnet{}
 	expected := &Subnet{
 		Name: to.StringPtr("vnet"),
@@ -41,7 +48,7 @@ func TestSubnetRenderAzure(t *testing.T) {
 		},
 		CIDR: to.StringPtr("10.0.0.0/8"),
 	}
-	if err := subnet.RenderAzure(apiTarget, nil, expected, nil); err != nil {
+	if err := subnet.RenderAzure(context, apiTarget, nil, expected, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 

--- a/upup/pkg/fi/cloudup/azuretasks/virtualnetwork.go
+++ b/upup/pkg/fi/cloudup/azuretasks/virtualnetwork.go
@@ -117,7 +117,7 @@ func (*VirtualNetwork) CheckChanges(a, e, changes *VirtualNetwork) error {
 }
 
 // RenderAzure creates or updates a Virtual Network.
-func (*VirtualNetwork) RenderAzure(t *azure.AzureAPITarget, a, e, changes *VirtualNetwork) error {
+func (*VirtualNetwork) RenderAzure(c *fi.CloudupContext, t *azure.AzureAPITarget, a, e, changes *VirtualNetwork) error {
 	if a == nil {
 		klog.Infof("Creating a new Virtual Network with name: %s", fi.ValueOf(e.Name))
 	} else {

--- a/upup/pkg/fi/cloudup/azuretasks/virtualnetwork_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/virtualnetwork_test.go
@@ -24,13 +24,20 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-05-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 )
 
 func TestVirtualNetworkRenderAzure(t *testing.T) {
+	ctx := testcontext.ForTest(t)
 	cloud := NewMockAzureCloud("eastus")
 	apiTarget := azure.NewAzureAPITarget(cloud)
+	context, err := fi.NewCloudupContext(ctx, apiTarget, nil, cloud, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("error from NewCloudupContext: %v", err)
+	}
+
 	vnet := &VirtualNetwork{}
 	expected := &VirtualNetwork{
 		Name: to.StringPtr("vnet"),
@@ -42,7 +49,7 @@ func TestVirtualNetworkRenderAzure(t *testing.T) {
 			"key": to.StringPtr("val"),
 		},
 	}
-	if err := vnet.RenderAzure(apiTarget, nil, expected, nil); err != nil {
+	if err := vnet.RenderAzure(context, apiTarget, nil, expected, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
@@ -267,7 +267,7 @@ func (s *VMScaleSet) CheckChanges(a, e, changes *VMScaleSet) error {
 }
 
 // RenderAzure creates or updates a VM Scale Set.
-func (s *VMScaleSet) RenderAzure(t *azure.AzureAPITarget, a, e, changes *VMScaleSet) error {
+func (s *VMScaleSet) RenderAzure(c *fi.CloudupContext, t *azure.AzureAPITarget, a, e, changes *VMScaleSet) error {
 	if a == nil {
 		klog.Infof("Creating a new VM Scale Set with name: %s", fi.ValueOf(e.Name))
 	} else {

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 )
@@ -91,11 +92,17 @@ func newTestVMScaleSet() *VMScaleSet {
 }
 
 func TestVMScaleSetRenderAzure(t *testing.T) {
+	ctx := testcontext.ForTest(t)
 	cloud := NewMockAzureCloud("eastus")
 	apiTarget := azure.NewAzureAPITarget(cloud)
+	context, err := fi.NewCloudupContext(ctx, apiTarget, nil, cloud, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("error from NewCloudupContext: %v", err)
+	}
+
 	vmss := &VMScaleSet{}
 	expected := newTestVMScaleSet()
-	if err := vmss.RenderAzure(apiTarget, nil, expected, nil); err != nil {
+	if err := vmss.RenderAzure(context, apiTarget, nil, expected, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -124,7 +124,7 @@ func (d *Droplet) Run(c *fi.CloudupContext) error {
 	return fi.CloudupDefaultDeltaRunMethod(d, c)
 }
 
-func (_ *Droplet) RenderDO(t *do.DOAPITarget, a, e, changes *Droplet) error {
+func (_ *Droplet) RenderDO(c *fi.CloudupContext, t *do.DOAPITarget, a, e, changes *Droplet) error {
 	userData, err := fi.ResourceAsString(e.UserData)
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
@@ -115,7 +115,7 @@ func (_ *LoadBalancer) CheckChanges(a, e, changes *LoadBalancer) error {
 	return nil
 }
 
-func (_ *LoadBalancer) RenderDO(t *do.DOAPITarget, a, e, changes *LoadBalancer) error {
+func (_ *LoadBalancer) RenderDO(c *fi.CloudupContext, t *do.DOAPITarget, a, e, changes *LoadBalancer) error {
 	Rules := []godo.ForwardingRule{
 		{
 			EntryProtocol:  "https",

--- a/upup/pkg/fi/cloudup/dotasks/volume.go
+++ b/upup/pkg/fi/cloudup/dotasks/volume.go
@@ -102,7 +102,7 @@ func (_ *Volume) CheckChanges(a, e, changes *Volume) error {
 	return nil
 }
 
-func (_ *Volume) RenderDO(t *do.DOAPITarget, a, e, changes *Volume) error {
+func (_ *Volume) RenderDO(c *fi.CloudupContext, t *do.DOAPITarget, a, e, changes *Volume) error {
 	if a != nil {
 		// in general, we shouldn't need to render changes to a volume
 		// however there can be cases where we may want to resize or rename.
@@ -137,7 +137,7 @@ type terraformVolume struct {
 	Region *string `cty:"region"`
 }
 
-func (_ *Volume) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Volume) error {
+func (_ *Volume) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Volume) error {
 	tf := &terraformVolume{
 		Name:   e.Name,
 		SizeGB: e.SizeGB,

--- a/upup/pkg/fi/cloudup/dotasks/vpc.go
+++ b/upup/pkg/fi/cloudup/dotasks/vpc.go
@@ -92,7 +92,7 @@ func (_ *VPC) CheckChanges(a, e, changes *VPC) error {
 	return nil
 }
 
-func (_ *VPC) RenderDO(t *do.DOAPITarget, a, e, changes *VPC) error {
+func (_ *VPC) RenderDO(c *fi.CloudupContext, t *do.DOAPITarget, a, e, changes *VPC) error {
 	if a != nil {
 		return nil
 	}

--- a/upup/pkg/fi/cloudup/gcetasks/address.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address.go
@@ -127,7 +127,7 @@ func (_ *Address) CheckChanges(a, e, changes *Address) error {
 	return nil
 }
 
-func (_ *Address) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Address) error {
+func (_ *Address) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *Address) error {
 	cloud := t.Cloud
 	addr := &compute.Address{
 		Name:    *e.Name,
@@ -157,7 +157,7 @@ type terraformAddress struct {
 	Name *string `cty:"name"`
 }
 
-func (_ *Address) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Address) error {
+func (_ *Address) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Address) error {
 	tf := &terraformAddress{
 		Name: e.Name,
 	}

--- a/upup/pkg/fi/cloudup/gcetasks/backend_service.go
+++ b/upup/pkg/fi/cloudup/gcetasks/backend_service.go
@@ -103,7 +103,7 @@ func (_ *BackendService) CheckChanges(a, e, changes *BackendService) error {
 	return nil
 }
 
-func (_ *BackendService) RenderGCE(t *gce.GCEAPITarget, a, e, changes *BackendService) error {
+func (_ *BackendService) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *BackendService) error {
 	cloud := t.Cloud
 	var hcs []string
 	for _, hc := range e.HealthChecks {
@@ -160,7 +160,7 @@ type terraformBackendService struct {
 	Backend             []terraformBackend         `cty:"backend"`
 }
 
-func (_ *BackendService) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *BackendService) error {
+func (_ *BackendService) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *BackendService) error {
 	tf := &terraformBackendService{
 		Name:                e.Name,
 		LoadBalancingScheme: e.LoadBalancingScheme,

--- a/upup/pkg/fi/cloudup/gcetasks/disk.go
+++ b/upup/pkg/fi/cloudup/gcetasks/disk.go
@@ -103,7 +103,7 @@ func (_ *Disk) CheckChanges(a, e, changes *Disk) error {
 	return nil
 }
 
-func (_ *Disk) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Disk) error {
+func (_ *Disk) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *Disk) error {
 	cloud := t.Cloud
 	typeURL := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/diskTypes/%s",
 		cloud.Project(),
@@ -170,7 +170,7 @@ type terraformDisk struct {
 	Labels     map[string]string `cty:"labels"`
 }
 
-func (_ *Disk) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Disk) error {
+func (_ *Disk) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Disk) error {
 	cloud := t.Cloud.(gce.GCECloud)
 
 	labels := make(map[string]string)

--- a/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
@@ -188,7 +188,7 @@ func (e *FirewallRule) mapToGCE(project string) (*compute.Firewall, error) {
 	return firewall, nil
 }
 
-func (_ *FirewallRule) RenderGCE(t *gce.GCEAPITarget, a, e, changes *FirewallRule) error {
+func (_ *FirewallRule) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *FirewallRule) error {
 	cloud := t.Cloud
 	firewall, err := e.mapToGCE(cloud.Project())
 	if err != nil {
@@ -229,7 +229,7 @@ type terraformFirewall struct {
 	Disabled bool `cty:"disabled"`
 }
 
-func (_ *FirewallRule) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *FirewallRule) error {
+func (_ *FirewallRule) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *FirewallRule) error {
 	g, err := e.mapToGCE(t.Project)
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
@@ -108,7 +108,7 @@ func (_ *ForwardingRule) CheckChanges(a, e, changes *ForwardingRule) error {
 	return nil
 }
 
-func (_ *ForwardingRule) RenderGCE(t *gce.GCEAPITarget, a, e, changes *ForwardingRule) error {
+func (_ *ForwardingRule) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *ForwardingRule) error {
 	name := fi.ValueOf(e.Name)
 
 	o := &compute.ForwardingRule{
@@ -209,7 +209,7 @@ type terraformForwardingRule struct {
 	BackendService      *terraformWriter.Literal `cty:"backend_service"`
 }
 
-func (_ *ForwardingRule) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ForwardingRule) error {
+func (_ *ForwardingRule) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *ForwardingRule) error {
 	name := fi.ValueOf(e.Name)
 
 	tf := &terraformForwardingRule{

--- a/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
@@ -95,7 +95,7 @@ func (_ *HealthCheck) CheckChanges(a, e, changes *HealthCheck) error {
 	return nil
 }
 
-func (_ *HealthCheck) RenderGCE(t *gce.GCEAPITarget, a, e, changes *HealthCheck) error {
+func (_ *HealthCheck) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *HealthCheck) error {
 	cloud := t.Cloud
 	hc := &compute.HealthCheck{
 		Name: *e.Name,
@@ -134,7 +134,7 @@ type terraformHealthCheck struct {
 	TCPHealthCheck terraformTCPBlock `cty:"tcp_health_check"`
 }
 
-func (_ *HealthCheck) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *HealthCheck) error {
+func (_ *HealthCheck) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *HealthCheck) error {
 	tf := &terraformHealthCheck{
 		Name: *e.Name,
 		TCPHealthCheck: terraformTCPBlock{

--- a/upup/pkg/fi/cloudup/gcetasks/httphealthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/httphealthcheck.go
@@ -73,7 +73,7 @@ func (_ *HTTPHealthcheck) CheckChanges(a, e, changes *HTTPHealthcheck) error {
 	return nil
 }
 
-func (h *HTTPHealthcheck) RenderGCE(t *gce.GCEAPITarget, a, e, changes *HTTPHealthcheck) error {
+func (h *HTTPHealthcheck) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *HTTPHealthcheck) error {
 	if a == nil {
 		o := &compute.HttpHealthCheck{
 			Name:        fi.ValueOf(e.Name),

--- a/upup/pkg/fi/cloudup/gcetasks/instance.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance.go
@@ -311,7 +311,7 @@ func (i *Instance) isZero() bool {
 	return reflect.DeepEqual(zero, i)
 }
 
-func (_ *Instance) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Instance) error {
+func (_ *Instance) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *Instance) error {
 	cloud := t.Cloud
 	project := cloud.Project()
 	zone := *e.Zone
@@ -419,7 +419,7 @@ type terraformInstanceAttachedDisk struct {
 	Size    int64  `cty:"size"`
 }
 
-func (_ *Instance) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Instance) error {
+func (_ *Instance) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Instance) error {
 	project := t.Project
 
 	// This is a "little" hacky...

--- a/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
@@ -85,7 +85,7 @@ func (_ *InstanceGroupManager) CheckChanges(a, e, changes *InstanceGroupManager)
 	return nil
 }
 
-func (_ *InstanceGroupManager) RenderGCE(t *gce.GCEAPITarget, a, e, changes *InstanceGroupManager) error {
+func (_ *InstanceGroupManager) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *InstanceGroupManager) error {
 	project := t.Cloud.Project()
 
 	instanceTemplateURL, err := e.InstanceTemplate.URL(project)
@@ -184,7 +184,7 @@ type terraformVersion struct {
 	InstanceTemplate *terraformWriter.Literal `cty:"instance_template"`
 }
 
-func (_ *InstanceGroupManager) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *InstanceGroupManager) error {
+func (_ *InstanceGroupManager) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *InstanceGroupManager) error {
 	tf := &terraformInstanceGroupManager{
 		Name:             e.Name,
 		Zone:             e.Zone,

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -448,7 +448,7 @@ func (e *InstanceTemplate) URL(project string) (string, error) {
 	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/instanceTemplates/%s", project, *e.ID), nil
 }
 
-func (_ *InstanceTemplate) RenderGCE(t *gce.GCEAPITarget, a, e, changes *InstanceTemplate) error {
+func (_ *InstanceTemplate) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *InstanceTemplate) error {
 	project := t.Cloud.Project()
 	region := t.Cloud.Region()
 
@@ -601,7 +601,7 @@ func mapServiceAccountsToTerraform(serviceAccounts []*ServiceAccount, saScopes [
 	return out
 }
 
-func (_ *InstanceTemplate) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *InstanceTemplate) error {
+func (_ *InstanceTemplate) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *InstanceTemplate) error {
 	project := t.Project
 
 	i, err := e.mapToGCE(project, t.Cloud.Region())

--- a/upup/pkg/fi/cloudup/gcetasks/network.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network.go
@@ -137,7 +137,7 @@ func (_ *Network) CheckChanges(a, e, changes *Network) error {
 	return nil
 }
 
-func (_ *Network) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Network) error {
+func (_ *Network) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *Network) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Verify the network was found
@@ -199,7 +199,7 @@ type terraformNetwork struct {
 	AutoCreateSubnetworks *bool   `cty:"auto_create_subnetworks"`
 }
 
-func (_ *Network) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Network) error {
+func (_ *Network) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Network) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Not terraform owned / managed

--- a/upup/pkg/fi/cloudup/gcetasks/poolhealthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/poolhealthcheck.go
@@ -84,7 +84,7 @@ func (_ *PoolHealthCheck) CheckChanges(a, e, changes *PoolHealthCheck) error {
 	return nil
 }
 
-func (p *PoolHealthCheck) RenderGCE(t *gce.GCEAPITarget, a, e, changes *PoolHealthCheck) error {
+func (p *PoolHealthCheck) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *PoolHealthCheck) error {
 	if a == nil {
 		targetPool := fi.ValueOf(p.Pool.Name)
 		req := &compute.TargetPoolsAddHealthCheckRequest{

--- a/upup/pkg/fi/cloudup/gcetasks/projectiambinding.go
+++ b/upup/pkg/fi/cloudup/gcetasks/projectiambinding.go
@@ -97,8 +97,8 @@ func (_ *ProjectIAMBinding) CheckChanges(a, e, changes *ProjectIAMBinding) error
 	return nil
 }
 
-func (_ *ProjectIAMBinding) RenderGCE(t *gce.GCEAPITarget, a, e, changes *ProjectIAMBinding) error {
-	ctx := context.TODO()
+func (_ *ProjectIAMBinding) RenderGCE(c *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *ProjectIAMBinding) error {
+	ctx := c.Context()
 
 	projectID := fi.ValueOf(e.Project)
 	member := fi.ValueOf(e.Member)
@@ -132,7 +132,7 @@ type terraformProjectIAMBinding struct {
 	Members []string `cty:"members"`
 }
 
-func (_ *ProjectIAMBinding) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ProjectIAMBinding) error {
+func (_ *ProjectIAMBinding) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *ProjectIAMBinding) error {
 	tf := &terraformProjectIAMBinding{
 		Project: fi.ValueOf(e.Project),
 		Role:    fi.ValueOf(e.Role),

--- a/upup/pkg/fi/cloudup/gcetasks/router.go
+++ b/upup/pkg/fi/cloudup/gcetasks/router.go
@@ -143,7 +143,7 @@ func (*Router) CheckChanges(a, e, changes *Router) error {
 }
 
 // RenderGCE creates or updates a Router.
-func (*Router) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Router) error {
+func (*Router) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *Router) error {
 	cloud := t.Cloud
 	project := cloud.Project()
 	region := fi.ValueOf(e.Region)
@@ -205,7 +205,7 @@ type terraformRouter struct {
 }
 
 // RenderTerraform renders the Terraform config.
-func (*Router) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Router) error {
+func (*Router) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Router) error {
 	tr := &terraformRouter{
 		Name: e.Name,
 	}

--- a/upup/pkg/fi/cloudup/gcetasks/serviceaccount.go
+++ b/upup/pkg/fi/cloudup/gcetasks/serviceaccount.go
@@ -98,9 +98,8 @@ func (_ *ServiceAccount) CheckChanges(a, e, changes *ServiceAccount) error {
 	return nil
 }
 
-func (_ *ServiceAccount) RenderGCE(t *gce.GCEAPITarget, a, e, changes *ServiceAccount) error {
-	ctx := context.TODO()
-
+func (_ *ServiceAccount) RenderGCE(c *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *ServiceAccount) error {
+	ctx := c.Context()
 	cloud := t.Cloud
 
 	email := fi.ValueOf(e.Email)
@@ -171,7 +170,7 @@ type terraformServiceAccount struct {
 	DisplayName *string `cty:"display_name"`
 }
 
-func (_ *ServiceAccount) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ServiceAccount) error {
+func (_ *ServiceAccount) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *ServiceAccount) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Not terraform owned / managed

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketacl.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketacl.go
@@ -86,7 +86,7 @@ func (_ *StorageBucketAcl) CheckChanges(a, e, changes *StorageBucketAcl) error {
 	return nil
 }
 
-func (_ *StorageBucketAcl) RenderGCE(t *gce.GCEAPITarget, a, e, changes *StorageBucketAcl) error {
+func (_ *StorageBucketAcl) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *StorageBucketAcl) error {
 	bucket := fi.ValueOf(e.Bucket)
 	entity := fi.ValueOf(e.Entity)
 	role := fi.ValueOf(e.Role)
@@ -121,7 +121,7 @@ type terraformStorageBucketAcl struct {
 	RoleEntity []string `cty:"role_entity"`
 }
 
-func (_ *StorageBucketAcl) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *StorageBucketAcl) error {
+func (_ *StorageBucketAcl) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *StorageBucketAcl) error {
 	var roleEntities []string
 	roleEntities = append(roleEntities, fi.ValueOf(e.Role)+":"+fi.ValueOf(e.Entity))
 	tf := &terraformStorageBucketAcl{

--- a/upup/pkg/fi/cloudup/gcetasks/storagebucketiam.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storagebucketiam.go
@@ -96,8 +96,8 @@ func (_ *StorageBucketIAM) CheckChanges(a, e, changes *StorageBucketIAM) error {
 	return nil
 }
 
-func (_ *StorageBucketIAM) RenderGCE(t *gce.GCEAPITarget, a, e, changes *StorageBucketIAM) error {
-	ctx := context.TODO()
+func (_ *StorageBucketIAM) RenderGCE(c *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *StorageBucketIAM) error {
+	ctx := c.Context()
 
 	bucket := fi.ValueOf(e.Bucket)
 	member := fi.ValueOf(e.Member)
@@ -131,7 +131,7 @@ type terraformStorageBucketIAM struct {
 	Member string `cty:"member"`
 }
 
-func (_ *StorageBucketIAM) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *StorageBucketIAM) error {
+func (_ *StorageBucketIAM) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *StorageBucketIAM) error {
 	tf := &terraformStorageBucketIAM{
 		Bucket: fi.ValueOf(e.Bucket),
 		Role:   fi.ValueOf(e.Role),

--- a/upup/pkg/fi/cloudup/gcetasks/storageobjectacl.go
+++ b/upup/pkg/fi/cloudup/gcetasks/storageobjectacl.go
@@ -92,7 +92,7 @@ func (_ *StorageObjectAcl) CheckChanges(a, e, changes *StorageObjectAcl) error {
 	return nil
 }
 
-func (_ *StorageObjectAcl) RenderGCE(t *gce.GCEAPITarget, a, e, changes *StorageObjectAcl) error {
+func (_ *StorageObjectAcl) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *StorageObjectAcl) error {
 	bucket := fi.ValueOf(e.Bucket)
 	object := fi.ValueOf(e.Object)
 	entity := fi.ValueOf(e.Entity)
@@ -129,7 +129,7 @@ type terraformStorageObjectAcl struct {
 	RoleEntity []string `cty:"role_entity"`
 }
 
-func (_ *StorageObjectAcl) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *StorageObjectAcl) error {
+func (_ *StorageObjectAcl) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *StorageObjectAcl) error {
 	var roleEntities []string
 	roleEntities = append(roleEntities, fi.ValueOf(e.Role)+":"+fi.ValueOf(e.Name))
 	tf := &terraformStorageObjectAcl{

--- a/upup/pkg/fi/cloudup/gcetasks/subnet.go
+++ b/upup/pkg/fi/cloudup/gcetasks/subnet.go
@@ -101,7 +101,7 @@ func (_ *Subnet) CheckChanges(a, e, changes *Subnet) error {
 	return nil
 }
 
-func (_ *Subnet) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Subnet) error {
+func (_ *Subnet) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *Subnet) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Verify the subnet was found
@@ -251,7 +251,7 @@ type terraformSubnetRange struct {
 	CIDR string `cty:"ip_cidr_range"`
 }
 
-func (_ *Subnet) RenderSubnet(t *terraform.TerraformTarget, a, e, changes *Subnet) error {
+func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Subnet) error {
 	shared := fi.ValueOf(e.Shared)
 	if shared {
 		// Not terraform owned / managed

--- a/upup/pkg/fi/cloudup/gcetasks/targetpool.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool.go
@@ -78,7 +78,7 @@ func (e *TargetPool) URL(cloud gce.GCECloud) string {
 	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/targetPools/%s", cloud.Project(), cloud.Region(), name)
 }
 
-func (_ *TargetPool) RenderGCE(t *gce.GCEAPITarget, a, e, changes *TargetPool) error {
+func (_ *TargetPool) RenderGCE(ctx *fi.CloudupContext, t *gce.GCEAPITarget, a, e, changes *TargetPool) error {
 	name := fi.ValueOf(e.Name)
 
 	o := &compute.TargetPool{
@@ -111,7 +111,7 @@ type terraformTargetPool struct {
 	SessionAffinity string   `cty:"session_affinity"`
 }
 
-func (_ *TargetPool) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *TargetPool) error {
+func (_ *TargetPool) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *TargetPool) error {
 	name := fi.ValueOf(e.Name)
 
 	tf := &terraformTargetPool{

--- a/upup/pkg/fi/cloudup/hetznertasks/firewall.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/firewall.go
@@ -111,7 +111,7 @@ func (_ *Firewall) CheckChanges(a, e, changes *Firewall) error {
 	return nil
 }
 
-func (_ *Firewall) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *Firewall) error {
+func (_ *Firewall) RenderHetzer(c *fi.CloudupContext, t *hetzner.HetznerAPITarget, a, e, changes *Firewall) error {
 	client := t.Cloud.FirewallClient()
 	if a == nil {
 		opts := hcloud.FirewallCreateOpts{
@@ -225,7 +225,7 @@ type terraformFirewallRule struct {
 	Port      *string   `cty:"port"`
 }
 
-func (_ *Firewall) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Firewall) error {
+func (_ *Firewall) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Firewall) error {
 	{
 		tf := &terraformFirewall{
 			Name: e.Name,

--- a/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
@@ -189,8 +189,9 @@ func (_ *LoadBalancer) CheckChanges(a, e, changes *LoadBalancer) error {
 	return nil
 }
 
-func (_ *LoadBalancer) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *LoadBalancer) error {
-	ctx := context.TODO()
+func (_ *LoadBalancer) RenderHetzer(c *fi.CloudupContext, t *hetzner.HetznerAPITarget, a, e, changes *LoadBalancer) error {
+	ctx := c.Context()
+
 	actionClient := t.Cloud.ActionClient()
 	client := t.Cloud.LoadBalancerClient()
 
@@ -345,7 +346,7 @@ type terraformLoadBalancerTarget struct {
 	UsePrivateIP   *bool                    `cty:"use_private_ip"`
 }
 
-func (_ *LoadBalancer) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *LoadBalancer) error {
+func (_ *LoadBalancer) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *LoadBalancer) error {
 	{
 		tf := &terraformLoadBalancer{
 			Name:     e.Name,

--- a/upup/pkg/fi/cloudup/hetznertasks/network.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/network.go
@@ -133,7 +133,7 @@ func (_ *Network) CheckChanges(a, e, changes *Network) error {
 	return nil
 }
 
-func (_ *Network) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *Network) error {
+func (_ *Network) RenderHetzer(c *fi.CloudupContext, t *hetzner.HetznerAPITarget, a, e, changes *Network) error {
 	client := t.Cloud.NetworkClient()
 
 	var network *hcloud.Network
@@ -217,7 +217,7 @@ type terraformNetworkSubnet struct {
 	IPRange     *string                  `cty:"ip_range"`
 }
 
-func (_ *Network) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Network) error {
+func (_ *Network) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Network) error {
 	{
 		tf := &terraformNetwork{
 			Name:    e.Name,

--- a/upup/pkg/fi/cloudup/hetznertasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/servergroup.go
@@ -154,7 +154,7 @@ func (_ *ServerGroup) CheckChanges(a, e, changes *ServerGroup) error {
 	return nil
 }
 
-func (_ *ServerGroup) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *ServerGroup) error {
+func (_ *ServerGroup) RenderHetzer(c *fi.CloudupContext, t *hetzner.HetznerAPITarget, a, e, changes *ServerGroup) error {
 	client := t.Cloud.ServerClient()
 
 	if a != nil {
@@ -297,7 +297,7 @@ type terraformServerPublicNet struct {
 	EnableIPv6 *bool `cty:"ipv6_enabled"`
 }
 
-func (_ *ServerGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ServerGroup) error {
+func (_ *ServerGroup) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *ServerGroup) error {
 	name := terraformWriter.LiteralWithIndex(fi.ValueOf(e.Name))
 	tf := &terraformServer{
 		Count:      fi.PtrTo(e.Count),

--- a/upup/pkg/fi/cloudup/hetznertasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/sshkey.go
@@ -103,7 +103,7 @@ func (_ *SSHKey) CheckChanges(a, e, changes *SSHKey) error {
 	return nil
 }
 
-func (_ *SSHKey) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *SSHKey) error {
+func (_ *SSHKey) RenderHetzer(c *fi.CloudupContext, t *hetzner.HetznerAPITarget, a, e, changes *SSHKey) error {
 	client := t.Cloud.SSHKeyClient()
 	if a == nil {
 		name := fi.ValueOf(e.Name)
@@ -136,7 +136,7 @@ type terraformSSHKey struct {
 	Labels    map[string]string `cty:"labels"`
 }
 
-func (_ *SSHKey) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SSHKey) error {
+func (_ *SSHKey) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *SSHKey) error {
 	tf := &terraformSSHKey{
 		Name:      e.Name,
 		PublicKey: fi.PtrTo(e.PublicKey),

--- a/upup/pkg/fi/cloudup/hetznertasks/volume.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/volume.go
@@ -101,7 +101,7 @@ func (_ *Volume) CheckChanges(a, e, changes *Volume) error {
 	return nil
 }
 
-func (_ *Volume) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *Volume) error {
+func (_ *Volume) RenderHetzer(c *fi.CloudupContext, t *hetzner.HetznerAPITarget, a, e, changes *Volume) error {
 	client := t.Cloud.VolumeClient()
 
 	if a == nil {
@@ -146,7 +146,7 @@ type terraformVolume struct {
 	Labels   map[string]string `cty:"labels"`
 }
 
-func (_ *Volume) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Volume) error {
+func (_ *Volume) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Volume) error {
 	tf := &terraformVolume{
 		Name:     e.Name,
 		Size:     fi.PtrTo(e.Size),

--- a/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
@@ -255,7 +255,7 @@ func (_ *FloatingIP) ShouldCreate(a, e, changes *FloatingIP) (bool, error) {
 	return false, nil
 }
 
-func (f *FloatingIP) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *FloatingIP) error {
+func (f *FloatingIP) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *FloatingIP) error {
 	cloud := t.Cloud
 
 	if a == nil {

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -311,7 +311,7 @@ func generateInstanceName(e *Instance) (string, error) {
 	return strings.ToLower(fmt.Sprintf("%s-%s", fi.ValueOf(e.GroupName), hash[0:6])), nil
 }
 
-func (_ *Instance) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *Instance) error {
+func (_ *Instance) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *Instance) error {
 	cloud := t.Cloud
 	if a == nil {
 		serverName, err := generateInstanceName(e)

--- a/upup/pkg/fi/cloudup/openstacktasks/lb.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lb.go
@@ -190,7 +190,7 @@ func (_ *LB) CheckChanges(a, e, changes *LB) error {
 	return nil
 }
 
-func (_ *LB) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *LB) error {
+func (_ *LB) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *LB) error {
 	if a == nil {
 		klog.V(2).Infof("Creating LB with Name: %q", fi.ValueOf(e.Name))
 

--- a/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
@@ -139,7 +139,7 @@ func (_ *LBListener) CheckChanges(a, e, changes *LBListener) error {
 	return nil
 }
 
-func (_ *LBListener) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *LBListener) error {
+func (_ *LBListener) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *LBListener) error {
 	useVIPACL, err := t.Cloud.UseLoadBalancerVIPACL()
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/openstacktasks/lbpool.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lbpool.go
@@ -123,7 +123,7 @@ func (_ *LBPool) CheckChanges(a, e, changes *LBPool) error {
 	return nil
 }
 
-func (_ *LBPool) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *LBPool) error {
+func (_ *LBPool) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *LBPool) error {
 	if a == nil {
 
 		// wait that lb is in ACTIVE state

--- a/upup/pkg/fi/cloudup/openstacktasks/network.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/network.go
@@ -114,7 +114,7 @@ func (_ *Network) ShouldCreate(a, e, changes *Network) (bool, error) {
 	return false, nil
 }
 
-func (_ *Network) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *Network) error {
+func (_ *Network) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *Network) error {
 	if a == nil {
 		klog.V(2).Infof("Creating Network with name:%q", fi.ValueOf(e.Name))
 

--- a/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
@@ -158,7 +158,7 @@ func GetServerFixedIP(client *gophercloud.ServiceClient, serverID string, interf
 	return server, memberAddress, err
 }
 
-func (_ *PoolAssociation) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *PoolAssociation) error {
+func (_ *PoolAssociation) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *PoolAssociation) error {
 	if a == nil {
 
 		for _, serverID := range e.ServerGroup.GetMembers() {

--- a/upup/pkg/fi/cloudup/openstacktasks/poolmonitor.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolmonitor.go
@@ -98,7 +98,7 @@ func (_ *PoolMonitor) CheckChanges(a, e, changes *PoolMonitor) error {
 	return nil
 }
 
-func (_ *PoolMonitor) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *PoolMonitor) error {
+func (_ *PoolMonitor) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *PoolMonitor) error {
 	if a == nil {
 		klog.V(2).Infof("Creating PoolMonitor with Name: %q", fi.ValueOf(e.Name))
 

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -190,7 +190,7 @@ func (_ *Port) CheckChanges(a, e, changes *Port) error {
 	return nil
 }
 
-func (*Port) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *Port) error {
+func (*Port) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *Port) error {
 	if a == nil {
 		klog.V(2).Infof("Creating Port with name: %q", fi.ValueOf(e.Name))
 

--- a/upup/pkg/fi/cloudup/openstacktasks/port_test.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 )
@@ -786,8 +787,14 @@ func Test_Port_RenderOpenstack(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.desc, func(t *testing.T) {
+			ctx := testcontext.ForTest(t)
+			context, err := fi.NewCloudupContext(ctx, nil, nil, nil, nil, nil, nil, nil)
+			if err != nil {
+				t.Fatalf("error from NewCloudupContext: %v", err)
+			}
+
 			var port Port
-			err := (&port).RenderOpenstack(testCase.target, testCase.actual, testCase.expected, testCase.changes)
+			err = (&port).RenderOpenstack(context, testCase.target, testCase.actual, testCase.expected, testCase.changes)
 
 			compareErrors(t, err, testCase.expectedError)
 

--- a/upup/pkg/fi/cloudup/openstacktasks/router.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/router.go
@@ -91,7 +91,7 @@ func (_ *Router) CheckChanges(a, e, changes *Router) error {
 	return nil
 }
 
-func (_ *Router) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *Router) error {
+func (_ *Router) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *Router) error {
 	if a == nil {
 		klog.V(2).Infof("Creating Router with name:%q", fi.ValueOf(e.Name))
 

--- a/upup/pkg/fi/cloudup/openstacktasks/routerinterface.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/routerinterface.go
@@ -119,7 +119,7 @@ func (*RouterInterface) CheckChanges(a, e, changes *RouterInterface) error {
 	return nil
 }
 
-func (_ *RouterInterface) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *RouterInterface) error {
+func (_ *RouterInterface) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *RouterInterface) error {
 	if a == nil {
 		routerID := fi.ValueOf(e.Router.ID)
 		subnetID := fi.ValueOf(e.Subnet.ID)

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
@@ -109,7 +109,7 @@ func (_ *SecurityGroup) CheckChanges(a, e, changes *SecurityGroup) error {
 	return nil
 }
 
-func (_ *SecurityGroup) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *SecurityGroup) error {
+func (_ *SecurityGroup) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *SecurityGroup) error {
 	if a == nil {
 		klog.V(2).Infof("Creating SecurityGroup with Name:%q", fi.ValueOf(e.Name))
 

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygrouprule.go
@@ -149,7 +149,7 @@ func (*SecurityGroupRule) CheckChanges(a, e, changes *SecurityGroupRule) error {
 	return nil
 }
 
-func (*SecurityGroupRule) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *SecurityGroupRule) error {
+func (*SecurityGroupRule) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *SecurityGroupRule) error {
 	if a == nil {
 		klog.V(2).Infof("Creating SecurityGroupRule")
 		etherType := fi.ValueOf(e.EtherType)

--- a/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
@@ -122,7 +122,7 @@ func (_ *ServerGroup) CheckChanges(a, e, changes *ServerGroup) error {
 	return nil
 }
 
-func (_ *ServerGroup) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *ServerGroup) error {
+func (_ *ServerGroup) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *ServerGroup) error {
 	if a == nil {
 		klog.V(2).Infof("Creating ServerGroup with Name:%q", fi.ValueOf(e.Name))
 

--- a/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/sshkey.go
@@ -113,7 +113,7 @@ func openstackKeyPairName(org string) string {
 	return name
 }
 
-func (_ *SSHKey) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *SSHKey) error {
+func (_ *SSHKey) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *SSHKey) error {
 	if a == nil {
 		klog.V(2).Infof("Creating Keypair with name:%q", fi.ValueOf(e.Name))
 

--- a/upup/pkg/fi/cloudup/openstacktasks/subnet.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/subnet.go
@@ -140,7 +140,7 @@ func (*Subnet) CheckChanges(a, e, changes *Subnet) error {
 	return nil
 }
 
-func (*Subnet) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *Subnet) error {
+func (*Subnet) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *Subnet) error {
 	if a == nil {
 		klog.V(2).Infof("Creating Subnet with name:%q", fi.ValueOf(e.Name))
 

--- a/upup/pkg/fi/cloudup/openstacktasks/volume.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/volume.go
@@ -121,7 +121,7 @@ func (_ *Volume) CheckChanges(a, e, changes *Volume) error {
 	return nil
 }
 
-func (_ *Volume) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *Volume) error {
+func (_ *Volume) RenderOpenstack(c *fi.CloudupContext, t *openstack.OpenstackAPITarget, a, e, changes *Volume) error {
 	if a == nil {
 		klog.V(2).Infof("Creating PersistentVolume with Name:%q", fi.ValueOf(e.Name))
 

--- a/upup/pkg/fi/cloudup/scalewaytasks/volume.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/volume.go
@@ -100,7 +100,7 @@ func (_ *Volume) CheckChanges(a, e, changes *Volume) error {
 	return nil
 }
 
-func (_ *Volume) RenderScw(t *scaleway.ScwAPITarget, a, e, changes *Volume) error {
+func (_ *Volume) RenderScw(ctx *fi.CloudupContext, t *scaleway.ScwAPITarget, a, e, changes *Volume) error {
 	if a != nil {
 		klog.Infof("Scaleway does not support changes to volumes for the moment")
 		return nil

--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -496,7 +496,7 @@ func (s *Elastigroup) CheckChanges(a, e, changes *Elastigroup) error {
 	return nil
 }
 
-func (eg *Elastigroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Elastigroup) error {
+func (eg *Elastigroup) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *Elastigroup) error {
 	return eg.createOrUpdate(t.Cloud, a, e, changes)
 }
 
@@ -1460,7 +1460,7 @@ type terraformTaint struct {
 	Effect *string `cty:"effect"`
 }
 
-func (_ *Elastigroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Elastigroup) error {
+func (_ *Elastigroup) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Elastigroup) error {
 	cloud := t.Cloud.(awsup.AWSCloud)
 	e.applyDefaults()
 

--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -349,7 +349,7 @@ func (s *LaunchSpec) CheckChanges(a, e, changes *LaunchSpec) error {
 	return nil
 }
 
-func (o *LaunchSpec) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *LaunchSpec) error {
+func (o *LaunchSpec) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *LaunchSpec) error {
 	return o.createOrUpdate(t.Cloud, a, e, changes)
 }
 
@@ -883,7 +883,7 @@ type terraformBlockDeviceMappingEBS struct {
 	DeleteOnTermination *bool   `cty:"delete_on_termination"`
 }
 
-func (_ *LaunchSpec) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *LaunchSpec) error {
+func (_ *LaunchSpec) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *LaunchSpec) error {
 	cloud := t.Cloud.(awsup.AWSCloud)
 
 	tf := &terraformLaunchSpec{

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -343,7 +343,7 @@ func (s *Ocean) CheckChanges(a, e, changes *Ocean) error {
 	return nil
 }
 
-func (o *Ocean) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Ocean) error {
+func (o *Ocean) RenderAWS(ctx *fi.CloudupContext, t *awsup.AWSAPITarget, a, e, changes *Ocean) error {
 	return o.createOrUpdate(t.Cloud, a, e, changes)
 }
 
@@ -1052,7 +1052,7 @@ type terraformOcean struct {
 	SecurityGroups           []*terraformWriter.Literal `cty:"security_groups"`
 }
 
-func (_ *Ocean) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Ocean) error {
+func (_ *Ocean) RenderTerraform(ctx *fi.CloudupContext, t *terraform.TerraformTarget, a, e, changes *Ocean) error {
 	cloud := t.Cloud.(awsup.AWSCloud)
 
 	tf := &terraformOcean{

--- a/upup/pkg/fi/context.go
+++ b/upup/pkg/fi/context.go
@@ -177,7 +177,7 @@ func (c *Context[T]) Render(a, e, changes Task[T]) error {
 	}
 
 	if _, ok := c.Target.(*DryRunTarget[T]); ok {
-		return c.Target.(*DryRunTarget[T]).Render(a, e, changes)
+		return c.Target.(*DryRunTarget[T]).Render(c, a, e, changes)
 	}
 
 	v := reflect.ValueOf(e)

--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -101,7 +101,7 @@ func (t *DryRunTarget[T]) DefaultCheckExisting() bool {
 	return true
 }
 
-func (t *DryRunTarget[T]) Render(a, e, changes Task[T]) error {
+func (t *DryRunTarget[T]) Render(ctx *Context[T], a, e, changes Task[T]) error {
 	valA := reflect.ValueOf(a)
 	aIsNil := valA.IsNil()
 

--- a/upup/pkg/fi/nodeup/nodetasks/aptsource.go
+++ b/upup/pkg/fi/nodeup/nodetasks/aptsource.go
@@ -55,7 +55,7 @@ func (*AptSource) CheckChanges(a, e, changes *AptSource) error {
 	return nil
 }
 
-func (f *AptSource) RenderLocal(t *local.LocalTarget, a, e, changes *AptSource) error {
+func (f *AptSource) RenderLocal(c *fi.NodeupContext, t *local.LocalTarget, a, e, changes *AptSource) error {
 	tmpDir, err := os.MkdirTemp("", "aptsource")
 	if err != nil {
 		return fmt.Errorf("error creating temp dir: %v", err)

--- a/upup/pkg/fi/nodeup/nodetasks/archive.go
+++ b/upup/pkg/fi/nodeup/nodetasks/archive.go
@@ -133,7 +133,7 @@ func (_ *Archive) CheckChanges(a, e, changes *Archive) error {
 }
 
 // RenderLocal implements the fi.Task::Render functionality for a local target
-func (_ *Archive) RenderLocal(t *local.LocalTarget, a, e, changes *Archive) error {
+func (_ *Archive) RenderLocal(c *fi.NodeupContext, t *local.LocalTarget, a, e, changes *Archive) error {
 	if a == nil {
 		klog.Infof("Installing archive %q", e.Name)
 

--- a/upup/pkg/fi/nodeup/nodetasks/bindmount.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bindmount.go
@@ -184,7 +184,7 @@ type Executor interface {
 	CombinedOutput(args []string) ([]byte, error)
 }
 
-func (_ *BindMount) RenderLocal(t *local.LocalTarget, a, e, changes *BindMount) error {
+func (_ *BindMount) RenderLocal(c *fi.NodeupContext, t *local.LocalTarget, a, e, changes *BindMount) error {
 	return e.execute(t)
 }
 

--- a/upup/pkg/fi/nodeup/nodetasks/chattr.go
+++ b/upup/pkg/fi/nodeup/nodetasks/chattr.go
@@ -65,7 +65,7 @@ func (s *Chattr) CheckChanges(a, e, changes *Chattr) error {
 	return nil
 }
 
-func (_ *Chattr) RenderLocal(t *local.LocalTarget, a, e, changes *Chattr) error {
+func (_ *Chattr) RenderLocal(c *fi.NodeupContext, t *local.LocalTarget, a, e, changes *Chattr) error {
 	return e.execute(t)
 }
 

--- a/upup/pkg/fi/nodeup/nodetasks/group.go
+++ b/upup/pkg/fi/nodeup/nodetasks/group.go
@@ -87,7 +87,7 @@ func buildGroupaddArgs(e *GroupTask) []string {
 	return args
 }
 
-func (_ *GroupTask) RenderLocal(t *local.LocalTarget, a, e, changes *GroupTask) error {
+func (_ *GroupTask) RenderLocal(c *fi.NodeupContext, t *local.LocalTarget, a, e, changes *GroupTask) error {
 	if a == nil {
 		args := buildGroupaddArgs(e)
 		klog.Infof("Creating group %q", e.Name)

--- a/upup/pkg/fi/nodeup/nodetasks/load_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/load_image.go
@@ -87,7 +87,7 @@ func (_ *LoadImageTask) CheckChanges(a, e, changes *LoadImageTask) error {
 	return nil
 }
 
-func (_ *LoadImageTask) RenderLocal(t *local.LocalTarget, a, e, changes *LoadImageTask) error {
+func (_ *LoadImageTask) RenderLocal(c *fi.NodeupContext, t *local.LocalTarget, a, e, changes *LoadImageTask) error {
 	runtime := e.Runtime
 	if runtime != "docker" && runtime != "containerd" {
 		return fmt.Errorf("no runtime specified")

--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -268,7 +268,7 @@ func (_ *Package) CheckChanges(a, e, changes *Package) error {
 // It just avoids unnecessary failures from running e.g. concurrent apt-get installs
 var packageManagerLock sync.Mutex
 
-func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) error {
+func (_ *Package) RenderLocal(c *fi.NodeupContext, t *local.LocalTarget, a, e, changes *Package) error {
 	packageManagerLock.Lock()
 	defer packageManagerLock.Unlock()
 

--- a/upup/pkg/fi/nodeup/nodetasks/prefix.go
+++ b/upup/pkg/fi/nodeup/nodetasks/prefix.go
@@ -82,7 +82,7 @@ func (_ *Prefix) CheckChanges(a, e, changes *Prefix) error {
 	return nil
 }
 
-func (_ *Prefix) RenderLocal(t *local.LocalTarget, a, e, changes *Prefix) error {
+func (_ *Prefix) RenderLocal(c *fi.NodeupContext, t *local.LocalTarget, a, e, changes *Prefix) error {
 	mac, err := getInstanceMetadataFirstValue("mac")
 	if err != nil {
 		return err

--- a/upup/pkg/fi/nodeup/nodetasks/update_etc_hosts_task.go
+++ b/upup/pkg/fi/nodeup/nodetasks/update_etc_hosts_task.go
@@ -71,7 +71,7 @@ func (_ *UpdateEtcHostsTask) CheckChanges(a, e, changes *UpdateEtcHostsTask) err
 	return nil
 }
 
-func (_ *UpdateEtcHostsTask) RenderLocal(t *local.LocalTarget, a, e, changes *UpdateEtcHostsTask) error {
+func (_ *UpdateEtcHostsTask) RenderLocal(c *fi.NodeupContext, t *local.LocalTarget, a, e, changes *UpdateEtcHostsTask) error {
 	etcHostsPath := "/etc/hosts"
 
 	mutator := func(existing []string) (*hosts.HostMap, error) {

--- a/upup/pkg/fi/nodeup/nodetasks/update_packages.go
+++ b/upup/pkg/fi/nodeup/nodetasks/update_packages.go
@@ -65,7 +65,7 @@ func (s *UpdatePackages) CheckChanges(a, e, changes *UpdatePackages) error {
 	return nil
 }
 
-func (_ *UpdatePackages) RenderLocal(t *local.LocalTarget, a, e, changes *UpdatePackages) error {
+func (_ *UpdatePackages) RenderLocal(c *fi.NodeupContext, t *local.LocalTarget, a, e, changes *UpdatePackages) error {
 	if os.Getenv("SKIP_PACKAGE_UPDATE") != "" {
 		klog.Infof("SKIP_PACKAGE_UPDATE was set; skipping package update")
 		return nil

--- a/upup/pkg/fi/nodeup/nodetasks/user.go
+++ b/upup/pkg/fi/nodeup/nodetasks/user.go
@@ -90,7 +90,7 @@ func buildUseraddArgs(e *UserTask) []string {
 	return args
 }
 
-func (_ *UserTask) RenderLocal(t *local.LocalTarget, a, e, changes *UserTask) error {
+func (_ *UserTask) RenderLocal(c *fi.NodeupContext, t *local.LocalTarget, a, e, changes *UserTask) error {
 	if a == nil {
 		args := buildUseraddArgs(e)
 		klog.Infof("Creating user %q", e.Name)


### PR DESCRIPTION
~Builds on #14807.~ (no longer builds on this)

By passing the fi.Context into the Render methods, we can get a context.Context, and we can also work towards a standard Task signature.

Defined an interface for AWSTasks that defines the expected signature, and asserted that all types implement it (the seccond commit)