### PR TITLE
Automated cherry pick of #14815: Update containerd to v1.6.14

### DIFF
--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -47,7 +47,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 		// Set version based on Kubernetes version
 		if fi.ValueOf(containerd.Version) == "" {
 			if b.IsKubernetesGTE("1.23") {
-				containerd.Version = fi.PtrTo("1.6.13")
+				containerd.Version = fi.PtrTo("1.6.14")
 				containerd.Runc = &kops.Runc{
 					Version: fi.PtrTo("1.1.4"),
 				}

--- a/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_master-us-test-1a.masters.additionalobjects.example.com_user_data
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_master-us-test-1a.masters.additionalobjects.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -269,7 +269,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/additionalobjects.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: r6G08j2ljHfSCKnmy+BHF0DP/os3forPLq44TDhCXi8=
+NodeupConfigHash: CVM3fiYtWgFVtG3FSHwvL3Ehim/gBatpcS8/risg/S8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_nodes.additionalobjects.example.com_user_data
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_nodes.additionalobjects.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -169,7 +169,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/additionalobjects.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: gqZd6JqFB89JGfnNghwjuCAJxCSIi/zSRbsLAkkzV7E=
+NodeupConfigHash: 8r1VRpj+4+8Q8KbY7YCxHA+HGQuhK1aiVfYsHIWQCrQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
@@ -23,7 +23,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -279,7 +279,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://tests/additionalobjects.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://tests/additionalobjects.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -70,4 +70,4 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -142,7 +142,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -277,7 +277,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: xn8taxc3Yn1041uig6Y3NCYpQuuz1sgMhdzky4o+smQ=
+NodeupConfigHash: v7lOtAcnqEuOr1KxP1XMtr7t/uMmJ2kd5a4iAhJdgr8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
@@ -142,7 +142,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -177,7 +177,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 4tg8zy492jtU6mfSxb+iLZLUG/5FTrPgXOW9fo0hw6c=
+NodeupConfigHash: NUMhu5ptscF7v6cxHVRM6ONMQhXeVDqFYjzJLOvsZtU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -53,7 +53,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -64,7 +64,7 @@ Assets:
   - 3d98ac8b4fb8dc99f9952226f2565951cc366c442656a889facc5b1b2ec2ba52@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubelet
   - 94d686bb6772f6fb59e3a32beff908ab406b79acdfb2427abdc4ac3ce1bb98d7@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -72,7 +72,7 @@ Assets:
   - 8f066c9a048dd1704bf22ccf6e994e2fa2ea1175c9768a786f6cb6608765025e@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubelet
   - 449278789de283648e4076ade46816da249714f96e71567e035e9d17e1fff06d@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -279,7 +279,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/complex.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/complex.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 3d98ac8b4fb8dc99f9952226f2565951cc366c442656a889facc5b1b2ec2ba52@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubelet
   - 94d686bb6772f6fb59e3a32beff908ab406b79acdfb2427abdc4ac3ce1bb98d7@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 8f066c9a048dd1704bf22ccf6e994e2fa2ea1175c9768a786f6cb6608765025e@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubelet
   - 449278789de283648e4076ade46816da249714f96e71567e035e9d17e1fff06d@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -67,7 +67,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 packages:
 - nfs-common
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-default.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-default.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: karpenter-nodes-default
 InstanceGroupRole: Node
-NodeupConfigHash: KhradbQIM6eDGu5gSn3HRWGbE2zxsEL/RKV/714etqY=
+NodeupConfigHash: A86eb6d4Cjoo0Q2o8QLa/I4r3fIwq5QfT1q/hD0eD98=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-single-machinetype.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-single-machinetype.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: karpenter-nodes-single-machinetype
 InstanceGroupRole: Node
-NodeupConfigHash: LHbKhuEFm2c4jnFUt69sk11eY+roZmmTThPrLSsLYxs=
+NodeupConfigHash: nbFt86n2dLsv7fQU1qE5xCTpEF86vBBBMXIVTmz85Nk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -262,7 +262,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: 0YXeBptdul7VXzP05cW1p7+2xBJRzrxp5f5skDlYbnM=
+NodeupConfigHash: 9amUpwMA8pyx0JczUjHJFwH6uPbImHgrlSUt9vgHA/Q=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: s160N8wSgfdRqOXD6NuYD56mOwBMwf1DlNXKl6VHXEk=
+NodeupConfigHash: pRxy4Ta2yctZSiu9WNIe4P6ByjzuVEr+RpHOvPUxR3E=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -31,7 +31,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-default_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-default_content
@@ -3,13 +3,13 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -75,5 +75,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-single-machinetype_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-single-machinetype_content
@@ -3,13 +3,13 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -68,5 +68,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -273,7 +273,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -67,5 +67,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -263,7 +263,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: B9ohQ8+ztyt3sSAYGI3tzCcjygReIK1OYSuRNMHSKkk=
+NodeupConfigHash: 9GBwTII2NxrdSxpbiaUXkdo9dC/inw/4d1/zdqV8JCM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: +qaxTy+Pje/WRFgpXFqhxyIV2xYN0GXAHW4oRf5UVA8=
+NodeupConfigHash: d78Lc/xbUYrlKBQYOPyEK07Ncix7S6LcQhKRqkTqbt4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -277,7 +277,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -70,5 +70,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -261,7 +261,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: UBxI7F6ZMfQMeMhaoWciaojeRN8WBRHT9Nf84o+8kfo=
+NodeupConfigHash: g/UGo94ySJXl01HoGly4cQl6R37457qfLGYtSVNhSaU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -167,7 +167,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 9lIz+m7iSnH9SzNmJQsOqwKrYqDndR15boR+zr/aAmI=
+NodeupConfigHash: wjXE3Hm/bWjNLpa0abPVlXC9CdgC1+FTFD4FNV5ImBE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
@@ -51,7 +51,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 3d98ac8b4fb8dc99f9952226f2565951cc366c442656a889facc5b1b2ec2ba52@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubelet
   - 94d686bb6772f6fb59e3a32beff908ab406b79acdfb2427abdc4ac3ce1bb98d7@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - 8f066c9a048dd1704bf22ccf6e994e2fa2ea1175c9768a786f6cb6608765025e@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubelet
   - 449278789de283648e4076ade46816da249714f96e71567e035e9d17e1fff06d@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -274,7 +274,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 3d98ac8b4fb8dc99f9952226f2565951cc366c442656a889facc5b1b2ec2ba52@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubelet
   - 94d686bb6772f6fb59e3a32beff908ab406b79acdfb2427abdc4ac3ce1bb98d7@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 8f066c9a048dd1704bf22ccf6e994e2fa2ea1175c9768a786f6cb6608765025e@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubelet
   - 449278789de283648e4076ade46816da249714f96e71567e035e9d17e1fff06d@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -68,5 +68,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -261,7 +261,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: okQYWWL04TTt4NKFqaoakaenfHwWWXt+vmTJpQtr5E0=
+NodeupConfigHash: 4qZRXp9+sCPMjo2qdHUKOIdGUS5aGPrWyinYAceTaW0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -167,7 +167,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: L+JptkXci2fu5WbxUjKFeV0XJdRlfMBgJzBsp5YH9ro=
+NodeupConfigHash: bbEpzjWdFca0PjMPxvP1zvLApI9trWCfxaJwS/DkYDI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 367e3fbdf67d3c51d0d6790c606420ae7d063daa7c274f74d496dbaf7c2c7346@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/amd64/kubelet
   - 07898c9f3e8bd94c6ee3211f3de4adab38a0c6900130206ff685ee632076393b@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - 4c77e4c466761d26431fe3292577b102477dee20c4c3267a014d1bc0913cd742@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/arm64/kubelet
   - e0c15a7b7e0086b459587ce472caf7282becfd4423d3c71226ac350fadf2fa8f@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -274,7 +274,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 367e3fbdf67d3c51d0d6790c606420ae7d063daa7c274f74d496dbaf7c2c7346@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/amd64/kubelet
   - 07898c9f3e8bd94c6ee3211f3de4adab38a0c6900130206ff685ee632076393b@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 4c77e4c466761d26431fe3292577b102477dee20c4c3267a014d1bc0913cd742@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/arm64/kubelet
   - e0c15a7b7e0086b459587ce472caf7282becfd4423d3c71226ac350fadf2fa8f@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -68,5 +68,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -261,7 +261,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: g8xlvntMOxg+bHfe5N8+NKeqhmxo2v2B2eIMcTwXIiY=
+NodeupConfigHash: IJ/9tsCkShOwmVgH1Ny0mQhJ94Ydijsvv7fspsCI9b8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -167,7 +167,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 2O3yyU5NfxiyfTNLfg4BcBOgC1NwFXZa+lYA0Thyc18=
+NodeupConfigHash: RjBLkpR68jnhWyUFL+Kbe4HZOAJ6lMjCQJgjUxjgN2A=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
@@ -50,7 +50,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 0eeb400fd028f5848c6d63c88b63148867bc36773e80ff9a9509c59e41859f51@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/amd64/kubelet
   - 908abb954a0d131e5b702f4faecaa310d19ca217c09bb90a340f24a2b5e2a567@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - c01a2ce56a4484354a7db11abac8166fa45215855662726b43639072608ecbfa@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/arm64/kubelet
   - de553916b8607682b10cd6f6c333204b5f0186a10e2007a44528542845ffb28c@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -274,7 +274,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 0eeb400fd028f5848c6d63c88b63148867bc36773e80ff9a9509c59e41859f51@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/amd64/kubelet
   - 908abb954a0d131e5b702f4faecaa310d19ca217c09bb90a340f24a2b5e2a567@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - c01a2ce56a4484354a7db11abac8166fa45215855662726b43639072608ecbfa@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/arm64/kubelet
   - de553916b8607682b10cd6f6c333204b5f0186a10e2007a44528542845ffb28c@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -68,5 +68,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -269,7 +269,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: zPKFwFk0Qctv3NvmJXCQ1hptyMy/vxIu/Rm+r2nUuBo=
+NodeupConfigHash: c3D00bLpWQHgCabNqXOWD+j3916+E877JmZAb+xlPDc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -169,7 +169,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 3Om8CTQ7+kzTX0gkgj1yOHk53NxJapGeCwXDQF3xDzU=
+NodeupConfigHash: MbP2C//WJxo8ivhpa/XilrxVmmaukSe8uZzJDc0lUXY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_cluster-completed.spec_content
@@ -23,7 +23,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -277,7 +277,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://tests/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://tests/minimal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -70,4 +70,4 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -266,7 +266,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: dZGdwh4FoWrNPHvIAm9coZZOZ7a32+/Q9xXcOTkFgxY=
+NodeupConfigHash: Z0oHXPbOPr+p23+/mlNCxs3eONBofzmA/BXJ9AQF1Rw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: eoqVTsVkwcOBz1Gl7bwm1fDAp5hqVm0eLv4X7JyVSN0=
+NodeupConfigHash: 8ShXPLNMMSOoXdn7XoVtnL2QHGSH0zUXEhUvg1gYkeo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
@@ -32,7 +32,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - da575ceb7c44fddbe7d2514c16798f39f8c10e54b5dbef3bcee5ac547637db11@https://storage.googleapis.com/kubernetes-release/release/v1.24.3/bin/linux/amd64/kubelet
   - 8a45348bdaf81d46caf1706c8bf95b3f431150554f47d444ffde89e8cdd712c1@https://storage.googleapis.com/kubernetes-release/release/v1.24.3/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - 6c04ae25ee9b434f40e0d2466eb4ef5604dc43f306ddf1e5f165fc9d3c521e12@https://storage.googleapis.com/kubernetes-release/release/v1.24.3/bin/linux/arm64/kubelet
   - bdad4d3063ddb7bfa5ecf17fb8b029d5d81d7d4ea1650e4369aafa13ed97149a@https://storage.googleapis.com/kubernetes-release/release/v1.24.3/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -274,7 +274,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://tests/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://tests/minimal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - da575ceb7c44fddbe7d2514c16798f39f8c10e54b5dbef3bcee5ac547637db11@https://storage.googleapis.com/kubernetes-release/release/v1.24.3/bin/linux/amd64/kubelet
   - 8a45348bdaf81d46caf1706c8bf95b3f431150554f47d444ffde89e8cdd712c1@https://storage.googleapis.com/kubernetes-release/release/v1.24.3/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 6c04ae25ee9b434f40e0d2466eb4ef5604dc43f306ddf1e5f165fc9d3c521e12@https://storage.googleapis.com/kubernetes-release/release/v1.24.3/bin/linux/arm64/kubelet
   - bdad4d3063ddb7bfa5ecf17fb8b029d5d81d7d4ea1650e4369aafa13ed97149a@https://storage.googleapis.com/kubernetes-release/release/v1.24.3/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -68,5 +68,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -266,7 +266,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: dHmvVtyeaWNW7QWoyhAwbE+syORWkLpQX2LwlgraPkQ=
+NodeupConfigHash: RNvcP4jNB2dFfvkKOU+m/QdffattYXdWwWi627eZm+I=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: J2Rncps0SUHyp0fQ5UTApVHYItrpelxEbA+BLU5I0Ps=
+NodeupConfigHash: o5KyC+V2N35P5N7xrS5sytSFQrlm8rizOT8MzUqC4pw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
@@ -31,7 +31,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 367e3fbdf67d3c51d0d6790c606420ae7d063daa7c274f74d496dbaf7c2c7346@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/amd64/kubelet
   - 07898c9f3e8bd94c6ee3211f3de4adab38a0c6900130206ff685ee632076393b@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - 4c77e4c466761d26431fe3292577b102477dee20c4c3267a014d1bc0913cd742@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/arm64/kubelet
   - e0c15a7b7e0086b459587ce472caf7282becfd4423d3c71226ac350fadf2fa8f@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -274,7 +274,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://tests/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://tests/minimal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 367e3fbdf67d3c51d0d6790c606420ae7d063daa7c274f74d496dbaf7c2c7346@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/amd64/kubelet
   - 07898c9f3e8bd94c6ee3211f3de4adab38a0c6900130206ff685ee632076393b@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 4c77e4c466761d26431fe3292577b102477dee20c4c3267a014d1bc0913cd742@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/arm64/kubelet
   - e0c15a7b7e0086b459587ce472caf7282becfd4423d3c71226ac350fadf2fa8f@https://storage.googleapis.com/kubernetes-release/release/v1.25.0-rc.1/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -68,5 +68,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -266,7 +266,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: p1EbiRNsND06nQHX7rEQ/fV33+ee8hKJVbKAH8L1Bq4=
+NodeupConfigHash: bbEzG8sDYC/Rf50WZv2D+KcZpFF+8dWUGa4r105hlKQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: NvvPPIP8oXP6+TdPQzq4NiICKysOONb3TKqEas33FDI=
+NodeupConfigHash: d8vVTJvmL5XOCbtMeN8aJCZTtJcRwoIiGVn3WJMbyIs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
@@ -31,7 +31,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 0eeb400fd028f5848c6d63c88b63148867bc36773e80ff9a9509c59e41859f51@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/amd64/kubelet
   - 908abb954a0d131e5b702f4faecaa310d19ca217c09bb90a340f24a2b5e2a567@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - c01a2ce56a4484354a7db11abac8166fa45215855662726b43639072608ecbfa@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/arm64/kubelet
   - de553916b8607682b10cd6f6c333204b5f0186a10e2007a44528542845ffb28c@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -274,7 +274,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://tests/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://tests/minimal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 0eeb400fd028f5848c6d63c88b63148867bc36773e80ff9a9509c59e41859f51@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/amd64/kubelet
   - 908abb954a0d131e5b702f4faecaa310d19ca217c09bb90a340f24a2b5e2a567@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - c01a2ce56a4484354a7db11abac8166fa45215855662726b43639072608ecbfa@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/arm64/kubelet
   - de553916b8607682b10cd6f6c333204b5f0186a10e2007a44528542845ffb28c@https://storage.googleapis.com/kubernetes-release/release/v1.26.0-alpha.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -68,5 +68,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -136,7 +136,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -266,7 +266,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: 8O0qfUw5mVIDYrPvqfrW59Pl5XNFDORcbruJU5jPbuk=
+NodeupConfigHash: ga4fYRk82Qese2WkqW/RSq+rXsEZzaUiqilowyvR15g=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -136,7 +136,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -170,7 +170,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: O7rcy4/hbdvtesIlThinQkbm2dvY/EJUMWtDza5u09w=
+NodeupConfigHash: OOcJj3VkaLWAf8GdbYgF0GU788CwXmj0Qj1ZVSxM5r4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
@@ -36,7 +36,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -274,7 +274,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/minimal-ipv6.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/minimal-ipv6.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -68,5 +68,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -136,7 +136,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -268,7 +268,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: B1/oaWRNv08KOutU7na0w9bRjbIMyGZXZYBUnfz9iJg=
+NodeupConfigHash: lwl7chA3mUmcUz0plM3TSqAdcK9wWgzsCd0UMjmcEvg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -136,7 +136,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -171,7 +171,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: W92TZirON1jpi6eoJWDKmxKA5BA5rxwFQgHs9b2BNis=
+NodeupConfigHash: FdViORanRW4VCpgbsIl9NbjkyMckR07BErqNyUfiq9I=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_cluster-completed.spec_content
@@ -36,7 +36,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -276,7 +276,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/minimal-ipv6.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/minimal-ipv6.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -69,5 +69,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: "1"
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -56,7 +56,7 @@ Assets:
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - ab63ef67b254a2eae51782106593c266e0b054ac2248e2cb913f6d165afae83c@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/mounter
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -65,7 +65,7 @@ Assets:
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - 6ef5620ad47035a168bf28335aa39a09f246e17f5d6e42f0d8daba7d90fc4e9f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/mounter
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -273,7 +273,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://tests/minimal-gce.example.com/manifests/etcd/main-master-us-test1-a.yaml
 - memfs://tests/minimal-gce.example.com/manifests/etcd/events-master-us-test1-a.yaml

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-nodes_content
@@ -4,14 +4,14 @@ Assets:
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - ab63ef67b254a2eae51782106593c266e0b054ac2248e2cb913f6d165afae83c@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/mounter
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - 6ef5620ad47035a168bf28335aa39a09f246e17f5d6e42f0d8daba7d90fc4e9f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/mounter
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -69,4 +69,4 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -252,7 +252,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: Master
-NodeupConfigHash: A2icgNf+f9r8/imKoH7wMejWUCObICDs1O9aRYdwR4k=
+NodeupConfigHash: d5M7Ug9MWaDnbYP7JR8y4P7m1q33317k381zBVOTuxY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -167,7 +167,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: iG21BZgVQbrb4E71O0YF5UsXgFEArxwVf2eTmXhe5Sw=
+NodeupConfigHash: nyk3fShcYVrNx6h595uOWPU+w0brF6IItY4C4bN6bOo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -28,7 +28,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: "1"
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -56,7 +56,7 @@ Assets:
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - ab63ef67b254a2eae51782106593c266e0b054ac2248e2cb913f6d165afae83c@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/mounter
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -65,7 +65,7 @@ Assets:
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - 6ef5620ad47035a168bf28335aa39a09f246e17f5d6e42f0d8daba7d90fc4e9f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/mounter
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -273,7 +273,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/manifests/etcd/main-master-us-test1-a.yaml
 - memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/manifests/etcd/events-master-us-test1-a.yaml

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-nodes_content
@@ -4,14 +4,14 @@ Assets:
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - ab63ef67b254a2eae51782106593c266e0b054ac2248e2cb913f6d165afae83c@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/mounter
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - 6ef5620ad47035a168bf28335aa39a09f246e17f5d6e42f0d8daba7d90fc4e9f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/mounter
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -69,4 +69,4 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -252,7 +252,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: Master
-NodeupConfigHash: jUgWkR0eTRxt2NQzXhyMGUDSX9sQzalwNYeKeHlJdvg=
+NodeupConfigHash: 65XUmWaj75Yia7i6qcjbwik25JWDH6lcz1JpRyiowoo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -167,7 +167,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: fCMn/ieWfSrXEVS3rHc2fYWyucIiJ4fMwKAa2oAA8lA=
+NodeupConfigHash: 2pGacer2es9azVB0IsPuoueNqHtbhkkxFIytxOZn+hQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: "1"
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
@@ -56,7 +56,7 @@ Assets:
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - ab63ef67b254a2eae51782106593c266e0b054ac2248e2cb913f6d165afae83c@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/mounter
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -65,7 +65,7 @@ Assets:
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - 6ef5620ad47035a168bf28335aa39a09f246e17f5d6e42f0d8daba7d90fc4e9f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/mounter
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -273,7 +273,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/manifests/etcd/main-master-us-test1-a.yaml
 - memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/manifests/etcd/events-master-us-test1-a.yaml

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-nodes_content
@@ -4,14 +4,14 @@ Assets:
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - ab63ef67b254a2eae51782106593c266e0b054ac2248e2cb913f6d165afae83c@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/mounter
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - 6ef5620ad47035a168bf28335aa39a09f246e17f5d6e42f0d8daba7d90fc4e9f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/mounter
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -69,4 +69,4 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -252,7 +252,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: Master
-NodeupConfigHash: jUgWkR0eTRxt2NQzXhyMGUDSX9sQzalwNYeKeHlJdvg=
+NodeupConfigHash: 65XUmWaj75Yia7i6qcjbwik25JWDH6lcz1JpRyiowoo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -167,7 +167,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: fCMn/ieWfSrXEVS3rHc2fYWyucIiJ4fMwKAa2oAA8lA=
+NodeupConfigHash: 2pGacer2es9azVB0IsPuoueNqHtbhkkxFIytxOZn+hQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -30,7 +30,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   docker:
     skipInstall: true
   etcdClusters:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content
@@ -55,7 +55,7 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -63,7 +63,7 @@ Assets:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -267,7 +267,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://tests/minimal.k8s.local/manifests/etcd/main-master-fsn1.yaml
 - memfs://tests/minimal.k8s.local/manifests/etcd/events-master-fsn1.yaml

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-nodes-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-nodes-fsn1_content
@@ -3,7 +3,7 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -11,7 +11,7 @@ Assets:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -70,4 +70,4 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14

--- a/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_master-fsn1_user_data
+++ b/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_master-fsn1_user_data
@@ -130,7 +130,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -248,7 +248,7 @@ CloudProvider: hetzner
 ConfigBase: memfs://tests/minimal.k8s.local
 InstanceGroupName: master-fsn1
 InstanceGroupRole: Master
-NodeupConfigHash: OYm6gx7IzEff2/+wXXHOfBXXFMEjG3oZ4kkkJkU/zRQ=
+NodeupConfigHash: 03UUabPRgwtoDsDpH2isKpd3XZ0KWWIfxC/JC+tGXrI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_nodes-fsn1_user_data
+++ b/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_nodes-fsn1_user_data
@@ -130,7 +130,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -162,7 +162,7 @@ CloudProvider: hetzner
 ConfigBase: memfs://tests/minimal.k8s.local
 InstanceGroupName: nodes-fsn1
 InstanceGroupRole: Node
-NodeupConfigHash: Hmb0+SZ/yiCOTlCN0NVM1wtj8yk+NyKFNEZammsb2+0=
+NodeupConfigHash: Dz31a3erozjak0z7Vn8Ogf0DXjl5A5EVg9rEPBXhXCk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -262,7 +262,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecalico.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: 8+rpaXG2pzMm81xmVFSNSMrJglMXMyPy7Y9f/amv/mw=
+NodeupConfigHash: jlXHLeoTkTDuf//idrt+xY+Fa5rJrGANyO/BPRBb2wU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecalico.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: Shask5LS/zgg8aygVhp2w+qskMHM9iT7JnR2pVS+fHg=
+NodeupConfigHash: CKGR7O2zlBSvpIKx0Oj2fvIAYtr77yRsLCsk4dWGjsI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
@@ -33,7 +33,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -273,7 +273,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/privatecalico.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/privatecalico.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -67,5 +67,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -262,7 +262,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecanal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: O1u43306IFNFNReo/pDN1XX04uotD6BxIQyT1ENJ5xc=
+NodeupConfigHash: yV9rKhgVckeESx6q52Bps2UoR0fySqP2HUR/zMQZSc0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecanal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: BJRTAPMw21rt1FYm/rvCpSHrxiEeeMqyuyOCs4/BFN4=
+NodeupConfigHash: 1LnPJmdEpYxYLH9Gi6O8ruhZumgSrBHkhpHJcabmiEQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
@@ -33,7 +33,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -273,7 +273,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/privatecanal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/privatecanal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -67,5 +67,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -262,7 +262,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: HcP4D/gG5DtcgEBi98PCYQpILlQYSHIXMwwUO5kKW6s=
+NodeupConfigHash: Htyp5khqlDX5WvaasWiLRwnFZsPj76VHU0cN7UfQNsI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: a7XbpJTQuxAMoatDVNN3xdve88RWAiSgzEPQiELcWzk=
+NodeupConfigHash: 5FwRDCqDlnGaFxbwIBNh1rCqwNgZsP5HZe7Io5H/2Lw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -36,7 +36,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 3d98ac8b4fb8dc99f9952226f2565951cc366c442656a889facc5b1b2ec2ba52@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubelet
   - 94d686bb6772f6fb59e3a32beff908ab406b79acdfb2427abdc4ac3ce1bb98d7@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - 8f066c9a048dd1704bf22ccf6e994e2fa2ea1175c9768a786f6cb6608765025e@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubelet
   - 449278789de283648e4076ade46816da249714f96e71567e035e9d17e1fff06d@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -273,7 +273,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/privatecilium.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/privatecilium.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 3d98ac8b4fb8dc99f9952226f2565951cc366c442656a889facc5b1b2ec2ba52@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubelet
   - 94d686bb6772f6fb59e3a32beff908ab406b79acdfb2427abdc4ac3ce1bb98d7@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 8f066c9a048dd1704bf22ccf6e994e2fa2ea1175c9768a786f6cb6608765025e@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubelet
   - 449278789de283648e4076ade46816da249714f96e71567e035e9d17e1fff06d@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -67,5 +67,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -262,7 +262,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privateflannel.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: 1LxYst20Fz2VBeMDv28EBFv/SscvXLrqRR7opoyAxis=
+NodeupConfigHash: 1zszf/Sqsq/Lvs6Yh1Zt0fUDQFYQ2gIlgtktuztA2MA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privateflannel.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: ifnbOLhrwTNM38o0YDOnjmpKK04yn5oDZlnZL9ooBSk=
+NodeupConfigHash: Lb6rNBeYhzNmMB1jfUnS+8tGtu9HxHvad0uQZmk4DvA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
@@ -33,7 +33,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -273,7 +273,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/privateflannel.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/privateflannel.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 7f9183fce12606818612ce80b6c09757452c4fb50aefea5fc5843951c5020e24@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubelet
   - e23cc7092218c95c22d8ee36fb9499194a36ac5b5349ca476886b7edc0203885@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 69572a7b3d179d4a479aa2e0f90e2f091d8d84ef33a35422fc89975dc137a590@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubelet
   - 24db547bbae294c5c44f2b4a777e45f0e2f3d6295eace0d0c4be2b2dfa45330d@https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -67,5 +67,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -263,7 +263,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: Gdmub+IZSAVlyzDOSE94/Pi+00uaHSjp6eGlwgy625c=
+NodeupConfigHash: VSZTVA0e3//GCaJVxsSHgs554IZthTWj/nkSUCniA7E=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -133,7 +133,7 @@ containerd:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 2ojwO4b/oCW/YwTrGn3AZd+LCtpLvHHGDkLbcKtDFzI=
+NodeupConfigHash: HiiKAqnlA5WEEqHy+rZF5eUy1304iQcTrQseZXJP+ss=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
@@ -32,7 +32,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.4
-    version: 1.6.13
+    version: 1.6.14
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -59,7 +59,7 @@ Assets:
   - 3d98ac8b4fb8dc99f9952226f2565951cc366c442656a889facc5b1b2ec2ba52@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubelet
   - 94d686bb6772f6fb59e3a32beff908ab406b79acdfb2427abdc4ac3ce1bb98d7@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -67,7 +67,7 @@ Assets:
   - 8f066c9a048dd1704bf22ccf6e994e2fa2ea1175c9768a786f6cb6608765025e@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubelet
   - 449278789de283648e4076ade46816da249714f96e71567e035e9d17e1fff06d@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -274,7 +274,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 etcdManifests:
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/events-master-us-test-1a.yaml

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 3d98ac8b4fb8dc99f9952226f2565951cc366c442656a889facc5b1b2ec2ba52@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubelet
   - 94d686bb6772f6fb59e3a32beff908ab406b79acdfb2427abdc4ac3ce1bb98d7@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-amd64.tar.gz
+  - 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
   - db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
   arm64:
   - 8f066c9a048dd1704bf22ccf6e994e2fa2ea1175c9768a786f6cb6608765025e@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubelet
   - 449278789de283648e4076ade46816da249714f96e71567e035e9d17e1fff06d@https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064@https://github.com/containerd/containerd/releases/download/v1.6.13/containerd-1.6.13-linux-arm64.tar.gz
+  - 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809@https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-arm64.tar.gz
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -67,5 +67,5 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.4
-  version: 1.6.13
+  version: 1.6.14
 useInstanceIDForNodeName: true

--- a/upup/pkg/fi/cloudup/containerd.go
+++ b/upup/pkg/fi/cloudup/containerd.go
@@ -229,6 +229,7 @@ func findAllContainerdHashesAmd64() map[string]string {
 		"1.6.11": "21870d7022c52f5f74336d440deffb208ba747b332a88e6369e2aecb69382e48",
 		"1.6.12": "a56c39795fd0d0ee356b4099a4dfa34689779f61afc858ef84c765c63e983a7d",
 		"1.6.13": "97f00411587512e62ec762828e581047b23199f8744754706d09976ec24a2736",
+		"1.6.14": "7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd",
 	}
 
 	return hashes
@@ -250,6 +251,7 @@ func findAllContainerdHashesArm64() map[string]string {
 		"1.6.11": "1b34d8ff067da482af021dac325dc4e993d7356c0bd9dc8e5a3bb8271c1532de",
 		"1.6.12": "0a0133336596b2d1dcafe3587eb91ab302afc28f273614e0e02300694b5457a0",
 		"1.6.13": "8c7892ae7c2e96a4a9358b1064fb5519a5c0528b715beee67b72e74d7a644064",
+		"1.6.14": "3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809",
 	}
 
 	return hashes


### PR DESCRIPTION
Cherry pick of #14815 on release-1.25.

#14815: Update containerd to v1.6.14

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```