### PR TITLE
Set the nonMasqueradeCIDR for GCE networking

### DIFF
--- a/upup/pkg/fi/cloudup/defaults.go
+++ b/upup/pkg/fi/cloudup/defaults.go
@@ -107,11 +107,7 @@ func PerformAssignments(c *kops.Cluster, cloud fi.Cloud) error {
 	}
 
 	if c.Spec.Networking.NonMasqueradeCIDR == "" {
-		if c.Spec.Networking.GCE != nil {
-			// Don't set NonMasqueradeCIDR
-		} else {
-			c.Spec.Networking.NonMasqueradeCIDR = "100.64.0.0/10"
-		}
+		c.Spec.Networking.NonMasqueradeCIDR = "100.64.0.0/10"
 	}
 
 	// TODO: Unclear this should be here - it isn't too hard to change

--- a/upup/pkg/fi/cloudup/gce/network.go
+++ b/upup/pkg/fi/cloudup/gce/network.go
@@ -183,6 +183,16 @@ func performNetworkAssignmentsIPAliases(ctx context.Context, c *kops.Cluster, cl
 	c.Spec.Networking.PodCIDR = podCIDR.String()
 	c.Spec.Networking.ServiceClusterIPRange = serviceCIDR.String()
 
+	// NonMasqueradeCIDR should include all the pods and any hosts which can route to the pod IP.
+	// Here, that is any IP on the network.
+	// Networks on GCE don't have a well-defined CIDR (instead, subnets do).
+	// We use networkCIDR instead; these IPs are routable on the GCE network.
+	// Technically this means that the service CIDR would be subject to masquerade,
+	// but that traffic is already remapped before it reaches the masquerade rule.
+	// Ideally we would support all the ip ranges in use (all the private IP ranges),
+	// but as long as we cover the pod CIDR we should be OK.
+	c.Spec.Networking.NonMasqueradeCIDR = networkCIDR
+
 	return nil
 }
 


### PR DESCRIPTION
We do need a non-masquerade CIDR, and we can use the range we draw the pod CIDRs from (10.0.0.0/8).

