### PR TITLE
Document missing kops permission for aws NTH addon in SQS mode

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -306,6 +306,7 @@ The kOps CLI requires additional IAM permissions to manage the requisite EventBr
         "events:RemoveTargets",
         "events:TagResource",
         "sqs:CreateQueue",
+        "sqs:TagQueue",
         "sqs:DeleteQueue",
         "sqs:GetQueueAttributes",
         "sqs:ListQueues",


### PR DESCRIPTION
### Context

Kops 1.25.3 failed to create the SQS queue for aws node termination handler addon in SQS mode:
```
W0209 14:52:45.394593     231 executor.go:139] error running task "SQS/<cluster name redacted>-nth" (7m34s remaining to succeed): error creating SQS queue: AccessDenied: Access to the resource https://sqs.us-east-1.amazonaws.com/ is denied.
15:52:45  	status code: 403, request id: 1cd940c8-db6c-5038-a172-1c97d1911040
```
Adding `"sqs:TagQueue"` to the kops role fixed the error.

### Implementation

The PR adjusts the documented permissions that kops requires to setup infrastructure for kops NTH addon in SQS mode.