### PR TITLE
WIP: Allow built-in manifests to be replaced by external addons

### DIFF
--- a/pkg/kubemanifest/containerargs.go
+++ b/pkg/kubemanifest/containerargs.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubemanifest
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ContainerVisitorFunction func(container map[string]interface{}) error
+
+func (m *Object) VisitContainers(visitorFn ContainerVisitorFunction) error {
+	visitorObj := &containerVisitor{
+		visitor: visitorFn,
+	}
+	err := m.accept(visitorObj)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type containerVisitor struct {
+	visitorBase
+	visitor ContainerVisitorFunction
+}
+
+func (m *containerVisitor) VisitMap(path []string, v map[string]interface{}) error {
+	n := len(path)
+	if n < 2 || path[n-2] != "containers" || !strings.HasPrefix(path[n-1], "[") {
+		return nil
+	}
+
+	if err := m.visitor(v); err != nil {
+		return fmt.Errorf("error visiting container %v: %w", v, err)
+	}
+
+	return nil
+}

--- a/pkg/kubemanifest/visitor.go
+++ b/pkg/kubemanifest/visitor.go
@@ -40,10 +40,16 @@ func (m *visitorBase) VisitFloat64(path []string, v float64, mutator func(float6
 	return nil
 }
 
+func (m *visitorBase) VisitMap(path []string, v map[string]interface{}) error {
+	klog.V(10).Infof("object value at %s: %f", strings.Join(path, "."), v)
+	return nil
+}
+
 type Visitor interface {
 	VisitBool(path []string, v bool, mutator func(bool)) error
 	VisitString(path []string, v string, mutator func(string)) error
 	VisitFloat64(path []string, v float64, mutator func(float64)) error
+	VisitMap(path []string, v map[string]interface{}) error
 }
 
 func visit(visitor Visitor, data interface{}, path []string, mutator func(interface{})) error {
@@ -78,6 +84,11 @@ func visit(visitor Visitor, data interface{}, path []string, mutator func(interf
 	case nil:
 	case map[string]interface{}:
 		m := data
+
+		if err := visitor.VisitMap(path, m); err != nil {
+			return err
+		}
+
 		for k, v := range m {
 			path = append(path, k)
 
@@ -103,6 +114,9 @@ func visit(visitor Visitor, data interface{}, path []string, mutator func(interf
 			}
 			path = path[:len(path)-1]
 		}
+
+	case []string:
+		// ignore - we don't have any visitors for this currently
 
 	default:
 		return fmt.Errorf("unhandled type in manifest: %T", data)


### PR DESCRIPTION
For discussion, in conjunction with https://github.com/kubernetes/cloud-provider-gcp/pull/434

Allows built in manifests to be replaced by manifests supplied via the "additional objects" mechanism.  That's behind a feature flag so we can make changes.

This allows use of kOps to test components (hopefully meaning that we can run components that are tested with kOps).  It also allows sophisticated users to plug in replacement manifests for the built-ins and allows us to make progress towards a more modular world.

OTOH the approach feels a _little_ hacky - I was wondering whether we should use labels or similar - but OTOH creating the same object with a built-in and an additional object is going to result in "bad things (tm)", so it's probably a good signaling mechanism.