### PR TITLE
Populate cluster with default values in `kops replace`

### DIFF
--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -141,7 +141,7 @@ func RunReplace(ctx context.Context, f *util.Factory, out io.Writer, c *ReplaceO
 
 						err = cloudup.PerformAssignments(v, cloud)
 						if err != nil {
-							return fmt.Errorf("error populating configuration: %v", err)
+							return fmt.Errorf("error populating configuration: %w", err)
 						}
 
 						_, err = clientset.CreateCluster(ctx, v)

--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -138,6 +138,12 @@ func RunReplace(ctx context.Context, f *util.Factory, out io.Writer, c *ReplaceO
 						if !c.Force {
 							return fmt.Errorf("cluster %v does not exist (try adding --force flag)", clusterName)
 						}
+
+						err = cloudup.PerformAssignments(v, cloud)
+						if err != nil {
+							return fmt.Errorf("error populating configuration: %v", err)
+						}
+
 						_, err = clientset.CreateCluster(ctx, v)
 						if err != nil {
 							return fmt.Errorf("error creating cluster: %v", err)


### PR DESCRIPTION
Similar to what is done in `kops create` and `kops edit`, I believe `kops replace` should also augment the cluster definition with the defaults provided by the `PerformAssignments` method.

I stumbled upon this while trying to follow this guide: https://kops.sigs.k8s.io/manifests_and_customizing_via_api/#yaml-examples.
After creating a cluster from a manifest file using `kops create -f ...`, I changed the `cloudLabels` field and run a `kops replace -f ...` which threw an error related to a non-existing field nonMasqueradeCIDR. I believe this is one of the values that are populated by the `PerformAssignments` method during `kops create` but not `kops replace`.