### PR TITLE
Determine default API access method by IG subnet type

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -657,7 +657,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 	}
 
 	assetBuilder := assets.NewAssetBuilder(clientset.VFSContext(), cluster.Spec.Assets, cluster.Spec.KubernetesVersion, false)
-	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, cloud, assetBuilder)
+	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, instanceGroups, cloud, assetBuilder)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -261,7 +261,7 @@ func updateCluster(ctx context.Context, clientset simple.Clientset, oldCluster, 
 	}
 
 	assetBuilder := assets.NewAssetBuilder(clientset.VFSContext(), newCluster.Spec.Assets, newCluster.Spec.KubernetesVersion, false)
-	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, newCluster, cloud, assetBuilder)
+	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, newCluster, instanceGroups, cloud, assetBuilder)
 	if err != nil {
 		return fmt.Sprintf("error populating cluster spec: %s", err), nil
 	}

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -296,7 +296,7 @@ func updateInstanceGroup(ctx context.Context, clientset simple.Clientset, channe
 	}
 
 	assetBuilder := assets.NewAssetBuilder(clientset.VFSContext(), cluster.Spec.Assets, cluster.Spec.KubernetesVersion, false)
-	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, cloud, assetBuilder)
+	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, []*api.InstanceGroup{newGroup}, cloud, assetBuilder)
 	if err != nil {
 		return fmt.Sprintf("error populating cluster spec: %s", err), nil
 	}

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -254,7 +254,7 @@ func BuildNodeupModelContext(model *testutils.Model) (*NodeupModelContext, error
 		return nil, fmt.Errorf("error from PerformAssignments: %v", err)
 	}
 
-	nodeupModelContext.Cluster, err = mockedPopulateClusterSpec(ctx, model.Cluster, cloud)
+	nodeupModelContext.Cluster, err = mockedPopulateClusterSpec(ctx, model.Cluster, model.InstanceGroups, cloud)
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error from mockedPopulateClusterSpec: %v", err)
 	}
@@ -289,7 +289,7 @@ func BuildNodeupModelContext(model *testutils.Model) (*NodeupModelContext, error
 	return nodeupModelContext, nil
 }
 
-func mockedPopulateClusterSpec(ctx context.Context, c *kops.Cluster, cloud fi.Cloud) (*kops.Cluster, error) {
+func mockedPopulateClusterSpec(ctx context.Context, c *kops.Cluster, instanceGroups []*kops.InstanceGroup, cloud fi.Cloud) (*kops.Cluster, error) {
 	vfs.Context.ResetMemfsContext(true)
 
 	assetBuilder := assets.NewAssetBuilder(vfs.Context, c.Spec.Assets, c.Spec.KubernetesVersion, false)
@@ -298,7 +298,7 @@ func mockedPopulateClusterSpec(ctx context.Context, c *kops.Cluster, cloud fi.Cl
 		return nil, fmt.Errorf("error building vfspath: %v", err)
 	}
 	clientset := vfsclientset.NewVFSClientset(vfs.Context, basePath)
-	return cloudup.PopulateClusterSpec(ctx, clientset, c, cloud, assetBuilder)
+	return cloudup.PopulateClusterSpec(ctx, clientset, c, instanceGroups, cloud, assetBuilder)
 }
 
 // Fixed cert and key, borrowed from the create_kubecfg_test.go test

--- a/pkg/apis/kops/v1alpha2/defaults.go
+++ b/pkg/apis/kops/v1alpha2/defaults.go
@@ -18,7 +18,6 @@ package v1alpha2
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -53,27 +52,6 @@ func SetDefaults_ClusterSpec(obj *ClusterSpec) {
 	if obj.LegacyCloudProvider != "openstack" {
 		if obj.LegacyAPI == nil {
 			obj.LegacyAPI = &APISpec{}
-		}
-
-		if obj.LegacyAPI.IsEmpty() {
-			switch obj.Topology.ControlPlane {
-			case TopologyPublic:
-				obj.LegacyAPI.DNS = &DNSAccessSpec{}
-
-			case TopologyPrivate:
-				obj.LegacyAPI.LoadBalancer = &LoadBalancerAccessSpec{}
-
-			default:
-				klog.Infof("unknown master topology type: %q", obj.Topology.ControlPlane)
-			}
-		}
-
-		if obj.LegacyAPI.LoadBalancer != nil && obj.LegacyAPI.LoadBalancer.Type == "" {
-			obj.LegacyAPI.LoadBalancer.Type = LoadBalancerTypePublic
-		}
-
-		if obj.LegacyAPI.LoadBalancer != nil && obj.LegacyAPI.LoadBalancer.Class == "" && obj.LegacyCloudProvider == "aws" {
-			obj.LegacyAPI.LoadBalancer.Class = LoadBalancerClassClassic
 		}
 	}
 

--- a/pkg/apis/kops/v1alpha3/defaults.go
+++ b/pkg/apis/kops/v1alpha3/defaults.go
@@ -18,7 +18,6 @@ package v1alpha3
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -44,30 +43,6 @@ func SetDefaults_ClusterSpec(obj *ClusterSpec) {
 
 	if obj.Networking.Topology.DNS == "" {
 		obj.Networking.Topology.DNS = DNSTypePublic
-	}
-
-	if obj.CloudProvider.Openstack == nil {
-		if obj.API.DNS == nil && obj.API.LoadBalancer == nil {
-			switch obj.Networking.Topology.ControlPlane {
-			case TopologyPublic:
-				obj.API.DNS = &DNSAccessSpec{}
-
-			case TopologyPrivate:
-				obj.API.LoadBalancer = &LoadBalancerAccessSpec{}
-
-			default:
-				klog.Infof("unknown controlPlane topology type: %q", obj.Networking.Topology.ControlPlane)
-			}
-		}
-
-		if obj.API.LoadBalancer != nil && obj.API.LoadBalancer.Type == "" {
-			obj.API.LoadBalancer.Type = LoadBalancerTypePublic
-		}
-
-	}
-
-	if obj.API.LoadBalancer != nil && obj.API.LoadBalancer.Class == "" && obj.CloudProvider.AWS != nil {
-		obj.API.LoadBalancer.Class = LoadBalancerClassClassic
 	}
 
 	if obj.Authorization == nil {

--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -32,13 +32,15 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 )
 
-func awsValidateCluster(c *kops.Cluster) field.ErrorList {
+func awsValidateCluster(c *kops.Cluster, strict bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if c.Spec.API.LoadBalancer != nil {
 		lbPath := field.NewPath("spec", "api", "loadBalancer")
 		lbSpec := c.Spec.API.LoadBalancer
-		allErrs = append(allErrs, IsValidValue(lbPath.Child("class"), &lbSpec.Class, kops.SupportedLoadBalancerClasses)...)
+		if strict || lbSpec.Class != "" {
+			allErrs = append(allErrs, IsValidValue(lbPath.Child("class"), &lbSpec.Class, kops.SupportedLoadBalancerClasses)...)
+		}
 		allErrs = append(allErrs, awsValidateTopologyDNS(lbPath.Child("type"), c)...)
 		allErrs = append(allErrs, awsValidateSecurityGroupOverride(lbPath.Child("securityGroupOverride"), lbSpec)...)
 		allErrs = append(allErrs, awsValidateAdditionalSecurityGroups(lbPath.Child("additionalSecurityGroups"), lbSpec.AdditionalSecurityGroups)...)

--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -600,7 +600,7 @@ func TestLoadBalancerSubnets(t *testing.T) {
 			})
 		}
 		cluster.Spec.API.LoadBalancer.Subnets = test.lbSubnets
-		errs := awsValidateCluster(&cluster)
+		errs := awsValidateCluster(&cluster, true)
 		testErrors(t, test, errs, test.expected)
 	}
 }
@@ -670,7 +670,7 @@ func TestAWSAuthentication(t *testing.T) {
 				},
 			},
 		}
-		errs := awsValidateCluster(&cluster)
+		errs := awsValidateCluster(&cluster, true)
 		testErrors(t, test, errs, test.expected)
 	}
 }

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -68,7 +68,7 @@ func newValidateCluster(cluster *kops.Cluster, strict bool) field.ErrorList {
 	// Additional cloud-specific validation rules
 	switch cluster.Spec.GetCloudProvider() {
 	case kops.CloudProviderAWS:
-		allErrs = append(allErrs, awsValidateCluster(cluster)...)
+		allErrs = append(allErrs, awsValidateCluster(cluster, strict)...)
 	case kops.CloudProviderGCE:
 		allErrs = append(allErrs, gceValidateCluster(cluster)...)
 	}

--- a/pkg/commands/helpers_readwrite.go
+++ b/pkg/commands/helpers_readwrite.go
@@ -41,7 +41,7 @@ func UpdateCluster(ctx context.Context, clientset simple.Clientset, cluster *kop
 	}
 
 	assetBuilder := assets.NewAssetBuilder(clientset.VFSContext(), cluster.Spec.Assets, cluster.Spec.KubernetesVersion, false)
-	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, cloud, assetBuilder)
+	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, instanceGroups, cloud, assetBuilder)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func UpdateInstanceGroup(ctx context.Context, clientset simple.Clientset, cluste
 	}
 
 	assetBuilder := assets.NewAssetBuilder(clientset.VFSContext(), cluster.Spec.Assets, cluster.Spec.KubernetesVersion, false)
-	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, cloud, assetBuilder)
+	fullCluster, err := cloudup.PopulateClusterSpec(ctx, clientset, cluster, allInstanceGroups, cloud, assetBuilder)
 	if err != nil {
 		return err
 	}

--- a/pkg/instancegroups/rollingupdate_os_test.go
+++ b/pkg/instancegroups/rollingupdate_os_test.go
@@ -61,7 +61,7 @@ func getTestSetupOS(t *testing.T, ctx context.Context) (*RollingUpdateCluster, *
 	assetBuilder := assets.NewAssetBuilder(vfs.Context, inCluster.Spec.Assets, inCluster.Spec.KubernetesVersion, false)
 	basePath, _ := vfs.Context.BuildVfsPath(inCluster.Spec.ConfigBase)
 	clientset := vfsclientset.NewVFSClientset(vfs.Context, basePath)
-	cluster, err := cloudup.PopulateClusterSpec(ctx, clientset, inCluster, mockcloud, assetBuilder)
+	cluster, err := cloudup.PopulateClusterSpec(ctx, clientset, inCluster, nil, mockcloud, assetBuilder)
 	if err != nil {
 		t.Fatalf("Failed to populate cluster spec: %v", err)
 	}

--- a/pkg/model/components/kubescheduler/tests/kubeschedulerconfig/completed-cluster.yaml
+++ b/pkg/model/components/kubescheduler/tests/kubeschedulerconfig/completed-cluster.yaml
@@ -2,8 +2,7 @@ metadata:
   creationTimestamp: null
   name: minimal.example.com
 spec:
-  api:
-    dns: {}
+  api: {}
   authorization:
     alwaysAllow: {}
   cloudProvider: {}

--- a/pkg/model/components/kubescheduler/tests/minimal/completed-cluster.yaml
+++ b/pkg/model/components/kubescheduler/tests/minimal/completed-cluster.yaml
@@ -2,8 +2,7 @@ metadata:
   creationTimestamp: null
   name: minimal.example.com
 spec:
-  api:
-    dns: {}
+  api: {}
   authorization:
     alwaysAllow: {}
   cloudProvider: {}

--- a/pkg/model/components/kubescheduler/tests/mixing/completed-cluster.yaml
+++ b/pkg/model/components/kubescheduler/tests/mixing/completed-cluster.yaml
@@ -2,8 +2,7 @@ metadata:
   creationTimestamp: null
   name: minimal.example.com
 spec:
-  api:
-    dns: {}
+  api: {}
   authorization:
     alwaysAllow: {}
   cloudProvider: {}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -815,7 +815,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 
 // upgradeSpecs ensures that fields are fully populated / defaulted
 func (c *ApplyClusterCmd) upgradeSpecs(ctx context.Context, assetBuilder *assets.AssetBuilder) error {
-	fullCluster, err := PopulateClusterSpec(ctx, c.Clientset, c.Cluster, c.Cloud, assetBuilder)
+	fullCluster, err := PopulateClusterSpec(ctx, c.Clientset, c.Cluster, c.InstanceGroups, c.Cloud, assetBuilder)
 	if err != nil {
 		return err
 	}

--- a/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
@@ -116,7 +116,7 @@ func mockedPopulateClusterSpec(ctx context.Context, c *kopsapi.Cluster, cloud fi
 		return nil, fmt.Errorf("error building vfspath: %v", err)
 	}
 	clientset := vfsclientset.NewVFSClientset(vfs.Context, basePath)
-	return PopulateClusterSpec(ctx, clientset, c, cloud, assetBuilder)
+	return PopulateClusterSpec(ctx, clientset, c, nil, cloud, assetBuilder)
 }
 
 func TestPopulateCluster_Docker_Spec(t *testing.T) {


### PR DESCRIPTION
I believe this is the last substantive reference to the control-plane and node topology field in the cluster spec.