### PR TITLE
Cleanup double-license header in file

### DIFF
--- a/util/pkg/vfs/k8scontext.go
+++ b/util/pkg/vfs/k8scontext.go
@@ -1,20 +1,4 @@
 /*
-Copyright 2019 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-/*
 Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
We somehow ended up with 2 license headers here (the same, though with
different dates).
