### PR TITLE
Add VFSContext to various clientsets

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/kops/pkg/kubemanifest"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/util/pkg/text"
-	"k8s.io/kops/util/pkg/vfs"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -102,6 +101,8 @@ func RunCreate(ctx context.Context, f *util.Factory, out io.Writer, c *CreateOpt
 		return err
 	}
 
+	vfsContext := f.VFSContext()
+
 	clusterName := ""
 	// var cSpec = false
 	var sb bytes.Buffer
@@ -118,7 +119,7 @@ func RunCreate(ctx context.Context, f *util.Factory, out io.Writer, c *CreateOpt
 				return err
 			}
 		} else {
-			contents, err = vfs.Context.ReadFile(f)
+			contents, err = vfsContext.ReadFile(f)
 			if err != nil {
 				return fmt.Errorf("error reading file %q: %v", f, err)
 			}

--- a/cmd/kops/delete.go
+++ b/cmd/kops/delete.go
@@ -28,7 +28,6 @@ import (
 	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/kopscodecs"
 	"k8s.io/kops/util/pkg/text"
-	"k8s.io/kops/util/pkg/vfs"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -91,7 +90,7 @@ func RunDelete(ctx context.Context, factory *util.Factory, out io.Writer, d *Del
 				return fmt.Errorf("reading from stdin: %v", err)
 			}
 		} else {
-			contents, err = vfs.Context.ReadFile(f)
+			contents, err = factory.VFSContext().ReadFile(f)
 			if err != nil {
 				return fmt.Errorf("reading file %q: %v", f, err)
 			}

--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/kops/pkg/kopscodecs"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/util/pkg/text"
-	"k8s.io/kops/util/pkg/vfs"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -90,6 +89,8 @@ func RunReplace(ctx context.Context, f *util.Factory, out io.Writer, c *ReplaceO
 		return err
 	}
 
+	vfsContext := f.VFSContext()
+
 	for _, f := range c.Filenames {
 		var contents []byte
 		if f == "-" {
@@ -98,7 +99,7 @@ func RunReplace(ctx context.Context, f *util.Factory, out io.Writer, c *ReplaceO
 				return err
 			}
 		} else {
-			contents, err = vfs.Context.ReadFile(f)
+			contents, err = vfsContext.ReadFile(f)
 			if err != nil {
 				return fmt.Errorf("error reading file %q: %v", f, err)
 			}

--- a/cmd/kops/util/factory.go
+++ b/cmd/kops/util/factory.go
@@ -113,12 +113,13 @@ func (f *Factory) KopsClient() (simple.Clientset, error) {
 				return nil, fmt.Errorf("error building kops API client: %v", err)
 			}
 
-			f.clientset = &api.RESTClientset{
-				BaseURL: &url.URL{
+			f.clientset = api.NewRESTClientset(
+				f.VFSContext(),
+				&url.URL{
 					Scheme: "k8s",
 				},
-				KopsClient: kopsClient.Kops(),
-			}
+				kopsClient.Kops(),
+			)
 		} else {
 			basePath, err := f.VFSContext().BuildVfsPath(registryPath)
 			if err != nil {
@@ -129,7 +130,7 @@ func (f *Factory) KopsClient() (simple.Clientset, error) {
 				return nil, field.Invalid(field.NewPath("State Store"), registryPath, INVALID_STATE_ERROR)
 			}
 
-			f.clientset = vfsclientset.NewVFSClientset(basePath)
+			f.clientset = vfsclientset.NewVFSClientset(f.VFSContext(), basePath)
 		}
 		if strings.HasPrefix(registryPath, "file://") {
 			klog.Warning("The local filesystem state store is not functional for running clusters")

--- a/cmd/kops/util/factory.go
+++ b/cmd/kops/util/factory.go
@@ -51,6 +51,7 @@ type Factory struct {
 
 	kubernetesClient  kubernetes.Interface
 	certManagerClient certmanager.Interface
+	vfsContext        *vfs.VFSContext
 
 	cachedRESTConfig *rest.Config
 	dynamicClient    dynamic.Interface
@@ -119,7 +120,7 @@ func (f *Factory) KopsClient() (simple.Clientset, error) {
 				KopsClient: kopsClient.Kops(),
 			}
 		} else {
-			basePath, err := vfs.Context.BuildVfsPath(registryPath)
+			basePath, err := f.VFSContext().BuildVfsPath(registryPath)
 			if err != nil {
 				return nil, fmt.Errorf("error building path for %q: %v", registryPath, err)
 			}
@@ -220,4 +221,12 @@ func (f *Factory) RESTMapper() (*restmapper.DeferredDiscoveryRESTMapper, error) 
 	}
 
 	return f.restMapper, nil
+}
+
+func (f *Factory) VFSContext() *vfs.VFSContext {
+	if f.vfsContext == nil {
+		// TODO vfs.NewVFSContext()
+		f.vfsContext = vfs.Context
+	}
+	return f.vfsContext
 }

--- a/cmd/kops/version.go
+++ b/cmd/kops/version.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/kops"
 	"k8s.io/kops/cmd/kops/util"
 	"k8s.io/kops/pkg/apis/kops/registry"
-	"k8s.io/kops/util/pkg/vfs"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -116,7 +115,7 @@ func serverVersion(f *util.Factory, options *VersionOptions) string {
 	if err != nil {
 		return "could not fetch cluster"
 	}
-	configBase, err := vfs.Context.BuildVfsPath(cluster.Spec.ConfigBase)
+	configBase, err := f.VFSContext().BuildVfsPath(cluster.Spec.ConfigBase)
 	if err != nil {
 		return "could not talk to vfs"
 	}

--- a/examples/kops-api-example/apply.go
+++ b/examples/kops-api-example/apply.go
@@ -21,10 +21,11 @@ import (
 
 	"k8s.io/kops/pkg/client/simple/vfsclientset"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
+	"k8s.io/kops/util/pkg/vfs"
 )
 
 func apply(ctx context.Context) error {
-	clientset := vfsclientset.NewVFSClientset(registryBase)
+	clientset := vfsclientset.NewVFSClientset(vfs.Context, registryBase)
 
 	cluster, err := clientset.GetCluster(ctx, clusterName)
 	if err != nil {

--- a/examples/kops-api-example/up.go
+++ b/examples/kops-api-example/up.go
@@ -27,10 +27,11 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/upup/pkg/fi/utils"
+	"k8s.io/kops/util/pkg/vfs"
 )
 
 func up(ctx context.Context) error {
-	clientset := vfsclientset.NewVFSClientset(registryBase)
+	clientset := vfsclientset.NewVFSClientset(vfs.Context, registryBase)
 
 	cluster := &api.Cluster{}
 	cluster.ObjectMeta.Name = clusterName

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -294,7 +294,7 @@ func mockedPopulateClusterSpec(ctx context.Context, c *kops.Cluster, cloud fi.Cl
 	if err != nil {
 		return nil, fmt.Errorf("error building vfspath: %v", err)
 	}
-	clientset := vfsclientset.NewVFSClientset(basePath)
+	clientset := vfsclientset.NewVFSClientset(vfs.Context, basePath)
 	return cloudup.PopulateClusterSpec(ctx, clientset, c, cloud, assetBuilder)
 }
 

--- a/pkg/client/simple/api/clientset.go
+++ b/pkg/client/simple/api/clientset.go
@@ -38,8 +38,21 @@ import (
 
 // RESTClientset is an implementation of clientset that uses a "real" generated REST client
 type RESTClientset struct {
+	vfsContext *vfs.VFSContext
 	BaseURL    *url.URL
 	KopsClient kopsinternalversion.KopsInterface
+}
+
+func NewRESTClientset(vfsContext *vfs.VFSContext, baseURL *url.URL, kopsClient kopsinternalversion.KopsInterface) *RESTClientset {
+	return &RESTClientset{
+		vfsContext: vfsContext,
+		BaseURL:    baseURL,
+		KopsClient: kopsClient,
+	}
+}
+
+func (c *RESTClientset) VFSContext() *vfs.VFSContext {
+	return c.vfsContext
 }
 
 // GetCluster implements the GetCluster method of Clientset for a kubernetes-API state store
@@ -79,11 +92,11 @@ func (c *RESTClientset) UpdateCluster(ctx context.Context, cluster *kops.Cluster
 // ConfigBaseFor implements the ConfigBaseFor method of Clientset for a kubernetes-API state store
 func (c *RESTClientset) ConfigBaseFor(cluster *kops.Cluster) (vfs.Path, error) {
 	if cluster.Spec.ConfigBase != "" {
-		return vfs.Context.BuildVfsPath(cluster.Spec.ConfigBase)
+		return c.VFSContext().BuildVfsPath(cluster.Spec.ConfigBase)
 	}
 	// URL for clusters looks like https://<server>/apis/kops/v1alpha2/namespaces/<cluster>/clusters/<cluster>
 	// We probably want to add a subresource for full resources
-	return vfs.Context.BuildVfsPath(c.BaseURL.String())
+	return c.VFSContext().BuildVfsPath(c.BaseURL.String())
 }
 
 // ListClusters implements the ListClusters method of Clientset for a kubernetes-API state store

--- a/pkg/client/simple/clientset.go
+++ b/pkg/client/simple/clientset.go
@@ -28,6 +28,9 @@ import (
 )
 
 type Clientset interface {
+	// VFSContext returns a VFSContext.
+	VFSContext() *vfs.VFSContext
+
 	// GetCluster reads a cluster by name
 	GetCluster(ctx context.Context, name string) (*kops.Cluster, error)
 

--- a/pkg/client/simple/vfsclientset/clientset_test.go
+++ b/pkg/client/simple/vfsclientset/clientset_test.go
@@ -24,6 +24,9 @@ import (
 )
 
 func TestSSHCredentialStoreOnConfigBase(t *testing.T) {
+	clientset := VFSClientset{
+		vfsContext: vfs.Context,
+	}
 	vfs.Context.ResetMemfsContext(true)
 	configBase := "memfs://some/config/base"
 	cluster := &kops.Cluster{
@@ -32,7 +35,7 @@ func TestSSHCredentialStoreOnConfigBase(t *testing.T) {
 		},
 	}
 
-	p, err := pkiPath(cluster)
+	p, err := clientset.pkiPath(cluster)
 	if err != nil {
 		t.Errorf("Failed to create ssh path: %v", err)
 	}
@@ -46,6 +49,9 @@ func TestSSHCredentialStoreOnConfigBase(t *testing.T) {
 }
 
 func TestSSHCredentialStoreOnOwnCFS(t *testing.T) {
+	clientset := VFSClientset{
+		vfsContext: vfs.Context,
+	}
 	vfs.Context.ResetMemfsContext(true)
 	configBase := "memfs://some/config/base"
 	keyPath := "memfs://keys/some/config/base/pki"
@@ -56,7 +62,7 @@ func TestSSHCredentialStoreOnOwnCFS(t *testing.T) {
 		},
 	}
 
-	p, err := pkiPath(cluster)
+	p, err := clientset.pkiPath(cluster)
 	if err != nil {
 		t.Errorf("Failed to create ssh path: %v", err)
 	}

--- a/pkg/instancegroups/rollingupdate_os_test.go
+++ b/pkg/instancegroups/rollingupdate_os_test.go
@@ -60,7 +60,7 @@ func getTestSetupOS(t *testing.T, ctx context.Context) (*RollingUpdateCluster, *
 
 	assetBuilder := assets.NewAssetBuilder(inCluster.Spec.Assets, inCluster.Spec.KubernetesVersion, false)
 	basePath, _ := vfs.Context.BuildVfsPath(inCluster.Spec.ConfigBase)
-	clientset := vfsclientset.NewVFSClientset(basePath)
+	clientset := vfsclientset.NewVFSClientset(vfs.Context, basePath)
 	cluster, err := cloudup.PopulateClusterSpec(ctx, clientset, inCluster, mockcloud, assetBuilder)
 	if err != nil {
 		t.Fatalf("Failed to populate cluster spec: %v", err)

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -266,7 +266,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 
 	cluster := c.Cluster
 
-	configBase, err := vfs.Context.BuildVfsPath(cluster.Spec.ConfigBase)
+	configBase, err := c.Clientset.VFSContext().BuildVfsPath(cluster.Spec.ConfigBase)
 	if err != nil {
 		return fmt.Errorf("error parsing config base %q: %v", cluster.Spec.ConfigBase, err)
 	}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -122,7 +122,7 @@ func runChannelBuilderTest(t *testing.T, key string, addonManifests []string) {
 	if err != nil {
 		t.Errorf("error building vfspath: %v", err)
 	}
-	clientset := vfsclientset.NewVFSClientset(basePath)
+	clientset := vfsclientset.NewVFSClientset(vfs.Context, basePath)
 
 	secretStore, err := clientset.SecretStore(cluster)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/util/pkg/architectures"
-	"k8s.io/kops/util/pkg/vfs"
 )
 
 const (
@@ -352,7 +351,7 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 	}
 
 	if opt.DiscoveryStore != "" {
-		discoveryPath, err := vfs.Context.BuildVfsPath(opt.DiscoveryStore)
+		discoveryPath, err := clientset.VFSContext().BuildVfsPath(opt.DiscoveryStore)
 		if err != nil {
 			return nil, fmt.Errorf("error building DiscoveryStore for cluster: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -159,7 +159,7 @@ func (c *populateClusterSpec) run(ctx context.Context, clientset simple.Clientse
 		}
 	}
 
-	configBase, err := vfs.Context.BuildVfsPath(cluster.Spec.ConfigBase)
+	configBase, err := clientset.VFSContext().BuildVfsPath(cluster.Spec.ConfigBase)
 	if err != nil {
 		return fmt.Errorf("error parsing ConfigBase %q: %v", cluster.Spec.ConfigBase, err)
 	}

--- a/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
@@ -115,7 +115,7 @@ func mockedPopulateClusterSpec(ctx context.Context, c *kopsapi.Cluster, cloud fi
 	if err != nil {
 		return nil, fmt.Errorf("error building vfspath: %v", err)
 	}
-	clientset := vfsclientset.NewVFSClientset(basePath)
+	clientset := vfsclientset.NewVFSClientset(vfs.Context, basePath)
 	return PopulateClusterSpec(ctx, clientset, c, cloud, assetBuilder)
 }
 

--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -72,6 +72,12 @@ func NewVFSContext() *VFSContext {
 	return v
 }
 
+func NewTestingVFSContext() *VFSContext {
+	vfsContext := NewVFSContext()
+	vfsContext.ResetMemfsContext(true)
+	return vfsContext
+}
+
 func (v *VFSContext) WithGCSClient(gcsClient *storage.Service) *VFSContext {
 	v.mutex.Lock()
 	defer v.mutex.Unlock()


### PR DESCRIPTION
`VFSContext` is not a context, it is a clientset. This starts to refactor some references to `VFSContext` so that the pull it from a higher-level clientset.

There will be more work to push either a `VFSContext` or a higher-level clientset into the things that currently reference the global variable. The next thing to hold a reference to `VFSContext` is probably `ModelBuilderContext`.

/cc @justinsb