### PR TITLE
Automated cherry pick of #14986: Infer the dns suffix from the cluster name for

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -292,16 +292,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 
 	// The dns suffix logic mirrors the existing logic, so we should be compatible with existing clusters
 	// (etcd makes it difficult to change peer urls, treating it as a cluster event, for reasons unknown)
-	dnsInternalSuffix := ""
-	if b.Cluster.IsGossip() {
-		// @TODO: This is hacky, but we want it so that we can have a different internal & external name
-		dnsInternalSuffix = b.Cluster.APIInternalName()
-		dnsInternalSuffix = strings.TrimPrefix(dnsInternalSuffix, "api.")
-	}
-
-	if dnsInternalSuffix == "" {
-		dnsInternalSuffix = ".internal." + b.Cluster.ObjectMeta.Name
-	}
+	dnsInternalSuffix := ".internal." + b.Cluster.Name
 
 	ports, err := PortsForCluster(etcdCluster)
 	if err != nil {

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -14,7 +14,7 @@ spec:
     - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
       --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
       --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=internal.minimal.k8s.local --grpc-port=3997 --peer-urls=https://__name__:2381
+      --dns-suffix=.internal.minimal.k8s.local --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -14,7 +14,7 @@ spec:
     - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
       --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/main
       --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=internal.minimal.k8s.local --grpc-port=3996 --peer-urls=https://__name__:2380
+      --dns-suffix=.internal.minimal.k8s.local --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -14,7 +14,7 @@ spec:
     - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
       --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
       --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-      --dns-suffix=internal.minimal.k8s.local --grpc-port=3997 --peer-urls=https://__name__:2381
+      --dns-suffix=.internal.minimal.k8s.local --grpc-port=3997 --peer-urls=https://__name__:2381
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -14,7 +14,7 @@ spec:
     - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
       --backup-store=memfs://clusters.example.com/minimal.k8s.local/backups/etcd/main
       --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-      --dns-suffix=internal.minimal.k8s.local --grpc-port=3996 --peer-urls=https://__name__:2380
+      --dns-suffix=.internal.minimal.k8s.local --grpc-port=3996 --peer-urls=https://__name__:2380
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/control-plane=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1


### PR DESCRIPTION
Cherry pick of #14986 on release-1.26.

#14986: Infer the dns suffix from the cluster name for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```