### PR TITLE
Automated cherry pick of #15091: add k8s node labels

### DIFF
--- a/pkg/nodeidentity/openstack/identify.go
+++ b/pkg/nodeidentity/openstack/identify.go
@@ -36,7 +36,8 @@ import (
 )
 
 const (
-	cacheTTL = 60 * time.Minute
+	cacheTTL                           = 60 * time.Minute
+	ClusterAutoscalerNodeTemplateLabel = "k8s.io_cluster-autoscaler_node-template_label_"
 )
 
 // nodeIdentifier identifies a node
@@ -134,6 +135,13 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 			labels[nodelabels.RoleLabelAPIServer16] = ""
 		default:
 			klog.Warningf("Unknown node role %q for server %s(%d)", value, server.Name, server.ID)
+		}
+	}
+
+	for key, value := range server.Metadata {
+		if strings.HasPrefix(key, ClusterAutoscalerNodeTemplateLabel) {
+			trimKey := strings.ReplaceAll(strings.TrimPrefix(key, ClusterAutoscalerNodeTemplateLabel), "_", "/")
+			labels[trimKey] = value
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #15091 on release-1.26.

#15091: add k8s node labels

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```