### PR TITLE
Disable kops-configuration after package updates

### DIFF
--- a/nodeup/pkg/bootstrap/install.go
+++ b/nodeup/pkg/bootstrap/install.go
@@ -175,7 +175,7 @@ func (i *Installation) buildSystemdJob() *nodetasks.InstallService {
 	service := &nodetasks.InstallService{Service: nodetasks.Service{
 		Name:       serviceName,
 		Definition: fi.PtrTo(manifestString),
-		Enabled:    fi.PtrTo(false),
+		Enabled:    fi.PtrTo(true),
 	}}
 
 	service.InitDefaults()

--- a/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
+++ b/nodeup/pkg/bootstrap/tests/simple/tasks.yaml
@@ -17,7 +17,7 @@ definition: |
 
   [Install]
   WantedBy=multi-user.target
-enabled: false
+enabled: true
 manageState: true
 running: true
 smartRestart: true

--- a/nodeup/pkg/model/kops-configuration.go
+++ b/nodeup/pkg/model/kops-configuration.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/systemd"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
+)
+
+// KopsConfigurationBuilder configures the kops-configuration service
+type KopsConfigurationBuilder struct {
+	*NodeupModelContext
+}
+
+var _ fi.NodeupModelBuilder = &KopsConfigurationBuilder{}
+
+// Build is responsible for disabling the kops-cofiguration service
+func (b *KopsConfigurationBuilder) Build(c *fi.NodeupModelBuilderContext) error {
+	serviceName := "kops-configuration.service"
+
+	manifest := &systemd.Manifest{}
+	manifest.Set("Unit", "Description", "Run kOps bootstrap (nodeup)")
+	manifest.Set("Unit", "Documentation", "https://github.com/kubernetes/kops")
+
+	manifest.Set("Service", "EnvironmentFile", "/etc/sysconfig/kops-configuration")
+	manifest.Set("Service", "EnvironmentFile", "/etc/environment")
+	manifest.Set("Service", "ExecStart", "/opt/kops/bin/nodeup --conf=/opt/kops/conf/kube_env.yaml --v=8")
+	manifest.Set("Service", "Type", "oneshot")
+
+	manifest.Set("Install", "WantedBy", "multi-user.target")
+
+	manifestString := manifest.Render()
+	klog.V(8).Infof("Built service manifest %q\n%s", serviceName, manifestString)
+
+	service := &nodetasks.Service{
+		Name:        serviceName,
+		Definition:  fi.PtrTo(manifestString),
+		Enabled:     fi.PtrTo(false),
+		ManageState: fi.PtrTo(false),
+	}
+
+	service.InitDefaults()
+
+	c.AddTask(service)
+
+	return nil
+}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -340,6 +340,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	loader.Builders = append(loader.Builders, &model.KopsControllerBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.WarmPoolBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &model.PrefixBuilder{NodeupModelContext: modelContext})
+	loader.Builders = append(loader.Builders, &model.KopsConfigurationBuilder{NodeupModelContext: modelContext})
 
 	loader.Builders = append(loader.Builders, &networking.CommonBuilder{NodeupModelContext: modelContext})
 	loader.Builders = append(loader.Builders, &networking.CalicoBuilder{NodeupModelContext: modelContext})


### PR DESCRIPTION
When the `systemd` package is updated, it restarts and `kops-configuration` will not continue because of #15078.

See test failure in https://github.com/kubernetes/kops/pull/15109.