### PR TITLE
Avoid triggering upgrade tests on release commits

### DIFF
--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.26.0-beta.1
+    version: v{{ KopsVersion }}
 spec:
   replicas: 1
   strategy:
@@ -19,7 +19,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.26.0-beta.1
+        version: v{{ KopsVersion }}
     spec:
       priorityClassName: system-cluster-critical
       affinity:
@@ -47,7 +47,7 @@ spec:
       nodeSelector: null
       containers:
       - name: dns-controller
-        image: registry.k8s.io/kops/dns-controller:1.26.0-beta.1
+        image: registry.k8s.io/kops/dns-controller:{{ KopsVersion }}
         args:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.26.0-beta.1
+    version: v{{ KopsVersion }}
 spec:
   selector:
     matchLabels:
@@ -31,7 +31,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.26.0-beta.1
+        version: v{{ KopsVersion }}
 {{ if UseKopsControllerForNodeBootstrap }}
       annotations:
         dns.alpha.kubernetes.io/internal: kops-controller.internal.{{ ClusterName }}
@@ -67,7 +67,7 @@ spec:
       serviceAccount: kops-controller
       containers:
       - name: kops-controller
-        image: registry.k8s.io/kops/kops-controller:1.26.0-beta.1
+        image: registry.k8s.io/kops/kops-controller:{{ KopsVersion }}
         volumeMounts:
 {{ if .UseHostCertificates }}
         - mountPath: /etc/ssl/certs

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	kopsroot "k8s.io/kops"
 	kopscontrollerconfig "k8s.io/kops/cmd/kops-controller/pkg/config"
 	"k8s.io/kops/pkg/apis/kops"
 	apiModel "k8s.io/kops/pkg/apis/kops/model"
@@ -351,6 +352,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["IsKubernetesLT"] = tf.IsKubernetesLT
 
 	dest["KopsFeatureEnabled"] = tf.kopsFeatureEnabled
+	dest["KopsVersion"] = func() string { return kopsroot.KOPS_RELEASE_VERSION }
 
 	return nil
 }


### PR DESCRIPTION
Release commits modify the dns-controller and kops-controller manifests, triggering the `pull-kops-e2e-aws-upgrade-126-ko126-to-klatest-kolatest-many-addons` test. That test always fails because images with the new versions never exist yet.

Use a template function in those manifests so that they avoid triggering that test.