### PR TITLE
Automated cherry pick of #14880: Use short service name with discovery labels

### DIFF
--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -278,7 +278,7 @@ func addGossipController(mgr manager.Manager, opt *config.Options) error {
 		Name:      "coredns",
 	}
 
-	controller, err := controllers.NewHostsReconciler(mgr, configMapID)
+	controller, err := controllers.NewHostsReconciler(mgr, opt, configMapID)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops-controller/pkg/config/options.go
+++ b/cmd/kops-controller/pkg/config/options.go
@@ -23,6 +23,7 @@ import (
 )
 
 type Options struct {
+	ClusterName           string         `json:"clusterName,omitempty"`
 	Cloud                 string         `json:"cloud,omitempty"`
 	ConfigBase            string         `json:"configBase,omitempty"`
 	SecretStore           string         `json:"secretStore,omitempty"`

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -262,7 +262,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 	var clientHost string
 
 	if featureflag.APIServerNodes.Enabled() {
-		clientHost = etcdCluster.Name + ".etcd." + b.ClusterName()
+		clientHost = etcdCluster.Name + ".etcd.internal." + b.ClusterName()
 	} else {
 		clientHost = "__name__"
 	}

--- a/pkg/model/components/kopscontroller/template_functions.go
+++ b/pkg/model/components/kopscontroller/template_functions.go
@@ -49,8 +49,6 @@ func (t *templateFunctions) GossipServices() ([]*corev1.Service, error) {
 		return nil, nil
 	}
 
-	suffix := t.Cluster.Name
-
 	var services []*corev1.Service
 
 	// api service
@@ -63,7 +61,7 @@ func (t *templateFunctions) GossipServices() ([]*corev1.Service, error) {
 			"k8s-app": "kops-controller",
 		}
 		service.Labels = map[string]string{
-			kops.DiscoveryLabelKey: "api.internal." + suffix,
+			kops.DiscoveryLabelKey: "api",
 		}
 		services = append(services, service)
 	}
@@ -78,7 +76,7 @@ func (t *templateFunctions) GossipServices() ([]*corev1.Service, error) {
 			"k8s-app": "kops-controller",
 		}
 		service.Labels = map[string]string{
-			kops.DiscoveryLabelKey: "kops-controller.internal." + suffix,
+			kops.DiscoveryLabelKey: "kops-controller",
 		}
 		services = append(services, service)
 	}
@@ -96,7 +94,7 @@ func (t *templateFunctions) GossipServices() ([]*corev1.Service, error) {
 				{Name: "https", Port: int32(ports.ClientPort), Protocol: corev1.ProtocolTCP},
 			}
 			service.Labels = map[string]string{
-				kops.DiscoveryLabelKey: etcdCluster.Name + ".etcd." + suffix,
+				kops.DiscoveryLabelKey: etcdCluster.Name + ".etcd",
 			}
 			service.Spec.Selector = etcdmanager.SelectorForCluster(etcdCluster)
 			services = append(services, service)

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cef401a491db199533e3419485f72a24405558710238e9aa6c94becfb9ffe040
+    manifestHash: 122d6e4f0f90e25d765cc3bdc4da178505a1877a924b0397fb9c839fa3d8c47c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/additionalobjects.example.com","secretStore":"memfs://tests/additionalobjects.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.additionalobjects.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"additionalobjects.example.com","cloud":"aws","configBase":"memfs://tests/additionalobjects.example.com","secretStore":"memfs://tests/additionalobjects.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.additionalobjects.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    dns.alpha.kubernetes.io/internal: events.etcd.minimal.example.com
+    dns.alpha.kubernetes.io/internal: events.etcd.internal.minimal.example.com
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events
@@ -15,7 +15,7 @@ spec:
     - -c
     - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
       --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://events.etcd.minimal.example.com:4002 --cluster-name=etcd-events
+      --client-urls=https://events.etcd.internal.minimal.example.com:4002 --cluster-name=etcd-events
       --containerized=true --dns-suffix=.internal.minimal.example.com --grpc-port=3997
       --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    dns.alpha.kubernetes.io/internal: main.etcd.minimal.example.com
+    dns.alpha.kubernetes.io/internal: main.etcd.internal.minimal.example.com
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main
@@ -15,7 +15,7 @@ spec:
     - -c
     - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
       --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://main.etcd.minimal.example.com:4001 --cluster-name=etcd
+      --client-urls=https://main.etcd.internal.minimal.example.com:4001 --cluster-name=etcd
       --containerized=true --dns-suffix=.internal.minimal.example.com --grpc-port=3996
       --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b637abaef9194a7a5e03248fcafe0ba0d59288e2839c4f2ad69ddbca67c91cdc
+    manifestHash: 7764c419abb36a1c362cafc7362889dd83e1346280019aef316cb2d17387e792
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["apiservers.minimal.example.com","nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["apiservers.minimal.example.com","nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a366253bb43f0a1292d6187d567b5a0f8730e83f5ce4f7036043b53d602b4870
+    manifestHash: d17d9bc5761e7649a5e95278de1ca1e27c480d7795cc933a26ab5418b06e9004
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1442981fceafd9b580b59a951f2a9ab040f2757db13aa1c69a5d271018bbb554
+    manifestHash: 204aab19bed7367ace38285591800db801da97fb953bb0ee36c6fe37b4e8f53d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/bastionuserdata.example.com","secretStore":"memfs://clusters.example.com/bastionuserdata.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.bastionuserdata.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"bastionuserdata.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/bastionuserdata.example.com","secretStore":"memfs://clusters.example.com/bastionuserdata.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.bastionuserdata.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c3869cd1c487a10dd9fda584767f8b561da83a584dac2ac703e6d42cae4c3d92
+    manifestHash: 541cc50d85013fa267b1e23a42da8a849dcc384c4ab337b397923aa4de06e130
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/complex.example.com","secretStore":"memfs://clusters.example.com/complex.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.complex.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"complex.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/complex.example.com","secretStore":"memfs://clusters.example.com/complex.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.complex.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a52ed6985ef96cb38ec6e6ffb06dd33f14bc176fd4391a35da2167d5b365f641
+    manifestHash: e8dec542ef431f0ece341b54e2ee189ba84d76839e488a30a6012424fa4f718d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/compress.example.com","secretStore":"memfs://clusters.example.com/compress.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.compress.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"compress.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/compress.example.com","secretStore":"memfs://clusters.example.com/compress.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.compress.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 51767b6519d44e1d0a9645fb83cbbc74c5a3a86fa9c4a17651466525eb66106a
+    manifestHash: a95acb0913f3a6286e8985ea80b8d5eea4d8ae5e34bdb88f57ccdb36b62fb64b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/containerd.example.com","secretStore":"memfs://clusters.example.com/containerd.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.containerd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"containerd.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/containerd.example.com","secretStore":"memfs://clusters.example.com/containerd.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.containerd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 51767b6519d44e1d0a9645fb83cbbc74c5a3a86fa9c4a17651466525eb66106a
+    manifestHash: a95acb0913f3a6286e8985ea80b8d5eea4d8ae5e34bdb88f57ccdb36b62fb64b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/containerd.example.com","secretStore":"memfs://clusters.example.com/containerd.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.containerd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"containerd.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/containerd.example.com","secretStore":"memfs://clusters.example.com/containerd.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.containerd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e154b6f3171bdd4c0ae8ba4cd85f27ce56c0d8a78f036b626906e526f81eaf09
+    manifestHash: 062b38e478bd5a5b7f5aa3069f30c9a9e128565e5ac149c394cda22f7bc3f1bf
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/123.example.com","secretStore":"memfs://clusters.example.com/123.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.123.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"123.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/123.example.com","secretStore":"memfs://clusters.example.com/123.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.123.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bfd1a8772455f3571d698895386968adbbcf23ca152323f2eb8bcd14519304c7
+    manifestHash: b403bae0756771ebaa2b5c4532e019d950797700a7a2426a754002d1b490ae35
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/docker.example.com","secretStore":"memfs://clusters.example.com/docker.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.docker.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"docker.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/docker.example.com","secretStore":"memfs://clusters.example.com/docker.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.docker.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cf4b046d161194502c155140845b9ca4b58be670670c027ad9013c6f34036cbe
+    manifestHash: 55f9375b423a5d9c116de279cee1e03a9685f03abdc482fa5bf6a34af0a1afe0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/existing-iam.example.com","secretStore":"memfs://tests/existing-iam.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"existing-iam.example.com","cloud":"aws","configBase":"memfs://tests/existing-iam.example.com","secretStore":"memfs://tests/existing-iam.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0393bcecb9e3c6353b8f7bbf9f6d76c3deffabfefe53af92cf66ec412ede13d9
+    manifestHash: 2d66c7a5e17e534e6fa2c0c0a7706784500978e86c353e324b720052fd5f5063
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/existingsg.example.com","secretStore":"memfs://clusters.example.com/existingsg.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.existingsg.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"existingsg.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/existingsg.example.com","secretStore":"memfs://clusters.example.com/existingsg.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.existingsg.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a366253bb43f0a1292d6187d567b5a0f8730e83f5ce4f7036043b53d602b4870
+    manifestHash: d17d9bc5761e7649a5e95278de1ca1e27c480d7795cc933a26ab5418b06e9004
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a366253bb43f0a1292d6187d567b5a0f8730e83f5ce4f7036043b53d602b4870
+    manifestHash: d17d9bc5761e7649a5e95278de1ca1e27c480d7795cc933a26ab5418b06e9004
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2292838c20c3fd80118bb0baf24b909b7c14640481074ec065370993e362cec7
+    manifestHash: e481597055d270a88a65b5534e70fb7f4adea307fa3ffc73f04b2785d8fdd853
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/externallb.example.com","secretStore":"memfs://clusters.example.com/externallb.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.externallb.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"externallb.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/externallb.example.com","secretStore":"memfs://clusters.example.com/externallb.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.externallb.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2d372aecbef9ac7d6a62c44855b81e7826634a483711c336e6b007002371f704
+    manifestHash: f5e9c28ab1cf60d3bacd6bb3c3a8ba69391a2698a173cc1d4cfa4ca1e99f094f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/externalpolicies.example.com","secretStore":"memfs://clusters.example.com/externalpolicies.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.externalpolicies.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"externalpolicies.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/externalpolicies.example.com","secretStore":"memfs://clusters.example.com/externalpolicies.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.externalpolicies.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6b25f526ea54d54187d5fc4552f6021186d9a16abb966aa5556eebdf0098f878
+    manifestHash: cc1ba7fb6882373644ada1c7a423221c5aeac94d948e44bb8fc384ee38463019
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/ha.example.com","secretStore":"memfs://tests/ha.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.ha.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"ha.example.com","cloud":"aws","configBase":"memfs://tests/ha.example.com","secretStore":"memfs://tests/ha.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.ha.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f926a1534397fda736bc6585a57a666d9a34cca17da95ae5183a9965dc52fb3d
+    manifestHash: 13fe04d0ed14cb4739fcefebb30038b5dc5168de1ec74aba60c33979f4760bf8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/ha-gce.example.com","secretStore":"memfs://tests/ha-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"ha-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"ha-gce.example.com","cloud":"gce","configBase":"memfs://tests/ha-gce.example.com","secretStore":"memfs://tests/ha-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"ha-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a366253bb43f0a1292d6187d567b5a0f8730e83f5ce4f7036043b53d602b4870
+    manifestHash: d17d9bc5761e7649a5e95278de1ca1e27c480d7795cc933a26ab5418b06e9004
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6aed2249dc101ef1cba81f1b85dd55bcfd53c729b729a835863764fda4e874e5
+    manifestHash: 2ee5760022b56148f470545c516282de49b880aecf2b29c09d7be8f3483a6eb3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a366253bb43f0a1292d6187d567b5a0f8730e83f5ce4f7036043b53d602b4870
+    manifestHash: d17d9bc5761e7649a5e95278de1ca1e27c480d7795cc933a26ab5418b06e9004
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6aed2249dc101ef1cba81f1b85dd55bcfd53c729b729a835863764fda4e874e5
+    manifestHash: 2ee5760022b56148f470545c516282de49b880aecf2b29c09d7be8f3483a6eb3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6aed2249dc101ef1cba81f1b85dd55bcfd53c729b729a835863764fda4e874e5
+    manifestHash: 2ee5760022b56148f470545c516282de49b880aecf2b29c09d7be8f3483a6eb3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6aed2249dc101ef1cba81f1b85dd55bcfd53c729b729a835863764fda4e874e5
+    manifestHash: 2ee5760022b56148f470545c516282de49b880aecf2b29c09d7be8f3483a6eb3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6aed2249dc101ef1cba81f1b85dd55bcfd53c729b729a835863764fda4e874e5
+    manifestHash: 2ee5760022b56148f470545c516282de49b880aecf2b29c09d7be8f3483a6eb3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a366253bb43f0a1292d6187d567b5a0f8730e83f5ce4f7036043b53d602b4870
+    manifestHash: d17d9bc5761e7649a5e95278de1ca1e27c480d7795cc933a26ab5418b06e9004
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 36bfa78442d8f65730cf400c1d732dc37f71b11e28037b8711553052773eaf2f
+    manifestHash: cb93ab389590ca23772ecac4d772ba4fbf5efaa03e42543cad9b16478d8ad45f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"gce","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a366253bb43f0a1292d6187d567b5a0f8730e83f5ce4f7036043b53d602b4870
+    manifestHash: d17d9bc5761e7649a5e95278de1ca1e27c480d7795cc933a26ab5418b06e9004
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0d651791e7758c42cb7960d278f4d8575ef20562aaf7d081d6219db7a6813d95
+    manifestHash: 0c0d111afd237bfc4eced2d90cafa9202d2027ec8b8c0654e3f51ba20ddd433b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b21c330d87aad8b4aab72ad1dbbabe4b82853771a9b86e686bd701a6319e7e02
+    manifestHash: 38d6b9dd6cd85211a81f6a0c02613d6377394d456e897eae473ec5dd58224d8c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b21c330d87aad8b4aab72ad1dbbabe4b82853771a9b86e686bd701a6319e7e02
+    manifestHash: 38d6b9dd6cd85211a81f6a0c02613d6377394d456e897eae473ec5dd58224d8c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b21c330d87aad8b4aab72ad1dbbabe4b82853771a9b86e686bd701a6319e7e02
+    manifestHash: 38d6b9dd6cd85211a81f6a0c02613d6377394d456e897eae473ec5dd58224d8c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b21c330d87aad8b4aab72ad1dbbabe4b82853771a9b86e686bd701a6319e7e02
+    manifestHash: 38d6b9dd6cd85211a81f6a0c02613d6377394d456e897eae473ec5dd58224d8c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 918728a9efaa01b921638a611269a4c8de49b5bf7fe831c168d846d2a7f29659
+    manifestHash: 11cdab6c885f5d8b9c8c57eea135808ed6b743f3bb50db985377fac0fc25d400
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-etcd.example.com","secretStore":"memfs://clusters.example.com/minimal-etcd.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-etcd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-etcd.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-etcd.example.com","secretStore":"memfs://clusters.example.com/minimal-etcd.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-etcd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a366253bb43f0a1292d6187d567b5a0f8730e83f5ce4f7036043b53d602b4870
+    manifestHash: d17d9bc5761e7649a5e95278de1ca1e27c480d7795cc933a26ab5418b06e9004
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a51b731659f1c2daa92a7bf73a2881a48521f23e95bc5cbd4b96e1a7ae2406a4
+    manifestHash: 2444a795b306da7277b3ce101036b1b7b6697b869aa8a5edeff657e55b152b31
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","secretStore":"memfs://clusters.example.com/minimal-ipv6.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
+    {"clusterName":"minimal-ipv6.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","secretStore":"memfs://clusters.example.com/minimal-ipv6.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a51b731659f1c2daa92a7bf73a2881a48521f23e95bc5cbd4b96e1a7ae2406a4
+    manifestHash: 2444a795b306da7277b3ce101036b1b7b6697b869aa8a5edeff657e55b152b31
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","secretStore":"memfs://clusters.example.com/minimal-ipv6.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
+    {"clusterName":"minimal-ipv6.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","secretStore":"memfs://clusters.example.com/minimal-ipv6.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a51b731659f1c2daa92a7bf73a2881a48521f23e95bc5cbd4b96e1a7ae2406a4
+    manifestHash: 2444a795b306da7277b3ce101036b1b7b6697b869aa8a5edeff657e55b152b31
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","secretStore":"memfs://clusters.example.com/minimal-ipv6.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
+    {"clusterName":"minimal-ipv6.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","secretStore":"memfs://clusters.example.com/minimal-ipv6.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a51b731659f1c2daa92a7bf73a2881a48521f23e95bc5cbd4b96e1a7ae2406a4
+    manifestHash: 2444a795b306da7277b3ce101036b1b7b6697b869aa8a5edeff657e55b152b31
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","secretStore":"memfs://clusters.example.com/minimal-ipv6.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
+    {"clusterName":"minimal-ipv6.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","secretStore":"memfs://clusters.example.com/minimal-ipv6.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ca08a2d22e30eef4bab9486dc06e1d3f19937e716520e808e297d1d1399aae36
+    manifestHash: ce1bc964f295c2573022c73794d8c00ef9d07f941f8f49efdaf689b955dc09a9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com","secretStore":"memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.this.is.truly.a.really.really.long.cluster-name.min-h1jir9"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"this.is.truly.a.really.really.long.cluster-name.minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com","secretStore":"memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.this.is.truly.a.really.really.long.cluster-name.min-h1jir9"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: eb870f207fc9c01ea2c5f81475b07d8cd6ffea89becf3e8f7a938dae79e7d97e
+    manifestHash: 55a12e442663f1139296135b9d83aecb60f160477cab191478583d2a78490f26
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-warmpool.example.com","secretStore":"memfs://clusters.example.com/minimal-warmpool.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-warmpool.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-warmpool.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-warmpool.example.com","secretStore":"memfs://clusters.example.com/minimal-warmpool.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-warmpool.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a366253bb43f0a1292d6187d567b5a0f8730e83f5ce4f7036043b53d602b4870
+    manifestHash: d17d9bc5761e7649a5e95278de1ca1e27c480d7795cc933a26ab5418b06e9004
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bb9b4762b49a6994a55d7d67e6a87a7ae6cc178f4ed31fed847a047605fda960
+    manifestHash: 1b769bfc51a80d773c70c62cc6cb7ff9f0b6f1514955c6eef95be06a122819a9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal-gce.example.com","secretStore":"memfs://tests/minimal-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce.example.com","secretStore":"memfs://tests/minimal-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bb9b4762b49a6994a55d7d67e6a87a7ae6cc178f4ed31fed847a047605fda960
+    manifestHash: 1b769bfc51a80d773c70c62cc6cb7ff9f0b6f1514955c6eef95be06a122819a9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal-gce.example.com","secretStore":"memfs://tests/minimal-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce.example.com","secretStore":"memfs://tests/minimal-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 19f44fd55e16d64e77385eb2245e6837028e1f0e390170c514cd1ba1033c7b06
+    manifestHash: 089f11b052ff86898fbd9f8b0efe02231602c05f49bed84afb4d728d4a7bcc87
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal-gce-ilb.example.com","secretStore":"memfs://tests/minimal-gce-ilb.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-ilb.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce-ilb.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-ilb.example.com","secretStore":"memfs://tests/minimal-gce-ilb.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-ilb.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 04a448e21bdd9a4f073457c75d7b5788eed5be36d6ba0a05c81142bf4fee15d1
+    manifestHash: 5c2bea3e71b042e9b095247e2321d2845c5e67b96e6e2e22d2567b20975a94f3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","secretStore":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","secretStore":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 04a448e21bdd9a4f073457c75d7b5788eed5be36d6ba0a05c81142bf4fee15d1
+    manifestHash: 5c2bea3e71b042e9b095247e2321d2845c5e67b96e6e2e22d2567b20975a94f3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","secretStore":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","secretStore":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 092d7b6623722b476fa74f37e4d898584a8c87cc830125f681ca3a2ea2d72d56
+    manifestHash: 8be902ae1583e7685342f086298e0535474b5469b15318a5a115ea3d53b870e1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal-gce-private.example.com","secretStore":"memfs://tests/minimal-gce-private.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-private.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce-private.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-private.example.com","secretStore":"memfs://tests/minimal-gce-private.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-private.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cc2074acfbd6f45d3430ebdc90b06cfec9e873aa77e557bb5172be9047523a5e
+    manifestHash: 85826f5dd38f55cb3b41b909757a30ddb76239f473293f6b5a59f0bfcdac2537
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","secretStore":"memfs://clusters.example.com/minimal.k8s.local/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"discovery":{"enabled":true}}
+    {"clusterName":"minimal.k8s.local","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","secretStore":"memfs://clusters.example.com/minimal.k8s.local/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"discovery":{"enabled":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -251,7 +251,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
     app.kubernetes.io/managed-by: kops
-    discovery.kops.k8s.io/internal-name: api.internal.minimal.k8s.local
+    discovery.kops.k8s.io/internal-name: api
     k8s-addon: kops-controller.addons.k8s.io
   name: api-internal
   namespace: kube-system
@@ -275,7 +275,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
     app.kubernetes.io/managed-by: kops
-    discovery.kops.k8s.io/internal-name: kops-controller.internal.minimal.k8s.local
+    discovery.kops.k8s.io/internal-name: kops-controller
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller-internal
   namespace: kube-system

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cc2074acfbd6f45d3430ebdc90b06cfec9e873aa77e557bb5172be9047523a5e
+    manifestHash: 85826f5dd38f55cb3b41b909757a30ddb76239f473293f6b5a59f0bfcdac2537
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","secretStore":"memfs://clusters.example.com/minimal.k8s.local/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"discovery":{"enabled":true}}
+    {"clusterName":"minimal.k8s.local","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","secretStore":"memfs://clusters.example.com/minimal.k8s.local/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"discovery":{"enabled":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -251,7 +251,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
     app.kubernetes.io/managed-by: kops
-    discovery.kops.k8s.io/internal-name: api.internal.minimal.k8s.local
+    discovery.kops.k8s.io/internal-name: api
     k8s-addon: kops-controller.addons.k8s.io
   name: api-internal
   namespace: kube-system
@@ -275,7 +275,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
     app.kubernetes.io/managed-by: kops
-    discovery.kops.k8s.io/internal-name: kops-controller.internal.minimal.k8s.local
+    discovery.kops.k8s.io/internal-name: kops-controller
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller-internal
   namespace: kube-system

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 70aaf433dc20c6785503fc6efa1ad42c9d046803be24aeeff45667e41abfe50b
+    manifestHash: 22706727a05653320ce4ae52d645b9c0c39506783bdeb8d153dd335a34393af5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"hetzner","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"hetzner":{}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"hetzner","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"hetzner":{}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: acdd085ffbd905cab6e0a1562bf4de4ce2aade35e56ec128e1cc696ef43dc1df
+    manifestHash: 0aef64c72303ed68bb359cc963f3921adf93473f5ccba413c1a7013c13f83b9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/mixedinstances.example.com","secretStore":"memfs://clusters.example.com/mixedinstances.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.mixedinstances.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"mixedinstances.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/mixedinstances.example.com","secretStore":"memfs://clusters.example.com/mixedinstances.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.mixedinstances.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: acdd085ffbd905cab6e0a1562bf4de4ce2aade35e56ec128e1cc696ef43dc1df
+    manifestHash: 0aef64c72303ed68bb359cc963f3921adf93473f5ccba413c1a7013c13f83b9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/mixedinstances.example.com","secretStore":"memfs://clusters.example.com/mixedinstances.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.mixedinstances.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"mixedinstances.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/mixedinstances.example.com","secretStore":"memfs://clusters.example.com/mixedinstances.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.mixedinstances.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 07bfe8ca317eeb1632ff554e6efc810d52859212e1ef8de53002e49355a05aa9
+    manifestHash: 113447df6f0fbe2620ff1c784bfc9d4c46675836f1a308adef7d108bf70f2b08
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com","secretStore":"memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.nthimdsprocessor.longclustername.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"nthimdsprocessor.longclustername.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com","secretStore":"memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.nthimdsprocessor.longclustername.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 07bfe8ca317eeb1632ff554e6efc810d52859212e1ef8de53002e49355a05aa9
+    manifestHash: 113447df6f0fbe2620ff1c784bfc9d4c46675836f1a308adef7d108bf70f2b08
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com","secretStore":"memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.nthimdsprocessor.longclustername.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"nthimdsprocessor.longclustername.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com","secretStore":"memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.nthimdsprocessor.longclustername.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a366253bb43f0a1292d6187d567b5a0f8730e83f5ce4f7036043b53d602b4870
+    manifestHash: d17d9bc5761e7649a5e95278de1ca1e27c480d7795cc933a26ab5418b06e9004
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c5823bc015af334ec667399b066f6fdaa59f39c16aa4a2f1de05948df5b7e905
+    manifestHash: e19aca241903ce4f67202e3b2f21b3599559bd393e5bfb3f227e72f7a62f7b62
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/private-shared-ip.example.com","secretStore":"memfs://clusters.example.com/private-shared-ip.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.private-shared-ip.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"private-shared-ip.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/private-shared-ip.example.com","secretStore":"memfs://clusters.example.com/private-shared-ip.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.private-shared-ip.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dcec9371913358997d7388fca1aa5d972d8e5af40eba57bd3284947f1bc4ce23
+    manifestHash: fdc27498ddc1e17eeb40ed79bb841ce15078328bda69ed5fecd0634cf226ef9f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/private-shared-subnet.example.com","secretStore":"memfs://clusters.example.com/private-shared-subnet.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.private-shared-subnet.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"private-shared-subnet.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/private-shared-subnet.example.com","secretStore":"memfs://clusters.example.com/private-shared-subnet.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.private-shared-subnet.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 68b66e68476d4be3f5d2319a4b768978cd0f10efcaebb60d9d422a9c86cf3870
+    manifestHash: a3c0618bc059f468bc611fa207fe2ba0c98da3d1e19609bb51809a7e44491721
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatecalico.example.com","secretStore":"memfs://clusters.example.com/privatecalico.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecalico.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"privatecalico.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatecalico.example.com","secretStore":"memfs://clusters.example.com/privatecalico.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecalico.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1fcaeabcf11cd15412087e1dc6c1b84debfe401d0a5a5aa39bb0b6f2eb626aeb
+    manifestHash: e492ca6e88fea4a2577d20221bf6da10e333d40e1cb161da9db7f90d3e9dc0d5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatecanal.example.com","secretStore":"memfs://clusters.example.com/privatecanal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecanal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"privatecanal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatecanal.example.com","secretStore":"memfs://clusters.example.com/privatecanal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecanal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bbe03c1303bdcfacf50c9117502125d7f442d8fed0fd94b82c455f860dac5f36
+    manifestHash: 32496da44d7d9e715e447f9227f48c5be223a1b007ad2c6e9017dab759f6c19c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatecilium.example.com","secretStore":"memfs://clusters.example.com/privatecilium.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecilium.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"privatecilium.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatecilium.example.com","secretStore":"memfs://clusters.example.com/privatecilium.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecilium.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bbe03c1303bdcfacf50c9117502125d7f442d8fed0fd94b82c455f860dac5f36
+    manifestHash: 32496da44d7d9e715e447f9227f48c5be223a1b007ad2c6e9017dab759f6c19c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatecilium.example.com","secretStore":"memfs://clusters.example.com/privatecilium.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecilium.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"privatecilium.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatecilium.example.com","secretStore":"memfs://clusters.example.com/privatecilium.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecilium.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 28c6854ea0934f82e0e41c3f0edae9c237b757a036e4ebc65ba1a9bb8f6d5460
+    manifestHash: 98be41be793d12faa993f2e4ac979e5c43b6162d47b240f81bfb9cd22294da35
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatecilium.example.com","secretStore":"memfs://clusters.example.com/privatecilium.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecilium.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"privatecilium.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatecilium.example.com","secretStore":"memfs://clusters.example.com/privatecilium.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecilium.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1d2db9b685d85e55b7a536bda8e78bd30b03714ec1c6d0949c65701fe4f7d0c2
+    manifestHash: b6bf7681b6055ad5c4a6f96427003be7e78ec024a81014f99e5138486c793fa9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privateciliumadvanced.example.com","secretStore":"memfs://clusters.example.com/privateciliumadvanced.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateciliumadvanced.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca","etcd-clients-ca-cilium"],"certNames":["kubelet","kubelet-server","etcd-client-cilium"]}}
+    {"clusterName":"privateciliumadvanced.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privateciliumadvanced.example.com","secretStore":"memfs://clusters.example.com/privateciliumadvanced.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateciliumadvanced.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca","etcd-clients-ca-cilium"],"certNames":["kubelet","kubelet-server","etcd-client-cilium"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b70b94502462976ec81041cc75d5334334d4106d929046ac60ce9fa12241ffbb
+    manifestHash: 9b433780baff891cb60534d429c81fb82aba992722f4fbbe236a80ebe71c45c9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatedns1.example.com","secretStore":"memfs://clusters.example.com/privatedns1.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatedns1.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"privatedns1.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatedns1.example.com","secretStore":"memfs://clusters.example.com/privatedns1.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatedns1.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9a10f341df716b1c45b48466b648c94a1b47be90436ff9fe035072089c9580b0
+    manifestHash: 3dc7440a447dbe7d60f9e9220f021f9a399fb3def64e18740f7f73c73cbe7568
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatedns2.example.com","secretStore":"memfs://clusters.example.com/privatedns2.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatedns2.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"privatedns2.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatedns2.example.com","secretStore":"memfs://clusters.example.com/privatedns2.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatedns2.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cb6fea3b2dad63131cd8ce809585e49f7dc527862200ecbea3594c35aba80340
+    manifestHash: 6fbf5113051ab465c6b51ea2e15e3ede7a2b5863b158fc23cab52a0133c6d57c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privateflannel.example.com","secretStore":"memfs://clusters.example.com/privateflannel.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateflannel.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"privateflannel.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privateflannel.example.com","secretStore":"memfs://clusters.example.com/privateflannel.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateflannel.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fe1b892e8c0e4029168866ec7348345903184a0d70ff1f0871c700ed1c4d5201
+    manifestHash: fa232a7066ca1edb9497d766e851fccd2fccdfb774bfa2a331cac770e9a74ec8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatekopeio.example.com","secretStore":"memfs://clusters.example.com/privatekopeio.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatekopeio.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"privatekopeio.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatekopeio.example.com","secretStore":"memfs://clusters.example.com/privatekopeio.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatekopeio.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 82a4b8efeda070bd423507e594eaa33bb2e55eb27b7c5420edc389cce85e6409
+    manifestHash: 38a9c428c2bbbf08f02d14aee02f64e395ada521bcfac08ed3fba1d145ad20a4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privateweave.example.com","secretStore":"memfs://clusters.example.com/privateweave.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateweave.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"privateweave.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privateweave.example.com","secretStore":"memfs://clusters.example.com/privateweave.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateweave.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6aed2249dc101ef1cba81f1b85dd55bcfd53c729b729a835863764fda4e874e5
+    manifestHash: 2ee5760022b56148f470545c516282de49b880aecf2b29c09d7be8f3483a6eb3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5877eeaf9443c4004786a81c196fc57e640429c1f24497e18dea122bcfab6130
+    manifestHash: 5554d7750d9913272fe1d54ce280d015eeb88bd65cad49a53698cdb1e39a4c40
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/sharedsubnet.example.com","secretStore":"memfs://clusters.example.com/sharedsubnet.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.sharedsubnet.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"sharedsubnet.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/sharedsubnet.example.com","secretStore":"memfs://clusters.example.com/sharedsubnet.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.sharedsubnet.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac6415ceb9c6c68227f562d14892457b47d57a937773e62071693178fcd33fc7
+    manifestHash: dc2391c45f38ae4d87e87407944fa3aa27abacbfbb31a501d771d7a8e5310c60
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/sharedvpc.example.com","secretStore":"memfs://clusters.example.com/sharedvpc.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.sharedvpc.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"sharedvpc.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/sharedvpc.example.com","secretStore":"memfs://clusters.example.com/sharedvpc.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.sharedvpc.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a51b731659f1c2daa92a7bf73a2881a48521f23e95bc5cbd4b96e1a7ae2406a4
+    manifestHash: 2444a795b306da7277b3ce101036b1b7b6697b869aa8a5edeff657e55b152b31
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","secretStore":"memfs://clusters.example.com/minimal-ipv6.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
+    {"clusterName":"minimal-ipv6.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","secretStore":"memfs://clusters.example.com/minimal-ipv6.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 053064f539271ed01a45411603737d87a7842817947b1105ea54584ecaca1dac
+    manifestHash: 485588fbde3718e256346f8b3ed40c5db8ebeeb4264f1ed265dabfbe904b5a1c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/unmanaged.example.com","secretStore":"memfs://clusters.example.com/unmanaged.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.unmanaged.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"unmanaged.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/unmanaged.example.com","secretStore":"memfs://clusters.example.com/unmanaged.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.unmanaged.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a366253bb43f0a1292d6187d567b5a0f8730e83f5ce4f7036043b53d602b4870
+    manifestHash: d17d9bc5761e7649a5e95278de1ca1e27c480d7795cc933a26ab5418b06e9004
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -587,6 +587,7 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 	cluster := tf.Cluster
 
 	config := &kopscontrollerconfig.Options{
+		ClusterName: cluster.Name,
 		Cloud:       string(cluster.Spec.GetCloudProvider()),
 		ConfigBase:  cluster.Spec.ConfigBase,
 		SecretStore: cluster.Spec.SecretStore,

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","secretStore":"memfs://clusters.example.com/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cca9c926c2ac056f329f1a340ec09d3fb790bdb8f29efc12de0aeab45d8f99fb
+    manifestHash: 0363ea0ae35e59cfb343679689a7181205c5f81d0c3c00ae51af4469dd912fb9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:


### PR DESCRIPTION
Cherry pick of #14880 on release-1.26.

#14880: Use short service name with discovery labels

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.