### PR TITLE
Automated cherry pick of #15081: azure: Use Basic SKU for the API LB

### DIFF
--- a/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
@@ -149,7 +149,7 @@ func (*LoadBalancer) RenderAzure(t *azure.AzureAPITarget, a, e, changes *LoadBal
 	lb := network.LoadBalancer{
 		Location: to.StringPtr(t.Cloud.Region()),
 		Sku: &network.LoadBalancerSku{
-			Name: network.LoadBalancerSkuNameBasic,
+			Name: network.LoadBalancerSkuNameStandard,
 		},
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{

--- a/upup/pkg/fi/cloudup/azuretasks/publicipaddress.go
+++ b/upup/pkg/fi/cloudup/azuretasks/publicipaddress.go
@@ -116,7 +116,10 @@ func (*PublicIPAddress) RenderAzure(t *azure.AzureAPITarget, a, e, changes *Publ
 		Name:     to.StringPtr(*e.Name),
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAddressVersion:   network.IPv4,
-			PublicIPAllocationMethod: network.Dynamic,
+			PublicIPAllocationMethod: network.Static,
+		},
+		Sku: &network.PublicIPAddressSku{
+			Name: network.PublicIPAddressSkuNameStandard,
 		},
 		Tags: e.Tags,
 	}

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -702,6 +702,7 @@ func setupZones(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.Stri
 			}
 			zoneToSubnetMap[zoneName] = subnet
 		}
+		return zoneToSubnetMap, nil
 
 	case api.CloudProviderAWS:
 		if len(opt.Zones) > 0 && len(opt.SubnetIDs) > 0 {


### PR DESCRIPTION
Cherry pick of #15081 on release-1.26.

#15081: azure: Use Basic SKU for the API LB

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```