### PR TITLE
VFS: Add context to CreateFile & WriteFile

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kops/pkg/pki"
 	"k8s.io/kops/pkg/testutils"
 	"k8s.io/kops/pkg/testutils/golden"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/pkg/truncate"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
@@ -1338,7 +1339,7 @@ func storeKeyset(t *testing.T, ctx context.Context, keyStore fi.Keystore, name s
 }
 
 func (i *integrationTest) runTestTerraformAWS(t *testing.T) {
-	ctx := testutils.ContextForTest(t)
+	ctx := testcontext.ForTest(t)
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -1426,7 +1427,7 @@ func (i *integrationTest) runTestTerraformAWS(t *testing.T) {
 }
 
 func (i *integrationTest) runTestPhase(t *testing.T, phase cloudup.Phase) {
-	ctx := testutils.ContextForTest(t)
+	ctx := testcontext.ForTest(t)
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -1471,7 +1472,7 @@ func (i *integrationTest) runTestPhase(t *testing.T, phase cloudup.Phase) {
 }
 
 func (i *integrationTest) runTestTerraformGCE(t *testing.T) {
-	ctx := testutils.ContextForTest(t)
+	ctx := testcontext.ForTest(t)
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -1510,7 +1511,7 @@ func (i *integrationTest) runTestTerraformGCE(t *testing.T) {
 }
 
 func (i *integrationTest) runTestTerraformHetzner(t *testing.T) {
-	ctx := testutils.ContextForTest(t)
+	ctx := testcontext.ForTest(t)
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 

--- a/pkg/assets/copyfile.go
+++ b/pkg/assets/copyfile.go
@@ -168,7 +168,7 @@ func writeFile(ctx context.Context, cluster *kops.Cluster, p vfs.Path, data []by
 		return err
 	}
 
-	if err = p.WriteFile(bytes.NewReader(data), acl); err != nil {
+	if err = p.WriteFile(ctx, bytes.NewReader(data), acl); err != nil {
 		return fmt.Errorf("error writing path %v: %v", p, err)
 	}
 

--- a/pkg/client/simple/vfsclientset/addons.go
+++ b/pkg/client/simple/vfsclientset/addons.go
@@ -89,7 +89,7 @@ func (c *vfsAddonsClient) Replace(addons kubemanifest.ObjectList) error {
 	}
 
 	rs := bytes.NewReader(b)
-	if err := configPath.WriteFile(rs, acl); err != nil {
+	if err := configPath.WriteFile(ctx, rs, acl); err != nil {
 		return fmt.Errorf("error writing addons file %s: %v", configPath, err)
 	}
 

--- a/pkg/client/simple/vfsclientset/commonvfs.go
+++ b/pkg/client/simple/vfsclientset/commonvfs.go
@@ -160,9 +160,9 @@ func (c *commonVFS) writeConfig(ctx context.Context, cluster *kops.Cluster, conf
 
 	rs := bytes.NewReader(data)
 	if create {
-		err = configPath.CreateFile(rs, acl)
+		err = configPath.CreateFile(ctx, rs, acl)
 	} else {
-		err = configPath.WriteFile(rs, acl)
+		err = configPath.WriteFile(ctx, rs, acl)
 	}
 	if err != nil {
 		if create && os.IsExist(err) {

--- a/pkg/model/components/image_test.go
+++ b/pkg/model/components/image_test.go
@@ -23,10 +23,12 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/assets"
 	"k8s.io/kops/pkg/featureflag"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/util/pkg/vfs"
 )
 
 func TestImage(t *testing.T) {
+	ctx := testcontext.ForTest(t)
 	featureflag.ParseFlags("-ImageDigest")
 	grid := []struct {
 		Component string
@@ -70,7 +72,7 @@ func TestImage(t *testing.T) {
 				t.Errorf("error building vfs path for %s: %v", k, err)
 				continue
 			}
-			if err := p.WriteFile(bytes.NewReader([]byte(v)), nil); err != nil {
+			if err := p.WriteFile(ctx, bytes.NewReader([]byte(v)), nil); err != nil {
 				t.Errorf("error writing vfs path %s: %v", k, err)
 				continue
 			}

--- a/pkg/testutils/testcontext/context.go
+++ b/pkg/testutils/testcontext/context.go
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testutils
+package testcontext
 
 import (
 	"context"
 	"testing"
 )
 
-// ContextForTest returns a Context for the given test scope.
-func ContextForTest(t *testing.T) context.Context {
+// ForTest returns a Context for the given test scope.
+func ForTest(t *testing.T) context.Context {
 	ctx := context.TODO()
 	// We might choose to bind the test to the context in future,
 	// or bind the logger etc.

--- a/upup/models/vfs.go
+++ b/upup/models/vfs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package models
 
 import (
+	"context"
 	"embed"
 	"errors"
 	"io"
@@ -52,11 +53,11 @@ func (p *AssetPath) Join(relativePath ...string) vfs.Path {
 	return &AssetPath{location: joined}
 }
 
-func (p *AssetPath) WriteFile(data io.ReadSeeker, acl vfs.ACL) error {
+func (p *AssetPath) WriteFile(ctx context.Context, data io.ReadSeeker, acl vfs.ACL) error {
 	return ReadOnlyError
 }
 
-func (p *AssetPath) CreateFile(data io.ReadSeeker, acl vfs.ACL) error {
+func (p *AssetPath) CreateFile(ctx context.Context, data io.ReadSeeker, acl vfs.ACL) error {
 	return ReadOnlyError
 }
 

--- a/upup/pkg/fi/fitasks/managedfile.go
+++ b/upup/pkg/fi/fitasks/managedfile.go
@@ -149,6 +149,8 @@ func (e *ManagedFile) getACL(c *fi.CloudupContext, p vfs.Path) (vfs.ACL, error) 
 }
 
 func (_ *ManagedFile) Render(c *fi.CloudupContext, a, e, changes *ManagedFile) error {
+	ctx := c.Context()
+
 	location := fi.ValueOf(e.Location)
 	if location == "" {
 		return fi.RequiredField("Location")
@@ -170,7 +172,7 @@ func (_ *ManagedFile) Render(c *fi.CloudupContext, a, e, changes *ManagedFile) e
 		return err
 	}
 
-	err = p.WriteFile(bytes.NewReader(data), acl)
+	err = p.WriteFile(ctx, bytes.NewReader(data), acl)
 	if err != nil {
 		return fmt.Errorf("error creating ManagedFile %q: %v", location, err)
 	}

--- a/upup/pkg/fi/secrets/clientset_secretstore.go
+++ b/upup/pkg/fi/secrets/clientset_secretstore.go
@@ -91,7 +91,7 @@ func (c *ClientsetSecretStore) MirrorTo(ctx context.Context, basedir vfs.Path) e
 			return err
 		}
 
-		if err := p.WriteFile(bytes.NewReader(data), acl); err != nil {
+		if err := p.WriteFile(ctx, bytes.NewReader(data), acl); err != nil {
 			return fmt.Errorf("error writing secret to %q: %v", p, err)
 		}
 	}

--- a/upup/pkg/fi/secrets/vfs_secretstore.go
+++ b/upup/pkg/fi/secrets/vfs_secretstore.go
@@ -80,7 +80,7 @@ func (c *VFSSecretStore) MirrorTo(ctx context.Context, basedir vfs.Path) error {
 
 		klog.Infof("mirroring secret %s -> %s", name, p)
 
-		err = createSecret(secret, p, acl, true)
+		err = createSecret(ctx, secret, p, acl, true)
 		if err != nil {
 			return fmt.Errorf("error writing secret %q for mirror: %v", name, err)
 		}
@@ -159,7 +159,7 @@ func (c *VFSSecretStore) GetOrCreateSecret(id string, secret *fi.Secret) (*fi.Se
 			return nil, false, err
 		}
 
-		err = createSecret(secret, p, acl, false)
+		err = createSecret(ctx, secret, p, acl, false)
 		if err != nil {
 			if os.IsExist(err) && i == 0 {
 				klog.Infof("Got already-exists error when writing secret; likely due to concurrent creation.  Will retry")
@@ -193,7 +193,7 @@ func (c *VFSSecretStore) ReplaceSecret(id string, secret *fi.Secret) (*fi.Secret
 		return nil, err
 	}
 
-	err = createSecret(secret, p, acl, true)
+	err = createSecret(ctx, secret, p, acl, true)
 	if err != nil {
 		return nil, fmt.Errorf("unable to write secret: %v", err)
 	}
@@ -222,7 +222,7 @@ func (c *VFSSecretStore) loadSecret(p vfs.Path) (*fi.Secret, error) {
 }
 
 // createSecret will create the Secret, overwriting an existing secret if replace is true
-func createSecret(s *fi.Secret, p vfs.Path, acl vfs.ACL, replace bool) error {
+func createSecret(ctx context.Context, s *fi.Secret, p vfs.Path, acl vfs.ACL, replace bool) error {
 	data, err := json.Marshal(s)
 	if err != nil {
 		return fmt.Errorf("error serializing secret: %v", err)
@@ -230,7 +230,7 @@ func createSecret(s *fi.Secret, p vfs.Path, acl vfs.ACL, replace bool) error {
 
 	rs := bytes.NewReader(data)
 	if replace {
-		return p.WriteFile(rs, acl)
+		return p.WriteFile(ctx, rs, acl)
 	}
-	return p.CreateFile(rs, acl)
+	return p.CreateFile(ctx, rs, acl)
 }

--- a/upup/pkg/fi/vfs_castore.go
+++ b/upup/pkg/fi/vfs_castore.go
@@ -192,7 +192,7 @@ func writeKeysetBundle(ctx context.Context, cluster *kops.Cluster, p vfs.Path, n
 	if err != nil {
 		return err
 	}
-	return p.WriteFile(bytes.NewReader(objectData), acl)
+	return p.WriteFile(ctx, bytes.NewReader(objectData), acl)
 }
 
 // serializeKeysetBundle converts a Keyset bundle to yaml, for writing to VFS.
@@ -326,7 +326,7 @@ func mirrorSSHCredential(ctx context.Context, cluster *kops.Cluster, basedir vfs
 		return err
 	}
 
-	err = p.WriteFile(bytes.NewReader([]byte(sshCredential.Spec.PublicKey)), acl)
+	err = p.WriteFile(ctx, bytes.NewReader([]byte(sshCredential.Spec.PublicKey)), acl)
 	if err != nil {
 		return fmt.Errorf("error writing %q: %v", p, err)
 	}
@@ -410,7 +410,7 @@ func (c *VFSCAStore) AddSSHPublicKey(ctx context.Context, pubkey []byte) error {
 		return err
 	}
 
-	return p.WriteFile(bytes.NewReader(pubkey), acl)
+	return p.WriteFile(ctx, bytes.NewReader(pubkey), acl)
 }
 
 func (c *VFSCAStore) buildSSHPublicKeyPath(id string) vfs.Path {

--- a/util/pkg/vfs/azureblob.go
+++ b/util/pkg/vfs/azureblob.go
@@ -146,7 +146,7 @@ func (p *AzureBlobPath) WriteTo(w io.Writer) (n int64, err error) {
 var createFileLockAzureBlob sync.Mutex
 
 // CreateFile writes the file contents only if the file does not already exist.
-func (p *AzureBlobPath) CreateFile(data io.ReadSeeker, acl ACL) error {
+func (p *AzureBlobPath) CreateFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	createFileLockAzureBlob.Lock()
 	defer createFileLockAzureBlob.Unlock()
 
@@ -158,15 +158,13 @@ func (p *AzureBlobPath) CreateFile(data io.ReadSeeker, acl ACL) error {
 	if !os.IsNotExist(err) {
 		return err
 	}
-	return p.WriteFile(data, acl)
+	return p.WriteFile(ctx, data, acl)
 }
 
 // WriteFile writes the blob to the reader.
 //
 // TODO(kenji): Support ACL.
-func (p *AzureBlobPath) WriteFile(data io.ReadSeeker, acl ACL) error {
-	ctx := context.TODO()
-
+func (p *AzureBlobPath) WriteFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	client, err := p.getClient(ctx)
 	if err != nil {
 		return err

--- a/util/pkg/vfs/fs.go
+++ b/util/pkg/vfs/fs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vfs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -50,7 +51,7 @@ func (p *FSPath) Join(relativePath ...string) Path {
 	return &FSPath{location: joined}
 }
 
-func (p *FSPath) WriteFile(data io.ReadSeeker, acl ACL) error {
+func (p *FSPath) WriteFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	dir := path.Dir(p.location)
 	err := os.MkdirAll(dir, 0o755)
 	if err != nil {
@@ -96,7 +97,7 @@ func (p *FSPath) WriteFile(data io.ReadSeeker, acl ACL) error {
 // TODO: should we take a file lock or equivalent here?  Can we use RENAME_NOREPLACE ?
 var createFileLock sync.Mutex
 
-func (p *FSPath) CreateFile(data io.ReadSeeker, acl ACL) error {
+func (p *FSPath) CreateFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	createFileLock.Lock()
 	defer createFileLock.Unlock()
 
@@ -110,7 +111,7 @@ func (p *FSPath) CreateFile(data io.ReadSeeker, acl ACL) error {
 		return err
 	}
 
-	return p.WriteFile(data, acl)
+	return p.WriteFile(ctx, data, acl)
 }
 
 // ReadFile implements Path::ReadFile

--- a/util/pkg/vfs/fs_test.go
+++ b/util/pkg/vfs/fs_test.go
@@ -21,9 +21,12 @@ import (
 	"os"
 	"path"
 	"testing"
+
+	"k8s.io/kops/pkg/testutils/testcontext"
 )
 
 func TestCreateFile(t *testing.T) {
+	ctx := testcontext.ForTest(t)
 	TempDir := t.TempDir()
 
 	tests := []struct {
@@ -38,13 +41,13 @@ func TestCreateFile(t *testing.T) {
 	for _, test := range tests {
 		fspath := &FSPath{test.path}
 		// Create file
-		err := fspath.CreateFile(bytes.NewReader(test.data), nil)
+		err := fspath.CreateFile(ctx, bytes.NewReader(test.data), nil)
 		if err != nil {
 			t.Fatalf("Error writing file %s, error: %v", test.path, err)
 		}
 
 		// Create file again should result in error
-		err = fspath.CreateFile(bytes.NewReader([]byte("data")), nil)
+		err = fspath.CreateFile(ctx, bytes.NewReader([]byte("data")), nil)
 		if err != os.ErrExist {
 			t.Errorf("Expected to get os.ErrExist, got: %v", err)
 		}
@@ -61,6 +64,8 @@ func TestCreateFile(t *testing.T) {
 }
 
 func TestWriteTo(t *testing.T) {
+	ctx := testcontext.ForTest(t)
+
 	TempDir := t.TempDir()
 
 	tests := []struct {
@@ -77,7 +82,7 @@ func TestWriteTo(t *testing.T) {
 
 		fspath := NewFSPath(test.path)
 		// Create file
-		err := fspath.CreateFile(bytes.NewReader(test.data), nil)
+		err := fspath.CreateFile(ctx, bytes.NewReader(test.data), nil)
 		if err != nil {
 			t.Fatalf("Error writing file %s, error: %v", test.path, err)
 		}

--- a/util/pkg/vfs/gsfs.go
+++ b/util/pkg/vfs/gsfs.go
@@ -167,9 +167,7 @@ func (p *GSPath) Join(relativePath ...string) Path {
 	}
 }
 
-func (p *GSPath) WriteFile(data io.ReadSeeker, acl ACL) error {
-	ctx := context.TODO()
-
+func (p *GSPath) WriteFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	md5Hash, err := hashing.HashAlgorithmMD5.Hash(data)
 	if err != nil {
 		return err
@@ -224,7 +222,7 @@ func (p *GSPath) WriteFile(data io.ReadSeeker, acl ACL) error {
 // TODO: should we enable versioning?
 var createFileLockGCS sync.Mutex
 
-func (p *GSPath) CreateFile(data io.ReadSeeker, acl ACL) error {
+func (p *GSPath) CreateFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	createFileLockGCS.Lock()
 	defer createFileLockGCS.Unlock()
 
@@ -238,7 +236,7 @@ func (p *GSPath) CreateFile(data io.ReadSeeker, acl ACL) error {
 		return err
 	}
 
-	return p.WriteFile(data, acl)
+	return p.WriteFile(ctx, data, acl)
 }
 
 // ReadFile implements Path::ReadFile

--- a/util/pkg/vfs/k8sfs.go
+++ b/util/pkg/vfs/k8sfs.go
@@ -18,6 +18,7 @@ package vfs
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"path"
@@ -85,11 +86,11 @@ func (p *KubernetesPath) Join(relativePath ...string) Path {
 	}
 }
 
-func (p *KubernetesPath) WriteFile(data io.ReadSeeker, acl ACL) error {
+func (p *KubernetesPath) WriteFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	return fmt.Errorf("KubernetesPath::WriteFile not supported")
 }
 
-func (p *KubernetesPath) CreateFile(data io.ReadSeeker, acl ACL) error {
+func (p *KubernetesPath) CreateFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	return fmt.Errorf("KubernetesPath::CreateFile not supported")
 }
 

--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vfs
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -104,7 +105,7 @@ func (p *MemFSPath) Join(relativePath ...string) Path {
 	return current
 }
 
-func (p *MemFSPath) WriteFile(r io.ReadSeeker, acl ACL) error {
+func (p *MemFSPath) WriteFile(ctx context.Context, r io.ReadSeeker, acl ACL) error {
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return fmt.Errorf("error reading data: %v", err)
@@ -114,13 +115,13 @@ func (p *MemFSPath) WriteFile(r io.ReadSeeker, acl ACL) error {
 	return nil
 }
 
-func (p *MemFSPath) CreateFile(data io.ReadSeeker, acl ACL) error {
+func (p *MemFSPath) CreateFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	// Check if exists
 	if p.contents != nil {
 		return os.ErrExist
 	}
 
-	return p.WriteFile(data, acl)
+	return p.WriteFile(ctx, data, acl)
 }
 
 // ReadFile implements Path::ReadFile

--- a/util/pkg/vfs/memfs_test.go
+++ b/util/pkg/vfs/memfs_test.go
@@ -22,9 +22,13 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"k8s.io/kops/pkg/testutils/testcontext"
 )
 
 func TestMemFsCreateFile(t *testing.T) {
+	ctx := testcontext.ForTest(t)
+
 	tests := []struct {
 		path string
 		data []byte
@@ -37,14 +41,14 @@ func TestMemFsCreateFile(t *testing.T) {
 	for _, test := range tests {
 		memfspath := NewMemFSPath(NewMemFSContext(), test.path)
 		// Create file
-		err := memfspath.CreateFile(bytes.NewReader(test.data), nil)
+		err := memfspath.CreateFile(ctx, bytes.NewReader(test.data), nil)
 		if err != nil {
 			t.Errorf("Failed writing path %s, error: %v", test.path, err)
 			continue
 		}
 
 		// Create file again should result in error
-		err = memfspath.CreateFile(bytes.NewReader([]byte("data")), nil)
+		err = memfspath.CreateFile(ctx, bytes.NewReader([]byte("data")), nil)
 		if err != os.ErrExist {
 			t.Errorf("Expected to get os.ErrExist, got: %v", err)
 		}

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -257,8 +257,7 @@ func (p *S3Path) getRequestACL(aclObj ACL) (*string, error) {
 	return nil, nil
 }
 
-func (p *S3Path) WriteFile(data io.ReadSeeker, aclObj ACL) error {
-	ctx := context.TODO()
+func (p *S3Path) WriteFile(ctx context.Context, data io.ReadSeeker, aclObj ACL) error {
 	client, err := p.client(ctx)
 	if err != nil {
 		return err
@@ -300,7 +299,7 @@ func (p *S3Path) WriteFile(data io.ReadSeeker, aclObj ACL) error {
 // TODO: should we enable versioning?
 var createFileLockS3 sync.Mutex
 
-func (p *S3Path) CreateFile(data io.ReadSeeker, acl ACL) error {
+func (p *S3Path) CreateFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	createFileLockS3.Lock()
 	defer createFileLockS3.Unlock()
 
@@ -314,7 +313,7 @@ func (p *S3Path) CreateFile(data io.ReadSeeker, acl ACL) error {
 		return err
 	}
 
-	return p.WriteFile(data, acl)
+	return p.WriteFile(ctx, data, acl)
 }
 
 // ReadFile implements Path::ReadFile

--- a/util/pkg/vfs/sshfs.go
+++ b/util/pkg/vfs/sshfs.go
@@ -154,9 +154,7 @@ func mkdirAll(sftpClient *sftp.Client, dir string) error {
 	return nil
 }
 
-func (p *SSHPath) WriteFile(data io.ReadSeeker, acl ACL) error {
-	ctx := context.TODO()
-
+func (p *SSHPath) WriteFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	sftpClient, err := p.newClient(ctx)
 	if err != nil {
 		return err
@@ -244,7 +242,7 @@ func (p *SSHPath) WriteFile(data io.ReadSeeker, acl ACL) error {
 // Not a great approach, but fine for a single process (with low concurrency)
 var createFileLockSSH sync.Mutex
 
-func (p *SSHPath) CreateFile(data io.ReadSeeker, acl ACL) error {
+func (p *SSHPath) CreateFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	createFileLockSSH.Lock()
 	defer createFileLockSSH.Unlock()
 
@@ -258,7 +256,7 @@ func (p *SSHPath) CreateFile(data io.ReadSeeker, acl ACL) error {
 		return err
 	}
 
-	return p.WriteFile(data, acl)
+	return p.WriteFile(ctx, data, acl)
 }
 
 // ReadFile implements Path::ReadFile

--- a/util/pkg/vfs/swiftfs.go
+++ b/util/pkg/vfs/swiftfs.go
@@ -323,9 +323,7 @@ func (p *SwiftPath) Join(relativePath ...string) Path {
 	}
 }
 
-func (p *SwiftPath) WriteFile(data io.ReadSeeker, acl ACL) error {
-	ctx := context.TODO()
-
+func (p *SwiftPath) WriteFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	done, err := RetryWithBackoff(swiftWriteBackoff, func() (bool, error) {
 		client, err := p.getClient(ctx)
 		if err != nil {
@@ -360,9 +358,7 @@ func (p *SwiftPath) WriteFile(data io.ReadSeeker, acl ACL) error {
 // TODO: should we enable versioning?
 var createFileLockSwift sync.Mutex
 
-func (p *SwiftPath) CreateFile(data io.ReadSeeker, acl ACL) error {
-	ctx := context.TODO()
-
+func (p *SwiftPath) CreateFile(ctx context.Context, data io.ReadSeeker, acl ACL) error {
 	client, err := p.getClient(ctx)
 	if err != nil {
 		return err
@@ -394,7 +390,7 @@ func (p *SwiftPath) CreateFile(data io.ReadSeeker, acl ACL) error {
 		return err
 	}
 
-	return p.WriteFile(data, acl)
+	return p.WriteFile(ctx, data, acl)
 }
 
 func (p *SwiftPath) createBucket() error {

--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vfs
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -49,9 +50,9 @@ type Path interface {
 	// If the file did not exist, err = os.ErrNotExist
 	// As this reads the entire file into memory, consider using WriteTo for bigger files
 	ReadFile() ([]byte, error)
-	WriteFile(data io.ReadSeeker, acl ACL) error
+	WriteFile(ctx context.Context, data io.ReadSeeker, acl ACL) error
 	// CreateFile writes the file contents, but only if the file does not already exist
-	CreateFile(data io.ReadSeeker, acl ACL) error
+	CreateFile(ctx context.Context, data io.ReadSeeker, acl ACL) error
 
 	// Remove deletes the file
 	Remove() error


### PR DESCRIPTION
As "request" methods, these should have context parameters.

Note I also had to move ContextForTest into its own package to avoid circular dependencies, I think this makes sense though.