### PR TITLE
Automated cherry pick of #15078: disable kops-configuration.service after successful

### DIFF
--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -180,6 +180,6 @@ func (i *Installation) buildSystemdJob() *nodetasks.InstallService {
 	}}
 
 	service.InitDefaults()
-
+	service.Enabled = fi.PtrTo(false)
 	return service
 }

--- a/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
+++ b/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
@@ -17,7 +17,7 @@ definition: |
 
   [Install]
   WantedBy=multi-user.target
-enabled: true
+enabled: false
 manageState: true
 running: true
 smartRestart: true


### PR DESCRIPTION
Cherry pick of #15078 on release-1.26.

#15078: disable kops-configuration.service after successful

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```