### PR TITLE
Automated cherry pick of #14951: Upgrade k8s-dns-node-cache to 1.22.16

### DIFF
--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -110,7 +110,7 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if nodeLocalDNS.Image == nil {
-		nodeLocalDNS.Image = fi.PtrTo("registry.k8s.io/dns/k8s-dns-node-cache:1.22.15")
+		nodeLocalDNS.Image = fi.PtrTo("registry.k8s.io/dns/k8s-dns-node-cache:1.22.16")
 	}
 
 	return nil

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
@@ -125,7 +125,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
@@ -115,7 +115,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
@@ -113,7 +113,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
@@ -110,7 +110,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -154,7 +154,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
@@ -108,7 +108,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -116,7 +116,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
@@ -108,7 +108,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
@@ -130,7 +130,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -124,7 +124,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
@@ -116,7 +116,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
@@ -119,7 +119,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
@@ -108,7 +108,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -109,7 +109,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
@@ -108,7 +108,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
@@ -125,7 +125,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
@@ -116,7 +116,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -132,7 +132,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -137,7 +137,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -128,7 +128,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -144,7 +144,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 172.20.0.10

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
@@ -146,7 +146,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 172.20.0.10

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
@@ -147,7 +147,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 172.20.0.10

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
@@ -146,7 +146,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 172.20.0.10

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
@@ -147,7 +147,7 @@ spec:
       cpuRequest: 25m
       enabled: true
       forwardToKubeDNS: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       localIP: 169.254.20.10
       memoryRequest: 5Mi
     provider: CoreDNS

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: nodelocaldns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4bdace9531e4f15ff36af9c34fdcc9a716ac4481d42e8b45980016e1ccb03109
+    manifestHash: a15ad12db934f7b6c87123d2f63ff1bed142e4e64c5a9470e6eefc87d0705b7a
     name: nodelocaldns.addons.k8s.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-nodelocaldns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-nodelocaldns.addons.k8s.io-k8s-1.12_content
@@ -137,7 +137,7 @@ spec:
         - -conf=/etc/Corefile
         - -upstreamsvc=kube-dns-upstream
         - -setupiptables=false
-        image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
         livenessProbe:
           httpGet:
             host: 169.254.20.10

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -143,7 +143,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 172.20.0.10

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -142,7 +142,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -136,7 +136,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 172.20.0.10

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_cluster-completed.spec_content
@@ -125,7 +125,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
@@ -133,7 +133,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
@@ -132,7 +132,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
@@ -132,7 +132,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -131,7 +131,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
@@ -120,7 +120,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
@@ -114,7 +114,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
@@ -132,7 +132,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: fd00:5e4f:ce::a

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -132,7 +132,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: fd00:5e4f:ce::a

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
@@ -132,7 +132,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: fd00:5e4f:ce::a

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -132,7 +132,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: fd00:5e4f:ce::a

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -106,7 +106,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -115,7 +115,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_cluster-completed.spec_content
@@ -106,7 +106,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -124,7 +124,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -125,7 +125,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
@@ -128,7 +128,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -128,7 +128,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -124,7 +124,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
@@ -124,7 +124,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
@@ -107,7 +107,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -108,7 +108,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -120,7 +120,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
@@ -116,7 +116,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
@@ -116,7 +116,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -109,7 +109,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
@@ -108,7 +108,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
@@ -111,7 +111,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
@@ -110,7 +110,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -110,7 +110,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
@@ -128,7 +128,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
@@ -127,7 +127,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -110,7 +110,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -110,7 +110,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -130,7 +130,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -117,7 +117,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
@@ -113,7 +113,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
@@ -110,7 +110,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
@@ -127,7 +127,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
@@ -110,7 +110,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_cluster-completed.spec_content
@@ -110,7 +110,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
@@ -128,7 +128,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -108,7 +108,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
@@ -108,7 +108,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -132,7 +132,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: fd00:5e4f:ce::a

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
@@ -110,7 +110,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
@@ -108,7 +108,7 @@ spec:
     nodeLocalDNS:
       cpuRequest: 25m
       enabled: false
-      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.15
+      image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.16
       memoryRequest: 5Mi
     provider: CoreDNS
     serverIP: 100.64.0.10


### PR DESCRIPTION
Cherry pick of #14951 on release-1.26.

#14951: Upgrade k8s-dns-node-cache to 1.22.16

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.