### PR TITLE
Automated cherry pick of #15054: Always disable the reboot manager for Flatcar

### DIFF
--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -55,6 +55,8 @@ error is encountered while updating an InstanceGroup.
 
 * The experimental support for using Vault as a state store has been removed.
 
+* Support for automated reboots with Flatcar has been removed. Use [FLUO](https://github.com/flatcar/flatcar-linux-update-operator/) instead, to gracefully reboot nodes.
+
 * The "external" networking option is not supported for Kubernetes 1.26 or later. For "bring your own"
 CNIs, use the "cni" networking option instead.
 

--- a/nodeup/pkg/model/update_service.go
+++ b/nodeup/pkg/model/update_service.go
@@ -50,11 +50,6 @@ func (b *UpdateServiceBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 }
 
 func (b *UpdateServiceBuilder) buildFlatcarSystemdService(c *fi.NodeupModelBuilderContext) {
-	if b.NodeupConfig.UpdatePolicy != kops.UpdatePolicyExternal {
-		klog.Infof("UpdatePolicy requests automatic updates; skipping creation of systemd unit %q", flatcarServiceName)
-		return
-	}
-
 	for _, spec := range b.NodeupConfig.Hooks {
 		for _, hook := range spec {
 			if hook.Name == flatcarServiceName || hook.Name == flatcarServiceName+".service" {


### PR DESCRIPTION
Cherry pick of #15054 on release-1.26.

#15054: Always disable the reboot manager for Flatcar

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```