### PR TITLE
OpenStack: add request address check for node bootstrap

### DIFF
--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -133,7 +134,8 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	id, err := s.verifier.VerifyToken(ctx, r.Header.Get("Authorization"), body, s.opt.Server.UseInstanceIDForNodeName)
+	remoteAddress := strings.Split(r.RemoteAddr, ":")[0]
+	id, err := s.verifier.VerifyToken(ctx, r.Header.Get("Authorization"), remoteAddress, body, s.opt.Server.UseInstanceIDForNodeName)
 	if err != nil {
 		klog.Infof("bootstrap %s verify err: %v", r.RemoteAddr, err)
 		w.WriteHeader(http.StatusForbidden)

--- a/pkg/bootstrap/authenticate.go
+++ b/pkg/bootstrap/authenticate.go
@@ -39,5 +39,5 @@ type VerifyResult struct {
 
 // Verifier verifies authentication credentials for requests.
 type Verifier interface {
-	VerifyToken(ctx context.Context, token string, body []byte, useInstanceIDForNodeName bool) (*VerifyResult, error)
+	VerifyToken(ctx context.Context, token string, remoteAddr string, body []byte, useInstanceIDForNodeName bool) (*VerifyResult, error)
 }

--- a/upup/pkg/fi/cloudup/awsup/aws_verifier.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_verifier.go
@@ -120,7 +120,7 @@ type ResponseMetadata struct {
 	RequestId string `xml:"RequestId"`
 }
 
-func (a awsVerifier) VerifyToken(ctx context.Context, token string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
+func (a awsVerifier) VerifyToken(ctx context.Context, token string, remoteAddr string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
 	if !strings.HasPrefix(token, AWSAuthenticationTokenPrefix) {
 		return nil, fmt.Errorf("incorrect authorization type")
 	}

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
@@ -64,7 +64,7 @@ func NewTPMVerifier(opt *gcetpm.TPMVerifierOptions) (bootstrap.Verifier, error) 
 
 var _ bootstrap.Verifier = &tpmVerifier{}
 
-func (v *tpmVerifier) VerifyToken(ctx context.Context, authToken string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
+func (v *tpmVerifier) VerifyToken(ctx context.Context, authToken string, remoteAddr string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
 	// Reminder: we shouldn't trust any data we get from the client until we've checked the signature (and even then...)
 	// Thankfully the GCE SDK does seem to escape the parameters correctly, for example.
 

--- a/upup/pkg/fi/cloudup/hetzner/verifier.go
+++ b/upup/pkg/fi/cloudup/hetzner/verifier.go
@@ -54,7 +54,7 @@ func NewHetznerVerifier(opt *HetznerVerifierOptions) (bootstrap.Verifier, error)
 	}, nil
 }
 
-func (h hetznerVerifier) VerifyToken(ctx context.Context, token string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
+func (h hetznerVerifier) VerifyToken(ctx context.Context, token string, remoteAddr string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
 	if !strings.HasPrefix(token, HetznerAuthenticationTokenPrefix) {
 		return nil, fmt.Errorf("incorrect authorization type")
 	}

--- a/upup/pkg/fi/cloudup/openstack/verifier.go
+++ b/upup/pkg/fi/cloudup/openstack/verifier.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	gos "github.com/gophercloud/gophercloud/openstack"
@@ -114,6 +115,12 @@ func (o openstackVerifier) VerifyToken(ctx context.Context, token string, remote
 	}
 	if !allowed {
 		return nil, fmt.Errorf("request is not coming from trusted sources %v (request: %s)", addrs, remoteAddr)
+	}
+
+	now := time.Now()
+	diff := now.Sub(instance.Created)
+	if diff > 30*time.Minute || diff < 0 {
+		return nil, fmt.Errorf("instance created time diff is %s, denying request", diff)
 	}
 
 	result := &bootstrap.VerifyResult{

--- a/upup/pkg/fi/cloudup/openstack/verifier.go
+++ b/upup/pkg/fi/cloudup/openstack/verifier.go
@@ -80,7 +80,7 @@ func NewOpenstackVerifier(opt *OpenStackVerifierOptions) (bootstrap.Verifier, er
 	}, nil
 }
 
-func (o openstackVerifier) VerifyToken(ctx context.Context, token string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
+func (o openstackVerifier) VerifyToken(ctx context.Context, token string, remoteAddr string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
 	if !strings.HasPrefix(token, OpenstackAuthenticationTokenPrefix) {
 		return nil, fmt.Errorf("incorrect authorization type")
 	}
@@ -103,6 +103,17 @@ func (o openstackVerifier) VerifyToken(ctx context.Context, token string, body [
 		for _, props := range addrList {
 			addrs = append(addrs, props.Addr)
 		}
+	}
+
+	allowed := false
+	for _, addr := range addrs {
+		if addr == remoteAddr {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return nil, fmt.Errorf("request is not coming from trusted sources %v (request: %s)", addrs, remoteAddr)
 	}
 
 	result := &bootstrap.VerifyResult{


### PR DESCRIPTION
still this is not perfect. In order to use something like hmac, we need somehow share the secret with worker nodes. The current situation is that there are no secrets in user_data or no credentials to state store. I would not like to add any secrets to user_data when its now cleaned.