### PR TITLE
Automated cherry pick of #15088: Update etcd to v3.5.7

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -30,7 +30,7 @@ var _ loader.OptionsBuilder = &EtcdOptionsBuilder{}
 
 const (
 	DefaultEtcd3Version_1_20 = "3.4.13"
-	DefaultEtcd3Version_1_22 = "3.5.6"
+	DefaultEtcd3Version_1_22 = "3.5.7"
 )
 
 // BuildOptions is responsible for filling in the defaults for the etcd cluster model

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -181,7 +181,7 @@ metadata:
 spec:
   containers:
   - name: etcd-manager
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     resources:
       requests:
         cpu: 100m

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -62,7 +62,22 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 	return nil
 }
 
-var supportedEtcdVersions = []string{"3.1.12", "3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.3.17", "3.4.3", "3.4.13", "3.5.0", "3.5.1", "3.5.3", "3.5.4", "3.5.6"}
+var supportedEtcdVersions = []string{
+	"3.1.12",
+	"3.2.18",
+	"3.2.24",
+	"3.3.10",
+	"3.3.13",
+	"3.3.17",
+	"3.4.3",
+	"3.4.13",
+	"3.5.0",
+	"3.5.1",
+	"3.5.3",
+	"3.5.4",
+	"3.5.6",
+	"3.5.7",
+}
 
 func etcdVersionIsSupported(version string) bool {
 	version = strings.TrimPrefix(version, "v")

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -86,7 +86,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
       name: etcd-manager
       resources:
         requests:
@@ -155,7 +155,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -85,7 +85,7 @@ Contents: |
         --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
         --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
       name: etcd-manager
       resources:
         requests:
@@ -153,7 +153,7 @@ Contents: |
         --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
         --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -88,7 +88,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
       name: etcd-manager
       resources:
         requests:
@@ -159,7 +159,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -94,7 +94,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
       name: etcd-manager
       resources:
         requests:
@@ -171,7 +171,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+      image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
       name: etcd-manager
       resources:
         requests:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_master-us-test-1a.masters.additionalobjects.example.com_user_data
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_master-us-test-1a.masters.additionalobjects.example.com_user_data
@@ -141,11 +141,11 @@ etcdClusters:
   events:
     cpuRequest: 100m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
   main:
     cpuRequest: 200m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
@@ -37,7 +37,7 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://tests/additionalobjects.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -47,7 +47,7 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/additionalobjects.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -137,9 +137,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
@@ -32,14 +32,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -148,9 +148,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -64,14 +64,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/complex.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/containerd.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/docker.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/docker.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -42,14 +42,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
@@ -61,14 +61,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
@@ -62,14 +62,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
@@ -61,14 +61,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
@@ -61,14 +61,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -141,11 +141,11 @@ etcdClusters:
   events:
     cpuRequest: 100m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
   main:
     cpuRequest: 200m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_cluster-completed.spec_content
@@ -37,7 +37,7 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -47,7 +47,7 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -141,11 +141,11 @@ etcdClusters:
   events:
     cpuRequest: 100m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
   main:
     cpuRequest: 200m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
@@ -46,7 +46,7 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -56,7 +56,7 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -141,11 +141,11 @@ etcdClusters:
   events:
     cpuRequest: 100m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
   main:
     cpuRequest: 200m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
@@ -45,7 +45,7 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -141,11 +141,11 @@ etcdClusters:
   events:
     cpuRequest: 100m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
   main:
     cpuRequest: 200m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
@@ -45,7 +45,7 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://tests/minimal.example.com/backups/etcd/events
     cpuRequest: 100m
@@ -55,7 +55,7 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -142,9 +142,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
@@ -47,14 +47,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -142,9 +142,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_cluster-completed.spec_content
@@ -47,14 +47,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.long.cluster-name.minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.long.cluster-name.minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -35,14 +35,14 @@ spec:
     - instanceGroup: master-us-test1-a
       name: "1"
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://tests/minimal-gce.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test1-a
       name: "1"
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -18,7 +18,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-ilb-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -39,14 +39,14 @@ spec:
     - instanceGroup: master-us-test1-a
       name: "1"
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test1-a
       name: "1"
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -35,14 +35,14 @@ spec:
     - instanceGroup: master-us-test1-a
       name: "1"
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test1-a
       name: "1"
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-private-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-private-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -42,7 +42,7 @@ spec:
       name: etcd-1
     memoryRequest: 100Mi
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://tests/minimal.k8s.local/backups/etcd/events
     cpuRequest: 100m
@@ -51,7 +51,7 @@ spec:
       name: etcd-1
     memoryRequest: 100Mi
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: HCLOUD_TOKEN
       value: REDACTED
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -21,7 +21,7 @@ spec:
     env:
     - name: HCLOUD_TOKEN
       value: REDACTED
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_master-fsn1_user_data
+++ b/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_master-fsn1_user_data
@@ -138,11 +138,11 @@ etcdClusters:
   events:
     cpuRequest: 100m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
   main:
     cpuRequest: 200m
     memoryRequest: 100Mi
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/nthsqsresources.longclustername.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/nthsqsresources.longclustername.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
       /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
       /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
@@ -44,14 +44,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/privatecalico.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
@@ -44,14 +44,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/privatecanal.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecanal.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecanal.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -47,14 +47,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/cilium --volume-provider=aws --volume-tag=k8s.io/etcd/cilium
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned
       > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
       /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
       /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
@@ -44,14 +44,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/privateflannel.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateweave.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateweave.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -139,9 +139,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.6
+    version: 3.5.7
   main:
-    version: 3.5.6
+    version: 3.5.7
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
@@ -43,14 +43,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    version: 3.5.6
+    version: 3.5.7
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    version: 3.5.6
+    version: 3.5.7
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.6"
+  "etcdVersion": "3.5.7"
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -19,7 +19,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
       2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -18,7 +18,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20221209
+    image: registry.k8s.io/etcdadm/etcd-manager:v3.0.20230201
     name: etcd-manager
     resources:
       requests:


### PR DESCRIPTION
Cherry pick of #15088 on release-1.25.

#15088: Update etcd to v3.5.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```