### PR TITLE
Automated cherry pick of #14907: APIServer nodes also need apiserverAdditionalIPs

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1400,7 +1400,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 		}
 	}
 
-	if isMaster {
+	if hasAPIServer {
 		config.ApiserverAdditionalIPs = apiserverAdditionalIPs
 	}
 


### PR DESCRIPTION
Cherry pick of #14907 on release-1.26.

#14907: APIServer nodes also need apiserverAdditionalIPs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.