### PR TITLE
Automated cherry pick of #15083: Allow setting 'ignore-volume-microversion' for OCCP

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -432,6 +432,8 @@ spec:
                             type: boolean
                           ignore-volume-az:
                             type: boolean
+                          ignore-volume-microversion:
+                            type: boolean
                           override-volume-az:
                             type: string
                         type: object

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -782,9 +782,10 @@ type OpenstackLoadbalancerConfig struct {
 }
 
 type OpenstackBlockStorageConfig struct {
-	Version    *string `json:"bs-version,omitempty"`
-	IgnoreAZ   *bool   `json:"ignore-volume-az,omitempty"`
-	OverrideAZ *string `json:"override-volume-az,omitempty"`
+	Version                  *string `json:"bs-version,omitempty"`
+	IgnoreAZ                 *bool   `json:"ignore-volume-az,omitempty"`
+	OverrideAZ               *string `json:"override-volume-az,omitempty"`
+	IgnoreVolumeMicroVersion *bool   `json:"ignore-volume-microversion,omitempty"`
 	// CreateStorageClass provisions a default class for the Cinder plugin
 	CreateStorageClass *bool  `json:"createStorageClass,omitempty"`
 	CSIPluginImage     string `json:"csiPluginImage,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -781,9 +781,10 @@ type OpenstackLoadbalancerConfig struct {
 }
 
 type OpenstackBlockStorageConfig struct {
-	Version    *string `json:"bs-version,omitempty"`
-	IgnoreAZ   *bool   `json:"ignore-volume-az,omitempty"`
-	OverrideAZ *string `json:"override-volume-az,omitempty"`
+	Version                  *string `json:"bs-version,omitempty"`
+	IgnoreAZ                 *bool   `json:"ignore-volume-az,omitempty"`
+	OverrideAZ               *string `json:"override-volume-az,omitempty"`
+	IgnoreVolumeMicroVersion *bool   `json:"ignore-volume-microversion,omitempty"`
 	// CreateStorageClass provisions a default class for the Cinder plugin
 	CreateStorageClass *bool  `json:"createStorageClass,omitempty"`
 	CSIPluginImage     string `json:"csiPluginImage,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -6423,6 +6423,7 @@ func autoConvert_v1alpha2_OpenstackBlockStorageConfig_To_kops_OpenstackBlockStor
 	out.Version = in.Version
 	out.IgnoreAZ = in.IgnoreAZ
 	out.OverrideAZ = in.OverrideAZ
+	out.IgnoreVolumeMicroVersion = in.IgnoreVolumeMicroVersion
 	out.CreateStorageClass = in.CreateStorageClass
 	out.CSIPluginImage = in.CSIPluginImage
 	out.CSITopologySupport = in.CSITopologySupport
@@ -6438,6 +6439,7 @@ func autoConvert_kops_OpenstackBlockStorageConfig_To_v1alpha2_OpenstackBlockStor
 	out.Version = in.Version
 	out.IgnoreAZ = in.IgnoreAZ
 	out.OverrideAZ = in.OverrideAZ
+	out.IgnoreVolumeMicroVersion = in.IgnoreVolumeMicroVersion
 	out.CreateStorageClass = in.CreateStorageClass
 	out.CSIPluginImage = in.CSIPluginImage
 	out.CSITopologySupport = in.CSITopologySupport

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -4682,6 +4682,11 @@ func (in *OpenstackBlockStorageConfig) DeepCopyInto(out *OpenstackBlockStorageCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.IgnoreVolumeMicroVersion != nil {
+		in, out := &in.IgnoreVolumeMicroVersion, &out.IgnoreVolumeMicroVersion
+		*out = new(bool)
+		**out = **in
+	}
 	if in.CreateStorageClass != nil {
 		in, out := &in.CreateStorageClass, &out.CreateStorageClass
 		*out = new(bool)

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -779,9 +779,10 @@ type OpenstackLoadbalancerConfig struct {
 }
 
 type OpenstackBlockStorageConfig struct {
-	Version    *string `json:"bs-version,omitempty"`
-	IgnoreAZ   *bool   `json:"ignore-volume-az,omitempty"`
-	OverrideAZ *string `json:"override-volume-az,omitempty"`
+	Version                  *string `json:"bs-version,omitempty"`
+	IgnoreAZ                 *bool   `json:"ignore-volume-az,omitempty"`
+	OverrideAZ               *string `json:"override-volume-az,omitempty"`
+	IgnoreVolumeMicroVersion *bool   `json:"ignore-volume-microversion,omitempty"`
 	// CreateStorageClass provisions a default class for the Cinder plugin
 	CreateStorageClass *bool  `json:"createStorageClass,omitempty"`
 	CSIPluginImage     string `json:"csiPluginImage,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -6555,6 +6555,7 @@ func autoConvert_v1alpha3_OpenstackBlockStorageConfig_To_kops_OpenstackBlockStor
 	out.Version = in.Version
 	out.IgnoreAZ = in.IgnoreAZ
 	out.OverrideAZ = in.OverrideAZ
+	out.IgnoreVolumeMicroVersion = in.IgnoreVolumeMicroVersion
 	out.CreateStorageClass = in.CreateStorageClass
 	out.CSIPluginImage = in.CSIPluginImage
 	out.CSITopologySupport = in.CSITopologySupport
@@ -6570,6 +6571,7 @@ func autoConvert_kops_OpenstackBlockStorageConfig_To_v1alpha3_OpenstackBlockStor
 	out.Version = in.Version
 	out.IgnoreAZ = in.IgnoreAZ
 	out.OverrideAZ = in.OverrideAZ
+	out.IgnoreVolumeMicroVersion = in.IgnoreVolumeMicroVersion
 	out.CreateStorageClass = in.CreateStorageClass
 	out.CSIPluginImage = in.CSIPluginImage
 	out.CSITopologySupport = in.CSITopologySupport

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -4535,6 +4535,11 @@ func (in *OpenstackBlockStorageConfig) DeepCopyInto(out *OpenstackBlockStorageCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.IgnoreVolumeMicroVersion != nil {
+		in, out := &in.IgnoreVolumeMicroVersion, &out.IgnoreVolumeMicroVersion
+		*out = new(bool)
+		**out = **in
+	}
 	if in.CreateStorageClass != nil {
 		in, out := &in.CreateStorageClass, &out.CreateStorageClass
 		*out = new(bool)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -4810,6 +4810,11 @@ func (in *OpenstackBlockStorageConfig) DeepCopyInto(out *OpenstackBlockStorageCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.IgnoreVolumeMicroVersion != nil {
+		in, out := &in.IgnoreVolumeMicroVersion, &out.IgnoreVolumeMicroVersion
+		*out = new(bool)
+		**out = **in
+	}
 	if in.CreateStorageClass != nil {
 		in, out := &in.CreateStorageClass, &out.CreateStorageClass
 		*out = new(bool)

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -891,6 +891,7 @@ func MakeCloudConfig(spec kops.ClusterSpec) []string {
 			"[BlockStorage]",
 			fmt.Sprintf("bs-version=%s", fi.ValueOf(bs.Version)),
 			fmt.Sprintf("ignore-volume-az=%t", fi.ValueOf(bs.IgnoreAZ)),
+			fmt.Sprintf("ignore-volume-microversion=%t", fi.ValueOf(bs.IgnoreVolumeMicroVersion)),
 			"")
 	}
 


### PR DESCRIPTION
Cherry pick of #15083 on release-1.26.

#15083: Allow setting 'ignore-volume-microversion' for OCCP

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```