### PR TITLE
disable kops-configuration.service after successful execution

### DIFF
--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -175,6 +175,7 @@ func (i *Installation) buildSystemdJob() *nodetasks.InstallService {
 	service := &nodetasks.InstallService{Service: nodetasks.Service{
 		Name:       serviceName,
 		Definition: fi.PtrTo(manifestString),
+		Enabled:    fi.PtrTo(false),
 	}}
 
 	service.InitDefaults()

--- a/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
+++ b/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
@@ -17,7 +17,7 @@ definition: |
 
   [Install]
   WantedBy=multi-user.target
-enabled: true
+enabled: false
 manageState: true
 running: true
 smartRestart: true


### PR DESCRIPTION
fixes #15057

cc @johngmyers 

I do not know is this mistake that we enable the `kops-configuration.service` in cloud-init after the nodeup is successfully executed? If we do not do that (this PR), we can reboot machines easily in OpenStack and kops controller bootstrap will work fine (because its not executed anymore after initial execution)