### PR TITLE
OpenStack: include cloud config in normal nodes

### DIFF
--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -73,7 +73,8 @@ type CloudConfigBuilder struct {
 var _ fi.NodeupModelBuilder = &CloudConfigBuilder{}
 
 func (b *CloudConfigBuilder) Build(c *fi.NodeupModelBuilderContext) error {
-	if !b.HasAPIServer && b.NodeupConfig.KubeletConfig.CloudProvider == "external" {
+	// openstack needs cloud.config currently in all nodes because of csi components
+	if b.BootConfig.CloudProvider != kops.CloudProviderOpenstack && !b.HasAPIServer && b.NodeupConfig.KubeletConfig.CloudProvider == "external" {
 		return nil
 	}
 


### PR DESCRIPTION
fixes #14931

include cloud.config in normal nodes in case of OpenStack. It is currently used by cinder-csi driver. This is how it has been working.

@johngmyers could you check this