### PR TITLE
Automated cherry pick of #15002: Run kops-controller server on non-leaders as well

### DIFF
--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kops/pkg/rbac"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/util/pkg/vfs"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 type Server struct {
@@ -52,6 +53,8 @@ type Server struct {
 	// configBase is the base of the configuration storage.
 	configBase vfs.Path
 }
+
+var _ manager.LeaderElectionRunnable = &Server{}
 
 func NewServer(opt *config.Options, verifier bootstrap.Verifier) (*Server, error) {
 	server := &http.Server{
@@ -80,6 +83,10 @@ func NewServer(opt *config.Options, verifier bootstrap.Verifier) (*Server, error
 	server.Handler = recovery(r)
 
 	return s, nil
+}
+
+func (s *Server) NeedLeaderElection() bool {
+	return false
 }
 
 func (s *Server) Start(ctx context.Context) error {


### PR DESCRIPTION
Cherry pick of #15002 on release-1.25.

#15002: Run kops-controller server on non-leaders as well

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.