### PR TITLE
Always disable the reboot manager for Flatcar

### DIFF
--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -63,6 +63,8 @@ error is encountered while updating an InstanceGroup.
 
 * The experimental support for using Vault as a state store has been removed.
 
+* Support for automated reboots with Flatcar has been removed. Use [FLUO](https://github.com/flatcar/flatcar-linux-update-operator/) instead, to gracefully reboot nodes.
+
 * The "external" networking option is not supported for Kubernetes 1.26 or later. For "bring your own"
 CNIs, use the "cni" networking option instead.
 

--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -161,7 +161,6 @@ func (i *Installation) buildSystemdJob() *nodetasks.InstallService {
 	manifest := &systemd.Manifest{}
 	manifest.Set("Unit", "Description", "Run kOps bootstrap (nodeup)")
 	manifest.Set("Unit", "Documentation", "https://github.com/kubernetes/kops")
-	manifest.Set("Unit", "ConditionPathExists", "!/srv/kubernetes/kubelet-server.crt")
 
 	manifest.Set("Service", "EnvironmentFile", "/etc/sysconfig/kops-configuration")
 	manifest.Set("Service", "EnvironmentFile", "/etc/environment")

--- a/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
+++ b/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
@@ -8,7 +8,6 @@ definition: |
   [Unit]
   Description=Run kOps bootstrap (nodeup)
   Documentation=https://github.com/kubernetes/kops
-  ConditionPathExists=!/srv/kubernetes/kubelet-server.crt
 
   [Service]
   EnvironmentFile=/etc/sysconfig/kops-configuration

--- a/nodeup/pkg/model/update_service.go
+++ b/nodeup/pkg/model/update_service.go
@@ -50,11 +50,6 @@ func (b *UpdateServiceBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 }
 
 func (b *UpdateServiceBuilder) buildFlatcarSystemdService(c *fi.NodeupModelBuilderContext) {
-	if b.NodeupConfig.UpdatePolicy != kops.UpdatePolicyExternal {
-		klog.Infof("UpdatePolicy requests automatic updates; skipping creation of systemd unit %q", flatcarServiceName)
-		return
-	}
-
 	for _, spec := range b.NodeupConfig.Hooks {
 		for _, hook := range spec {
 			if hook.Name == flatcarServiceName || hook.Name == flatcarServiceName+".service" {


### PR DESCRIPTION
https://flatcar-linux.org/docs/latest/setup/releases/update-strategies/
> For Kubernetes the recommended reboot manager is [FLUO](https://github.com/flatcar/flatcar-linux-update-operator/) which replaces locksmithd because it knows how to gracefully reboot a Kubernetes node. The [kured](https://github.com/weaveworks/kured) reboot manager will be supported as well starting from Flatcar versions with a release number greater than 3067.0.0.