### PR TITLE
kubetest2-kops: include stderr when calling kops toolbox dump

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -46,6 +46,7 @@ func (d *deployer) DumpClusterLogs() error {
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(d.env()...)
 	cmd.SetStdout(yamlFile)
+	cmd.SetStderr(os.Stderr)
 	if err := cmd.Run(); err != nil {
 		return err
 	}
@@ -197,6 +198,7 @@ func (d *deployer) dumpClusterInfoSSH() error {
 	klog.Info(strings.Join(toolboxDumpArgs, " "))
 
 	cmd := exec.Command(toolboxDumpArgs[0], toolboxDumpArgs[1:]...)
+	cmd.SetStderr(os.Stderr)
 	dumpOutput, err := exec.Output(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
We're seeing some logs that don't include any output from kops toolbox
dump, but probably should.  Make sure we're including any stderr
output in our logs.
