### PR TITLE
azure: Use Basic SKU for the API LB

### DIFF
--- a/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
@@ -149,7 +149,7 @@ func (*LoadBalancer) RenderAzure(t *azure.AzureAPITarget, a, e, changes *LoadBal
 	lb := network.LoadBalancer{
 		Location: to.StringPtr(t.Cloud.Region()),
 		Sku: &network.LoadBalancerSku{
-			Name: network.LoadBalancerSkuNameBasic,
+			Name: network.LoadBalancerSkuNameStandard,
 		},
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{

--- a/upup/pkg/fi/cloudup/azuretasks/publicipaddress.go
+++ b/upup/pkg/fi/cloudup/azuretasks/publicipaddress.go
@@ -116,7 +116,10 @@ func (*PublicIPAddress) RenderAzure(t *azure.AzureAPITarget, a, e, changes *Publ
 		Name:     to.StringPtr(*e.Name),
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAddressVersion:   network.IPv4,
-			PublicIPAllocationMethod: network.Dynamic,
+			PublicIPAllocationMethod: network.Static,
+		},
+		Sku: &network.PublicIPAddressSku{
+			Name: network.PublicIPAddressSkuNameStandard,
 		},
 		Tags: e.Tags,
 	}

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -699,6 +699,7 @@ func setupZones(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.Stri
 			}
 			zoneToSubnetMap[zoneName] = subnet
 		}
+		return zoneToSubnetMap, nil
 
 	case api.CloudProviderAWS:
 		if len(opt.Zones) > 0 && len(opt.SubnetIDs) > 0 {


### PR DESCRIPTION
Using the Standard Load Balancer SKU allows using the LB with AZs and VMSSs:
https://learn.microsoft.com/en-us/azure/load-balancer/skus

This is the last piece from https://github.com/kubernetes/kops/pull/14514.