### PR TITLE
GCE: Create per-machine certificate

### DIFF
--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -248,6 +248,17 @@ func (s *Server) issueCert(ctx context.Context, name string, pubKey string, id *
 		issueReq.Subject = pkix.Name{
 			CommonName: rbac.KubeRouter,
 		}
+
+	case "machine-key":
+		clusterName := s.opt.ClusterName
+
+		issueReq.Subject = pkix.Name{
+			CommonName: fmt.Sprintf("kops:%s:machine:%s", clusterName, id.NodeName),
+			Organization: []string{
+				fmt.Sprintf("kops:%s:machines", clusterName),
+			},
+		}
+
 	default:
 		return "", fmt.Errorf("unexpected key name")
 	}

--- a/nodeup/pkg/model/containerd_test.go
+++ b/nodeup/pkg/model/containerd_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/pkg/diff"
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/pkg/testutils"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/util/pkg/distributions"
 )
@@ -132,6 +133,7 @@ func TestContainerdBuilder_BuildFlags(t *testing.T) {
 }
 
 func runContainerdBuilderTest(t *testing.T, key string, distro distributions.Distribution) {
+	ctx := testcontext.ForTest(t)
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -162,7 +164,7 @@ func runContainerdBuilderTest(t *testing.T, key string, distro distributions.Dis
 	nodeUpModelContext.Assets.AddForTest("ctr", "bin/ctr", "testing containerd content")
 	nodeUpModelContext.Assets.AddForTest("runc.amd64", "https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64", "testing runc content")
 
-	if err := nodeUpModelContext.Init(); err != nil {
+	if err := nodeUpModelContext.Init(ctx); err != nil {
 		t.Fatalf("error from nodeupModelContext.Init(): %v", err)
 		return
 	}

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/apis/nodeup"
 	"k8s.io/kops/pkg/dns"
+	"k8s.io/kops/pkg/kopscontrollerclient"
 	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/pkg/systemd"
 	"k8s.io/kops/upup/pkg/fi"
@@ -82,10 +84,12 @@ type NodeupModelContext struct {
 	ConfigurationMode string
 	InstanceID        string
 	MachineType       string
+
+	KopsControllerClient *kopscontrollerclient.Client
 }
 
 // Init completes initialization of the object, for example pre-parsing the kubernetes version
-func (c *NodeupModelContext) Init() error {
+func (c *NodeupModelContext) Init(ctx context.Context) error {
 	k8sVersion, err := util.ParseKubernetesVersion(c.NodeupConfig.KubernetesVersion)
 	if err != nil || k8sVersion == nil {
 		return fmt.Errorf("unable to parse KubernetesVersion %q", c.NodeupConfig.KubernetesVersion)
@@ -621,6 +625,13 @@ func (b *NodeupModelContext) addCNIBinAsset(c *fi.NodeupModelBuilderContext, ass
 func (c *NodeupModelContext) CNIBinDir() string {
 	// We used to map this on a per-distro basis, but this can require CNI manifests to be distro aware
 	return "/opt/cni/bin/"
+}
+
+// MachineKeyDir is the directory to store the machine key.
+func (c *NodeupModelContext) MachineKeyDir() string {
+	// We anticipate using this for other things (e.g. SPIFFE),
+	// hence the generic name.
+	return "/etc/kubernetes/pki/machine"
 }
 
 // CNIConfDir returns the CNI directory

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -634,6 +634,11 @@ func (c *NodeupModelContext) InstallNvidiaRuntime() bool {
 		c.GPUVendor == architectures.GPUVendorNvidia
 }
 
+// CloudProvider returns the CloudProviderID for the cloud we are running on.
+func (c *NodeupModelContext) CloudProvider() kops.CloudProviderID {
+	return c.BootConfig.CloudProvider
+}
+
 // RunningOnGCE returns true if we are running on GCE
 func (c *NodeupModelContext) RunningOnGCE() bool {
 	return c.BootConfig.CloudProvider == kops.CloudProviderGCE

--- a/nodeup/pkg/model/docker_test.go
+++ b/nodeup/pkg/model/docker_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/pkg/testutils"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/util/pkg/distributions"
 )
@@ -124,6 +125,7 @@ func TestDockerBuilder_BuildFlags(t *testing.T) {
 }
 
 func runDockerBuilderTest(t *testing.T, key string) {
+	ctx := testcontext.ForTest(t)
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -178,7 +180,7 @@ func runDockerBuilderTest(t *testing.T, key string) {
 		}
 	}
 
-	if err := nodeUpModelContext.Init(); err != nil {
+	if err := nodeUpModelContext.Init(ctx); err != nil {
 		t.Fatalf("error from nodeUpModelContext.Init(): %v", err)
 	}
 	context := &fi.NodeupModelBuilderContext{

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kops/pkg/client/simple/vfsclientset"
 	"k8s.io/kops/pkg/pki"
 	"k8s.io/kops/pkg/testutils"
+	"k8s.io/kops/pkg/testutils/testcontext"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/util/pkg/distributions"
@@ -54,6 +55,7 @@ func TestTaintsApplied(t *testing.T) {
 	}
 
 	for _, g := range tests {
+		ctx := testcontext.ForTest(t)
 		cluster := &kops.Cluster{Spec: kops.ClusterSpec{KubernetesVersion: g.version}}
 		input := testutils.BuildMinimalMasterInstanceGroup("eu-central-1a")
 		input.Spec.Taints = g.taints
@@ -71,7 +73,7 @@ func TestTaintsApplied(t *testing.T) {
 				NodeupConfig: config,
 			},
 		}
-		if err := b.Init(); err != nil {
+		if err := b.Init(ctx); err != nil {
 			t.Error(err)
 		}
 
@@ -179,7 +181,8 @@ func Test_RunKubeletBuilderWarmPool(t *testing.T) {
 }
 
 func runKubeletBuilder(t *testing.T, context *fi.NodeupModelBuilderContext, nodeupModelContext *NodeupModelContext) {
-	if err := nodeupModelContext.Init(); err != nil {
+	ctx := context.Context()
+	if err := nodeupModelContext.Init(ctx); err != nil {
 		t.Fatalf("error from nodeupModelContext.Init(): %v", err)
 	}
 
@@ -349,6 +352,7 @@ func mustParseKey(s string) *pki.PrivateKey {
 }
 
 func RunGoldenTest(t *testing.T, basedir string, key string, builder func(*NodeupModelContext, *fi.NodeupModelBuilderContext) error) {
+	ctx := testcontext.ForTest(t)
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 
@@ -385,7 +389,7 @@ func RunGoldenTest(t *testing.T, basedir string, key string, builder func(*Nodeu
 
 	nodeupModelContext.Distribution = distributions.DistributionUbuntu2004
 
-	if err := nodeupModelContext.Init(); err != nil {
+	if err := nodeupModelContext.Init(ctx); err != nil {
 		t.Fatalf("error from nodeupModelContext.Init(): %v", err)
 	}
 

--- a/nodeup/pkg/model/machine_certificate.go
+++ b/nodeup/pkg/model/machine_certificate.go
@@ -78,8 +78,7 @@ func (b *MachineCertificateBuilder) Build(ctx *fi.NodeupModelBuilderContext) err
 		certResource, keyResource, _ = issueCert.GetResources()
 	}
 
-	// TODO: Maybe this should be kops-controller-client ?
-	dir := "/etc/kubernetes/pki/machine"
+	dir := b.MachineKeyDir()
 	ctx.AddTask(&nodetasks.File{
 		Path:     filepath.Join(dir, "machine.crt"),
 		Contents: certResource,

--- a/nodeup/pkg/model/machine_certificate.go
+++ b/nodeup/pkg/model/machine_certificate.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
+)
+
+// MachineCertificateBuilder ensures the machine has a PKI certificate.
+type MachineCertificateBuilder struct {
+	*NodeupModelContext
+}
+
+var _ fi.NodeupModelBuilder = &MachineCertificateBuilder{}
+
+// Build is responsible for building the tasks for the machine-certificate.
+func (b *MachineCertificateBuilder) Build(ctx *fi.NodeupModelBuilderContext) error {
+	switch b.CloudProvider() {
+	case kops.CloudProviderGCE:
+		// ok
+	default:
+		// not on this cloud, yet
+		return nil
+	}
+
+	nodeName, err := b.NodeName()
+	if err != nil {
+		return err
+	}
+
+	var certResource fi.Resource
+	var keyResource fi.Resource
+
+	if !b.IsMaster && b.UseKopsControllerForNodeBootstrap() {
+		cert, key, err := b.GetBootstrapCert("machine-key", fi.CertificateIDCA)
+		if err != nil {
+			return err
+		}
+
+		certResource = cert
+		keyResource = key
+	} else {
+		clusterName := b.NodeupConfig.ClusterName
+
+		issueCert := &nodetasks.IssueCert{
+			Name:      "machine-key",
+			Signer:    fi.CertificateIDCA,
+			KeypairID: b.NodeupConfig.KeypairIDs[fi.CertificateIDCA],
+			Type:      "client",
+			Subject: nodetasks.PKIXName{
+				CommonName: fmt.Sprintf("kops:%s:machine:%s", clusterName, nodeName),
+				Organization: []string{
+					fmt.Sprintf("kops:%s:machines", clusterName),
+				},
+			},
+		}
+		ctx.AddTask(issueCert)
+
+		certResource, keyResource, _ = issueCert.GetResources()
+	}
+
+	// TODO: Maybe this should be kops-controller-client ?
+	dir := "/etc/kubernetes/pki/machine"
+	ctx.AddTask(&nodetasks.File{
+		Path:     filepath.Join(dir, "machine.crt"),
+		Contents: certResource,
+		Type:     nodetasks.FileType_File,
+		Mode:     fi.PtrTo("0644"),
+	})
+	ctx.AddTask(&nodetasks.File{
+		Path:     filepath.Join(dir, "machine.key"),
+		Contents: keyResource,
+		Type:     nodetasks.FileType_File,
+		Mode:     fi.PtrTo("0600"),
+	})
+
+	return nil
+}

--- a/pkg/apis/kops/model/features.go
+++ b/pkg/apis/kops/model/features.go
@@ -38,9 +38,15 @@ func UseKopsControllerForNodeBootstrap(cluster *kops.Cluster) bool {
 
 // UseKopsControllerForNodeConfig checks if nodeup should use kops-controller to get nodeup.Config.
 func UseKopsControllerForNodeConfig(cluster *kops.Cluster) bool {
-	if cluster.IsGossip() {
-		return false
+	switch cluster.Spec.GetCloudProvider() {
+	case kops.CloudProviderGCE:
+		// We can use cloud-discovery here.
+	default:
+		if cluster.IsGossip() {
+			return false
+		}
 	}
+
 	return UseKopsControllerForNodeBootstrap(cluster)
 }
 

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c333160f29a837393d0886a078ca34be06d1b4e73bd92e7921ecfd08b3e3d9f0
+    manifestHash: 95e884d9693517a9c8604c3c300e0546b2ba35cdf7322c6883e1d81a463845f3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"clusterName":"ha-gce.example.com","cloud":"gce","configBase":"memfs://tests/ha-gce.example.com","secretStore":"memfs://tests/ha-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"ha-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"ha-gce.example.com","cloud":"gce","configBase":"memfs://tests/ha-gce.example.com","secretStore":"memfs://tests/ha-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"ha-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy","machine-key"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cc82b5578be00506084b33c089df663466ebf1eea078616bf0fc7e79212a30b4
+    manifestHash: 5a711fd20b4c23f59e6c44369f18962069d4ca3e04e2792160770337dea893c9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"clusterName":"minimal.example.com","cloud":"gce","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal.example.com","cloud":"gce","configBase":"memfs://tests/minimal.example.com","secretStore":"memfs://tests/minimal.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy","machine-key"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5fb50ee334f72b0a298198a86531aac1ca27640f9771425b7d8692d348c88671
+    manifestHash: 1828d7f104dd7d133182481a0fbfde2b1d758ec1ab7849314516b16929006aac
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"clusterName":"minimal-gce.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce.example.com","secretStore":"memfs://tests/minimal-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce.example.com","secretStore":"memfs://tests/minimal-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy","machine-key"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5fb50ee334f72b0a298198a86531aac1ca27640f9771425b7d8692d348c88671
+    manifestHash: 1828d7f104dd7d133182481a0fbfde2b1d758ec1ab7849314516b16929006aac
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"clusterName":"minimal-gce.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce.example.com","secretStore":"memfs://tests/minimal-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce.example.com","secretStore":"memfs://tests/minimal-gce.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy","machine-key"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6f2feafcd7d540447b36cea4dc21cd29cedb74195b70b7563910ed776d9e671d
+    manifestHash: abcb00ea96b00ce8d0ed63f55634cabdd4d52f3917be0ede66641d5bac0a484a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"clusterName":"minimal-gce-ilb.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-ilb.example.com","secretStore":"memfs://tests/minimal-gce-ilb.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-ilb.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce-ilb.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-ilb.example.com","secretStore":"memfs://tests/minimal-gce-ilb.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-ilb.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy","machine-key"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 46acb65f4e99c537d0dda132da1b08ae90560fe21d2e8e997d422e342344ae53
+    manifestHash: cfb2450d127a096220496ea41797dff055b80426a0b2225f21f2a4722146c46d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","secretStore":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","secretStore":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy","machine-key"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 46acb65f4e99c537d0dda132da1b08ae90560fe21d2e8e997d422e342344ae53
+    manifestHash: cfb2450d127a096220496ea41797dff055b80426a0b2225f21f2a4722146c46d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","secretStore":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com","secretStore":"memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-with-a-very-very-very-very-very-long-name.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy","machine-key"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f77a155a02ea5d7dceb94c937f56b9e6c8a4b9cc76fa71c575245197f5b8f74
+    manifestHash: 0331a356234d2d5e07de71631cf4843ea36c9842c56d92dcd9a296aa3c9496c9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"clusterName":"minimal-gce-private.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-private.example.com","secretStore":"memfs://tests/minimal-gce-private.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-private.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"clusterName":"minimal-gce-private.example.com","cloud":"gce","configBase":"memfs://tests/minimal-gce-private.example.com","secretStore":"memfs://tests/minimal-gce-private.example.com/secrets","server":{"Listen":":3988","provider":{"gce":{"projectID":"testproject","region":"us-test1","clusterName":"minimal-gce-private.example.com","MaxTimeSkew":300}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy","machine-key"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -657,6 +657,10 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 			certNames = append(certNames, "kube-router")
 		}
 
+		if tf.cloud.ProviderID() == kops.CloudProviderGCE {
+			certNames = append(certNames, "machine-key")
+		}
+
 		pkiDir := "/etc/kubernetes/kops-controller/pki"
 		config.Server = &kopscontrollerconfig.ServerOptions{
 			Listen:                fmt.Sprintf(":%d", wellknownports.KopsControllerPort),

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -311,6 +311,9 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	}
 
 	loader := &Loader{}
+
+	loader.Builders = append(loader.Builders, &model.MachineCertificateBuilder{NodeupModelContext: modelContext})
+
 	loader.Builders = append(loader.Builders, &model.EtcHostsBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.NTPBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.MiscUtilsBuilder{NodeupModelContext: modelContext})

--- a/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
@@ -52,11 +52,15 @@ var (
 )
 
 func (b *BootstrapClientTask) GetDependencies(tasks map[string]fi.NodeupTask) []fi.NodeupTask {
-	// BootstrapClient depends on the protokube service to ensure gossip DNS
 	var deps []fi.NodeupTask
-	for _, v := range tasks {
-		if svc, ok := v.(*Service); ok && svc.Name == protokubeService {
-			deps = append(deps, v)
+
+	// If we aren't using a custom resolver, then
+	// BootstrapClient depends on the protokube service to ensure gossip DNS
+	if b.Client.Resolver == nil {
+		for _, v := range tasks {
+			if svc, ok := v.(*Service); ok && svc.Name == protokubeService {
+				deps = append(deps, v)
+			}
 		}
 	}
 	return deps


### PR DESCRIPTION
For GCE (at first), we get a machine certificate as part of bootstrapping (or self-sign for control-plane machines)

Breaking up the gossip-via-kops-controller PR, also looking at authentication.