### PR TITLE
Automated cherry pick of #15024: make openstack kops-controller boostrap auth better

### DIFF
--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -140,7 +140,7 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	id, err := s.verifier.VerifyToken(ctx, r.Header.Get("Authorization"), body, s.opt.Server.UseInstanceIDForNodeName)
+	id, err := s.verifier.VerifyToken(ctx, r, r.Header.Get("Authorization"), body, s.opt.Server.UseInstanceIDForNodeName)
 	if err != nil {
 		klog.Infof("bootstrap %s verify err: %v", r.RemoteAddr, err)
 		w.WriteHeader(http.StatusForbidden)

--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -163,6 +163,7 @@ func (i *Installation) buildSystemdJob() *nodetasks.InstallService {
 	manifest := &systemd.Manifest{}
 	manifest.Set("Unit", "Description", "Run kOps bootstrap (nodeup)")
 	manifest.Set("Unit", "Documentation", "https://github.com/kubernetes/kops")
+	manifest.Set("Unit", "ConditionPathExists", "!/srv/kubernetes/kubelet-server.crt")
 
 	manifest.Set("Service", "EnvironmentFile", "/etc/sysconfig/kops-configuration")
 	manifest.Set("Service", "EnvironmentFile", "/etc/environment")

--- a/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
+++ b/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
@@ -8,6 +8,7 @@ definition: |
   [Unit]
   Description=Run kOps bootstrap (nodeup)
   Documentation=https://github.com/kubernetes/kops
+  ConditionPathExists=!/srv/kubernetes/kubelet-server.crt
 
   [Service]
   EnvironmentFile=/etc/sysconfig/kops-configuration

--- a/pkg/bootstrap/authenticate.go
+++ b/pkg/bootstrap/authenticate.go
@@ -18,6 +18,7 @@ package bootstrap
 
 import (
 	"context"
+	"net/http"
 )
 
 // Authenticator generates authentication credentials for requests.
@@ -39,5 +40,5 @@ type VerifyResult struct {
 
 // Verifier verifies authentication credentials for requests.
 type Verifier interface {
-	VerifyToken(ctx context.Context, token string, body []byte, useInstanceIDForNodeName bool) (*VerifyResult, error)
+	VerifyToken(ctx context.Context, rawRequest *http.Request, token string, body []byte, useInstanceIDForNodeName bool) (*VerifyResult, error)
 }

--- a/upup/pkg/fi/cloudup/awsup/aws_verifier.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_verifier.go
@@ -120,7 +120,7 @@ type ResponseMetadata struct {
 	RequestId string `xml:"RequestId"`
 }
 
-func (a awsVerifier) VerifyToken(ctx context.Context, token string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
+func (a awsVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request, token string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
 	if !strings.HasPrefix(token, AWSAuthenticationTokenPrefix) {
 		return nil, fmt.Errorf("incorrect authorization type")
 	}

--- a/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
+++ b/upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier/tpmverifier.go
@@ -64,7 +64,7 @@ func NewTPMVerifier(opt *gcetpm.TPMVerifierOptions) (bootstrap.Verifier, error) 
 
 var _ bootstrap.Verifier = &tpmVerifier{}
 
-func (v *tpmVerifier) VerifyToken(ctx context.Context, authToken string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
+func (v *tpmVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request, authToken string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
 	// Reminder: we shouldn't trust any data we get from the client until we've checked the signature (and even then...)
 	// Thankfully the GCE SDK does seem to escape the parameters correctly, for example.
 

--- a/upup/pkg/fi/cloudup/hetzner/verifier.go
+++ b/upup/pkg/fi/cloudup/hetzner/verifier.go
@@ -19,6 +19,7 @@ package hetzner
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -54,7 +55,7 @@ func NewHetznerVerifier(opt *HetznerVerifierOptions) (bootstrap.Verifier, error)
 	}, nil
 }
 
-func (h hetznerVerifier) VerifyToken(ctx context.Context, token string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
+func (h hetznerVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request, token string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
 	if !strings.HasPrefix(token, HetznerAuthenticationTokenPrefix) {
 		return nil, fmt.Errorf("incorrect authorization type")
 	}


### PR DESCRIPTION
Cherry pick of #15024 on release-1.26.

#15024: make openstack kops-controller boostrap auth better

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```