### PR TITLE
move openstack cloud config to k8s secrets

### DIFF
--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
@@ -1,5 +1,14 @@
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-project
+  namespace: kube-system
+stringData:
+  cloud.config: |
+{{ OPENSTACK_CONF | indent 4 }}
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cloud-controller-manager
@@ -221,7 +230,7 @@ spec:
           requests:
             cpu: {{ or .ExternalCloudControllerManager.CPURequest "200m" }}
         volumeMounts:
-        - mountPath: /etc/kubernetes/cloud.config
+        - mountPath: /etc/kubernetes
           name: cloudconfig
           readOnly: true
 {{ if .UseHostCertificates }}
@@ -230,8 +239,8 @@ spec:
           readOnly: true
 {{ end }}
       volumes:
-      - hostPath:
-          path: /etc/kubernetes/cloud.config
+      - secret:
+          secretName: openstack-project
         name: cloudconfig
 {{ if .UseHostCertificates }}
       - hostPath:

--- a/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
@@ -350,15 +350,14 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-            - mountPath: /etc/kubernetes/cloud.config
+            - mountPath: /etc/kubernetes
               name: cloudconfig
               readOnly: true
       volumes:
         - name: socket-dir
           emptyDir: {}
-        - hostPath:
-            path: /etc/kubernetes/cloud.config
-            type: ""
+        - secret:
+            secretName: openstack-project
           name: cloudconfig
 
 ---
@@ -493,7 +492,7 @@ spec:
             - name: pods-probe-dir
               mountPath: /dev
               mountPropagation: "HostToContainer"
-            - mountPath: /etc/kubernetes/cloud.config
+            - mountPath: /etc/kubernetes
               name: cloudconfig
               readOnly: true
       volumes:
@@ -513,9 +512,8 @@ spec:
           hostPath:
             path: /dev
             type: Directory
-        - hostPath:
-            path: /etc/kubernetes/cloud.config
-            type: ""
+        - secret:
+            secretName: openstack-project
           name: cloudconfig
 ---
 apiVersion: storage.k8s.io/v1

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -65,6 +65,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	gcetpm "k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
+	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/util/pkg/env"
 	"sigs.k8s.io/yaml"
 )
@@ -182,6 +183,11 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			return cluster.Spec.Networking.NetworkID
 		}
 		return cluster.Name
+	}
+
+	dest["OPENSTACK_CONF"] = func() string {
+		lines := openstack.MakeCloudConfig(cluster.Spec)
+		return "[global]\n" + strings.Join(lines, "\n") + "\n"
 	}
 
 	if featureflag.Spotinst.Enabled() {


### PR DESCRIPTION
This will move openstack cloud.config usage to k8s secrets instead.

after this etcd-manager is only component that really needs cloud.config from control-plane local volume. in-tree configs can be removed afaik (remove the --cloud-config flag from kubelet, apiserver, control-manager?). https://github.com/kubernetes-sigs/etcdadm/blob/master/etcd-manager/pkg/volumes/openstack/volumes.go#L268