### PR TITLE
Use AMD64 for AWS LB controller testing

### DIFF
--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -25,7 +25,7 @@ NETWORKING="amazonvpc"
 
 OVERRIDES="${OVERRIDES-} --set=cluster.spec.cloudProvider.aws.loadBalancerController.enabled=true"
 OVERRIDES="${OVERRIDES} --set=cluster.spec.certManager.enabled=true"
-OVERRIDES="${OVERRIDES} --master-size=t4g.medium --node-size=t4g.medium"
+OVERRIDES="${OVERRIDES} --master-size=t3.medium --node-size=c5.large"
 
 # shellcheck disable=SC2034
 ZONES="eu-west-1a,eu-west-1b,eu-west-1c"


### PR DESCRIPTION
Even though `docker.io/amazon/aws-alb-ingress-controller:v2.4.5` is built with ARM64 support, the container images that are required for testing are not.

https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/e2e-kops-aws-aws-load-balancer-controller/1605678791877726208/artifacts/cluster-info/aws-lb-e2e-a60d3d/
```
==== START logs for container app of pod aws-lb-e2e-a60d3d/backend-b-7d8f879dc4-w7d98 ====
exec /bin/aws-app-mesh-examples-colorapp-teller: exec format error
==== END logs for container app of pod aws-lb-e2e-a60d3d/backend-b-7d8f879dc4-w7d98 ====
```

/cc @johngmyers @olemarkus 