### PR TITLE
AWS: set IMDS hop limit 1 on all new clusters

### DIFF
--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -47,14 +47,14 @@ spec:
 
 ## instanceMetadata
 
-By default, IMDSv2 is enabled for newly created clusters. The default hop limit is 1 for all node roles, except for control plane nodes with Kubernetes version lower than 1.26 or IRSA disabled, for which the default hop limit is 3. As of Kubernetes 1.27, these defaults are applied to existing clusters also.
+By default, IMDSv2 is enabled for newly created clusters. As of Kubernetes 1.27, this default is applied to existing clusters as well.
+The default hop limit is 1 for all node roles. 
 
-To enable IMDSv2 add the following configuration to the instance group:
+To enable IMDSv2, add the following configuration to the instance group:
 
 ```YAML
 spec:
   instanceMetadata:
-    httpPutResponseHopLimit: 1
     httpTokens: required
 ```
 

--- a/docs/releases/1.27-NOTES.md
+++ b/docs/releases/1.27-NOTES.md
@@ -8,7 +8,8 @@ This is a document to gather the release notes prior to the release.
 
 ## AWS
 
-* As of Kubernetes version 1.27, all nodes will default to running with the instance metadata service enabled, with max hop limit of 1. Control plane nodes with IRSA disabled will default to running with a max hop limit of 3.
+* As of Kubernetes version 1.27, all nodes will default to running with instance-metadata-service tokens required, with a max hop limit of 1.
+Newly created clusters will be configured as necessary to have these settings.
 
 ## GCP
 

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -288,8 +288,6 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.CloudupMode
 
 	if ig.Spec.InstanceMetadata != nil && ig.Spec.InstanceMetadata.HTTPPutResponseHopLimit != nil {
 		lt.HTTPPutResponseHopLimit = ig.Spec.InstanceMetadata.HTTPPutResponseHopLimit
-	} else if ig.IsControlPlane() && (b.Cluster.IsKubernetesLT("1.26") || !b.UseServiceAccountExternalPermissions()) {
-		lt.HTTPPutResponseHopLimit = fi.PtrTo[int64](3)
 	}
 
 	if ig.Spec.InstanceMetadata != nil && ig.Spec.InstanceMetadata.HTTPTokens != nil {

--- a/tests/integration/create_cluster/cilium-eni/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/cilium-eni/expected-v1alpha2.yaml
@@ -70,7 +70,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -65,7 +65,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/different-amis/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/different-amis/expected-v1alpha2.yaml
@@ -116,7 +116,6 @@ metadata:
 spec:
   image: ami-control-plane
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -86,7 +86,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -107,7 +106,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -128,7 +126,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -86,7 +86,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -107,7 +106,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -128,7 +126,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -78,7 +78,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -99,7 +98,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -120,7 +118,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -94,7 +94,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -115,7 +114,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -136,7 +134,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -157,7 +154,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -178,7 +174,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -96,7 +96,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
@@ -79,7 +79,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
@@ -80,7 +80,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.22/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.22/expected-v1alpha2.yaml
@@ -66,7 +66,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.23/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.23/expected-v1alpha2.yaml
@@ -66,7 +66,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
@@ -66,7 +66,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.25/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.25/expected-v1alpha2.yaml
@@ -66,7 +66,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.26-arm64/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-arm64/expected-v1alpha2.yaml
@@ -66,7 +66,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m6g.xlarge
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.26-irsa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-irsa/expected-v1alpha2.yaml
@@ -70,7 +70,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 1
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.26/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26/expected-v1alpha2.yaml
@@ -66,7 +66,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal_feature-gates/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal_feature-gates/expected-v1alpha2.yaml
@@ -90,7 +90,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -96,7 +96,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -69,7 +69,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -102,7 +102,6 @@ spec:
   - sg-exampleid4
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -75,7 +75,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -68,7 +68,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -68,7 +68,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -67,7 +67,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
   instanceMetadata:
-    httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/update_cluster/apiservernodes/kubernetes.tf
+++ b/tests/integration/update_cluster/apiservernodes/kubernetes.tf
@@ -522,7 +522,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -543,7 +543,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-bastionuserdata-exampl
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/kubernetes.tf
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/kubernetes.tf
@@ -423,7 +423,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-cas-priority-expander-
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/kubernetes.tf
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/kubernetes.tf
@@ -423,7 +423,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-cas-priority-expander-
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -322,7 +322,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-compress-example-com" 
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/containerd-custom/kubernetes.tf
+++ b/tests/integration/update_cluster/containerd-custom/kubernetes.tf
@@ -333,7 +333,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-containerd-example-com
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/containerd/kubernetes.tf
+++ b/tests/integration/update_cluster/containerd/kubernetes.tf
@@ -333,7 +333,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-containerd-example-com
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/digit/kubernetes.tf
+++ b/tests/integration/update_cluster/digit/kubernetes.tf
@@ -409,7 +409,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-123-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/docker-custom/kubernetes.tf
+++ b/tests/integration/update_cluster/docker-custom/kubernetes.tf
@@ -348,7 +348,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-docker-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -459,7 +459,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existing-iam-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {
@@ -542,7 +542,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existing-iam-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {
@@ -625,7 +625,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existing-iam-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -562,7 +562,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existingsg-example-com
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {
@@ -645,7 +645,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existingsg-example-com
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {
@@ -728,7 +728,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existingsg-example-com
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/external_dns/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns/kubernetes.tf
@@ -333,7 +333,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -337,7 +337,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externallb-example-com
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -411,7 +411,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externalpolicies-examp
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -531,7 +531,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-ha-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {
@@ -614,7 +614,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-ha-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {
@@ -697,7 +697,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-ha-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -436,7 +436,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/karpenter/kubernetes.tf
+++ b/tests/integration/update_cluster/karpenter/kubernetes.tf
@@ -610,7 +610,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/kubernetes.tf
@@ -623,7 +623,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/kubernetes.tf
@@ -608,7 +608,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/kubernetes.tf
@@ -608,7 +608,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
@@ -434,7 +434,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/many-addons/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons/kubernetes.tf
@@ -419,7 +419,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/minimal-etcd/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-etcd/kubernetes.tf
@@ -333,7 +333,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-etcd-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -329,7 +329,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
@@ -396,7 +396,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "enabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
@@ -396,7 +396,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "enabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
@@ -396,7 +396,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "enabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
@@ -396,7 +396,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "enabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/minimal-longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-longclustername/kubernetes.tf
@@ -333,7 +333,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-this-is-truly-a-really
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
@@ -341,7 +341,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-warmpool-examp
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -333,7 +333,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
@@ -333,7 +333,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-k8s-local" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -549,7 +549,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {
@@ -632,7 +632,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {
@@ -715,7 +715,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -549,7 +549,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {
@@ -632,7 +632,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {
@@ -715,7 +715,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/nth-imds-processor/kubernetes.tf
+++ b/tests/integration/update_cluster/nth-imds-processor/kubernetes.tf
@@ -333,7 +333,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-nthimdsprocessor-longc
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/nvidia/kubernetes.tf
+++ b/tests/integration/update_cluster/nvidia/kubernetes.tf
@@ -338,7 +338,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -524,7 +524,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-ip-exam
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -519,7 +519,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-subnet-
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -542,7 +542,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecanal-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
@@ -542,7 +542,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -542,7 +542,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -542,7 +542,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -559,7 +559,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateciliumadvanced-
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -625,7 +625,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns1-example-co
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -533,7 +533,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns2-example-co
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -542,7 +542,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateflannel-example
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -548,7 +548,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatekopeio-example-
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -565,7 +565,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateweave-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -438,7 +438,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -324,7 +324,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedsubnet-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -324,7 +324,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedvpc-example-com"
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
@@ -378,7 +378,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "enabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -524,7 +524,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-unmanaged-example-com"
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -354,7 +354,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   metadata_options {
     http_endpoint               = "enabled"
     http_protocol_ipv6          = "disabled"
-    http_put_response_hop_limit = 3
+    http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
   monitoring {

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -878,15 +878,9 @@ func setupControlPlane(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubne
 				g.Spec.Zones = []string{zone}
 			}
 
-			if cluster.IsKubernetesLT("1.27") {
-				if cloudProvider == api.CloudProviderAWS {
-					g.Spec.InstanceMetadata = &api.InstanceMetadataOptions{
-						HTTPPutResponseHopLimit: fi.PtrTo(int64(3)),
-						HTTPTokens:              fi.PtrTo("required"),
-					}
-				}
-				if cluster.IsKubernetesGTE("1.26") && fi.ValueOf(cluster.Spec.IAM.UseServiceAccountExternalPermissions) {
-					g.Spec.InstanceMetadata.HTTPPutResponseHopLimit = fi.PtrTo(int64(1))
+			if cluster.IsKubernetesLT("1.27") && cloudProvider == api.CloudProviderAWS {
+				g.Spec.InstanceMetadata = &api.InstanceMetadataOptions{
+					HTTPTokens: fi.PtrTo("required"),
 				}
 			}
 


### PR DESCRIPTION
Since this is for new clusters, we don't have to be particular about k8s versions.

The default hop limit if not specified in the cluster spec has been 1 ever since the field was added.