### PR TITLE
Automated cherry pick of #14880: Use short service name with discovery labels

### DIFF
--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -261,7 +261,7 @@ func addGossipController(mgr manager.Manager, opt *config.Options) error {
 		Name:      "coredns",
 	}
 
-	controller, err := controllers.NewHostsReconciler(mgr, configMapID)
+	controller, err := controllers.NewHostsReconciler(mgr, opt, configMapID)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops-controller/pkg/config/options.go
+++ b/cmd/kops-controller/pkg/config/options.go
@@ -22,6 +22,7 @@ import (
 )
 
 type Options struct {
+	ClusterName           string         `json:"clusterName,omitempty"`
 	Cloud                 string         `json:"cloud,omitempty"`
 	ConfigBase            string         `json:"configBase,omitempty"`
 	Server                *ServerOptions `json:"server,omitempty"`

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -262,7 +262,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 	var clientHost string
 
 	if featureflag.APIServerNodes.Enabled() {
-		clientHost = etcdCluster.Name + ".etcd." + b.ClusterName()
+		clientHost = etcdCluster.Name + ".etcd.internal." + b.ClusterName()
 	} else {
 		clientHost = "__name__"
 	}

--- a/pkg/model/components/kopscontroller/template_functions.go
+++ b/pkg/model/components/kopscontroller/template_functions.go
@@ -50,8 +50,6 @@ func (t *templateFunctions) GossipServices() ([]*corev1.Service, error) {
 		return nil, nil
 	}
 
-	suffix := t.Cluster.Name
-
 	var services []*corev1.Service
 
 	// api service
@@ -64,7 +62,7 @@ func (t *templateFunctions) GossipServices() ([]*corev1.Service, error) {
 			"k8s-app": "kops-controller",
 		}
 		service.Labels = map[string]string{
-			kops.DiscoveryLabelKey: "api.internal." + suffix,
+			kops.DiscoveryLabelKey: "api",
 		}
 		services = append(services, service)
 	}
@@ -79,7 +77,7 @@ func (t *templateFunctions) GossipServices() ([]*corev1.Service, error) {
 			"k8s-app": "kops-controller",
 		}
 		service.Labels = map[string]string{
-			kops.DiscoveryLabelKey: "kops-controller.internal." + suffix,
+			kops.DiscoveryLabelKey: "kops-controller",
 		}
 		services = append(services, service)
 	}
@@ -97,7 +95,7 @@ func (t *templateFunctions) GossipServices() ([]*corev1.Service, error) {
 				{Name: "https", Port: int32(ports.ClientPort), Protocol: corev1.ProtocolTCP},
 			}
 			service.Labels = map[string]string{
-				kops.DiscoveryLabelKey: etcdCluster.Name + ".etcd." + suffix,
+				kops.DiscoveryLabelKey: etcdCluster.Name + ".etcd",
 			}
 			service.Spec.Selector = etcdmanager.SelectorForCluster(etcdCluster)
 			services = append(services, service)

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b211e511fe3d8e48f053709876c9d13a9b9d97c3e2dc710b1bbab88e49f577b
+    manifestHash: 9bea07bd2eef1a55ab8959b472828628a224355b00bba442cf50d15f144815d2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/additionalobjects.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.additionalobjects.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"additionalobjects.example.com","cloud":"aws","configBase":"memfs://tests/additionalobjects.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.additionalobjects.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    dns.alpha.kubernetes.io/internal: events.etcd.minimal.example.com
+    dns.alpha.kubernetes.io/internal: events.etcd.internal.minimal.example.com
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events
@@ -15,7 +15,7 @@ spec:
     - -c
     - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
       --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-      --client-urls=https://events.etcd.minimal.example.com:4002 --cluster-name=etcd-events
+      --client-urls=https://events.etcd.internal.minimal.example.com:4002 --cluster-name=etcd-events
       --containerized=true --dns-suffix=.internal.minimal.example.com --grpc-port=3997
       --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    dns.alpha.kubernetes.io/internal: main.etcd.minimal.example.com
+    dns.alpha.kubernetes.io/internal: main.etcd.internal.minimal.example.com
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main
@@ -15,7 +15,7 @@ spec:
     - -c
     - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
       --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-      --client-urls=https://main.etcd.minimal.example.com:4001 --cluster-name=etcd
+      --client-urls=https://main.etcd.internal.minimal.example.com:4001 --cluster-name=etcd
       --containerized=true --dns-suffix=.internal.minimal.example.com --grpc-port=3996
       --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 44afbe2da24e6061221714645b9b443f2850699f5f6e60cfbba7407e0cbb3b49
+    manifestHash: 8b240f3c55ed695b075cadd239d72bffa7364270491466b5c668c939e2654d14
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["apiservers.minimal.example.com","nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["apiservers.minimal.example.com","nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a41771ee3bc07dd6f8436098232c60cbefbafd1cc7efeacf0be6b430ebdef9a
+    manifestHash: 09396718b704427d10f32ec53a780a63fef75c1127525d48c99297a5983229d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 40b7feb8ed5258e8f0a0a7acb7ef977831303b9da84d32869f730feadc6f8bfa
+    manifestHash: 4d3502c711eaed1ca62656a95f0d4f101ad8fc5308d1e422caa657aee3dd4d83
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/bastionuserdata.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.bastionuserdata.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"bastionuserdata.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/bastionuserdata.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.bastionuserdata.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0ce966fe5811869f6791ffcacd715b0019d96848d6d35445cf4d47b2857d2af3
+    manifestHash: 864baa217f5b77b76812d0c51b0a584f047f6e5e6488bc87fadc0df4553aaee2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/complex.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.complex.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"complex.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/complex.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.complex.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5c9bda27dcdee9980d3f1c05e282ca1f815f86496a5461eb344f83ea2c5d4d06
+    manifestHash: 33373643bb67b1e8f332ff93ad3701d1087b951a70b8be260a1a8c23764eeb13
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/compress.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.compress.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"compress.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/compress.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.compress.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1746ecb734bacb441faef21ea034c1555a8f6f2e5d6290c277e0bdf5e3290ed4
+    manifestHash: b85f2457fd8c63847a1f9e0f79d3c221a81012be8afbb7265ec959f62abf7623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/containerd.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.containerd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"containerd.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/containerd.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.containerd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1746ecb734bacb441faef21ea034c1555a8f6f2e5d6290c277e0bdf5e3290ed4
+    manifestHash: b85f2457fd8c63847a1f9e0f79d3c221a81012be8afbb7265ec959f62abf7623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/containerd.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.containerd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"containerd.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/containerd.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.containerd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 34f93a20d760578975b02244400aff4b77afc3caaa32238e3bbd539ffbf5e986
+    manifestHash: 02630cec3efbc2d2678c1e04d43a181a7c41ffae03a17259fd8959ff9579cad8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/123.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.123.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"123.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/123.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.123.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5be20b7ae20f0f3ee10ef0456adf0a451afb9b63e0e2b88cd481f29b61c27bce
+    manifestHash: 232864c7c9e4052b7294dace66ed84747b6969f9b3aaba501da2d4539156a40c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/docker.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.docker.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"docker.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/docker.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.docker.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5898caafa372aba0fb1e41b41f8108b8dc5064ed945578bcccea6ba861c32fed
+    manifestHash: abe169a5d4878544b660606d0aafff991ea85cb4078a8baa8409d88ab6c869a5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/existing-iam.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"existing-iam.example.com","cloud":"aws","configBase":"memfs://tests/existing-iam.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cbcbcc4efdca207942642134e2c86196e9d8afede30f5a47dca5cc67c8d05b16
+    manifestHash: 5a049abce6595f0e0d48db4a2e4aa6df1f1a00aa96ed24c279650ab0b7d09dc9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/existingsg.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.existingsg.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"existingsg.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/existingsg.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.existingsg.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a41771ee3bc07dd6f8436098232c60cbefbafd1cc7efeacf0be6b430ebdef9a
+    manifestHash: 09396718b704427d10f32ec53a780a63fef75c1127525d48c99297a5983229d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a41771ee3bc07dd6f8436098232c60cbefbafd1cc7efeacf0be6b430ebdef9a
+    manifestHash: 09396718b704427d10f32ec53a780a63fef75c1127525d48c99297a5983229d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b7e57b1b9ce102224dde4362166e4c081f35553b6f85ec93a3bf4719ac2deff2
+    manifestHash: f8f1cc08e3184f326373627773348f0c13b1ec28a083f7f3b0052ffe1944c3eb
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/externallb.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.externallb.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"externallb.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/externallb.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.externallb.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 28f68d4eeee966ec5614e23d49b120d44d9844f3f517bac23e69e0286d893f14
+    manifestHash: f8ebbb04751f482adb13f81026163b47402000f049c89dfa2c77d2323090a711
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/externalpolicies.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.externalpolicies.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"externalpolicies.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/externalpolicies.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.externalpolicies.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 59bfed1489cc7e1fc25917587e313b787a9bd2be782116e4a5bea6e05d4d72c9
+    manifestHash: c86ffc0d8b2d59de1234e2e486d026e2e4bde5f6d4df6364483243d6ee49a21e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/ha.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.ha.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"ha.example.com","cloud":"aws","configBase":"memfs://tests/ha.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.ha.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7b81c76147706d44c827ac2f0f3c3a30f8ef9670c9a71e0d650a667109e18b50
+    manifestHash: d31843ea55bb5c80be476028ef1d4f2bea945fe55dfc6808aa7821f34167b3f8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/ha-gce.example.com"}
+    {"clusterName":"ha-gce.example.com","cloud":"gce","configBase":"memfs://tests/ha-gce.example.com"}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a41771ee3bc07dd6f8436098232c60cbefbafd1cc7efeacf0be6b430ebdef9a
+    manifestHash: 09396718b704427d10f32ec53a780a63fef75c1127525d48c99297a5983229d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6b6919f9440037f9c3c785e3b4cd50cb443c14e7d870954081b57735c30954e8
+    manifestHash: 32f041cf3c65ea6da3c166b3b3545eccf4277db2ecd8e40b5a8233fd21a5002b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a41771ee3bc07dd6f8436098232c60cbefbafd1cc7efeacf0be6b430ebdef9a
+    manifestHash: 09396718b704427d10f32ec53a780a63fef75c1127525d48c99297a5983229d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6b6919f9440037f9c3c785e3b4cd50cb443c14e7d870954081b57735c30954e8
+    manifestHash: 32f041cf3c65ea6da3c166b3b3545eccf4277db2ecd8e40b5a8233fd21a5002b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6b6919f9440037f9c3c785e3b4cd50cb443c14e7d870954081b57735c30954e8
+    manifestHash: 32f041cf3c65ea6da3c166b3b3545eccf4277db2ecd8e40b5a8233fd21a5002b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6b6919f9440037f9c3c785e3b4cd50cb443c14e7d870954081b57735c30954e8
+    manifestHash: 32f041cf3c65ea6da3c166b3b3545eccf4277db2ecd8e40b5a8233fd21a5002b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6b6919f9440037f9c3c785e3b4cd50cb443c14e7d870954081b57735c30954e8
+    manifestHash: 32f041cf3c65ea6da3c166b3b3545eccf4277db2ecd8e40b5a8233fd21a5002b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a41771ee3bc07dd6f8436098232c60cbefbafd1cc7efeacf0be6b430ebdef9a
+    manifestHash: 09396718b704427d10f32ec53a780a63fef75c1127525d48c99297a5983229d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a41771ee3bc07dd6f8436098232c60cbefbafd1cc7efeacf0be6b430ebdef9a
+    manifestHash: 09396718b704427d10f32ec53a780a63fef75c1127525d48c99297a5983229d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6802f35718392637e22f55c1b529f813ad6d553716719076c3bf702226a310b3
+    manifestHash: e5df219d8590cfff75cf81ca26a4db689ad0b267f6f01168c529155ff8f53524
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://tests/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 257bfbbb569a09977a620efd8aecd1a1262e9baad2cffe0dd136990e2e08672e
+    manifestHash: f217bb808cf82fa8d8d5c4800ae724b475d7102bae7c432d08daa1b44b8c99a6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://tests/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 257bfbbb569a09977a620efd8aecd1a1262e9baad2cffe0dd136990e2e08672e
+    manifestHash: f217bb808cf82fa8d8d5c4800ae724b475d7102bae7c432d08daa1b44b8c99a6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://tests/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 257bfbbb569a09977a620efd8aecd1a1262e9baad2cffe0dd136990e2e08672e
+    manifestHash: f217bb808cf82fa8d8d5c4800ae724b475d7102bae7c432d08daa1b44b8c99a6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://tests/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://tests/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6367b0defb2f510536e8c924b46d2b836160b6eb3576622bcdcdee9527a6f35c
+    manifestHash: 1d2dd890534bbada67cf0a1bdb97ca50f249e2955813fb831e7f9440a2c01e76
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-etcd.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-etcd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-etcd.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-etcd.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-etcd.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a41771ee3bc07dd6f8436098232c60cbefbafd1cc7efeacf0be6b430ebdef9a
+    manifestHash: 09396718b704427d10f32ec53a780a63fef75c1127525d48c99297a5983229d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bf0d8b465778ea96314cc24f21cb9fd19c40c8177c04de0feaff353f19ef4b53
+    manifestHash: 283871d72beb17b2c579fb8bb8a942a728ee2ec0b3a64eeb1298df8267f90488
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
+    {"clusterName":"minimal-ipv6.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 638bfef3ad4c56405aab636d62d24baa2b4188d394fc5e98892b58b186fcee16
+    manifestHash: 080806b5dc99ab3d54202fcc1a18df39e5d13536ca2a0b8ac6c33f1551a610cc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"enableCloudIPAM":true}
+    {"clusterName":"minimal-ipv6.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"enableCloudIPAM":true}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bf0d8b465778ea96314cc24f21cb9fd19c40c8177c04de0feaff353f19ef4b53
+    manifestHash: 283871d72beb17b2c579fb8bb8a942a728ee2ec0b3a64eeb1298df8267f90488
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
+    {"clusterName":"minimal-ipv6.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"enableCloudIPAM":true}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 638bfef3ad4c56405aab636d62d24baa2b4188d394fc5e98892b58b186fcee16
+    manifestHash: 080806b5dc99ab3d54202fcc1a18df39e5d13536ca2a0b8ac6c33f1551a610cc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"enableCloudIPAM":true}
+    {"clusterName":"minimal-ipv6.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-ipv6.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-ipv6.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"enableCloudIPAM":true}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bd2e0389a4f1c7f96ad7b53f50007792ca08cb4d1c86d83d9e7782fbe16af31d
+    manifestHash: e2c3b0e0ad903f2251638028909da14f47dc4b3e2a8c4a301cacdcc7eb01ba64
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.this.is.truly.a.really.really.long.cluster-name.min-h1jir9"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"this.is.truly.a.really.really.long.cluster-name.minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.this.is.truly.a.really.really.long.cluster-name.min-h1jir9"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5f01096cec9af94fcc5a28d7255ed2b6527e14a3d5280bde429ba62609037f0c
+    manifestHash: 675166860de7920275d8a356771c9f52a894dcd86ac62c5df70d64d9952d3bc0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal-warmpool.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-warmpool.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-warmpool.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal-warmpool.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal-warmpool.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a41771ee3bc07dd6f8436098232c60cbefbafd1cc7efeacf0be6b430ebdef9a
+    manifestHash: 09396718b704427d10f32ec53a780a63fef75c1127525d48c99297a5983229d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1a01d5f273f9c9d7ffc8a0eb3cf69202bf4daced070b823149cbbb1355e52cc5
+    manifestHash: f674d34b56e0d853e1d6f142ee85cb97b0c9983b6ec553bc881c1e3b18154600
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal-gce.example.com","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce.example.com","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61c0f1a1163eddc0d347c5d2b151c1ed88da6091472bca470ad45bf4c886cbda
+    manifestHash: b2f0482196b03a02c508724349f2229769185f96d24e8a73fc0d904f2b10900a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal-gce-ilb.example.com"}
+    {"clusterName":"minimal-gce-ilb.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-ilb.example.com"}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ad9cd8d43954e9817da83caa49fdccf37a7714f3d7db82b695a60b58a50c71e4
+    manifestHash: 28db8caa80e0223a112702370b5e9eb30386a188c6ec203230a34f0fbfca5762
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ad9cd8d43954e9817da83caa49fdccf37a7714f3d7db82b695a60b58a50c71e4
+    manifestHash: 28db8caa80e0223a112702370b5e9eb30386a188c6ec203230a34f0fbfca5762
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2667eec0dbcdfad30a4c9138e6c12784f5671d27adb3e29073c597a18c111f2d
+    manifestHash: 72896c520f3e3659e7758b535b4ce12e3be1e13ed4fc3af921ca15d199deb489
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"gce","configBase":"memfs://tests/minimal-gce-private.example.com"}
+    {"clusterName":"minimal-gce-private.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-private.example.com"}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d6746dcf82a8cc074aa834a79a555db94abff5983e08afd6b98ded5bc5e609a9
+    manifestHash: 649d5d4a2bb8a590defe06d80e7359fad4091348005f24e03e74f421bd28f3fd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"discovery":{"enabled":true}}
+    {"clusterName":"minimal.k8s.local","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"discovery":{"enabled":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -251,7 +251,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
     app.kubernetes.io/managed-by: kops
-    discovery.kops.k8s.io/internal-name: api.internal.minimal.k8s.local
+    discovery.kops.k8s.io/internal-name: api
     k8s-addon: kops-controller.addons.k8s.io
   name: api-internal
   namespace: kube-system
@@ -275,7 +275,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
     app.kubernetes.io/managed-by: kops
-    discovery.kops.k8s.io/internal-name: kops-controller.internal.minimal.k8s.local
+    discovery.kops.k8s.io/internal-name: kops-controller
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller-internal
   namespace: kube-system

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d6746dcf82a8cc074aa834a79a555db94abff5983e08afd6b98ded5bc5e609a9
+    manifestHash: 649d5d4a2bb8a590defe06d80e7359fad4091348005f24e03e74f421bd28f3fd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"discovery":{"enabled":true}}
+    {"clusterName":"minimal.k8s.local","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"discovery":{"enabled":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -251,7 +251,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
     app.kubernetes.io/managed-by: kops
-    discovery.kops.k8s.io/internal-name: api.internal.minimal.k8s.local
+    discovery.kops.k8s.io/internal-name: api
     k8s-addon: kops-controller.addons.k8s.io
   name: api-internal
   namespace: kube-system
@@ -275,7 +275,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
     app.kubernetes.io/managed-by: kops
-    discovery.kops.k8s.io/internal-name: kops-controller.internal.minimal.k8s.local
+    discovery.kops.k8s.io/internal-name: kops-controller
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller-internal
   namespace: kube-system

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9c459347fdfe06ad26d33058ba5483d7e7237e34aa67d10d9487f09bf387735f
+    manifestHash: 1802f297e52cf8d78ad862a6e71032d71aaebe181d5e9ed12c0ebc788e3d8ad5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"hetzner","configBase":"memfs://tests/minimal.k8s.local","discovery":{"enabled":true}}
+    {"clusterName":"minimal.k8s.local","cloud":"hetzner","configBase":"memfs://tests/minimal.k8s.local","discovery":{"enabled":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -251,7 +251,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
     app.kubernetes.io/managed-by: kops
-    discovery.kops.k8s.io/internal-name: api.internal.minimal.k8s.local
+    discovery.kops.k8s.io/internal-name: api
     k8s-addon: kops-controller.addons.k8s.io
   name: api-internal
   namespace: kube-system
@@ -275,7 +275,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
     app.kubernetes.io/managed-by: kops
-    discovery.kops.k8s.io/internal-name: kops-controller.internal.minimal.k8s.local
+    discovery.kops.k8s.io/internal-name: kops-controller
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller-internal
   namespace: kube-system

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7618e42dea2ac62df715d695610b47a3200eb9c0e09458eb2c7324e8fc67f4c5
+    manifestHash: 51d290f82d082d5d6de1e41ad3cc4f736ec619e251e94bf7c4c8f986baff189c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/mixedinstances.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.mixedinstances.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"mixedinstances.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/mixedinstances.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.mixedinstances.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7618e42dea2ac62df715d695610b47a3200eb9c0e09458eb2c7324e8fc67f4c5
+    manifestHash: 51d290f82d082d5d6de1e41ad3cc4f736ec619e251e94bf7c4c8f986baff189c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/mixedinstances.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.mixedinstances.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"mixedinstances.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/mixedinstances.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.mixedinstances.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8d987c5fd195e56d5d3a5b6771dee49bdd6f7a7a6967078802c4d04c942b8525
+    manifestHash: 0adb4845aaacd21944bb399265c3e9af964b51aee25a85768ac873d8a70828d0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/nthsqsresources.longclustername.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.nthsqsresources.longclustername.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"nthsqsresources.longclustername.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/nthsqsresources.longclustername.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.nthsqsresources.longclustername.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a41771ee3bc07dd6f8436098232c60cbefbafd1cc7efeacf0be6b430ebdef9a
+    manifestHash: 09396718b704427d10f32ec53a780a63fef75c1127525d48c99297a5983229d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 99984fdb45cc9501de56f8bf6e9c1f75c8ea54c58803319210d75b1a05a41e21
+    manifestHash: 40026309e333b0220ed28154790b3c2ddf1d06bbafd88d47f25d8eaae66599b0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/private-shared-ip.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.private-shared-ip.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"private-shared-ip.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/private-shared-ip.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.private-shared-ip.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 81c331edf3c8b699f447380340922a93da373fa1f4f48bb497dcc7259dc80394
+    manifestHash: 8a7da26c615149dc9df3b1ca51b7a55fe1994c1cc7dee2e0be27a9a09b630408
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/private-shared-subnet.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.private-shared-subnet.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"private-shared-subnet.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/private-shared-subnet.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.private-shared-subnet.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f265fc076f97f699ff163bbe7d7cad01c40123593474580c09420f0122b4ef1
+    manifestHash: cbfad37c886e22e19bcc424f928442e6173ccb30b2d5f5d41f8fdbad833f4c60
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatecalico.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecalico.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"privatecalico.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatecalico.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecalico.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b9c4380135ebcda3bc2108fdcbc70f80e5780ed1738391aab9b9e832becfd115
+    manifestHash: bb5c93da45de109f1af6e4256d42938e6801e5309a6bbe5c8e6d8541d2cfd2cc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatecanal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecanal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"privatecanal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatecanal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecanal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 87ce0585e487e3153e3db9a85ebd214ccaabd8c97ea532747ed217c8565bb7f2
+    manifestHash: 314a7476fd57497bd5b9d47e757aa304e11d6882c481294495310f5d74a4d7f8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatecilium.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecilium.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"privatecilium.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatecilium.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecilium.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d3bd793a5a96581eead5fdae01e9647c9b2e0b1c35acfdd31affadc45ee0baed
+    manifestHash: 4668a39fd954c12d0eb4f073afbebc841395a9a6080cf6eafb6f270241eda62c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatecilium.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecilium.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"privatecilium.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatecilium.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatecilium.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a5bca5a6b851fb9ca179eb1c8c691c0071e0536b67063d32e6464c40f65253f0
+    manifestHash: 2c376253847d5614a06bb9fa2497c074fef117842e8ee1f9835ee49636945ad5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privateciliumadvanced.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateciliumadvanced.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca","etcd-clients-ca-cilium"],"certNames":["kubelet","kubelet-server","etcd-client-cilium"]}}
+    {"clusterName":"privateciliumadvanced.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privateciliumadvanced.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateciliumadvanced.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca","etcd-clients-ca-cilium"],"certNames":["kubelet","kubelet-server","etcd-client-cilium"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 46829ac60d6528b9e0a0a41dd13bef87315b1dc24ad8d1b54fe52a3fdbda5e5e
+    manifestHash: 055517c08fa147d6276b7a3ab41d7ecd5e45df42cf1b9125e196188bf82256b9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatedns1.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatedns1.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"privatedns1.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatedns1.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatedns1.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b3e2a9d94bc16019cccdea554685097d27e439945baa912ef1c712e2b39259e
+    manifestHash: b153cbb56315ec79dc59cb2df700cebf369bd1297f16518f078c33417ffa8d52
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatedns2.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatedns2.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"privatedns2.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatedns2.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatedns2.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 527f546806412703c81dddd9b8fcfdaa003a5a7ef200a581b1770deaafc7b268
+    manifestHash: cb579f19a18c3b5fdc36159c5d568a2ba04b636e9bde3d61f7a66870138ad698
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privateflannel.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateflannel.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"privateflannel.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privateflannel.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateflannel.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dd178780d6c54210ae28a1e38ed5f443264270bf86ae02a15e07c346b780795b
+    manifestHash: df35195b4da4ca42ebac86a00fe933c232310d538a2a739d3c5f8ee3626d3dc9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privatekopeio.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatekopeio.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"privatekopeio.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privatekopeio.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privatekopeio.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 71666f2be5d09a96734634ca659ddeaf3e5c7e486048d728fc431d2387149e45
+    manifestHash: 97d7e0b33ceb450c1da0ef2f92432587a354261e61c4079aa9796b5299cafae5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/privateweave.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateweave.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"privateweave.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/privateweave.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.privateweave.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6b6919f9440037f9c3c785e3b4cd50cb443c14e7d870954081b57735c30954e8
+    manifestHash: 32f041cf3c65ea6da3c166b3b3545eccf4277db2ecd8e40b5a8233fd21a5002b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ea0574b1d2560c36404fdaa714b5555af4b4b08ee1c32fcbeb5776acbe6f7450
+    manifestHash: d4509d1ebe9f783516283d213a786b346f737396d44728563f5ca6de358a8fc3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/sharedsubnet.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.sharedsubnet.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"sharedsubnet.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/sharedsubnet.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.sharedsubnet.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 348e39bd4b21e076ca3f3419cfd5692201ea934a119b136814822839af5e02f8
+    manifestHash: 96bf3e2e040a0fa7b59a6861308bb9d6f4914b996ae7ad357f25d62c04bcf7fb
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/sharedvpc.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.sharedvpc.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"sharedvpc.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/sharedvpc.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.sharedvpc.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6ee1ad197224be6d67c82a963f4805e9efdf88d623cc805208963eec4737877b
+    manifestHash: b940d8b1e4a1514c6e6284866af12cb4f6ccbea8fafe9392aca7ef26e4b878f7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/unmanaged.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.unmanaged.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"unmanaged.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/unmanaged.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.unmanaged.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a41771ee3bc07dd6f8436098232c60cbefbafd1cc7efeacf0be6b430ebdef9a
+    manifestHash: 09396718b704427d10f32ec53a780a63fef75c1127525d48c99297a5983229d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.example.com"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -580,8 +580,9 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 	cluster := tf.Cluster
 
 	config := &kopscontrollerconfig.Options{
-		Cloud:      string(cluster.Spec.GetCloudProvider()),
-		ConfigBase: cluster.Spec.ConfigBase,
+		ClusterName: cluster.Name,
+		Cloud:       string(cluster.Spec.GetCloudProvider()),
+		ConfigBase:  cluster.Spec.ConfigBase,
 	}
 
 	if featureflag.CacheNodeidentityInfo.Enabled() {

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.example.com","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["kops-custom-node-role","nodes.minimal.example.com"],"Region":"us-east-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0b77ffa363a98e4143a7ef736c59f1d56b774a0008c24146292f96b75d22f3d
+    manifestHash: 340e60491a0156b288339b88bd5ba03f8eee418316c13916f11d8132129a18b8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:


### PR DESCRIPTION
Cherry pick of #14880 on release-1.25.

#14880: Use short service name with discovery labels

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```