### PR TITLE
Automated cherry pick of #15078: disable kops-configuration.service after successful execution

### DIFF
--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -177,6 +177,7 @@ func (i *Installation) buildSystemdJob() *nodetasks.InstallService {
 	service := &nodetasks.InstallService{Service: nodetasks.Service{
 		Name:       serviceName,
 		Definition: fi.PtrTo(manifestString),
+		Enabled:    fi.PtrTo(false),
 	}}
 
 	service.InitDefaults()

--- a/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
+++ b/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
@@ -17,7 +17,7 @@ definition: |
 
   [Install]
   WantedBy=multi-user.target
-enabled: true
+enabled: false
 manageState: true
 running: true
 smartRestart: true


### PR DESCRIPTION
Cherry pick of #15078 on release-1.26.

#15078: disable kops-configuration.service after successful execution

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```