### PR TITLE
Etcd domains are now under .internal.

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -512,8 +512,8 @@ func (b *KubeAPIServerBuilder) buildPod(kubeAPIServer *kops.KubeAPIServerConfig)
 	// running on master nodes
 	if !b.IsMaster {
 		clusterName := b.Cluster.ObjectMeta.Name
-		mainEtcdDNSName := "main.etcd." + clusterName
-		eventsEtcdDNSName := "events.etcd." + clusterName
+		mainEtcdDNSName := "main.etcd.internal." + clusterName
+		eventsEtcdDNSName := "events.etcd.internal." + clusterName
 		for i := range kubeAPIServer.EtcdServers {
 			kubeAPIServer.EtcdServers[i] = strings.ReplaceAll(kubeAPIServer.EtcdServers[i], "127.0.0.1", mainEtcdDNSName)
 		}

--- a/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
@@ -30,8 +30,8 @@ contents: |
       - --etcd-cafile=/srv/kubernetes/kube-apiserver/etcd-ca.crt
       - --etcd-certfile=/srv/kubernetes/kube-apiserver/etcd-client.crt
       - --etcd-keyfile=/srv/kubernetes/kube-apiserver/etcd-client.key
-      - --etcd-servers-overrides=/events#https://events.etcd.minimal.example.com:4002
-      - --etcd-servers=https://main.etcd.minimal.example.com:4001
+      - --etcd-servers-overrides=/events#https://events.etcd.internal.minimal.example.com:4002
+      - --etcd-servers=https://main.etcd.internal.minimal.example.com:4001
       - --feature-gates=CSIMigrationAWS=true,InTreePluginAWSUnregister=true
       - --kubelet-client-certificate=/srv/kubernetes/kube-apiserver/kubelet-api.crt
       - --kubelet-client-key=/srv/kubernetes/kube-apiserver/kubelet-api.key


### PR DESCRIPTION
Dedicated APIServer nodes were broken by #14880 
