### PR TITLE
Fix `kops version` command when dev-building nodeup

### DIFF
--- a/docs/contributing/adding_a_feature.md
+++ b/docs/contributing/adding_a_feature.md
@@ -237,7 +237,7 @@ and then push nodeup using:
 export S3_BUCKET_NAME=<yourbucketname>
 make kops-install dev-upload UPLOAD_DEST=s3://${S3_BUCKET_NAME}
 
-KOPS_VERSION=`.build/dist/$(go env GOOS)/$(go env GOARCH)/kops version -- --short`
+KOPS_VERSION=`.build/dist/$(go env GOOS)/$(go env GOARCH)/kops version --short`
 export KOPS_BASE_URL=https://${S3_BUCKET_NAME}.s3.amazonaws.com/kops/${KOPS_VERSION}/
 export KOPS_ARCH=amd64
 kops create cluster <clustername> --zones us-east-1b


### PR DESCRIPTION
Tiny command fix - remove extraneous `--` which caused the actual `--short` flag to be ignored.