### PR TITLE
Revert "Temporarily disable cluster-autoscaler in many-addons test"

### DIFF
--- a/tests/e2e/templates/many-addons.yaml.tmpl
+++ b/tests/e2e/templates/many-addons.yaml.tmpl
@@ -11,9 +11,8 @@ spec:
     enabled: true
   channel: stable
   cloudProvider: {{.cloudProvider}}
-#  https://github.com/kubernetes/kops/issues/14875
-#  clusterAutoscaler:
-#    enabled: true
+  clusterAutoscaler:
+    enabled: true
   configBase: "{{.stateStore}}/{{.clusterName}}"
   etcdClusters:
   - etcdMembers:


### PR DESCRIPTION
This reverts commit a64ae909e13f6d8abaa72912838dfc201cef0a92 (PR #14934).

Issue should be fixed by #14952

