### PR TITLE
Automated cherry pick of #14887: set loadbalancer configs before initializing the OS

### DIFF
--- a/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   name: minimal.k8s.local
 spec:
+  api:
+    loadBalancer:
+      type: Public
   authorization:
     rbac: {}
   channel: stable

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -333,6 +333,7 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 				MaxRetries: fi.PtrTo(3),
 			},
 		}
+		initializeOpenstackAPI(opt, cluster)
 		osCloud, err := openstack.NewOpenstackCloud(cluster, "openstackmodel")
 		if err != nil {
 			return nil, err
@@ -1335,9 +1336,7 @@ func setupTopology(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.S
 func setupAPI(opt *NewClusterOptions, cluster *api.Cluster) error {
 	// Populate the API access, so that it can be discoverable
 	klog.Infof("Cloud Provider ID: %q", cluster.Spec.GetCloudProvider())
-	if cluster.Spec.GetCloudProvider() == api.CloudProviderOpenstack {
-		initializeOpenstackAPI(opt, cluster)
-	} else if cluster.Spec.GetCloudProvider() == api.CloudProviderAzure {
+	if cluster.Spec.GetCloudProvider() == api.CloudProviderAzure {
 		// Do nothing to disable the use of loadbalancer for the k8s API server.
 		// TODO(kenji): Remove this condition once we support the loadbalancer
 		// in pkg/model/azuremodel/api_loadbalancer.go.

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -363,12 +363,15 @@ func NewOpenstackCloud(cluster *kops.Cluster, uagent string) (OpenstackCloud, er
 		return nil, fmt.Errorf("error building openstack authenticated client: %v", err)
 	}
 
-	tags := map[string]string{
-		TagClusterName: cluster.Name,
+	if cluster != nil {
+		hasDNS := !cluster.IsGossip() && !cluster.UsesNoneDNS()
+		tags := map[string]string{
+			TagClusterName: cluster.Name,
+		}
+		return buildClients(provider, tags, cluster.Spec.CloudProvider.Openstack, config, region, hasDNS)
 	}
-
-	hasDNS := !cluster.IsGossip() && !cluster.UsesNoneDNS()
-	return buildClients(provider, tags, cluster.Spec.CloudProvider.Openstack, config, region, hasDNS)
+	// used by protokube
+	return buildClients(provider, nil, nil, config, region, false)
 }
 
 func buildClients(provider *gophercloud.ProviderClient, tags map[string]string, spec *kops.OpenstackSpec, config vfs.OpenstackConfig, region string, hasDNS bool) (OpenstackCloud, error) {


### PR DESCRIPTION
Cherry pick of #14887 on release-1.26.

#14887: set loadbalancer configs before initializing the OS

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```