### PR TITLE
Automated cherry pick of #14978: Update Go to v1.19.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
-          go-version: '1.19.4'
+          go-version: '1.19.5'
 
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
         with:
@@ -36,7 +36,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
       with:
-        go-version: '1.19.4'
+        go-version: '1.19.5'
 
     - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
       with:
@@ -53,7 +53,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
       with:
-        go-version: '1.19.4'
+        go-version: '1.19.5'
 
     - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
       with:
@@ -70,7 +70,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
-          go-version: '1.19.4'
+          go-version: '1.19.5'
 
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
         with:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
-          go-version: '1.19.4'
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+          go-version: '1.19.5'
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Update Dependencies
         id: update_deps
         run: |

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # Push the images
-- name: 'docker.io/library/golang:1.19.4-bullseye'
+- name: 'docker.io/library/golang:1.19.5-bullseye'
   id: images
   entrypoint: make
   env:
@@ -20,7 +20,7 @@ steps:
   - dns-controller-push
   - kube-apiserver-healthcheck-push
 # Push the artifacts
-- name: 'docker.io/library/golang:1.19.4-bullseye'
+- name: 'docker.io/library/golang:1.19.5-bullseye'
   id: artifacts
   entrypoint: make
   env:
@@ -35,7 +35,7 @@ steps:
   args:
   - gcs-upload-and-tag
 # Build cloudbuild artifacts (for attestation)
-- name: 'docker.io/library/golang:1.19.4-bullseye'
+- name: 'docker.io/library/golang:1.19.5-bullseye'
   id: cloudbuild-artifacts
   entrypoint: make
   env:


### PR DESCRIPTION
Cherry pick of #14978 on release-1.26.

#14978: Update Go to v1.19.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```