### PR TITLE
Automated cherry pick of #15052: bump aws-cni to 1.12.1 and re-order some manifests for a
#15109: bump aws cni to v1.12.2

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
+    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
+    manifestHash: 547e1a901abac73eddc6e58028feb822e3048585357ec73fa64dd9f71f457cce
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,31 +1,10 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
-
----
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -47,6 +26,23 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.12.1
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: aws-node
+  namespace: kube-system
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -56,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -232,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
         livenessProbe:
           exec:
             command:
@@ -281,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -118,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.2
         livenessProbe:
           exec:
             command:
@@ -277,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
+    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
+    manifestHash: 547e1a901abac73eddc6e58028feb822e3048585357ec73fa64dd9f71f457cce
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,31 +1,10 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
-
----
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -47,6 +26,23 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.12.1
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: aws-node
+  namespace: kube-system
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -56,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -232,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
         livenessProbe:
           exec:
             command:
@@ -281,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -118,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.2
         livenessProbe:
           exec:
             command:
@@ -277,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
+    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
+    manifestHash: 547e1a901abac73eddc6e58028feb822e3048585357ec73fa64dd9f71f457cce
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,31 +1,10 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
-
----
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -47,6 +26,23 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.12.1
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: aws-node
+  namespace: kube-system
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -56,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -232,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
         livenessProbe:
           exec:
             command:
@@ -281,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -118,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.2
         livenessProbe:
           exec:
             command:
@@ -277,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
+    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
+    manifestHash: 547e1a901abac73eddc6e58028feb822e3048585357ec73fa64dd9f71f457cce
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,31 +1,10 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
-
----
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -47,6 +26,23 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.12.1
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: aws-node
+  namespace: kube-system
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -56,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -232,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
         livenessProbe:
           exec:
             command:
@@ -281,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -118,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.2
         livenessProbe:
           exec:
             command:
@@ -277,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -186,7 +186,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
+    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -186,7 +186,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
+    manifestHash: 547e1a901abac73eddc6e58028feb822e3048585357ec73fa64dd9f71f457cce
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,31 +1,10 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
-
----
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -47,6 +26,23 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.12.1
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: aws-node
+  namespace: kube-system
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -56,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -232,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
         livenessProbe:
           exec:
             command:
@@ -281,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -118,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.2
         livenessProbe:
           exec:
             command:
@@ -277,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
+    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
+    manifestHash: 547e1a901abac73eddc6e58028feb822e3048585357ec73fa64dd9f71f457cce
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,31 +1,10 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
-
----
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -47,6 +26,23 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.12.1
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: aws-node
+  namespace: kube-system
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -56,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -232,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
         livenessProbe:
           exec:
             command:
@@ -281,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -118,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.2
         livenessProbe:
           exec:
             command:
@@ -277,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: eb20d586506b0f23e7a5af988add18d53aaec515feca8b86e1e692be8198d77f
+    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e06751fcea4a060a7aaae67102852a4855d099b1fd00e440f689d04a5042dd72
+    manifestHash: 547e1a901abac73eddc6e58028feb822e3048585357ec73fa64dd9f71f457cce
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,31 +1,10 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
-
----
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -47,6 +26,23 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.12.1
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: aws-node
+  namespace: kube-system
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -56,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -232,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
         livenessProbe:
           exec:
             command:
@@ -281,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -118,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -228,7 +228,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.2
         livenessProbe:
           exec:
             command:
@@ -277,7 +277,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -33,7 +33,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.1"
+    app.kubernetes.io/version: "v1.12.2"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.1"
+    app.kubernetes.io/version: "v1.12.2"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -88,7 +88,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.1"
+    app.kubernetes.io/version: "v1.12.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -108,7 +108,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.1"
+    app.kubernetes.io/version: "v1.12.2"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -129,7 +129,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1" }}"
+        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.2" }}"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -147,7 +147,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1" }}"
+          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.2" }}"
           ports:
             - containerPort: 61678
               name: metrics

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,27 +1,10 @@
 # Vendored from https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.12/config/master/aws-k8s-cni.yaml
 ---
-# Source: aws-vpc-cni/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: aws-node
-  namespace: kube-system
-  labels:
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/instance: aws-vpc-cni
-    k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.0"
----
-# Source: aws-vpc-cni/templates/customresourcedefinition.yaml
+# Source: crds/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eniconfigs.crd.k8s.amazonaws.com
-  labels:
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/instance: aws-vpc-cni
-    k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.0"
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -38,6 +21,19 @@ spec:
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig
+
+---
+# Source: aws-vpc-cni/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.12.1"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -48,7 +44,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.0"
+    app.kubernetes.io/version: "v1.12.1"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -92,7 +88,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.0"
+    app.kubernetes.io/version: "v1.12.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -112,7 +108,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.12.0"
+    app.kubernetes.io/version: "v1.12.1"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -133,7 +129,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0" }}"
+        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1" }}"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -151,7 +147,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0" }}"
+          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1" }}"
           ports:
             - containerPort: 61678
               name: metrics

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 550350671833a707fdcdc8a2d95f96694e9fadff927db9ed6af5924ca91df1c5
+    manifestHash: 430358747fef738619f074b0d5a51d42325b41f0b195416761fab46164f29600
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 430358747fef738619f074b0d5a51d42325b41f0b195416761fab46164f29600
+    manifestHash: a411ad1a94134f2d87100a7d8ca9f79486a8c3ebea61180619d7d56f50ef0dd3
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -1,31 +1,10 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
-
----
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -47,6 +26,23 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.12.1
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: aws-node
+  namespace: kube-system
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -56,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -234,7 +230,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
         livenessProbe:
           exec:
             command:
@@ -283,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -118,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -230,7 +230,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.2
         livenessProbe:
           exec:
             command:
@@ -279,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 550350671833a707fdcdc8a2d95f96694e9fadff927db9ed6af5924ca91df1c5
+    manifestHash: 430358747fef738619f074b0d5a51d42325b41f0b195416761fab46164f29600
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 430358747fef738619f074b0d5a51d42325b41f0b195416761fab46164f29600
+    manifestHash: a411ad1a94134f2d87100a7d8ca9f79486a8c3ebea61180619d7d56f50ef0dd3
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -1,31 +1,10 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
-
----
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
-    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -47,6 +26,23 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.12.1
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: aws-node
+  namespace: kube-system
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -56,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -122,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -146,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.1
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -234,7 +230,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
         livenessProbe:
           exec:
             command:
@@ -283,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -118,7 +118,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.12.1
+    app.kubernetes.io/version: v1.12.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -230,7 +230,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.2
         livenessProbe:
           exec:
             command:
@@ -279,7 +279,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true


### PR DESCRIPTION
Cherry pick of #15052 #15109 on release-1.26.

#15052: bump aws-cni to 1.12.1 and re-order some manifests for a
#15109: bump aws cni to v1.12.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```