### PR TITLE
Switch contained config file path to `/etc/containerd/config.toml`

### DIFF
--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -55,7 +55,9 @@ error is encountered while updating an InstanceGroup.
 
 # Other changes of note
 
-* Add unreachable route for pod IP on deletion option in Cilium.
+* containerd config is now written to `/etc/containerd/config.toml`.
+
+* Cilium can be configured to add unreachable route for pod IP on deletion.
 
 # Breaking changes
 

--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
@@ -40,16 +40,16 @@ contents: |
 
             [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
               SystemdCgroup = true
-path: /etc/containerd/config-kops.toml
+path: /etc/containerd/config.toml
 type: file
 ---
 afterFiles:
-- /etc/containerd/config-kops.toml
+- /etc/containerd/config.toml
 contents: |-
   [Service]
   EnvironmentFile=/etc/environment
   ExecStart=
-  ExecStart=/usr/bin/containerd --config /etc/containerd/config-kops.toml
+  ExecStart=/usr/bin/containerd --config /etc/containerd/config.toml
 onChangeExecute:
 - - systemctl
   - daemon-reload

--- a/nodeup/pkg/model/tests/containerdbuilder/from_docker_19.03.11/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/from_docker_19.03.11/tasks.yaml
@@ -1,6 +1,6 @@
 contents: |
   disabled_plugins = ["cri"]
-path: /etc/containerd/config-kops.toml
+path: /etc/containerd/config.toml
 type: file
 ---
 contents: CONTAINERD_OPTS=--log-level=info
@@ -214,7 +214,7 @@ definition: |
   EnvironmentFile=/etc/sysconfig/containerd
   EnvironmentFile=/etc/environment
   ExecStartPre=-/sbin/modprobe overlay
-  ExecStart=/usr/bin/containerd -c /etc/containerd/config-kops.toml "$CONTAINERD_OPTS"
+  ExecStart=/usr/bin/containerd -c /etc/containerd/config.toml "$CONTAINERD_OPTS"
   Delegate=yes
   KillMode=process
   Restart=always

--- a/nodeup/pkg/model/tests/containerdbuilder/from_docker_19.03.14/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/from_docker_19.03.14/tasks.yaml
@@ -1,6 +1,6 @@
 contents: |
   disabled_plugins = ["cri"]
-path: /etc/containerd/config-kops.toml
+path: /etc/containerd/config.toml
 type: file
 ---
 contents: CONTAINERD_OPTS=--log-level=info
@@ -214,7 +214,7 @@ definition: |
   EnvironmentFile=/etc/sysconfig/containerd
   EnvironmentFile=/etc/environment
   ExecStartPre=-/sbin/modprobe overlay
-  ExecStart=/usr/bin/containerd -c /etc/containerd/config-kops.toml "$CONTAINERD_OPTS"
+  ExecStart=/usr/bin/containerd -c /etc/containerd/config.toml "$CONTAINERD_OPTS"
   Type=notify
   Delegate=yes
   KillMode=process

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -40,7 +40,7 @@ contents: |
 
             [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
               SystemdCgroup = true
-path: /etc/containerd/config-kops.toml
+path: /etc/containerd/config.toml
 type: file
 ---
 contents: |2
@@ -347,7 +347,7 @@ definition: |
   EnvironmentFile=/etc/sysconfig/containerd
   EnvironmentFile=/etc/environment
   ExecStartPre=-/sbin/modprobe overlay
-  ExecStart=/usr/bin/containerd -c /etc/containerd/config-kops.toml "$CONTAINERD_OPTS"
+  ExecStart=/usr/bin/containerd -c /etc/containerd/config.toml "$CONTAINERD_OPTS"
   Type=notify
   Delegate=yes
   KillMode=process


### PR DESCRIPTION
Using `/etc/containerd/config-kops.toml` was useful when kOps installed deb/rpm packages from https://download.docker.com and was not safe to overwrite the package config file.
Since switching to `.tgz` packages, there is no longer a need for a special config file name, which is mostly confusing for operators.