### PR TITLE
Automated cherry pick of #14920: Populate cluster with default values in `kops replace`

### DIFF
--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -141,7 +141,7 @@ func RunReplace(ctx context.Context, f *util.Factory, out io.Writer, c *ReplaceO
 
 						err = cloudup.PerformAssignments(v, cloud)
 						if err != nil {
-							return fmt.Errorf("error populating configuration: %v", err)
+							return fmt.Errorf("error populating configuration: %w", err)
 						}
 
 						_, err = clientset.CreateCluster(ctx, v)

--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -138,6 +138,12 @@ func RunReplace(ctx context.Context, f *util.Factory, out io.Writer, c *ReplaceO
 						if !c.Force {
 							return fmt.Errorf("cluster %v does not exist (try adding --force flag)", clusterName)
 						}
+
+						err = cloudup.PerformAssignments(v, cloud)
+						if err != nil {
+							return fmt.Errorf("error populating configuration: %v", err)
+						}
+
 						_, err = clientset.CreateCluster(ctx, v)
 						if err != nil {
 							return fmt.Errorf("error creating cluster: %v", err)


### PR DESCRIPTION
Cherry pick of #14920 on release-1.26.

#14920: Populate cluster with default values in `kops replace`

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```