### PR TITLE
Automated cherry pick of #15020: Upgrade Node Termination Handler to 1.18.3

### DIFF
--- a/pkg/model/components/nodeterminationhandler.go
+++ b/pkg/model/components/nodeterminationhandler.go
@@ -75,7 +75,7 @@ func (b *NodeTerminationHandlerOptionsBuilder) BuildOptions(o interface{}) error
 	}
 
 	if nth.Version == nil {
-		nth.Version = fi.PtrTo("v1.18.1")
+		nth.Version = fi.PtrTo("v1.18.3")
 	}
 
 	return nil

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -220,7 +220,7 @@ spec:
     managedASGTag: aws-node-termination-handler/managed
     memoryRequest: 64Mi
     prometheusEnable: false
-    version: v1.18.1
+    version: v1.18.3
   nonMasqueradeCIDR: 172.20.0.0/16
   podCIDR: 172.20.128.0/17
   secretStore: memfs://clusters.example.com/minimal.example.com/secrets

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 76165f5029c21038f9470db4def5a1aeef4cf378ef88693c353c941ddf0f6f84
+    manifestHash: 1b132f49c96bf816e705f8cf95b9ed108777dd67118684c656c56576d60a9ebe
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 rules:
@@ -84,7 +84,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 roleRef:
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -199,7 +199,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-node-termination-handler.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.1
+        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
@@ -224,7 +224,7 @@ spec:
     managedASGTag: aws-node-termination-handler/managed
     memoryRequest: 64Mi
     prometheusEnable: false
-    version: v1.18.1
+    version: v1.18.3
   nonMasqueradeCIDR: 172.20.0.0/16
   podCIDR: 172.20.128.0/17
   secretStore: memfs://clusters.example.com/minimal.example.com/secrets

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: c2bf3ef23db2c89345ffbd50db5a0b02610eb224346a27b091cb4e1220ff89cb
+    manifestHash: 7035f67688131cea8befafa5b345137fd67adb4ea8d722b3cd5672e6d3540375
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 rules:
@@ -84,7 +84,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 roleRef:
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -199,7 +199,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-node-termination-handler.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.1
+        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
@@ -223,7 +223,7 @@ spec:
     managedASGTag: aws-node-termination-handler/managed
     memoryRequest: 64Mi
     prometheusEnable: false
-    version: v1.18.1
+    version: v1.18.3
   nonMasqueradeCIDR: 172.20.0.0/16
   podCIDR: 172.20.128.0/17
   secretStore: memfs://clusters.example.com/minimal.example.com/secrets

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: c2bf3ef23db2c89345ffbd50db5a0b02610eb224346a27b091cb4e1220ff89cb
+    manifestHash: 7035f67688131cea8befafa5b345137fd67adb4ea8d722b3cd5672e6d3540375
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 rules:
@@ -84,7 +84,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 roleRef:
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -199,7 +199,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-node-termination-handler.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.1
+        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
@@ -222,7 +222,7 @@ spec:
     managedASGTag: aws-node-termination-handler/managed
     memoryRequest: 64Mi
     prometheusEnable: false
-    version: v1.18.1
+    version: v1.18.3
   nonMasqueradeCIDR: 172.20.0.0/16
   podCIDR: 172.20.128.0/17
   secretStore: memfs://clusters.example.com/minimal.example.com/secrets

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: c2bf3ef23db2c89345ffbd50db5a0b02610eb224346a27b091cb4e1220ff89cb
+    manifestHash: 7035f67688131cea8befafa5b345137fd67adb4ea8d722b3cd5672e6d3540375
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 rules:
@@ -84,7 +84,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 roleRef:
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -199,7 +199,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-node-termination-handler.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.1
+        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
@@ -224,7 +224,7 @@ spec:
     managedASGTag: aws-node-termination-handler/managed
     memoryRequest: 64Mi
     prometheusEnable: false
-    version: v1.18.1
+    version: v1.18.3
   nonMasqueradeCIDR: 172.20.0.0/16
   podCIDR: 172.20.128.0/17
   secretStore: memfs://clusters.example.com/minimal.example.com/secrets

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -120,7 +120,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: c2bf3ef23db2c89345ffbd50db5a0b02610eb224346a27b091cb4e1220ff89cb
+    manifestHash: 7035f67688131cea8befafa5b345137fd67adb4ea8d722b3cd5672e6d3540375
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 rules:
@@ -84,7 +84,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 roleRef:
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -199,7 +199,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-node-termination-handler.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.1
+        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -219,7 +219,7 @@ spec:
     managedASGTag: aws-node-termination-handler/managed
     memoryRequest: 64Mi
     prometheusEnable: false
-    version: v1.18.1
+    version: v1.18.3
   nonMasqueradeCIDR: 172.20.0.0/16
   podCIDR: 172.20.128.0/17
   secretStore: memfs://clusters.example.com/minimal.example.com/secrets

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 8680e60478dc97128d24a22cfcdbafd280b0c32f59e5d9d59d3c688a7202d612
+    manifestHash: cd35da7c3cd5571ff5ce3cee8c363a917699f770c1f58f67b4623e0c84a793a7
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 rules:
@@ -84,7 +84,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 roleRef:
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -205,7 +205,7 @@ spec:
           value: https://sqs.us-test-1.amazonaws.com/123456789012/minimal-example-com-nth
         - name: WORKERS
           value: "10"
-        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.1
+        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -212,7 +212,7 @@ spec:
     managedASGTag: aws-node-termination-handler/managed
     memoryRequest: 64Mi
     prometheusEnable: false
-    version: v1.18.1
+    version: v1.18.3
   nonMasqueradeCIDR: 172.20.0.0/16
   podCIDR: 172.20.128.0/17
   secretStore: memfs://clusters.example.com/minimal.example.com/secrets

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -112,7 +112,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 8680e60478dc97128d24a22cfcdbafd280b0c32f59e5d9d59d3c688a7202d612
+    manifestHash: cd35da7c3cd5571ff5ce3cee8c363a917699f770c1f58f67b4623e0c84a793a7
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 rules:
@@ -84,7 +84,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 roleRef:
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -205,7 +205,7 @@ spec:
           value: https://sqs.us-test-1.amazonaws.com/123456789012/minimal-example-com-nth
         - name: WORKERS
           value: "10"
-        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.1
+        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -176,7 +176,7 @@ spec:
     managedASGTag: aws-node-termination-handler/managed
     memoryRequest: 64Mi
     prometheusEnable: false
-    version: v1.18.1
+    version: v1.18.3
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/secrets

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 784285158b562b0c7c8a13808d902237a524406122f9d76b92fe036f8c0f9f2a
+    manifestHash: 6e3384fa64e8d2e1180f3dfa8eff20b059d42fab79bd4aadf6f449ac573550e8
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 rules:
@@ -84,7 +84,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 roleRef:
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -206,7 +206,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-node-termination-handler.kube-system.sa.nthimdsproces-vt9566
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.1
+        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.3
         imagePullPolicy: IfNotPresent
         name: aws-node-termination-handler
         resources:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
@@ -175,7 +175,7 @@ spec:
     managedASGTag: aws-node-termination-handler/managed
     memoryRequest: 64Mi
     prometheusEnable: false
-    version: v1.18.1
+    version: v1.18.3
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/secrets

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: cc014009342e2acbb68675a1c9f3b2a21ba0468b929eb8f6c02b7a8c39e38b60
+    manifestHash: 8255a20f3b6faaad25ff1c6936dcf6da74d6638925db6c0b4e24e7b6f8091588
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 rules:
@@ -84,7 +84,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
   name: aws-node-termination-handler
 roleRef:
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.3
     k8s-addon: node-termination-handler.aws
     k8s-app: aws-node-termination-handler
   name: aws-node-termination-handler
@@ -202,7 +202,7 @@ spec:
           value: "false"
         - name: UPTIME_FROM_FILE
           value: /proc/uptime
-        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.1
+        image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.18.3
         imagePullPolicy: IfNotPresent
         name: aws-node-termination-handler
         resources:

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -1,6 +1,6 @@
 {{ with .CloudProvider.AWS.NodeTerminationHandler }}
-# Sourced from https://github.com/aws/aws-node-termination-handler/releases/download/v1.18.1/all-resources.yaml
-# and https://github.com/aws/aws-node-termination-handler/releases/download/v1.18.1/all-resources-queue-processor.yaml
+# Sourced from https://github.com/aws/aws-node-termination-handler/releases/download/v1.18.3/all-resources.yaml
+# and https://github.com/aws/aws-node-termination-handler/releases/download/v1.18.3/all-resources-queue-processor.yaml
 ---
 # Source: aws-node-termination-handler/templates/serviceaccount.yaml
 apiVersion: v1
@@ -299,7 +299,6 @@ spec:
         app.kubernetes.io/component: daemonset
         kubernetes.io/os: linux
         k8s-app: aws-node-termination-handler
-        kubernetes.io/os: linux
     spec:
       serviceAccountName: aws-node-termination-handler
       securityContext:


### PR DESCRIPTION
Cherry pick of #15020 on release-1.26.

#15020: Upgrade Node Termination Handler to 1.18.3

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.