### PR TITLE
OpenStack: Add support for clusters without DNS

### DIFF
--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -72,6 +72,11 @@ func TestCreateClusterOpenStackOctavia(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/ha_openstack_octavia", "v1alpha2")
 }
 
+func TestCreateClusterOpenStackNoDNS(t *testing.T) {
+	t.Setenv("OS_REGION_NAME", "us-test1")
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/ha_openstack_nodns", "v1alpha2")
+}
+
 // TestCreateClusterCilium runs kops with the cilium networking flags
 func TestCreateClusterCilium(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/cilium-eni", "v1alpha2")

--- a/nodeup/pkg/model/etc_hosts.go
+++ b/nodeup/pkg/model/etc_hosts.go
@@ -46,15 +46,15 @@ func (b *EtcHostsBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 				Addresses: []string{"127.0.0.1"},
 			})
 		}
-	} else if b.BootConfig.APIServerIP != "" {
+	} else if len(b.BootConfig.APIServerIPs) > 0 {
 		task.Records = append(task.Records, nodetasks.HostRecord{
 			Hostname:  b.APIInternalName(),
-			Addresses: []string{b.BootConfig.APIServerIP},
+			Addresses: b.BootConfig.APIServerIPs,
 		})
 		if b.UseKopsControllerForNodeBootstrap() {
 			task.Records = append(task.Records, nodetasks.HostRecord{
 				Hostname:  "kops-controller.internal." + b.NodeupConfig.ClusterName,
-				Addresses: []string{b.BootConfig.APIServerIP},
+				Addresses: b.BootConfig.APIServerIPs,
 			})
 		}
 	}

--- a/nodeup/pkg/model/kops_controller.go
+++ b/nodeup/pkg/model/kops_controller.go
@@ -62,8 +62,8 @@ func (b *KopsControllerBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		Subject:        nodetasks.PKIXName{CommonName: "kops-controller"},
 		AlternateNames: []string{"kops-controller.internal." + b.NodeupConfig.ClusterName},
 	}
-	if b.BootConfig.APIServerIP != "" {
-		issueCert.AlternateNames = append(issueCert.AlternateNames, b.BootConfig.APIServerIP)
+	if len(b.BootConfig.APIServerIPs) > 0 {
+		issueCert.AlternateNames = append(issueCert.AlternateNames, b.BootConfig.APIServerIPs...)
 	}
 	c.AddTask(issueCert)
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -507,7 +507,7 @@ func validateTopology(c *kops.Cluster, topology *kops.TopologySpec, fieldPath *f
 	if topology.DNS != "" {
 		cloud := c.Spec.GetCloudProvider()
 		allErrs = append(allErrs, IsValidValue(fieldPath.Child("dns", "type"), &topology.DNS, kops.SupportedDnsTypes)...)
-		if topology.DNS == kops.DNSTypeNone && cloud != kops.CloudProviderHetzner && cloud != kops.CloudProviderAWS && cloud != kops.CloudProviderGCE {
+		if topology.DNS == kops.DNSTypeNone && cloud != kops.CloudProviderOpenstack && cloud != kops.CloudProviderHetzner && cloud != kops.CloudProviderAWS && cloud != kops.CloudProviderGCE {
 			allErrs = append(allErrs, field.Invalid(fieldPath.Child("dns", "type"), topology.DNS, fmt.Sprintf("not supported for %q", c.Spec.GetCloudProvider())))
 		}
 	}

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -117,9 +117,9 @@ type BootConfig struct {
 	ConfigBase *string `json:",omitempty"`
 	// ConfigServer holds the configuration for the configuration server.
 	ConfigServer *ConfigServerOptions `json:",omitempty"`
-	// APIServerIP is the API server IP address.
+	// APIServerIPs is the API server IP addresses.
 	// This field is used for adding an alias for api.internal. in /etc/hosts, when Topology.DNS.Type == DNSTypeNone.
-	APIServerIP string `json:",omitempty"`
+	APIServerIPs []string `json:",omitempty"`
 	// InstanceGroupName is the name of the instance group.
 	InstanceGroupName string `json:",omitempty"`
 	// InstanceGroupRole is the instance group role.

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -167,8 +167,13 @@ func (b *BootstrapScript) buildEnvironmentVariables(cluster *kops.Cluster) (map[
 			)
 		}
 
+		// credentials needed always when using swift but when using None dns only in control plane
+		passEnvs := true
+		if !strings.HasPrefix(cluster.Spec.ConfigBase, "swift://") && cluster.UsesNoneDNS() && !b.ig.IsControlPlane() {
+			passEnvs = false
+		}
 		// Pass in required credentials when using user-defined swift endpoint
-		if os.Getenv("OS_AUTH_URL") != "" {
+		if os.Getenv("OS_AUTH_URL") != "" && passEnvs {
 			for _, envVar := range osEnvs {
 				env[envVar] = fmt.Sprintf("'%s'", os.Getenv(envVar))
 			}

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -516,6 +516,166 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 			},
 		},
 		{
+			desc: "multizone setup 3 masters 3 nodes without bastion with API loadbalancer dns none",
+			cluster: &kops.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: kops.ClusterSpec{
+					API: kops.APISpec{
+						LoadBalancer: &kops.LoadBalancerAccessSpec{
+							Type: kops.LoadBalancerTypePublic,
+						},
+					},
+					CloudProvider: kops.CloudProviderSpec{
+						Openstack: &kops.OpenstackSpec{
+							BlockStorage: &kops.OpenstackBlockStorageConfig{
+								Version:            fi.PtrTo("v3"),
+								IgnoreAZ:           fi.PtrTo(false),
+								CreateStorageClass: fi.PtrTo(false),
+								CSITopologySupport: fi.PtrTo(true),
+							},
+							Loadbalancer: &kops.OpenstackLoadbalancerConfig{
+								FloatingNetwork: fi.PtrTo("test"),
+								FloatingSubnet:  fi.PtrTo("test-lb-subnet"),
+								Method:          fi.PtrTo("ROUND_ROBIN"),
+								Provider:        fi.PtrTo("amphora"),
+								UseOctavia:      fi.PtrTo(true),
+							},
+							Monitor: &kops.OpenstackMonitor{
+								Delay:      fi.PtrTo("1m"),
+								MaxRetries: fi.PtrTo(3),
+								Timeout:    fi.PtrTo("30s"),
+							},
+							Network: &kops.OpenstackNetwork{
+								AvailabilityZoneHints: []*string{fi.PtrTo("zone-1"), fi.PtrTo("zone-2"), fi.PtrTo("zone-3")},
+							},
+							Router: &kops.OpenstackRouter{
+								DNSServers:            fi.PtrTo("8.8.8.8,8.8.4.4"),
+								ExternalSubnet:        fi.PtrTo("test-router-subnet"),
+								ExternalNetwork:       fi.PtrTo("test"),
+								AvailabilityZoneHints: []*string{fi.PtrTo("ha-zone")},
+							},
+							Metadata: &kops.OpenstackMetadata{
+								ConfigDrive: fi.PtrTo(false),
+							},
+						},
+					},
+					KubernetesVersion: "1.25.0",
+					Networking: kops.NetworkingSpec{
+						Subnets: []kops.ClusterSubnetSpec{
+							{
+								Name: "subnet-1",
+								Zone: "zone-1",
+								Type: kops.SubnetTypePrivate,
+							},
+							{
+								Name: "subnet-2",
+								Zone: "zone-2",
+								Type: kops.SubnetTypePrivate,
+							},
+							{
+								Name: "subnet-3",
+								Zone: "zone-3",
+								Type: kops.SubnetTypePrivate,
+							},
+						},
+						Topology: &kops.TopologySpec{
+							ControlPlane: kops.TopologyPrivate,
+							DNS:          kops.DNSTypeNone,
+							Nodes:        kops.TopologyPrivate,
+						},
+					},
+				},
+			},
+			instanceGroups: []*kops.InstanceGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "master-a",
+					},
+					Spec: kops.InstanceGroupSpec{
+						Role:        kops.InstanceGroupRoleControlPlane,
+						Image:       "image",
+						MinSize:     i32(1),
+						MaxSize:     i32(1),
+						MachineType: "blc.1-2",
+						Subnets:     []string{"subnet-1"},
+						Zones:       []string{"zone-1"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-a",
+					},
+					Spec: kops.InstanceGroupSpec{
+						Role:        kops.InstanceGroupRoleNode,
+						Image:       "image",
+						MinSize:     i32(1),
+						MaxSize:     i32(1),
+						MachineType: "blc.1-2",
+						Subnets:     []string{"subnet-1"},
+						Zones:       []string{"zone-1"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "master-b",
+					},
+					Spec: kops.InstanceGroupSpec{
+						Role:        kops.InstanceGroupRoleControlPlane,
+						Image:       "image",
+						MinSize:     i32(1),
+						MaxSize:     i32(1),
+						MachineType: "blc.1-2",
+						Subnets:     []string{"subnet-2"},
+						Zones:       []string{"zone-2"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-b",
+					},
+					Spec: kops.InstanceGroupSpec{
+						Role:        kops.InstanceGroupRoleNode,
+						Image:       "image",
+						MinSize:     i32(1),
+						MaxSize:     i32(1),
+						MachineType: "blc.1-2",
+						Subnets:     []string{"subnet-2"},
+						Zones:       []string{"zone-2"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "master-c",
+					},
+					Spec: kops.InstanceGroupSpec{
+						Role:        kops.InstanceGroupRoleControlPlane,
+						Image:       "image",
+						MinSize:     i32(1),
+						MaxSize:     i32(1),
+						MachineType: "blc.1-2",
+						Subnets:     []string{"subnet-3"},
+						Zones:       []string{"zone-3"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-c",
+					},
+					Spec: kops.InstanceGroupSpec{
+						Role:        kops.InstanceGroupRoleNode,
+						Image:       "image",
+						MinSize:     i32(1),
+						MaxSize:     i32(1),
+						MachineType: "blc.1-2",
+						Subnets:     []string{"subnet-3"},
+						Zones:       []string{"zone-3"},
+					},
+				},
+			},
+		},
+		{
 			desc: "multizone setup 3 masters 3 nodes without external router",
 			cluster: &kops.Cluster{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -26,6 +26,7 @@ Name: node-1-cluster
 Port:
   AdditionalSecurityGroups:
   - additional-sg
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -192,6 +193,7 @@ PublicACL: null
 ---
 AdditionalSecurityGroups:
 - additional-sg
+ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -26,6 +26,7 @@ Metadata:
 Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -190,6 +191,7 @@ Name: nodeupconfig-node
 PublicACL: null
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -26,6 +26,7 @@ Metadata:
 Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -190,6 +191,7 @@ Name: nodeupconfig-node
 PublicACL: null
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
@@ -25,6 +25,7 @@ Metadata:
 Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -189,6 +190,7 @@ Name: nodeupconfig-node
 PublicACL: null
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -1,69 +1,54 @@
 Lifecycle: ""
-Name: master
+Name: master-a
 ---
 Lifecycle: ""
-Name: node
+Name: master-b
+---
+Lifecycle: ""
+Name: master-c
+---
+Lifecycle: ""
+Name: node-a
+---
+Lifecycle: ""
+Name: node-b
+---
+Lifecycle: ""
+Name: node-c
 ---
 ForAPIServer: true
 ID: null
 IP: null
-LB: null
+LB:
+  ID: null
+  Lifecycle: Sync
+  Name: api.cluster
+  PortID: null
+  Provider: null
+  SecurityGroup:
+    Description: null
+    ID: null
+    Lifecycle: ""
+    Name: api.cluster
+    RemoveExtraRules: null
+    RemoveGroup: false
+  Subnet: subnet-1.cluster
+  VipSubnet: null
 Lifecycle: Sync
-Name: fip-master-1-cluster
----
-ForAPIServer: true
-ID: null
-IP: null
-LB: null
-Lifecycle: Sync
-Name: fip-master-2-cluster
----
-ForAPIServer: true
-ID: null
-IP: null
-LB: null
-Lifecycle: Sync
-Name: fip-master-3-cluster
----
-ForAPIServer: false
-ID: null
-IP: null
-LB: null
-Lifecycle: Sync
-Name: fip-node-1-cluster
----
-ForAPIServer: false
-ID: null
-IP: null
-LB: null
-Lifecycle: Sync
-Name: fip-node-2-cluster
----
-ForAPIServer: false
-ID: null
-IP: null
-LB: null
-Lifecycle: Sync
-Name: fip-node-3-cluster
+Name: fip-api.cluster
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
-FloatingIP:
-  ForAPIServer: true
-  ID: null
-  IP: null
-  LB: null
-  Lifecycle: Sync
-  Name: fip-master-1-cluster
+FloatingIP: null
 ForAPIServer: false
-GroupName: master
+GroupName: master-a
 ID: null
 Image: image
 Lifecycle: Sync
 Metadata:
-  KopsInstanceGroup: master
-  KopsName: master-1-cluster
+  KopsInstanceGroup: master-a
+  KopsName: master-a-1-cluster
   KopsNetwork: cluster
   KopsRole: ControlPlane
   KubernetesCluster: cluster
@@ -75,15 +60,15 @@ Metadata:
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_control-plane: "1"
   k8s.io_role_master: "1"
-  kops.k8s.io_instancegroup: master
-Name: master-1-cluster
+  kops.k8s.io_instancegroup: master-a
+Name: master-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
-  ForAPIServer: false
+  ForAPIServer: true
   ID: null
-  InstanceGroupName: master
+  InstanceGroupName: master-a
   Lifecycle: Sync
-  Name: port-master-1-cluster
+  Name: port-master-a-1-cluster
   Network:
     AvailabilityZoneHints: null
     ID: null
@@ -97,60 +82,48 @@ Port:
     Name: masters.cluster
     RemoveExtraRules: null
     RemoveGroup: false
-  - Description: null
-    ID: null
-    Lifecycle: ""
-    Name: master-public-name
-    RemoveExtraRules: null
-    RemoveGroup: false
   Subnets:
   - CIDR: null
     DNSServers: null
     ID: null
     Lifecycle: ""
-    Name: subnet-a.cluster
+    Name: subnet-1.cluster
     Network: null
     Tag: null
   Tags:
-  - KopsInstanceGroup=master
-  - KopsName=port-master-1
+  - KopsInstanceGroup=master-a
+  - KopsName=port-master-a-1
   - KubernetesCluster=cluster
-Region: region
+Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master
+  IGName: master-a
   Lifecycle: Sync
-  MaxSize: 3
-  Name: cluster-master
+  MaxSize: 1
+  Name: cluster-master-a
   Policies:
   - anti-affinity
 UserData:
   task:
     Lifecycle: ""
-    Name: master
+    Name: master-a
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
-FloatingIP:
-  ForAPIServer: true
-  ID: null
-  IP: null
-  LB: null
-  Lifecycle: Sync
-  Name: fip-master-2-cluster
+FloatingIP: null
 ForAPIServer: false
-GroupName: master
+GroupName: master-b
 ID: null
 Image: image
 Lifecycle: Sync
 Metadata:
-  KopsInstanceGroup: master
-  KopsName: master-2-cluster
+  KopsInstanceGroup: master-b
+  KopsName: master-b-1-cluster
   KopsNetwork: cluster
   KopsRole: ControlPlane
   KubernetesCluster: cluster
@@ -162,15 +135,15 @@ Metadata:
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_control-plane: "1"
   k8s.io_role_master: "1"
-  kops.k8s.io_instancegroup: master
-Name: master-2-cluster
+  kops.k8s.io_instancegroup: master-b
+Name: master-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
-  ForAPIServer: false
+  ForAPIServer: true
   ID: null
-  InstanceGroupName: master
+  InstanceGroupName: master-b
   Lifecycle: Sync
-  Name: port-master-2-cluster
+  Name: port-master-b-1-cluster
   Network:
     AvailabilityZoneHints: null
     ID: null
@@ -184,60 +157,48 @@ Port:
     Name: masters.cluster
     RemoveExtraRules: null
     RemoveGroup: false
-  - Description: null
-    ID: null
-    Lifecycle: ""
-    Name: master-public-name
-    RemoveExtraRules: null
-    RemoveGroup: false
   Subnets:
   - CIDR: null
     DNSServers: null
     ID: null
     Lifecycle: ""
-    Name: subnet-b.cluster
+    Name: subnet-2.cluster
     Network: null
     Tag: null
   Tags:
-  - KopsInstanceGroup=master
-  - KopsName=port-master-2
+  - KopsInstanceGroup=master-b
+  - KopsName=port-master-b-1
   - KubernetesCluster=cluster
-Region: region
+Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master
+  IGName: master-b
   Lifecycle: Sync
-  MaxSize: 3
-  Name: cluster-master
+  MaxSize: 1
+  Name: cluster-master-b
   Policies:
   - anti-affinity
 UserData:
   task:
     Lifecycle: ""
-    Name: master
+    Name: master-b
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
-FloatingIP:
-  ForAPIServer: true
-  ID: null
-  IP: null
-  LB: null
-  Lifecycle: Sync
-  Name: fip-master-3-cluster
+FloatingIP: null
 ForAPIServer: false
-GroupName: master
+GroupName: master-c
 ID: null
 Image: image
 Lifecycle: Sync
 Metadata:
-  KopsInstanceGroup: master
-  KopsName: master-3-cluster
+  KopsInstanceGroup: master-c
+  KopsName: master-c-1-cluster
   KopsNetwork: cluster
   KopsRole: ControlPlane
   KubernetesCluster: cluster
@@ -249,15 +210,15 @@ Metadata:
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_control-plane: "1"
   k8s.io_role_master: "1"
-  kops.k8s.io_instancegroup: master
-Name: master-3-cluster
+  kops.k8s.io_instancegroup: master-c
+Name: master-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
-  ForAPIServer: false
+  ForAPIServer: true
   ID: null
-  InstanceGroupName: master
+  InstanceGroupName: master-c
   Lifecycle: Sync
-  Name: port-master-3-cluster
+  Name: port-master-c-1-cluster
   Network:
     AvailabilityZoneHints: null
     ID: null
@@ -271,60 +232,48 @@ Port:
     Name: masters.cluster
     RemoveExtraRules: null
     RemoveGroup: false
-  - Description: null
-    ID: null
-    Lifecycle: ""
-    Name: master-public-name
-    RemoveExtraRules: null
-    RemoveGroup: false
   Subnets:
   - CIDR: null
     DNSServers: null
     ID: null
     Lifecycle: ""
-    Name: subnet-c.cluster
+    Name: subnet-3.cluster
     Network: null
     Tag: null
   Tags:
-  - KopsInstanceGroup=master
-  - KopsName=port-master-3
+  - KopsInstanceGroup=master-c
+  - KopsName=port-master-c-1
   - KubernetesCluster=cluster
-Region: region
+Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master
+  IGName: master-c
   Lifecycle: Sync
-  MaxSize: 3
-  Name: cluster-master
+  MaxSize: 1
+  Name: cluster-master-c
   Policies:
   - anti-affinity
 UserData:
   task:
     Lifecycle: ""
-    Name: master
+    Name: master-c
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
-FloatingIP:
-  ForAPIServer: false
-  ID: null
-  IP: null
-  LB: null
-  Lifecycle: Sync
-  Name: fip-node-1-cluster
+FloatingIP: null
 ForAPIServer: false
-GroupName: node
+GroupName: node-a
 ID: null
 Image: image
 Lifecycle: Sync
 Metadata:
-  KopsInstanceGroup: node
-  KopsName: node-1-cluster
+  KopsInstanceGroup: node-a
+  KopsName: node-a-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -333,15 +282,15 @@ Metadata:
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
-  kops.k8s.io_instancegroup: node
-Name: node-1-cluster
+  kops.k8s.io_instancegroup: node-a
+Name: node-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
   ForAPIServer: false
   ID: null
-  InstanceGroupName: node
+  InstanceGroupName: node-a
   Lifecycle: Sync
-  Name: port-node-1-cluster
+  Name: port-node-a-1-cluster
   Network:
     AvailabilityZoneHints: null
     ID: null
@@ -360,49 +309,43 @@ Port:
     DNSServers: null
     ID: null
     Lifecycle: ""
-    Name: subnet-a.cluster
+    Name: subnet-1.cluster
     Network: null
     Tag: null
   Tags:
-  - KopsInstanceGroup=node
-  - KopsName=port-node-1
+  - KopsInstanceGroup=node-a
+  - KopsName=port-node-a-1
   - KubernetesCluster=cluster
-Region: region
+Region: ""
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGName: node-a
   Lifecycle: Sync
-  MaxSize: 3
-  Name: cluster-node
+  MaxSize: 1
+  Name: cluster-node-a
   Policies:
   - anti-affinity
 UserData:
   task:
     Lifecycle: ""
-    Name: node
+    Name: node-a
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
-FloatingIP:
-  ForAPIServer: false
-  ID: null
-  IP: null
-  LB: null
-  Lifecycle: Sync
-  Name: fip-node-2-cluster
+FloatingIP: null
 ForAPIServer: false
-GroupName: node
+GroupName: node-b
 ID: null
 Image: image
 Lifecycle: Sync
 Metadata:
-  KopsInstanceGroup: node
-  KopsName: node-2-cluster
+  KopsInstanceGroup: node-b
+  KopsName: node-b-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -411,15 +354,15 @@ Metadata:
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
-  kops.k8s.io_instancegroup: node
-Name: node-2-cluster
+  kops.k8s.io_instancegroup: node-b
+Name: node-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
   ForAPIServer: false
   ID: null
-  InstanceGroupName: node
+  InstanceGroupName: node-b
   Lifecycle: Sync
-  Name: port-node-2-cluster
+  Name: port-node-b-1-cluster
   Network:
     AvailabilityZoneHints: null
     ID: null
@@ -438,49 +381,43 @@ Port:
     DNSServers: null
     ID: null
     Lifecycle: ""
-    Name: subnet-b.cluster
+    Name: subnet-2.cluster
     Network: null
     Tag: null
   Tags:
-  - KopsInstanceGroup=node
-  - KopsName=port-node-2
+  - KopsInstanceGroup=node-b
+  - KopsName=port-node-b-1
   - KubernetesCluster=cluster
-Region: region
+Region: ""
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGName: node-b
   Lifecycle: Sync
-  MaxSize: 3
-  Name: cluster-node
+  MaxSize: 1
+  Name: cluster-node-b
   Policies:
   - anti-affinity
 UserData:
   task:
     Lifecycle: ""
-    Name: node
+    Name: node-b
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
-FloatingIP:
-  ForAPIServer: false
-  ID: null
-  IP: null
-  LB: null
-  Lifecycle: Sync
-  Name: fip-node-3-cluster
+FloatingIP: null
 ForAPIServer: false
-GroupName: node
+GroupName: node-c
 ID: null
 Image: image
 Lifecycle: Sync
 Metadata:
-  KopsInstanceGroup: node
-  KopsName: node-3-cluster
+  KopsInstanceGroup: node-c
+  KopsName: node-c-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -489,15 +426,15 @@ Metadata:
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
-  kops.k8s.io_instancegroup: node
-Name: node-3-cluster
+  kops.k8s.io_instancegroup: node-c
+Name: node-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
   ForAPIServer: false
   ID: null
-  InstanceGroupName: node
+  InstanceGroupName: node-c
   Lifecycle: Sync
-  Name: port-node-3-cluster
+  Name: port-node-c-1-cluster
   Network:
     AvailabilityZoneHints: null
     ID: null
@@ -516,30 +453,30 @@ Port:
     DNSServers: null
     ID: null
     Lifecycle: ""
-    Name: subnet-c.cluster
+    Name: subnet-3.cluster
     Network: null
     Tag: null
   Tags:
-  - KopsInstanceGroup=node
-  - KopsName=port-node-3
+  - KopsInstanceGroup=node-c
+  - KopsName=port-node-c-1
   - KubernetesCluster=cluster
-Region: region
+Region: ""
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGName: node-c
   Lifecycle: Sync
-  MaxSize: 3
-  Name: cluster-node
+  MaxSize: 1
+  Name: cluster-node-c
   Policies:
   - anti-affinity
 UserData:
   task:
     Lifecycle: ""
-    Name: node
+    Name: node-c
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca
@@ -647,32 +584,259 @@ oldFormat: false
 subject: cn=service-account
 type: ca
 ---
+ID: null
+Lifecycle: Sync
+Name: api.cluster
+PortID: null
+Provider: null
+SecurityGroup:
+  Description: null
+  ID: null
+  Lifecycle: ""
+  Name: api.cluster
+  RemoveExtraRules: null
+  RemoveGroup: false
+Subnet: subnet-1.cluster
+VipSubnet: null
+---
+AllowedCIDRs: null
+ID: null
+Lifecycle: Sync
+Name: api.cluster
+Pool:
+  ID: null
+  Lifecycle: Sync
+  Loadbalancer:
+    ID: null
+    Lifecycle: Sync
+    Name: api.cluster
+    PortID: null
+    Provider: null
+    SecurityGroup:
+      Description: null
+      ID: null
+      Lifecycle: ""
+      Name: api.cluster
+      RemoveExtraRules: null
+      RemoveGroup: false
+    Subnet: subnet-1.cluster
+    VipSubnet: null
+  Name: api.cluster-https
+Port: 443
+---
+ID: null
+Lifecycle: Sync
+Loadbalancer:
+  ID: null
+  Lifecycle: Sync
+  Name: api.cluster
+  PortID: null
+  Provider: null
+  SecurityGroup:
+    Description: null
+    ID: null
+    Lifecycle: ""
+    Name: api.cluster
+    RemoveExtraRules: null
+    RemoveGroup: false
+  Subnet: subnet-1.cluster
+  VipSubnet: null
+Name: api.cluster-https
+---
 Base: null
 Contents:
   task:
     Lifecycle: ""
-    Name: master
+    Name: master-a
 Lifecycle: ""
-Location: igconfig/control-plane/master/nodeupconfig.yaml
-Name: nodeupconfig-master
+Location: igconfig/control-plane/master-a/nodeupconfig.yaml
+Name: nodeupconfig-master-a
 PublicACL: null
 ---
 Base: null
 Contents:
   task:
     Lifecycle: ""
-    Name: node
+    Name: master-b
 Lifecycle: ""
-Location: igconfig/node/node/nodeupconfig.yaml
-Name: nodeupconfig-node
+Location: igconfig/control-plane/master-b/nodeupconfig.yaml
+Name: nodeupconfig-master-b
 PublicACL: null
 ---
-AdditionalSecurityGroups: null
-ForAPIServer: false
+Base: null
+Contents:
+  task:
+    Lifecycle: ""
+    Name: master-c
+Lifecycle: ""
+Location: igconfig/control-plane/master-c/nodeupconfig.yaml
+Name: nodeupconfig-master-c
+PublicACL: null
+---
+Base: null
+Contents:
+  task:
+    Lifecycle: ""
+    Name: node-a
+Lifecycle: ""
+Location: igconfig/node/node-a/nodeupconfig.yaml
+Name: nodeupconfig-node-a
+PublicACL: null
+---
+Base: null
+Contents:
+  task:
+    Lifecycle: ""
+    Name: node-b
+Lifecycle: ""
+Location: igconfig/node/node-b/nodeupconfig.yaml
+Name: nodeupconfig-node-b
+PublicACL: null
+---
+Base: null
+Contents:
+  task:
+    Lifecycle: ""
+    Name: node-c
+Lifecycle: ""
+Location: igconfig/node/node-c/nodeupconfig.yaml
+Name: nodeupconfig-node-c
+PublicACL: null
+---
 ID: null
-InstanceGroupName: master
+InterfaceName: cluster
 Lifecycle: Sync
-Name: port-master-1-cluster
+Name: cluster-master-a
+Pool:
+  ID: null
+  Lifecycle: Sync
+  Loadbalancer:
+    ID: null
+    Lifecycle: Sync
+    Name: api.cluster
+    PortID: null
+    Provider: null
+    SecurityGroup:
+      Description: null
+      ID: null
+      Lifecycle: ""
+      Name: api.cluster
+      RemoveExtraRules: null
+      RemoveGroup: false
+    Subnet: subnet-1.cluster
+    VipSubnet: null
+  Name: api.cluster-https
+ProtocolPort: 443
+ServerGroup:
+  ClusterName: cluster
+  ID: null
+  IGName: master-a
+  Lifecycle: Sync
+  MaxSize: 1
+  Name: cluster-master-a
+  Policies:
+  - anti-affinity
+Weight: 1
+---
+ID: null
+InterfaceName: cluster
+Lifecycle: Sync
+Name: cluster-master-b
+Pool:
+  ID: null
+  Lifecycle: Sync
+  Loadbalancer:
+    ID: null
+    Lifecycle: Sync
+    Name: api.cluster
+    PortID: null
+    Provider: null
+    SecurityGroup:
+      Description: null
+      ID: null
+      Lifecycle: ""
+      Name: api.cluster
+      RemoveExtraRules: null
+      RemoveGroup: false
+    Subnet: subnet-1.cluster
+    VipSubnet: null
+  Name: api.cluster-https
+ProtocolPort: 443
+ServerGroup:
+  ClusterName: cluster
+  ID: null
+  IGName: master-b
+  Lifecycle: Sync
+  MaxSize: 1
+  Name: cluster-master-b
+  Policies:
+  - anti-affinity
+Weight: 1
+---
+ID: null
+InterfaceName: cluster
+Lifecycle: Sync
+Name: cluster-master-c
+Pool:
+  ID: null
+  Lifecycle: Sync
+  Loadbalancer:
+    ID: null
+    Lifecycle: Sync
+    Name: api.cluster
+    PortID: null
+    Provider: null
+    SecurityGroup:
+      Description: null
+      ID: null
+      Lifecycle: ""
+      Name: api.cluster
+      RemoveExtraRules: null
+      RemoveGroup: false
+    Subnet: subnet-1.cluster
+    VipSubnet: null
+  Name: api.cluster-https
+ProtocolPort: 443
+ServerGroup:
+  ClusterName: cluster
+  ID: null
+  IGName: master-c
+  Lifecycle: Sync
+  MaxSize: 1
+  Name: cluster-master-c
+  Policies:
+  - anti-affinity
+Weight: 1
+---
+ID: null
+Lifecycle: Sync
+Name: api.cluster
+Pool:
+  ID: null
+  Lifecycle: Sync
+  Loadbalancer:
+    ID: null
+    Lifecycle: Sync
+    Name: api.cluster
+    PortID: null
+    Provider: null
+    SecurityGroup:
+      Description: null
+      ID: null
+      Lifecycle: ""
+      Name: api.cluster
+      RemoveExtraRules: null
+      RemoveGroup: false
+    Subnet: subnet-1.cluster
+    VipSubnet: null
+  Name: api.cluster-https
+---
+AdditionalSecurityGroups: null
+ForAPIServer: true
+ID: null
+InstanceGroupName: master-a
+Lifecycle: Sync
+Name: port-master-a-1-cluster
 Network:
   AvailabilityZoneHints: null
   ID: null
@@ -686,31 +850,25 @@ SecurityGroups:
   Name: masters.cluster
   RemoveExtraRules: null
   RemoveGroup: false
-- Description: null
-  ID: null
-  Lifecycle: ""
-  Name: master-public-name
-  RemoveExtraRules: null
-  RemoveGroup: false
 Subnets:
 - CIDR: null
   DNSServers: null
   ID: null
   Lifecycle: ""
-  Name: subnet-a.cluster
+  Name: subnet-1.cluster
   Network: null
   Tag: null
 Tags:
-- KopsInstanceGroup=master
-- KopsName=port-master-1
+- KopsInstanceGroup=master-a
+- KopsName=port-master-a-1
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
-ForAPIServer: false
+ForAPIServer: true
 ID: null
-InstanceGroupName: master
+InstanceGroupName: master-b
 Lifecycle: Sync
-Name: port-master-2-cluster
+Name: port-master-b-1-cluster
 Network:
   AvailabilityZoneHints: null
   ID: null
@@ -724,31 +882,25 @@ SecurityGroups:
   Name: masters.cluster
   RemoveExtraRules: null
   RemoveGroup: false
-- Description: null
-  ID: null
-  Lifecycle: ""
-  Name: master-public-name
-  RemoveExtraRules: null
-  RemoveGroup: false
 Subnets:
 - CIDR: null
   DNSServers: null
   ID: null
   Lifecycle: ""
-  Name: subnet-b.cluster
+  Name: subnet-2.cluster
   Network: null
   Tag: null
 Tags:
-- KopsInstanceGroup=master
-- KopsName=port-master-2
+- KopsInstanceGroup=master-b
+- KopsName=port-master-b-1
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
-ForAPIServer: false
+ForAPIServer: true
 ID: null
-InstanceGroupName: master
+InstanceGroupName: master-c
 Lifecycle: Sync
-Name: port-master-3-cluster
+Name: port-master-c-1-cluster
 Network:
   AvailabilityZoneHints: null
   ID: null
@@ -762,31 +914,25 @@ SecurityGroups:
   Name: masters.cluster
   RemoveExtraRules: null
   RemoveGroup: false
-- Description: null
-  ID: null
-  Lifecycle: ""
-  Name: master-public-name
-  RemoveExtraRules: null
-  RemoveGroup: false
 Subnets:
 - CIDR: null
   DNSServers: null
   ID: null
   Lifecycle: ""
-  Name: subnet-c.cluster
+  Name: subnet-3.cluster
   Network: null
   Tag: null
 Tags:
-- KopsInstanceGroup=master
-- KopsName=port-master-3
+- KopsInstanceGroup=master-c
+- KopsName=port-master-c-1
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
 ForAPIServer: false
 ID: null
-InstanceGroupName: node
+InstanceGroupName: node-a
 Lifecycle: Sync
-Name: port-node-1-cluster
+Name: port-node-a-1-cluster
 Network:
   AvailabilityZoneHints: null
   ID: null
@@ -805,20 +951,20 @@ Subnets:
   DNSServers: null
   ID: null
   Lifecycle: ""
-  Name: subnet-a.cluster
+  Name: subnet-1.cluster
   Network: null
   Tag: null
 Tags:
-- KopsInstanceGroup=node
-- KopsName=port-node-1
+- KopsInstanceGroup=node-a
+- KopsName=port-node-a-1
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
 ForAPIServer: false
 ID: null
-InstanceGroupName: node
+InstanceGroupName: node-b
 Lifecycle: Sync
-Name: port-node-2-cluster
+Name: port-node-b-1-cluster
 Network:
   AvailabilityZoneHints: null
   ID: null
@@ -837,20 +983,20 @@ Subnets:
   DNSServers: null
   ID: null
   Lifecycle: ""
-  Name: subnet-b.cluster
+  Name: subnet-2.cluster
   Network: null
   Tag: null
 Tags:
-- KopsInstanceGroup=node
-- KopsName=port-node-2
+- KopsInstanceGroup=node-b
+- KopsName=port-node-b-1
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
 ForAPIServer: false
 ID: null
-InstanceGroupName: node
+InstanceGroupName: node-c
 Lifecycle: Sync
-Name: port-node-3-cluster
+Name: port-node-c-1-cluster
 Network:
   AvailabilityZoneHints: null
   ID: null
@@ -869,28 +1015,64 @@ Subnets:
   DNSServers: null
   ID: null
   Lifecycle: ""
-  Name: subnet-c.cluster
+  Name: subnet-3.cluster
   Network: null
   Tag: null
 Tags:
-- KopsInstanceGroup=node
-- KopsName=port-node-3
+- KopsInstanceGroup=node-c
+- KopsName=port-node-c-1
 - KubernetesCluster=cluster
 ---
 ClusterName: cluster
 ID: null
-IGName: master
+IGName: master-a
 Lifecycle: Sync
-MaxSize: 3
-Name: cluster-master
+MaxSize: 1
+Name: cluster-master-a
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGName: master-b
 Lifecycle: Sync
-MaxSize: 3
-Name: cluster-node
+MaxSize: 1
+Name: cluster-master-b
+Policies:
+- anti-affinity
+---
+ClusterName: cluster
+ID: null
+IGName: master-c
+Lifecycle: Sync
+MaxSize: 1
+Name: cluster-master-c
+Policies:
+- anti-affinity
+---
+ClusterName: cluster
+ID: null
+IGName: node-a
+Lifecycle: Sync
+MaxSize: 1
+Name: cluster-node-a
+Policies:
+- anti-affinity
+---
+ClusterName: cluster
+ID: null
+IGName: node-b
+Lifecycle: Sync
+MaxSize: 1
+Name: cluster-node-b
+Policies:
+- anti-affinity
+---
+ClusterName: cluster
+ID: null
+IGName: node-c
+Lifecycle: Sync
+MaxSize: 1
+Name: cluster-node-c
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -85,6 +85,7 @@ Metadata:
 Name: master-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master-a
   Lifecycle: Sync
@@ -159,6 +160,7 @@ Metadata:
 Name: master-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master-b
   Lifecycle: Sync
@@ -233,6 +235,7 @@ Metadata:
 Name: master-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master-c
   Lifecycle: Sync
@@ -310,6 +313,7 @@ Metadata:
 Name: node-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node-a
   Lifecycle: Sync
@@ -387,6 +391,7 @@ Metadata:
 Name: node-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node-b
   Lifecycle: Sync
@@ -464,6 +469,7 @@ Metadata:
 Name: node-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node-c
   Lifecycle: Sync
@@ -655,6 +661,7 @@ Pool:
     Subnet: subnet-a.cluster
     VipSubnet: null
   Name: master-public-name-https
+Port: 443
 ---
 ID: null
 Lifecycle: Sync
@@ -864,6 +871,7 @@ Pool:
   Name: master-public-name-https
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master-a
 Lifecycle: Sync
@@ -895,6 +903,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master-b
 Lifecycle: Sync
@@ -926,6 +935,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master-c
 Lifecycle: Sync
@@ -957,6 +967,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node-a
 Lifecycle: Sync
@@ -988,6 +999,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node-b
 Lifecycle: Sync
@@ -1019,6 +1031,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node-c
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -91,6 +91,7 @@ Metadata:
 Name: master-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master-a
   Lifecycle: Sync
@@ -177,6 +178,7 @@ Metadata:
 Name: master-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master-b
   Lifecycle: Sync
@@ -263,6 +265,7 @@ Metadata:
 Name: master-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master-c
   Lifecycle: Sync
@@ -346,6 +349,7 @@ Metadata:
 Name: node-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node-a
   Lifecycle: Sync
@@ -423,6 +427,7 @@ Metadata:
 Name: node-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node-b
   Lifecycle: Sync
@@ -500,6 +505,7 @@ Metadata:
 Name: node-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node-c
   Lifecycle: Sync
@@ -714,6 +720,7 @@ Name: nodeupconfig-node-c
 PublicACL: null
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master-a
 Lifecycle: Sync
@@ -751,6 +758,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master-b
 Lifecycle: Sync
@@ -788,6 +796,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master-c
 Lifecycle: Sync
@@ -825,6 +834,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node-a
 Lifecycle: Sync
@@ -856,6 +866,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node-b
 Lifecycle: Sync
@@ -887,6 +898,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node-c
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -43,6 +43,7 @@ Metadata:
 Name: master-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master-a
   Lifecycle: Sync
@@ -123,6 +124,7 @@ Metadata:
 Name: master-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master-b
   Lifecycle: Sync
@@ -203,6 +205,7 @@ Metadata:
 Name: master-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master-c
   Lifecycle: Sync
@@ -280,6 +283,7 @@ Metadata:
 Name: node-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node-a
   Lifecycle: Sync
@@ -351,6 +355,7 @@ Metadata:
 Name: node-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node-b
   Lifecycle: Sync
@@ -422,6 +427,7 @@ Metadata:
 Name: node-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node-c
   Lifecycle: Sync
@@ -636,6 +642,7 @@ Name: nodeupconfig-node-c
 PublicACL: null
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master-a
 Lifecycle: Sync
@@ -673,6 +680,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master-b
 Lifecycle: Sync
@@ -710,6 +718,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master-c
 Lifecycle: Sync
@@ -747,6 +756,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node-a
 Lifecycle: Sync
@@ -778,6 +788,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node-b
 Lifecycle: Sync
@@ -809,6 +820,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node-c
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -30,6 +30,7 @@ Metadata:
 Name: bastion-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: bastion
   Lifecycle: Sync
@@ -104,6 +105,7 @@ Metadata:
 Name: master-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -181,6 +183,7 @@ Metadata:
 Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -365,6 +368,7 @@ Name: nodeupconfig-node
 PublicACL: null
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: bastion
 Lifecycle: Sync
@@ -396,6 +400,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -433,6 +438,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -50,6 +50,7 @@ Metadata:
 Name: bastion-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: bastion
   Lifecycle: Sync
@@ -130,6 +131,7 @@ Metadata:
 Name: master-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -207,6 +209,7 @@ Metadata:
 Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -391,6 +394,7 @@ Name: nodeupconfig-node
 PublicACL: null
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: bastion
 Lifecycle: Sync
@@ -422,6 +426,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -459,6 +464,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -31,6 +31,7 @@ Metadata:
 Name: master-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -108,6 +109,7 @@ Metadata:
 Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -282,6 +284,7 @@ Name: nodeupconfig-node
 PublicACL: null
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -319,6 +322,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -51,6 +51,7 @@ Metadata:
 Name: master-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -134,6 +135,7 @@ Metadata:
 Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -308,6 +310,7 @@ Name: nodeupconfig-node
 PublicACL: null
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -345,6 +348,7 @@ Tags:
 - KubernetesCluster=cluster
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
@@ -51,6 +51,7 @@ Metadata:
 Name: master-1-tom-software-dev-playground-real33-k8s-local
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -134,6 +135,7 @@ Metadata:
 Name: node-1-tom-software-dev-playground-real33-k8s-local
 Port:
   AdditionalSecurityGroups: null
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -308,6 +310,7 @@ Name: nodeupconfig-node
 PublicACL: null
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -345,6 +348,7 @@ Tags:
 - KubernetesCluster=tom-software-dev-playground-real33--kngu8l
 ---
 AdditionalSecurityGroups: null
+ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -26,6 +26,7 @@ Name: node-1-cluster
 Port:
   AdditionalSecurityGroups:
   - additional-sg
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -192,6 +193,7 @@ PublicACL: null
 ---
 AdditionalSecurityGroups:
 - additional-sg
+ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -26,6 +26,7 @@ Name: node-1-cluster
 Port:
   AdditionalSecurityGroups:
   - additional-sg
+  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -192,6 +193,7 @@ PublicACL: null
 ---
 AdditionalSecurityGroups:
 - additional-sg
+ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync

--- a/tests/integration/create_cluster/ha_openstack_nodns/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_nodns/expected-v1alpha2.yaml
@@ -1,0 +1,156 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  name: ha.example.com
+spec:
+  api:
+    loadBalancer:
+      type: Public
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudConfig:
+    openstack:
+      blockStorage:
+        bs-version: v3
+        ignore-volume-az: false
+      loadbalancer:
+        floatingNetwork: vlan1
+        floatingSubnet: vlan1lbsubnet
+        method: ROUND_ROBIN
+        provider: octavia
+        useOctavia: true
+      monitor:
+        delay: 15s
+        maxRetries: 3
+        timeout: 10s
+      router:
+        dnsServers: 1.1.1.1
+        externalNetwork: vlan1
+        externalSubnet: vlan1subnet
+  cloudProvider: openstack
+  configBase: memfs://tests/ha.example.com
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - instanceGroup: control-plane-us-test1-1
+      name: etcd-1
+    - instanceGroup: control-plane-us-test1-2
+      name: etcd-2
+    - instanceGroup: control-plane-us-test1-3
+      name: etcd-3
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+    - instanceGroup: control-plane-us-test1-1
+      name: etcd-1
+    - instanceGroup: control-plane-us-test1-2
+      name: etcd-2
+    - instanceGroup: control-plane-us-test1-3
+      name: etcd-3
+    memoryRequest: 100Mi
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubelet:
+    anonymousAuth: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  - ::/0
+  kubernetesVersion: v1.25.0
+  networkCIDR: 10.0.0.0/16
+  networking:
+    calico: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  - ::/0
+  subnets:
+  - cidr: 10.0.32.0/19
+    name: us-test1
+    type: Private
+    zone: us-test1
+  - cidr: 10.0.0.0/22
+    name: utility-us-test1
+    type: Utility
+    zone: us-test1
+  topology:
+    dns:
+      type: None
+    masters: private
+    nodes: private
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: control-plane-us-test1-1
+spec:
+  image: ubuntu-20.04
+  machineType: m1.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test1
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: control-plane-us-test1-2
+spec:
+  image: ubuntu-20.04
+  machineType: m1.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test1
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: control-plane-us-test1-3
+spec:
+  image: ubuntu-20.04
+  machineType: m1.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test1
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: ha.example.com
+  name: nodes-us-test1
+spec:
+  image: ubuntu-20.04
+  machineType: m1.large
+  maxSize: 1
+  minSize: 1
+  role: Node
+  subnets:
+  - us-test1

--- a/tests/integration/create_cluster/ha_openstack_nodns/options.yaml
+++ b/tests/integration/create_cluster/ha_openstack_nodns/options.yaml
@@ -1,0 +1,19 @@
+CloudProvider: openstack
+ClusterName: ha.example.com
+Image: ubuntu-20.04
+KubernetesVersion: v1.25.0
+ControlPlaneCount: 3
+NetworkCIDR: 10.0.0.0/16
+Networking: calico
+Zones:
+  - us-test1
+OpenstackLBOctavia: true
+OpenstackExternalNet: vlan1
+OpenstackExternalSubnet: vlan1subnet
+OpenstackLBSubnet: vlan1lbsubnet
+OpenstackDNSServers: 1.1.1.1
+ControlPlaneSize: m1.medium
+NodeSize: m1.large
+APILoadBalancerType: public
+Topology: private
+DNSType: none

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -172,7 +172,7 @@ ConfigServer:
     MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
     9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
     -----END CERTIFICATE-----
-  server: https://:3988/
+  server: https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
 NodeupConfigHash: 6RM3ki/GGmnnKqQhn8h8yIS46bzvlD1rdChld696w5k=

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
@@ -169,7 +169,7 @@ ConfigServer:
     MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
     9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
     -----END CERTIFICATE-----
-  server: https://:3988/
+  server: https://kops-controller.internal.minimal-gce.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
 NodeupConfigHash: siYe0C6BwTCDJA4Gyt2wen36Y5zxKbjHW7IZe1b7n6Q=

--- a/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_nodes-fsn1_user_data
+++ b/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_nodes-fsn1_user_data
@@ -168,7 +168,7 @@ ConfigServer:
     MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
     9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
     -----END CERTIFICATE-----
-  server: https://:3988/
+  server: https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes-fsn1
 InstanceGroupRole: Node
 NodeupConfigHash: BT/Gm5OFWxKAbkzgyDaK3qCMmGQvPkX34qTusCN5dj8=

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1398,28 +1398,24 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 	// Set API server address to an IP from the cluster network CIDR
 	if cluster.UsesNoneDNS() {
 		switch cluster.Spec.GetCloudProvider() {
-		case kops.CloudProviderAWS, kops.CloudProviderHetzner:
+		case kops.CloudProviderAWS, kops.CloudProviderHetzner, kops.CloudProviderOpenstack:
 			// Use a private IP address that belongs to the cluster network CIDR (some additional addresses may be FQDNs or public IPs)
-			for _, networkCIDR := range append(cluster.Spec.Networking.AdditionalNetworkCIDRs, cluster.Spec.Networking.NetworkCIDR) {
-				_, cidr, err := net.ParseCIDR(networkCIDR)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to parse network CIDR %q: %w", networkCIDR, err)
-				}
-				for _, additionalIP := range apiserverAdditionalIPs {
+			for _, additionalIP := range apiserverAdditionalIPs {
+				for _, networkCIDR := range append(cluster.Spec.Networking.AdditionalNetworkCIDRs, cluster.Spec.Networking.NetworkCIDR) {
+					_, cidr, err := net.ParseCIDR(networkCIDR)
+					if err != nil {
+						return nil, nil, fmt.Errorf("failed to parse network CIDR %q: %w", networkCIDR, err)
+					}
 					if cidr.Contains(net.ParseIP(additionalIP)) {
-						bootConfig.APIServerIP = additionalIP
-						break
+						bootConfig.APIServerIPs = append(bootConfig.APIServerIPs, additionalIP)
 					}
 				}
-				if bootConfig.APIServerIP != "" {
-					break
-				}
 			}
+
 		case kops.CloudProviderGCE:
 			// Use any IP address that is found (including public ones)
 			for _, additionalIP := range apiserverAdditionalIPs {
-				bootConfig.APIServerIP = additionalIP
-				break
+				bootConfig.APIServerIPs = append(bootConfig.APIServerIPs, additionalIP)
 			}
 		default:
 			return nil, nil, fmt.Errorf("'none' DNS topology is not supported for cloud %q", cluster.Spec.GetCloudProvider())
@@ -1429,8 +1425,8 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 	useConfigServer := apiModel.UseKopsControllerForNodeBootstrap(cluster) && !ig.HasAPIServer()
 	if useConfigServer {
 		host := "kops-controller.internal." + cluster.ObjectMeta.Name
-		if cluster.UsesNoneDNS() {
-			host = bootConfig.APIServerIP
+		if cluster.UsesNoneDNS() && len(bootConfig.APIServerIPs) > 0 {
+			host = bootConfig.APIServerIPs[0] // TODO: how we could support array?
 		}
 		baseURL := url.URL{
 			Scheme: "https",

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -333,7 +333,7 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 				MaxRetries: fi.PtrTo(3),
 			},
 		}
-		initializeOpenstackAPI(opt, cluster)
+		initializeOpenstack(opt, cluster)
 		osCloud, err := openstack.NewOpenstackCloud(cluster, "openstackmodel")
 		if err != nil {
 			return nil, err
@@ -1310,6 +1310,14 @@ func setupTopology(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.S
 		}
 	}
 
+	err := setupDNSTopology(opt, cluster)
+	if err != nil {
+		return nil, err
+	}
+	return bastions, nil
+}
+
+func setupDNSTopology(opt *NewClusterOptions, cluster *api.Cluster) error {
 	switch strings.ToLower(opt.DNSType) {
 	case "":
 		if cluster.IsGossip() {
@@ -1326,10 +1334,9 @@ func setupTopology(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.S
 	case "none":
 		cluster.Spec.Networking.Topology.DNS = api.DNSTypeNone
 	default:
-		return nil, fmt.Errorf("unknown DNSType: %q", opt.DNSType)
+		return fmt.Errorf("unknown DNSType: %q", opt.DNSType)
 	}
-
-	return bastions, nil
+	return nil
 }
 
 func setupAPI(opt *NewClusterOptions, cluster *api.Cluster) error {
@@ -1391,7 +1398,7 @@ func setupAPI(opt *NewClusterOptions, cluster *api.Cluster) error {
 	return nil
 }
 
-func initializeOpenstackAPI(opt *NewClusterOptions, cluster *api.Cluster) {
+func initializeOpenstack(opt *NewClusterOptions, cluster *api.Cluster) {
 	if opt.APILoadBalancerType != "" {
 		cluster.Spec.API.LoadBalancer = &api.LoadBalancerAccessSpec{}
 		provider := "haproxy"
@@ -1416,6 +1423,17 @@ func initializeOpenstackAPI(opt *NewClusterOptions, cluster *api.Cluster) {
 
 		if opt.OpenstackLBSubnet != "" {
 			cluster.Spec.CloudProvider.Openstack.Loadbalancer.FloatingSubnet = fi.PtrTo(opt.OpenstackLBSubnet)
+		}
+	}
+
+	// this is needed in new clusters, otherwise openstack clients will automatically try to use openstack designate
+	if strings.ToLower(opt.DNSType) == "none" {
+		if cluster.Spec.Networking.Topology == nil {
+			cluster.Spec.Networking.Topology = &api.TopologySpec{
+				DNS: api.DNSTypeNone,
+			}
+		} else {
+			cluster.Spec.Networking.Topology.DNS = api.DNSTypeNone
 		}
 	}
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lblistener.go
@@ -30,6 +30,7 @@ import (
 type LBListener struct {
 	ID           *string
 	Name         *string
+	Port         *int
 	Pool         *LBPool
 	Lifecycle    fi.Lifecycle
 	AllowedCIDRs []string
@@ -61,6 +62,7 @@ func NewLBListenerTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle fi.Lif
 	listenerTask := &LBListener{
 		ID:           fi.PtrTo(listener.ID),
 		Name:         fi.PtrTo(listener.Name),
+		Port:         fi.PtrTo(listener.ProtocolPort),
 		AllowedCIDRs: listener.AllowedCIDRs,
 		Lifecycle:    lifecycle,
 	}
@@ -152,7 +154,7 @@ func (_ *LBListener) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, chan
 			DefaultPoolID:  fi.ValueOf(e.Pool.ID),
 			LoadbalancerID: fi.ValueOf(e.Pool.Loadbalancer.ID),
 			Protocol:       listeners.ProtocolTCP,
-			ProtocolPort:   443,
+			ProtocolPort:   fi.ValueOf(e.Port),
 		}
 
 		if useVIPACL && (fi.ValueOf(e.Pool.Loadbalancer.Provider) != "ovn") {


### PR DESCRIPTION
Refs https://github.com/kubernetes/kops/issues/14859

```
% kubectl get nodes
NAME                          STATUS   ROLES                AGE     VERSION
control-plane-espsti-omfcjm   Ready    control-plane,node   3m20s   v1.25.5
control-plane-esptnl-hxjzpy   Ready    control-plane,node   3m6s    v1.25.5
control-plane-helpa-kszzmr    Ready    control-plane,node   2m22s   v1.25.5
nodes-espsti-lo2kne           Ready    node                 3m6s    v1.25.5
nodes-esptnl-bq14jb           Ready    node                 3m5s    v1.25.5
```

node hosts file

```
...
# Begin host entries managed by kops - do not edit
10.222.156.209  api.internal.jessetesti.foobar.com
# End host entries managed by kops
```

so it seems working. 