### PR TITLE
Remove Zone from spec field

### DIFF
--- a/tests/integration/update_cluster/shared_subnet/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/shared_subnet/in-v1alpha2.yaml
@@ -35,7 +35,6 @@ spec:
     id: subnet-12345678
     name: us-test-1a
     type: Public
-    zone: us-test-1a
   topology:
     masters: public
     nodes: public


### PR DESCRIPTION
Issue: #14710 
Hello, I am a beginner and I am trying to slove good first issue. This pr is about letting cloud provide decide the zone instead of user. So i simply remove zone from the spec field. Lat me know if further changes required.