### PR TITLE
Automated cherry pick of #15096: Use ubuntu18.04 repos for nvidia-container-toolkit

### DIFF
--- a/nodeup/pkg/model/nvidia.go
+++ b/nodeup/pkg/model/nvidia.go
@@ -17,8 +17,6 @@ limitations under the License.
 package model
 
 import (
-	"fmt"
-
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 )
@@ -33,21 +31,11 @@ var _ fi.ModelBuilder = &NvidiaBuilder{}
 // Build is responsible for installing packages.
 func (b *NvidiaBuilder) Build(c *fi.ModelBuilderContext) error {
 	if b.InstallNvidiaRuntime() && b.Distribution.IsUbuntu() {
-		version := ""
-		if b.Distribution.Version() >= 22.04 {
-			version = "22.04"
-		} else if b.Distribution.Version() >= 20.04 {
-			version = "20.04"
-		} else {
-			version = "18.04"
-		}
 		c.AddTask(&nodetasks.AptSource{
 			Name:    "nvidia-container-runtime",
 			Keyring: "https://nvidia.github.io/nvidia-container-runtime/gpgkey",
 			Sources: []string{
-				fmt.Sprintf("deb https://nvidia.github.io/nvidia-container-runtime/stable/ubuntu%s/$(ARCH) /", version),
-				fmt.Sprintf("deb https://nvidia.github.io/libnvidia-container/stable/ubuntu%s/$(ARCH) /", version),
-				fmt.Sprintf("deb https://nvidia.github.io/nvidia-docker/ubuntu%s/$(ARCH) /", version),
+				"deb https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/$(ARCH) /",
 			},
 		})
 		c.AddTask(&nodetasks.Package{Name: "nvidia-container-runtime"})

--- a/nodeup/pkg/model/nvidia.go
+++ b/nodeup/pkg/model/nvidia.go
@@ -32,13 +32,13 @@ var _ fi.ModelBuilder = &NvidiaBuilder{}
 func (b *NvidiaBuilder) Build(c *fi.ModelBuilderContext) error {
 	if b.InstallNvidiaRuntime() && b.Distribution.IsUbuntu() {
 		c.AddTask(&nodetasks.AptSource{
-			Name:    "nvidia-container-runtime",
+			Name:    "nvidia-container-toolkit",
 			Keyring: "https://nvidia.github.io/libnvidia-container/gpgkey",
 			Sources: []string{
 				"deb https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/$(ARCH) /",
 			},
 		})
-		c.AddTask(&nodetasks.Package{Name: "nvidia-container-runtime"})
+		c.AddTask(&nodetasks.Package{Name: "nvidia-container-toolkit"})
 		c.AddTask(&nodetasks.Package{Name: b.NodeupConfig.NvidiaGPU.DriverPackage})
 	}
 	return nil

--- a/nodeup/pkg/model/nvidia.go
+++ b/nodeup/pkg/model/nvidia.go
@@ -33,7 +33,7 @@ func (b *NvidiaBuilder) Build(c *fi.ModelBuilderContext) error {
 	if b.InstallNvidiaRuntime() && b.Distribution.IsUbuntu() {
 		c.AddTask(&nodetasks.AptSource{
 			Name:    "nvidia-container-runtime",
-			Keyring: "https://nvidia.github.io/nvidia-container-runtime/gpgkey",
+			Keyring: "https://nvidia.github.io/libnvidia-container/gpgkey",
 			Sources: []string{
 				"deb https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/$(ARCH) /",
 			},


### PR DESCRIPTION
Cherry pick of #15096 on release-1.25.

#15096: Use ubuntu18.04 repos for nvidia-container-toolkit

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```