### PR TITLE
Automated cherry pick of #14937: Improve error message when trying to use IPv6 with amazonvpc

### DIFF
--- a/upup/pkg/fi/cloudup/defaults.go
+++ b/upup/pkg/fi/cloudup/defaults.go
@@ -93,7 +93,7 @@ func PerformAssignments(c *kops.Cluster, cloud fi.Cloud) error {
 		}
 
 		// Amazon VPC CNI uses the same network
-		if c.Spec.Networking.AmazonVPC != nil {
+		if c.Spec.Networking.AmazonVPC != nil && c.Spec.Networking.NonMasqueradeCIDR != "::/0" {
 			c.Spec.Networking.NonMasqueradeCIDR = c.Spec.Networking.NetworkCIDR
 		}
 	}


### PR DESCRIPTION
Cherry pick of #14937 on release-1.26.

#14937: Improve error message when trying to use IPv6 with amazonvpc

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.