### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -25,7 +25,7 @@ jobs:
         id: update_deps
         run: |
           make depup
-          echo "::set-output name=changes::$(git status --porcelain)"
+          echo "changes=$(git status --porcelain)" >> $GITHUB_OUTPUT
       - name: Create PR
         if: ${{ steps.update_deps.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

**What this PR does / why we need it**:

Resolve #15115 

Update `update-deps.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=changes::$(git status --porcelain)"
```

**TO-BE**

```yml
echo "changes=$(git status --porcelain)" >> $GITHUB_OUTPUT
```

