### PR TITLE
Use private topology for apiserver e2e test

### DIFF
--- a/tests/e2e/templates/apiserver.yaml.tmpl
+++ b/tests/e2e/templates/apiserver.yaml.tmpl
@@ -32,12 +32,18 @@ spec:
   sshAccess:
     - {{.publicIP}}
   topology:
-    masters: public
-    nodes: public
+    bastion:
+      bastionPublicName: bastion.{{.clusterName}}
+    masters: private
+    nodes: private
   subnets:
   - cidr: 172.20.32.0/19
     name: {{$zone}}
-    type: Public
+    type: Private
+    zone: {{$zone}}
+  - cidr: 172.20.0.0/22
+    name: utility-{{$zone}}
+    type: Utility
     zone: {{$zone}}
 
 ---
@@ -60,8 +66,10 @@ metadata:
   labels:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
-  associatePublicIp: true
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
+  instanceMetadata:
+    httpPutResponseHopLimit: 1
+    httpTokens: required
   machineType: t3.medium
   maxSize: 4
   minSize: 4
@@ -78,8 +86,10 @@ metadata:
   labels:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
-  associatePublicIp: true
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
+  instanceMetadata:
+    httpPutResponseHopLimit: 1
+    httpTokens: required
   machineType: c5.large
   maxSize: 1
   minSize: 1
@@ -96,11 +106,33 @@ metadata:
   labels:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
-  associatePublicIp: true
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
+  instanceMetadata:
+    httpPutResponseHopLimit: 1
+    httpTokens: required
   machineType: c5.large
   maxSize: 1
   minSize: 1
   role: APIServer
+  subnets:
+  - {{$zone}}
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  name: bastions
+  labels:
+    kops.k8s.io/cluster: {{.clusterName}}
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221018
+  instanceMetadata:
+    httpPutResponseHopLimit: 1
+    httpTokens: required
+  machineType: t3.micro
+  maxSize: 1
+  minSize: 1
+  role: Bastion
   subnets:
   - {{$zone}}


### PR DESCRIPTION
Because anyone needing dedicated apiserver nodes is unlikely to be using public topology.