### PR TITLE
Automated cherry pick of #15011: Upgrade AWS CCM to 1.25.2

### DIFF
--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -98,7 +98,7 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 		case 24:
 			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.1"
 		case 25:
-			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1"
+			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2"
 		default:
 			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.1"
 		}

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -19,7 +19,7 @@ spec:
     clusterCIDR: 100.64.0.0/10
     clusterName: minimal.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -48,7 +48,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-cloud-controller-manager.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 6a2b03cd482dfa68746e47da84351d9a7eae47adb1065cbe760226e0b9cb85ec
+    manifestHash: 2326c10b03f2a4b948680a69a942a0844db450319d13129c686b45e568ef0718
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterCIDR: 172.20.0.0/16
     clusterName: minimal.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -48,7 +48,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-cloud-controller-manager.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -127,7 +127,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b3336332893e85ed9c29fd02bc28446db6b55a6bca357a65d9b92c9a5af6f6ed
+    manifestHash: 42617bbcaaabb9f1b8f2e2a8f86b1f61ca63b8db923648b206ecf9e7335bf18d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
@@ -19,7 +19,7 @@ spec:
     clusterCIDR: 100.64.0.0/10
     clusterName: minimal.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -44,7 +44,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9c927fe5e4236bc4629228dfbd71848cc838edc24e675b3edd5792c309a7c3fb
+    manifestHash: bab8bf6ae91d0cee974aea7b36db08fdac51903dbac82083ecf5ac2d5ad90e53
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterCIDR: ::/0
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -44,7 +44,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -104,7 +104,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 4b59263d0ef1e096598f5b1bc6691a8805f998763d1be9ed0c2cd4759ee487de
+    manifestHash: 16c3e5fddd92e01433a979f3bf06de1923d67cdd0671e30c77bcc1171d0aed13
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
     clusterCIDR: 100.64.0.0/10
     clusterName: privatecalico.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -44,7 +44,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -104,7 +104,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: dd0e385882ba62cde842cfd85e681ccbe2a2f6356f9807901af229bd154708d1
+    manifestHash: f7b7c31f432926c9292c4df120f9168a23b6219b2674a90c01514ca1cd640a2a
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
     clusterCIDR: 100.64.0.0/10
     clusterName: privatecanal.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -44,7 +44,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -104,7 +104,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b896f7a2afd6dc74133fb0a82edbcec2ac1caca1b4d07d2ef732d027dfaddc0e
+    manifestHash: 7d42abab021f1c1330efa0889932fa8f15199fdd8fb4ed9c2ff577866307e37d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
     clusterCIDR: 100.64.0.0/10
     clusterName: privateflannel.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -44,7 +44,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.2
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -100,7 +100,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e4ec807c43b03174207c88173ba01293fd2d2884c51612a1adefd3f8b2a7580b
+    manifestHash: d49792a637967ce6f24eb0858190f40f98f19f2fd8e2322282eaa5001c694916
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #15011 on release-1.25.

#15011: Upgrade AWS CCM to 1.25.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.