### PR TITLE
update OpenStack node identifier to use Identifier

### DIFF
--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -204,7 +204,7 @@ func addNodeController(mgr manager.Manager, opt *config.Options) error {
 		}
 
 	case "openstack":
-		legacyIdentifier, err = nodeidentityos.New()
+		identifier, err = nodeidentityos.New(opt.CacheNodeidentityInfo)
 		if err != nil {
 			return fmt.Errorf("error building identifier: %v", err)
 		}


### PR DESCRIPTION
The old solution did use LegacyIdentifier. The only difference is that with LegacyIdentifier the kOps for OpenStack added also `node-role.kubernetes.io/node: ""` to control plane. However, I think that is not correct so I think this new model is better.
