### PR TITLE
Pass actual cluster name to cinder-csi-plugin

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -428,6 +428,10 @@ spec:
                         properties:
                           bs-version:
                             type: string
+                          clusterName:
+                            description: ClusterName sets the --cluster flag for the
+                              cinder-csi-plugin to the provided name
+                            type: string
                           createStorageClass:
                             description: CreateStorageClass provisions a default class
                               for the Cinder plugin

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -790,6 +790,8 @@ type OpenstackBlockStorageConfig struct {
 	CreateStorageClass *bool  `json:"createStorageClass,omitempty"`
 	CSIPluginImage     string `json:"csiPluginImage,omitempty"`
 	CSITopologySupport *bool  `json:"csiTopologySupport,omitempty"`
+	// ClusterName sets the --cluster flag for the cinder-csi-plugin to the provided name
+	ClusterName string `json:"clusterName,omitempty"`
 }
 
 // OpenstackMonitor defines the config for a health monitor

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -796,6 +796,8 @@ type OpenstackBlockStorageConfig struct {
 	CreateStorageClass *bool  `json:"createStorageClass,omitempty"`
 	CSIPluginImage     string `json:"csiPluginImage,omitempty"`
 	CSITopologySupport *bool  `json:"csiTopologySupport,omitempty"`
+	// ClusterName sets the --cluster flag for the cinder-csi-plugin to the provided name
+	ClusterName string `json:"clusterName,omitempty"`
 }
 
 // OpenstackMonitor defines the config for a health monitor

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -6420,6 +6420,7 @@ func autoConvert_v1alpha2_OpenstackBlockStorageConfig_To_kops_OpenstackBlockStor
 	out.CreateStorageClass = in.CreateStorageClass
 	out.CSIPluginImage = in.CSIPluginImage
 	out.CSITopologySupport = in.CSITopologySupport
+	out.ClusterName = in.ClusterName
 	return nil
 }
 
@@ -6436,6 +6437,7 @@ func autoConvert_kops_OpenstackBlockStorageConfig_To_v1alpha2_OpenstackBlockStor
 	out.CreateStorageClass = in.CreateStorageClass
 	out.CSIPluginImage = in.CSIPluginImage
 	out.CSITopologySupport = in.CSITopologySupport
+	out.ClusterName = in.ClusterName
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -787,6 +787,8 @@ type OpenstackBlockStorageConfig struct {
 	CreateStorageClass *bool  `json:"createStorageClass,omitempty"`
 	CSIPluginImage     string `json:"csiPluginImage,omitempty"`
 	CSITopologySupport *bool  `json:"csiTopologySupport,omitempty"`
+	// ClusterName sets the --cluster flag for the cinder-csi-plugin to the provided name
+	ClusterName string `json:"clusterName,omitempty"`
 }
 
 // OpenstackMonitor defines the config for a health monitor

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -6669,6 +6669,7 @@ func autoConvert_v1alpha3_OpenstackBlockStorageConfig_To_kops_OpenstackBlockStor
 	out.CreateStorageClass = in.CreateStorageClass
 	out.CSIPluginImage = in.CSIPluginImage
 	out.CSITopologySupport = in.CSITopologySupport
+	out.ClusterName = in.ClusterName
 	return nil
 }
 
@@ -6685,6 +6686,7 @@ func autoConvert_kops_OpenstackBlockStorageConfig_To_v1alpha3_OpenstackBlockStor
 	out.CreateStorageClass = in.CreateStorageClass
 	out.CSIPluginImage = in.CSIPluginImage
 	out.CSITopologySupport = in.CSITopologySupport
+	out.ClusterName = in.ClusterName
 	return nil
 }
 

--- a/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
@@ -14,6 +14,7 @@ spec:
     openstack:
       blockStorage:
         bs-version: v3
+        clusterName: minimal.k8s.local
         ignore-volume-az: false
       monitor:
         delay: 15s

--- a/tests/integration/create_cluster/ha_openstack_nodns/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_nodns/expected-v1alpha2.yaml
@@ -14,6 +14,7 @@ spec:
     openstack:
       blockStorage:
         bs-version: v3
+        clusterName: ha.example.com
         ignore-volume-az: false
       loadbalancer:
         floatingNetwork: vlan1

--- a/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
@@ -14,6 +14,7 @@ spec:
     openstack:
       blockStorage:
         bs-version: v3
+        clusterName: minimal.k8s.local
         ignore-volume-az: false
       loadbalancer:
         floatingNetwork: vlan1

--- a/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
@@ -333,7 +333,7 @@ spec:
             - name: CLOUD_CONFIG
               value: /etc/kubernetes/cloud.config
             - name: CLUSTER_NAME
-              value: kubernetes
+              value: "{{- if .CloudProvider.Openstack.BlockStorage.ClusterName -}} {{ .CloudProvider.Openstack.BlockStorage.ClusterName }} {{- else -}} kubernetes {{- end -}}"
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 9808
@@ -465,11 +465,18 @@ spec:
             - /bin/cinder-csi-plugin
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
+{{- if .CloudProvider.Openstack.BlockStorage.ClusterName }}
+            - "--cluster=$(CLUSTER_NAME)"
+{{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
               value: /etc/kubernetes/cloud.config
+{{- if .CloudProvider.Openstack.BlockStorage.ClusterName }}
+            - name: CLUSTER_NAME
+              value: {{ .CloudProvider.Openstack.BlockStorage.ClusterName }}
+{{- end }}
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 9808

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -324,8 +324,9 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 				ExternalNetwork: fi.PtrTo(opt.OpenstackExternalNet),
 			},
 			BlockStorage: &api.OpenstackBlockStorageConfig{
-				Version:  fi.PtrTo("v3"),
-				IgnoreAZ: fi.PtrTo(opt.OpenstackStorageIgnoreAZ),
+				Version:     fi.PtrTo("v3"),
+				IgnoreAZ:    fi.PtrTo(opt.OpenstackStorageIgnoreAZ),
+				ClusterName: opt.ClusterName,
 			},
 			Monitor: &api.OpenstackMonitor{
 				Delay:      fi.PtrTo("15s"),


### PR DESCRIPTION
This passes the acutal cluster name to the cinder-csi-plugin, so that the plugin will add the name as metadata to the backing volume in OpenStack.

Effectively, the change will help to better identify which volume in OpenStack belongs to which cluster, which is especially helpful when running multiple clusters in one OpenStack tenant/project.

Setting the cluster name in both - the controller and the nodeplugin - pods will ensure that dynamic and ephemeral volumes will receive the correct metadata.