### PR TITLE
gce: Always apply the metadata-proxy-ready node label

### DIFF
--- a/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
@@ -92,6 +92,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -139,6 +139,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1
@@ -159,6 +161,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1
@@ -179,6 +183,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/minimal-1.26-gce-dns-none/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-gce-dns-none/expected-v1alpha2.yaml
@@ -91,6 +91,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/minimal-1.26-gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-gce/expected-v1alpha2.yaml
@@ -91,6 +91,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -128,6 +128,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1013,6 +1013,13 @@ func setupNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetMap ma
 			}
 		}
 
+		if cloudProvider == api.CloudProviderGCE {
+			if g.Spec.NodeLabels == nil {
+				g.Spec.NodeLabels = make(map[string]string)
+			}
+			g.Spec.NodeLabels["cloud.google.com/metadata-proxy-ready"] = "true"
+		}
+
 		g.Spec.MachineType = opt.NodeSize
 		g.Spec.Image = opt.NodeImage
 


### PR DESCRIPTION
This restores the behaviour before #14127, which wasn't documented /
intended.
