### PR TITLE
Use state store to bootstrap clusters with Gossip DNS

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -310,9 +310,10 @@ func TestNvidia(t *testing.T) {
 func TestMinimalGossip(t *testing.T) {
 	newIntegrationTest("minimal.k8s.local", "minimal_gossip").
 		withAddons(
+			"rbac.addons.k8s.io-k8s-1.8",
+			awsCCMAddon,
 			awsEBSCSIAddon,
 			dnsControllerAddon,
-			awsCCMAddon,
 		).
 		runTestTerraformAWS(t)
 }
@@ -324,9 +325,10 @@ func TestMinimalGossipIRSA(t *testing.T) {
 		withServiceAccountRole("aws-cloud-controller-manager.kube-system", true).
 		withServiceAccountRole("ebs-csi-controller-sa.kube-system", true).
 		withAddons(
+			"rbac.addons.k8s.io-k8s-1.8",
+			awsCCMAddon,
 			awsEBSCSIAddon,
 			dnsControllerAddon,
-			awsCCMAddon,
 		).
 		runTestTerraformAWS(t)
 }

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -388,6 +388,10 @@ func (c *NodeupModelContext) UseVolumeMounts() bool {
 
 // UseKopsControllerForNodeBootstrap checks if nodeup should use kops-controller to bootstrap.
 func (c *NodeupModelContext) UseKopsControllerForNodeBootstrap() bool {
+	if c.IsGossip {
+		return false
+	}
+
 	return model.UseKopsControllerForNodeBootstrap(c.Cluster)
 }
 

--- a/pkg/apis/kops/model/features.go
+++ b/pkg/apis/kops/model/features.go
@@ -22,6 +22,10 @@ import (
 
 // UseKopsControllerForNodeBootstrap is true if nodeup should use kops-controller for bootstrapping.
 func UseKopsControllerForNodeBootstrap(cluster *kops.Cluster) bool {
+	if cluster.IsGossip() {
+		return false
+	}
+
 	switch cluster.Spec.GetCloudProvider() {
 	case kops.CloudProviderAWS:
 		return true

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -2,6 +2,19 @@
   "Statement": [
     {
       "Action": [
+        "s3:Get*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/cluster-completed.spec",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/igconfig/node/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kube-proxy/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/secrets/dockerconfig"
+      ]
+    },
+    {
+      "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -2,6 +2,19 @@
   "Statement": [
     {
       "Action": [
+        "s3:Get*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/cluster-completed.spec",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/igconfig/node/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kube-proxy/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/secrets/dockerconfig"
+      ]
+    },
+    {
+      "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
@@ -2,6 +2,19 @@
   "Statement": [
     {
       "Action": [
+        "s3:Get*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/pki/private/kube-proxy/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/pki/private/kubelet/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/secrets/dockerconfig"
+      ]
+    },
+    {
+      "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
@@ -150,32 +150,10 @@ __EOF_CLUSTER_SPEC
 
 cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 CloudProvider: aws
-ConfigServer:
-  CACertificates: |
-    -----BEGIN CERTIFICATE-----
-    MIIBbjCCARigAwIBAgIMFpANqBD8NSD82AUSMA0GCSqGSIb3DQEBCwUAMBgxFjAU
-    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwODAwWhcNMzEwNzA3MDcw
-    ODAwWjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
-    SwAwSAJBANFI3zr0Tk8krsW8vwjfMpzJOlWQ8616vG3YPa2qAgI7V4oKwfV0yIg1
-    jt+H6f4P/wkPAPTPTfRp9Iy8oHEEFw0CAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
-    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFNG3zVjTcLlJwDsJ4/K9DV7KohUA
-    MA0GCSqGSIb3DQEBCwUAA0EAB8d03fY2w7WKpfO29qI295pu2C4ca9AiVGOpgSc8
-    tmQsq6rcxt3T+rb589PVtz0mw/cKTxOk6gH2CCC+yHfy2w==
-    -----END CERTIFICATE-----
-    -----BEGIN CERTIFICATE-----
-    MIIBbjCCARigAwIBAgIMFpANvmSa0OAlYmXKMA0GCSqGSIb3DQEBCwUAMBgxFjAU
-    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwOTM2WhcNMzEwNzA3MDcw
-    OTM2WjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
-    SwAwSAJBAMF6F4aZdpe0RUpyykaBpWwZCnwbffhYGOw+fs6RdLuUq7QCNmJm/Eq7
-    WWOziMYDiI9SbclpD+6QiJ0N3EqppVUCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
-    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLImp6ARjPDAH6nhI+scWVt3Q9bn
-    MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
-    9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
-    -----END CERTIFICATE-----
-  server: https://kops-controller.internal.minimal.k8s.local:3988/
+ConfigBase: memfs://clusters.example.com/minimal.k8s.local
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: eUeXsJ9qSurrb/dNCZ9vqLZLQ5zmlKBnt8aSDjocwnA=
+NodeupConfigHash: qIzxkcq+JlMcWS91XdWMGjrM+qfLUxJRUZKMG+VyfZ8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 21c53eab91715d95b2d1330753eda0586dbc860c7e7ed75514423cdc4bad6645
+    manifestHash: 87491394e7ba274b291d93dee740e683da8fd3799ebb53233aeac37747057e16
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -18,6 +18,13 @@ spec:
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
+    version: 9.99.0
+  - id: k8s-1.8
+    manifest: rbac.addons.k8s.io/k8s-1.8.yaml
+    manifestHash: f81bd7c57bc1902ca342635d7ad7d01b82dfeaff01a1192b076e66907d87871e
+    name: rbac.addons.k8s.io
+    selector:
+      k8s-addon: rbac.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"clusterName":"minimal.k8s.local","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","secretStore":"memfs://clusters.example.com/minimal.k8s.local/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"discovery":{"enabled":true}}
+    {"clusterName":"minimal.k8s.local","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","secretStore":"memfs://clusters.example.com/minimal.k8s.local/secrets","discovery":{"enabled":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -32,8 +32,6 @@ spec:
       k8s-app: kops-controller
   template:
     metadata:
-      annotations:
-        dns.alpha.kubernetes.io/internal: kops-controller.internal.minimal.k8s.local
       creationTimestamp: null
       labels:
         k8s-addon: kops-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-rbac.addons.k8s.io-k8s-1.8_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-rbac.addons.k8s.io-k8s-1.8_content
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: rbac.addons.k8s.io
+    addonmanager.kubernetes.io/mode: Reconcile
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: rbac.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: kubelet-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: kubelet

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-nodes_content
@@ -15,13 +15,36 @@ Assets:
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
-CAs: {}
+CAs:
+  kubernetes-ca: |
+    -----BEGIN CERTIFICATE-----
+    MIIBbjCCARigAwIBAgIMFpANqBD8NSD82AUSMA0GCSqGSIb3DQEBCwUAMBgxFjAU
+    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwODAwWhcNMzEwNzA3MDcw
+    ODAwWjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
+    SwAwSAJBANFI3zr0Tk8krsW8vwjfMpzJOlWQ8616vG3YPa2qAgI7V4oKwfV0yIg1
+    jt+H6f4P/wkPAPTPTfRp9Iy8oHEEFw0CAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
+    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFNG3zVjTcLlJwDsJ4/K9DV7KohUA
+    MA0GCSqGSIb3DQEBCwUAA0EAB8d03fY2w7WKpfO29qI295pu2C4ca9AiVGOpgSc8
+    tmQsq6rcxt3T+rb589PVtz0mw/cKTxOk6gH2CCC+yHfy2w==
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    MIIBbjCCARigAwIBAgIMFpANvmSa0OAlYmXKMA0GCSqGSIb3DQEBCwUAMBgxFjAU
+    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwOTM2WhcNMzEwNzA3MDcw
+    OTM2WjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
+    SwAwSAJBAMF6F4aZdpe0RUpyykaBpWwZCnwbffhYGOw+fs6RdLuUq7QCNmJm/Eq7
+    WWOziMYDiI9SbclpD+6QiJ0N3EqppVUCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
+    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLImp6ARjPDAH6nhI+scWVt3Q9bn
+    MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
+    9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
+    -----END CERTIFICATE-----
 ClusterName: minimal.k8s.local
 ContainerRuntime: containerd
 Hooks:
 - null
 - null
 KeypairIDs:
+  kube-proxy: "6986354184403674830529235586"
+  kubelet: "6986354184404014133128804066"
   kubernetes-ca: "6982820025135291416230495506"
 KubeProxy:
   clusterCIDR: 100.96.0.0/11

--- a/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
@@ -605,6 +605,14 @@ resource "aws_s3_object" "minimal-k8s-local-addons-limit-range-addons-k8s-io" {
   server_side_encryption = "AES256"
 }
 
+resource "aws_s3_object" "minimal-k8s-local-addons-rbac-addons-k8s-io-k8s-1-8" {
+  bucket                 = "testingBucket"
+  content                = file("${path.module}/data/aws_s3_object_minimal.k8s.local-addons-rbac.addons.k8s.io-k8s-1.8_content")
+  key                    = "clusters.example.com/minimal.k8s.local/addons/rbac.addons.k8s.io/k8s-1.8.yaml"
+  provider               = aws.files
+  server_side_encryption = "AES256"
+}
+
 resource "aws_s3_object" "minimal-k8s-local-addons-storage-aws-addons-k8s-io-v1-15-0" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_minimal.k8s.local-addons-storage-aws.addons.k8s.io-v1.15.0_content")

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
@@ -2,6 +2,19 @@
   "Statement": [
     {
       "Action": [
+        "s3:Get*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/pki/private/kube-proxy/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/pki/private/kubelet/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/secrets/dockerconfig"
+      ]
+    },
+    {
+      "Action": [
         "s3:GetBucketLocation",
         "s3:GetEncryptionConfiguration",
         "s3:ListBucket",

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_nodes.minimal.k8s.local_user_data
@@ -150,32 +150,10 @@ __EOF_CLUSTER_SPEC
 
 cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 CloudProvider: aws
-ConfigServer:
-  CACertificates: |
-    -----BEGIN CERTIFICATE-----
-    MIIBbjCCARigAwIBAgIMFpANqBD8NSD82AUSMA0GCSqGSIb3DQEBCwUAMBgxFjAU
-    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwODAwWhcNMzEwNzA3MDcw
-    ODAwWjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
-    SwAwSAJBANFI3zr0Tk8krsW8vwjfMpzJOlWQ8616vG3YPa2qAgI7V4oKwfV0yIg1
-    jt+H6f4P/wkPAPTPTfRp9Iy8oHEEFw0CAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
-    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFNG3zVjTcLlJwDsJ4/K9DV7KohUA
-    MA0GCSqGSIb3DQEBCwUAA0EAB8d03fY2w7WKpfO29qI295pu2C4ca9AiVGOpgSc8
-    tmQsq6rcxt3T+rb589PVtz0mw/cKTxOk6gH2CCC+yHfy2w==
-    -----END CERTIFICATE-----
-    -----BEGIN CERTIFICATE-----
-    MIIBbjCCARigAwIBAgIMFpANvmSa0OAlYmXKMA0GCSqGSIb3DQEBCwUAMBgxFjAU
-    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwOTM2WhcNMzEwNzA3MDcw
-    OTM2WjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
-    SwAwSAJBAMF6F4aZdpe0RUpyykaBpWwZCnwbffhYGOw+fs6RdLuUq7QCNmJm/Eq7
-    WWOziMYDiI9SbclpD+6QiJ0N3EqppVUCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
-    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLImp6ARjPDAH6nhI+scWVt3Q9bn
-    MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
-    9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
-    -----END CERTIFICATE-----
-  server: https://kops-controller.internal.minimal.k8s.local:3988/
+ConfigBase: memfs://clusters.example.com/minimal.k8s.local
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: eUeXsJ9qSurrb/dNCZ9vqLZLQ5zmlKBnt8aSDjocwnA=
+NodeupConfigHash: qIzxkcq+JlMcWS91XdWMGjrM+qfLUxJRUZKMG+VyfZ8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 21c53eab91715d95b2d1330753eda0586dbc860c7e7ed75514423cdc4bad6645
+    manifestHash: 87491394e7ba274b291d93dee740e683da8fd3799ebb53233aeac37747057e16
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -18,6 +18,13 @@ spec:
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
+    version: 9.99.0
+  - id: k8s-1.8
+    manifest: rbac.addons.k8s.io/k8s-1.8.yaml
+    manifestHash: f81bd7c57bc1902ca342635d7ad7d01b82dfeaff01a1192b076e66907d87871e
+    name: rbac.addons.k8s.io
+    selector:
+      k8s-addon: rbac.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"clusterName":"minimal.k8s.local","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","secretStore":"memfs://clusters.example.com/minimal.k8s.local/secrets","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"],"useInstanceIDForNodeName":true},"discovery":{"enabled":true}}
+    {"clusterName":"minimal.k8s.local","cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","secretStore":"memfs://clusters.example.com/minimal.k8s.local/secrets","discovery":{"enabled":true}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -32,8 +32,6 @@ spec:
       k8s-app: kops-controller
   template:
     metadata:
-      annotations:
-        dns.alpha.kubernetes.io/internal: kops-controller.internal.minimal.k8s.local
       creationTimestamp: null
       labels:
         k8s-addon: kops-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-rbac.addons.k8s.io-k8s-1.8_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-rbac.addons.k8s.io-k8s-1.8_content
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: rbac.addons.k8s.io
+    addonmanager.kubernetes.io/mode: Reconcile
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: rbac.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: kubelet-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: kubelet

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-nodes_content
@@ -15,13 +15,36 @@ Assets:
   - dbb71e737eaef454a406ce21fd021bd8f1b35afb7635016745992bbd7c17a223@https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
-CAs: {}
+CAs:
+  kubernetes-ca: |
+    -----BEGIN CERTIFICATE-----
+    MIIBbjCCARigAwIBAgIMFpANqBD8NSD82AUSMA0GCSqGSIb3DQEBCwUAMBgxFjAU
+    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwODAwWhcNMzEwNzA3MDcw
+    ODAwWjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
+    SwAwSAJBANFI3zr0Tk8krsW8vwjfMpzJOlWQ8616vG3YPa2qAgI7V4oKwfV0yIg1
+    jt+H6f4P/wkPAPTPTfRp9Iy8oHEEFw0CAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
+    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFNG3zVjTcLlJwDsJ4/K9DV7KohUA
+    MA0GCSqGSIb3DQEBCwUAA0EAB8d03fY2w7WKpfO29qI295pu2C4ca9AiVGOpgSc8
+    tmQsq6rcxt3T+rb589PVtz0mw/cKTxOk6gH2CCC+yHfy2w==
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    MIIBbjCCARigAwIBAgIMFpANvmSa0OAlYmXKMA0GCSqGSIb3DQEBCwUAMBgxFjAU
+    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwOTM2WhcNMzEwNzA3MDcw
+    OTM2WjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
+    SwAwSAJBAMF6F4aZdpe0RUpyykaBpWwZCnwbffhYGOw+fs6RdLuUq7QCNmJm/Eq7
+    WWOziMYDiI9SbclpD+6QiJ0N3EqppVUCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
+    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLImp6ARjPDAH6nhI+scWVt3Q9bn
+    MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
+    9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
+    -----END CERTIFICATE-----
 ClusterName: minimal.k8s.local
 ContainerRuntime: containerd
 Hooks:
 - null
 - null
 KeypairIDs:
+  kube-proxy: "6986354184403674830529235586"
+  kubelet: "6986354184404014133128804066"
   kubernetes-ca: "6982820025135291416230495506"
 KubeProxy:
   clusterCIDR: 100.96.0.0/11

--- a/tests/integration/update_cluster/minimal_gossip_irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/kubernetes.tf
@@ -698,6 +698,14 @@ resource "aws_s3_object" "minimal-k8s-local-addons-limit-range-addons-k8s-io" {
   server_side_encryption = "AES256"
 }
 
+resource "aws_s3_object" "minimal-k8s-local-addons-rbac-addons-k8s-io-k8s-1-8" {
+  bucket                 = "testingBucket"
+  content                = file("${path.module}/data/aws_s3_object_minimal.k8s.local-addons-rbac.addons.k8s.io-k8s-1.8_content")
+  key                    = "clusters.example.com/minimal.k8s.local/addons/rbac.addons.k8s.io/k8s-1.8.yaml"
+  provider               = aws.files
+  server_side_encryption = "AES256"
+}
+
 resource "aws_s3_object" "minimal-k8s-local-addons-storage-aws-addons-k8s-io-v1-15-0" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_minimal.k8s.local-addons-storage-aws.addons.k8s.io-v1.15.0_content")


### PR DESCRIPTION
Gossip clusters need access to the state store to retrieve config, before NodeUp can run.

Closes #14899

/cc @johngmyers @olemarkus @zetaab 