### PR TITLE
digitalocean: don't print empty IP addresses

### DIFF
--- a/pkg/resources/digitalocean/resources.go
+++ b/pkg/resources/digitalocean/resources.go
@@ -356,10 +356,10 @@ func dumpDroplet(op *resources.DumpOperation, r *resources.Resource) error {
 	i := &resources.Instance{
 		Name: r.ID,
 	}
-	if ip, err := droplet.PublicIPv4(); err == nil {
+	if ip, err := droplet.PublicIPv4(); ip != "" && err == nil {
 		i.PublicAddresses = append(i.PublicAddresses, ip)
 	}
-	if ip, err := droplet.PublicIPv6(); err == nil {
+	if ip, err := droplet.PublicIPv6(); ip != "" && err == nil {
 		i.PublicAddresses = append(i.PublicAddresses, ip)
 	}
 	if img := droplet.Image; img != nil {


### PR DESCRIPTION
Now we have some IPv6 support, we were printing an empty address when
machines did not have an IPv6 address.
