### PR TITLE
Automated cherry pick of #15006: update OpenStack node identifier to use Identifier instead of

### DIFF
--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -204,7 +204,7 @@ func addNodeController(mgr manager.Manager, opt *config.Options) error {
 		}
 
 	case "openstack":
-		legacyIdentifier, err = nodeidentityos.New()
+		identifier, err = nodeidentityos.New(opt.CacheNodeidentityInfo)
 		if err != nil {
 			return fmt.Errorf("error building identifier: %v", err)
 		}


### PR DESCRIPTION
Cherry pick of #15006 on release-1.26.

#15006: update OpenStack node identifier to use Identifier instead of

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```