### PR TITLE
Automated cherry pick of #14848: Validate control-plane IG size

### DIFF
--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -49,6 +49,12 @@ func ValidateInstanceGroup(g *kops.InstanceGroup, cloud fi.Cloud, strict bool) f
 		if len(g.Spec.Subnets) == 0 {
 			allErrs = append(allErrs, field.Required(field.NewPath("spec", "subnets"), "master InstanceGroup must specify at least one Subnet"))
 		}
+		if fi.ValueOf(g.Spec.MinSize) > 1 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "minSize"), fi.ValueOf(g.Spec.MinSize), "master InstanceGroup must have minSize set to 1"))
+		}
+		if fi.ValueOf(g.Spec.MaxSize) > 1 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "maxSize"), fi.ValueOf(g.Spec.MaxSize), "master InstanceGroup must have maxSize set to 1, add more InstanceGroups instead"))
+		}
 	case kops.InstanceGroupRoleNode:
 	case kops.InstanceGroupRoleBastion:
 	case kops.InstanceGroupRoleAPIServer:

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -402,7 +402,7 @@ func TestValidInstanceGroup(t *testing.T) {
 				},
 			},
 			ExpectedErrors: []string{},
-			Description:    "Valid master instance group failed to validate",
+			Description:    "Valid control-plane instance group failed to validate",
 		},
 		{
 			IG: &kops.InstanceGroup{
@@ -466,6 +466,25 @@ func TestValidInstanceGroup(t *testing.T) {
 			},
 			ExpectedErrors: []string{"Forbidden::spec.image"},
 			Description:    "Valid instance group must have image set",
+		},
+		{
+			IG: &kops.InstanceGroup{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "eu-central-1a",
+				},
+				Spec: kops.InstanceGroupSpec{
+					Role:    kops.InstanceGroupRoleMaster,
+					Subnets: []string{"eu-central-1a"},
+					MaxSize: fi.PtrTo(int32(2)),
+					MinSize: fi.PtrTo(int32(2)),
+					Image:   "my-image",
+				},
+			},
+			ExpectedErrors: []string{
+				"Invalid value::spec.minSize",
+				"Invalid value::spec.maxSize",
+			},
+			Description: "Invalid master instance group sizes",
 		},
 	}
 	for _, g := range grid {


### PR DESCRIPTION
Cherry pick of #14848 on release-1.25.

#14848: Validate control-plane IG size

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```