### PR TITLE
Don't require subnets on DO and Hetzner

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -518,14 +518,9 @@ func validateTopology(c *kops.Cluster, topology *kops.TopologySpec, fieldPath *f
 func validateSubnets(c *kops.ClusterSpec, subnets []kops.ClusterSubnetSpec, fieldPath *field.Path, strict bool, providerConstraints *cloudProviderConstraints, networkCIDRs []*net.IPNet) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	// TODO these both can't be right. Can some cloud providers truly avoid specifying subnets?
 	if providerConstraints.requiresSubnets && len(subnets) == 0 {
 		// TODO: Auto choose zones from region?
 		allErrs = append(allErrs, field.Required(fieldPath, "must configure at least one subnet (use --zones)"))
-	}
-	// cannot be empty
-	if len(subnets) == 0 {
-		allErrs = append(allErrs, field.Required(fieldPath, ""))
 	}
 
 	// Each subnet must be valid


### PR DESCRIPTION
From a cursory review of the code, it looks like Hetzner can imply a subnet from the network's CIDR range and DO doesn't have the concept of subnets.

It's unfortunate that there aren't integration tests validating these code paths.