### PR TITLE
Do not include tags when searching existing volumes in OpenStack

### DIFF
--- a/upup/pkg/fi/cloudup/openstacktasks/volume.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/volume.go
@@ -46,8 +46,7 @@ func (c *Volume) CompareWithID() *string {
 func (c *Volume) Find(context *fi.CloudupContext) (*Volume, error) {
 	cloud := context.T.Cloud.(openstack.OpenstackCloud)
 	opt := cinderv3.ListOpts{
-		Name:     fi.ValueOf(c.Name),
-		Metadata: c.Tags,
+		Name: fi.ValueOf(c.Name),
 	}
 	volumes, err := cloud.ListVolumes(opt)
 	if err != nil {


### PR DESCRIPTION
fixes #14922

if we include tags when searching volumes, it basically means that we cannot modify tags at all.

After this PR the `kops update cluster` output is: (it will add tag `k8s.io/role/control-plane: 1` to all volumes)

```
Will modify resources:
  Volume/espsti.etcd-events.sre-sandbox.k8s.local
        Tags                     {k8s.io/role/master: 1, KubernetesCluster: sre-sandbox.k8s.local, k8s.io/etcd/events: espsti/espsti,esptnl,helpa} -> {k8s.io/etcd/events: espsti/espsti,esptnl,helpa, k8s.io/role/control-plane: 1, k8s.io/role/master: 1, KubernetesCluster: sre-sandbox.k8s.local}

  Volume/espsti.etcd-main.sre-sandbox.k8s.local
        Tags                     {KubernetesCluster: sre-sandbox.k8s.local, k8s.io/etcd/main: espsti/espsti,esptnl,helpa, k8s.io/role/master: 1} -> {k8s.io/etcd/main: espsti/espsti,esptnl,helpa, k8s.io/role/control-plane: 1, k8s.io/role/master: 1, KubernetesCluster: sre-sandbox.k8s.local}

  Volume/esptnl.etcd-events.sre-sandbox.k8s.local
        Tags                     {KubernetesCluster: sre-sandbox.k8s.local, k8s.io/etcd/events: esptnl/espsti,esptnl,helpa, k8s.io/role/master: 1} -> {k8s.io/etcd/events: esptnl/espsti,esptnl,helpa, k8s.io/role/control-plane: 1, k8s.io/role/master: 1, KubernetesCluster: sre-sandbox.k8s.local}

  Volume/esptnl.etcd-main.sre-sandbox.k8s.local
        Tags                     {k8s.io/etcd/main: esptnl/espsti,esptnl,helpa, k8s.io/role/master: 1, KubernetesCluster: sre-sandbox.k8s.local} -> {k8s.io/etcd/main: esptnl/espsti,esptnl,helpa, k8s.io/role/control-plane: 1, k8s.io/role/master: 1, KubernetesCluster: sre-sandbox.k8s.local}

  Volume/helpa.etcd-events.sre-sandbox.k8s.local
        Tags                     {KubernetesCluster: sre-sandbox.k8s.local, k8s.io/etcd/events: helpa/espsti,esptnl,helpa, k8s.io/role/master: 1} -> {k8s.io/role/control-plane: 1, k8s.io/role/master: 1, KubernetesCluster: sre-sandbox.k8s.local, k8s.io/etcd/events: helpa/espsti,esptnl,helpa}

  Volume/helpa.etcd-main.sre-sandbox.k8s.local
        Tags                     {k8s.io/role/master: 1, KubernetesCluster: sre-sandbox.k8s.local, k8s.io/etcd/main: helpa/espsti,esptnl,helpa} -> {k8s.io/etcd/main: helpa/espsti,esptnl,helpa, k8s.io/role/control-plane: 1, k8s.io/role/master: 1, KubernetesCluster: sre-sandbox.k8s.local}
```

so instead of creating new volumes it will update existing volume tags. Volume tag update is handled already in https://github.com/kubernetes/kops/blob/master/upup/pkg/fi/cloudup/openstacktasks/volume.go#L151-L158 and I verified that this works like should.