### PR TITLE
Automated cherry pick of #14923: Do not include tags when searching existing volumes in

### DIFF
--- a/upup/pkg/fi/cloudup/openstacktasks/volume.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/volume.go
@@ -46,8 +46,7 @@ func (c *Volume) CompareWithID() *string {
 func (c *Volume) Find(context *fi.CloudupContext) (*Volume, error) {
 	cloud := context.T.Cloud.(openstack.OpenstackCloud)
 	opt := cinderv3.ListOpts{
-		Name:     fi.ValueOf(c.Name),
-		Metadata: c.Tags,
+		Name: fi.ValueOf(c.Name),
 	}
 	volumes, err := cloud.ListVolumes(opt)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #14923 on release-1.26.

#14923: Do not include tags when searching existing volumes in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```