### PR TITLE
Allow built-in manifests to be replaced by external addons

### DIFF
--- a/pkg/kubemanifest/containerargs.go
+++ b/pkg/kubemanifest/containerargs.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubemanifest
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ContainerVisitorFunction func(container map[string]interface{}) error
+
+func (m *Object) VisitContainers(visitorFn ContainerVisitorFunction) error {
+	visitorObj := &containerVisitor{
+		visitor: visitorFn,
+	}
+	err := m.accept(visitorObj)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type containerVisitor struct {
+	visitorBase
+	visitor ContainerVisitorFunction
+}
+
+func (m *containerVisitor) VisitMap(path []string, v map[string]interface{}) error {
+	n := len(path)
+	if n < 2 || path[n-2] != "containers" || !strings.HasPrefix(path[n-1], "[") {
+		return nil
+	}
+
+	if err := m.visitor(v); err != nil {
+		return fmt.Errorf("error visiting container %v: %w", v, err)
+	}
+
+	return nil
+}

--- a/pkg/kubemanifest/visitor.go
+++ b/pkg/kubemanifest/visitor.go
@@ -40,10 +40,16 @@ func (m *visitorBase) VisitFloat64(path []string, v float64, mutator func(float6
 	return nil
 }
 
+func (m *visitorBase) VisitMap(path []string, v map[string]interface{}) error {
+	klog.V(10).Infof("object value at %s: %f", strings.Join(path, "."), v)
+	return nil
+}
+
 type Visitor interface {
 	VisitBool(path []string, v bool, mutator func(bool)) error
 	VisitString(path []string, v string, mutator func(string)) error
 	VisitFloat64(path []string, v float64, mutator func(float64)) error
+	VisitMap(path []string, v map[string]interface{}) error
 }
 
 func visit(visitor Visitor, data interface{}, path []string, mutator func(interface{})) error {
@@ -78,6 +84,11 @@ func visit(visitor Visitor, data interface{}, path []string, mutator func(interf
 	case nil:
 	case map[string]interface{}:
 		m := data
+
+		if err := visitor.VisitMap(path, m); err != nil {
+			return err
+		}
+
 		for k, v := range m {
 			path = append(path, k)
 
@@ -103,6 +114,9 @@ func visit(visitor Visitor, data interface{}, path []string, mutator func(interf
 			}
 			path = path[:len(path)-1]
 		}
+
+	case []string:
+		// ignore - we don't have any visitors for this currently
 
 	default:
 		return fmt.Errorf("unhandled type in manifest: %T", data)

--- a/pkg/model/components/addonmanifests/remap.go
+++ b/pkg/model/components/addonmanifests/remap.go
@@ -31,6 +31,10 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 )
 
+// KopsAddonLabelKey is the label we use for objects in kOps manifests.
+// The value corresponds to the name of the addon.
+const KopsAddonLabelKey = "addon.kops.k8s.io/name"
+
 func RemapAddonManifest(addon *addonsapi.AddonSpec, context *model.KopsModelContext, assetBuilder *assets.AssetBuilder, manifest []byte, serviceAccounts map[string]iam.Subject) ([]byte, error) {
 	name := fi.ValueOf(addon.Name)
 
@@ -119,7 +123,7 @@ func addLabels(addon *addonsapi.AddonSpec, objects kubemanifest.ObjectList) erro
 		}
 
 		meta.Labels["app.kubernetes.io/managed-by"] = "kops"
-		meta.Labels["addon.kops.k8s.io/name"] = *addon.Name
+		meta.Labels[KopsAddonLabelKey] = *addon.Name
 
 		// ensure selector is set where applicable
 		for key, val := range addon.Selector {

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/pruning.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/pruning.go
@@ -27,6 +27,7 @@ import (
 
 	channelsapi "k8s.io/kops/channels/pkg/api"
 	"k8s.io/kops/pkg/kubemanifest"
+	"k8s.io/kops/pkg/model/components/addonmanifests"
 )
 
 func (b *BootstrapChannelBuilder) addPruneDirectives(addons *AddonList) error {
@@ -49,8 +50,8 @@ func (b *BootstrapChannelBuilder) addPruneDirectivesForAddon(addon *Addon) error
 
 	// We add these labels to all objects we manage, so we reuse them for pruning.
 	selectorMap := map[string]string{
-		"app.kubernetes.io/managed-by": "kops",
-		"addon.kops.k8s.io/name":       *addon.Spec.Name,
+		"app.kubernetes.io/managed-by":   "kops",
+		addonmanifests.KopsAddonLabelKey: *addon.Spec.Name,
 	}
 	selector, err := labels.ValidatedSelectorFromSet(selectorMap)
 	if err != nil {


### PR DESCRIPTION
We identify the external manifests by checking for our labels.
Currently that label is kOps specific, and we'll likely have to evolve
that to something ecosystem-netural.

We only support the GCE CCM addon and the kopeio-networking addon at
first.

For the GCE CCM addon, we need to replace the arguments, in particular
we likely need the Pod CIDR.  Here we need to work with the GCE CCM to
find a mechanism that can allow some of these flags to be communicated
via a more extensible mechanism (env vars or config maps, likely,
though possibly CRDs).

This is all behind the ClusterAddons feature flag at the moment, so we
can figure this out with other projects safely.
