### PR TITLE
Reduce use of cluster topology field

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -92,7 +92,7 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 				Preemptible:          fi.PtrTo(fi.ValueOf(ig.Spec.GCPProvisioningModel) == "SPOT"),
 				GCPProvisioningModel: ig.Spec.GCPProvisioningModel,
 
-				HasExternalIP: fi.PtrTo(b.Cluster.Spec.Networking.Topology.ControlPlane == kops.TopologyPublic),
+				HasExternalIP: fi.PtrTo(subnet.Type == kops.SubnetTypePublic || subnet.Type == kops.SubnetTypeUtility),
 
 				Scopes: []string{
 					"compute-rw",

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -1163,7 +1163,6 @@ resource "aws_subnet" "us-east-1a-utility-complex-example-com" {
     "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
-    "kubernetes.io/role/internal-elb"           = "1"
   }
   vpc_id = aws_vpc.complex-example-com.id
 }
@@ -1183,7 +1182,6 @@ resource "aws_subnet" "us-test-1a-complex-example-com" {
     "kops.k8s.io/instance-group/nodes"             = "true"
     "kubernetes.io/cluster/complex.example.com"    = "owned"
     "kubernetes.io/role/elb"                       = "1"
-    "kubernetes.io/role/internal-elb"              = "1"
   }
   vpc_id = aws_vpc.complex-example-com.id
 }


### PR DESCRIPTION
I'm questioning why we have the `topology.nodes` and `topology.controlPlane` fields in the cluster spec. They're redundant with the cluster subnet specs.

This changes AWS subnet tagging to be based on the existence or not of private subnets. It changes GCE assignment of public IPs to nodes to behave like AWS: based on the subnet the instance is in, not whether the topology spec thinks the control plane is public.