### PR TITLE
Automated cherry pick of #15134: Use registry.k8s.io for legacy addons

### DIFF
--- a/addons/cluster-autoscaler/README.md
+++ b/addons/cluster-autoscaler/README.md
@@ -8,7 +8,7 @@ Note that you likely want to change `AWS_REGION` and `GROUP_NAME`, and probably 
 
 ```bash
 CLOUD_PROVIDER=aws
-IMAGE=k8s.gcr.io/cluster-autoscaler:v1.2.2
+IMAGE=registry.k8s.io/cluster-autoscaler:v1.2.2
 MIN_NODES=1
 MAX_NODES=5
 AWS_REGION=us-east-1

--- a/addons/cluster-autoscaler/cluster-autoscaler.sh
+++ b/addons/cluster-autoscaler/cluster-autoscaler.sh
@@ -19,7 +19,7 @@ set -e
 #Set all the variables in this section
 CLUSTER_NAME="myfirstcluster.k8s.local"
 CLOUD_PROVIDER=aws
-IMAGE=k8s.gcr.io/cluster-autoscaler:v1.1.0
+IMAGE=registry.k8s.io/cluster-autoscaler:v1.1.0
 MIN_NODES=2
 MAX_NODES=20
 AWS_REGION=us-east-1

--- a/addons/ingress-nginx/README.md
+++ b/addons/ingress-nginx/README.md
@@ -13,7 +13,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons
 ## Creating a simple ingress
 
 ```
-kubectl run echoheaders --image=k8s.gcr.io/echoserver:1.4 --replicas=1 --port=8080
+kubectl run echoheaders --image=registry.k8s.io/echoserver:1.4 --replicas=1 --port=8080
 kubectl expose deployment echoheaders --port=80 --target-port=8080 --name=echoheaders-x
 kubectl expose deployment echoheaders --port=80 --target-port=8080 --name=echoheaders-y
 

--- a/addons/ingress-nginx/v1.4.0.yaml
+++ b/addons/ingress-nginx/v1.4.0.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: default-http-backend
-        image: k8s.gcr.io/defaultbackend:1.0
+        image: registry.k8s.io/defaultbackend:1.0
         livenessProbe:
           httpGet:
             path: /healthz
@@ -101,7 +101,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: k8s.gcr.io/nginx-ingress-controller:0.8.3
+      - image: registry.k8s.io/nginx-ingress-controller:0.8.3
         name: ingress-nginx
         imagePullPolicy: Always
         ports:

--- a/addons/ingress-nginx/v1.6.0-gce.yaml
+++ b/addons/ingress-nginx/v1.6.0-gce.yaml
@@ -194,7 +194,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: default-http-backend
-        image: k8s.gcr.io/defaultbackend:1.4
+        image: registry.k8s.io/defaultbackend:1.4
         livenessProbe:
           httpGet:
             path: /healthz

--- a/addons/ingress-nginx/v1.6.0.yaml
+++ b/addons/ingress-nginx/v1.6.0.yaml
@@ -197,7 +197,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: default-http-backend
-        image: k8s.gcr.io/defaultbackend:1.4
+        image: registry.k8s.io/defaultbackend:1.4
         livenessProbe:
           httpGet:
             path: /healthz

--- a/addons/kube-state-metrics/v1.0.1.yaml
+++ b/addons/kube-state-metrics/v1.0.1.yaml
@@ -76,7 +76,7 @@ spec:
             memory: 200Mi
             cpu: 200m
       - name: addon-resizer
-        image: k8s.gcr.io/addon-resizer:1.0
+        image: registry.k8s.io/addon-resizer:1.0
         resources:
           limits:
             cpu: 100m

--- a/addons/kube-state-metrics/v1.1.0-rc.0.yaml
+++ b/addons/kube-state-metrics/v1.1.0-rc.0.yaml
@@ -76,7 +76,7 @@ spec:
             memory: 200Mi
             cpu: 200m
       - name: addon-resizer
-        image: k8s.gcr.io/addon-resizer:1.0
+        image: registry.k8s.io/addon-resizer:1.0
         resources:
           limits:
             cpu: 100m

--- a/addons/kube-state-metrics/v1.1.0.yaml
+++ b/addons/kube-state-metrics/v1.1.0.yaml
@@ -76,7 +76,7 @@ spec:
             memory: 500Mi
             cpu: 300m
       - name: addon-resizer
-        image: k8s.gcr.io/addon-resizer:1.8.1
+        image: registry.k8s.io/addon-resizer:1.8.1
         resources:
           limits:
             cpu: 100m

--- a/addons/kubernetes-dashboard/v1.1.0.yaml
+++ b/addons/kubernetes-dashboard/v1.1.0.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.1.0
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.1.0
         imagePullPolicy: Always
         ports:
         - name: http

--- a/addons/kubernetes-dashboard/v1.10.1.yaml
+++ b/addons/kubernetes-dashboard/v1.10.1.yaml
@@ -114,7 +114,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.10.1
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/addons/kubernetes-dashboard/v1.4.0.yaml
+++ b/addons/kubernetes-dashboard/v1.4.0.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.4.0
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.4.0
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/addons/kubernetes-dashboard/v1.5.0.yaml
+++ b/addons/kubernetes-dashboard/v1.5.0.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.5.0
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.5.0
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/addons/kubernetes-dashboard/v1.6.0.yaml
+++ b/addons/kubernetes-dashboard/v1.6.0.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.6.0
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.6.0
         ports:
         - containerPort: 9090
           protocol: TCP

--- a/addons/kubernetes-dashboard/v1.6.1.yaml
+++ b/addons/kubernetes-dashboard/v1.6.1.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.6.1
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.6.1
         ports:
         - containerPort: 9090
           protocol: TCP

--- a/addons/kubernetes-dashboard/v1.6.3.yaml
+++ b/addons/kubernetes-dashboard/v1.6.3.yaml
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.6.3
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.6.3
         ports:
         - containerPort: 9090
           protocol: TCP

--- a/addons/kubernetes-dashboard/v1.7.0.yaml
+++ b/addons/kubernetes-dashboard/v1.7.0.yaml
@@ -90,7 +90,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.7.0
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.7.0
         ports:
         - containerPort: 9090
           protocol: TCP

--- a/addons/kubernetes-dashboard/v1.7.1.yaml
+++ b/addons/kubernetes-dashboard/v1.7.1.yaml
@@ -90,7 +90,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.7.1
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.7.1
         ports:
         - containerPort: 9090
           protocol: TCP

--- a/addons/kubernetes-dashboard/v1.8.0.yaml
+++ b/addons/kubernetes-dashboard/v1.8.0.yaml
@@ -110,7 +110,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.0
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.8.0
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/addons/kubernetes-dashboard/v1.8.1.yaml
+++ b/addons/kubernetes-dashboard/v1.8.1.yaml
@@ -114,7 +114,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.8.1
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/addons/kubernetes-dashboard/v1.8.3.yaml
+++ b/addons/kubernetes-dashboard/v1.8.3.yaml
@@ -114,7 +114,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.3
+        image: registry.k8s.io/kubernetes-dashboard-amd64:v1.8.3
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/addons/logging-elasticsearch/v1.5.0.yaml
+++ b/addons/logging-elasticsearch/v1.5.0.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: fluentd-es
-        image: k8s.gcr.io/fluentd-elasticsearch:1.22
+        image: registry.k8s.io/fluentd-elasticsearch:1.22
         command:
           - '/bin/sh'
           - '-c'
@@ -89,7 +89,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-      - image: k8s.gcr.io/elasticsearch:v2.4.1-2
+      - image: registry.k8s.io/elasticsearch:v2.4.1-2
         name: elasticsearch-logging
         resources:
           # need more cpu upon initialization, therefore burstable class
@@ -146,7 +146,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: k8s.gcr.io/kibana:v4.6.1-1
+        image: registry.k8s.io/kibana:v4.6.1-1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/addons/logging-elasticsearch/v1.6.0.yaml
+++ b/addons/logging-elasticsearch/v1.6.0.yaml
@@ -113,7 +113,7 @@ spec:
       serviceAccountName: fluentd-es
       containers:
       - name: fluentd-es
-        image: k8s.gcr.io/fluentd-elasticsearch:1.22
+        image: registry.k8s.io/fluentd-elasticsearch:1.22
         command:
           - '/bin/sh'
           - '-c'
@@ -185,7 +185,7 @@ spec:
     spec:
       serviceAccountName: elasticsearch-logging
       containers:
-      - image: k8s.gcr.io/elasticsearch:v2.4.1-2
+      - image: registry.k8s.io/elasticsearch:v2.4.1-2
         name: elasticsearch-logging
         resources:
           # need more cpu upon initialization, therefore burstable class
@@ -242,7 +242,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: k8s.gcr.io/kibana:v4.6.1-1
+        image: registry.k8s.io/kibana:v4.6.1-1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/addons/logging-elasticsearch/v1.7.0.yaml
+++ b/addons/logging-elasticsearch/v1.7.0.yaml
@@ -113,7 +113,7 @@ spec:
       serviceAccountName: fluentd-es
       containers:
       - name: fluentd-es
-        image: k8s.gcr.io/fluentd-elasticsearch:1.22
+        image: registry.k8s.io/fluentd-elasticsearch:1.22
         command:
           - '/bin/sh'
           - '-c'
@@ -185,7 +185,7 @@ spec:
     spec:
       serviceAccountName: elasticsearch-logging
       containers:
-      - image: k8s.gcr.io/elasticsearch:v5.6.4
+      - image: registry.k8s.io/elasticsearch:v5.6.4
         name: elasticsearch-logging
         resources:
           # need more cpu upon initialization, therefore burstable class

--- a/addons/metrics-server/v1.16.x.yaml
+++ b/addons/metrics-server/v1.16.x.yaml
@@ -136,7 +136,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        image: registry.k8s.io/metrics-server-amd64:v0.3.6
         imagePullPolicy: Always
         command:
             - /metrics-server

--- a/addons/metrics-server/v1.8.x.yaml
+++ b/addons/metrics-server/v1.8.x.yaml
@@ -136,7 +136,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        image: registry.k8s.io/metrics-server-amd64:v0.3.6
         imagePullPolicy: Always
         command:
             - /metrics-server

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -604,9 +604,6 @@ func (b *KubeAPIServerBuilder) buildPod(kubeAPIServer *kops.KubeAPIServerConfig)
 	}
 
 	image := kubeAPIServer.Image
-	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) && b.IsKubernetesLT("1.25") {
-		image = strings.Replace(image, "registry.k8s.io", "k8s.gcr.io", 1)
-	}
 	if b.Architecture != architectures.ArchitectureAmd64 {
 		image = strings.Replace(image, "-amd64", "-"+string(b.Architecture), 1)
 	}

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/pkg/k8scodecs"
 	"k8s.io/kops/pkg/kubemanifest"
-	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/pkg/rbac"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
@@ -205,9 +204,6 @@ func (b *KubeControllerManagerBuilder) buildPod(kcm *kops.KubeControllerManagerC
 	flags = append(flags, "--flex-volume-plugin-dir="+volumePluginDir)
 
 	image := kcm.Image
-	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) && b.IsKubernetesLT("1.25") {
-		image = strings.Replace(image, "registry.k8s.io", "k8s.gcr.io", 1)
-	}
 	if b.Architecture != architectures.ArchitectureAmd64 {
 		image = strings.Replace(image, "-amd64", "-"+string(b.Architecture), 1)
 	}

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/pkg/k8scodecs"
 	"k8s.io/kops/pkg/kubemanifest"
-	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/pkg/rbac"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
@@ -165,9 +164,6 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	image := c.Image
 	if b.Architecture != architectures.ArchitectureAmd64 {
 		image = strings.Replace(image, "-amd64", "-"+string(b.Architecture), 1)
-	}
-	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) && b.IsKubernetesLT("1.25") {
-		image = strings.Replace(image, "registry.k8s.io", "k8s.gcr.io", 1)
 	}
 
 	container := &v1.Container{

--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/pkg/k8scodecs"
 	"k8s.io/kops/pkg/kubemanifest"
-	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/pkg/model/components/kubescheduler"
 	"k8s.io/kops/pkg/rbac"
 	"k8s.io/kops/upup/pkg/fi"
@@ -223,9 +222,6 @@ func (b *KubeSchedulerBuilder) buildPod(kubeScheduler *kops.KubeSchedulerConfig)
 	}
 
 	image := kubeScheduler.Image
-	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) && b.IsKubernetesLT("1.25") {
-		image = strings.Replace(image, "registry.k8s.io", "k8s.gcr.io", 1)
-	}
 	if b.Architecture != architectures.ArchitectureAmd64 {
 		image = strings.Replace(image, "-amd64", "-"+string(b.Architecture), 1)
 	}

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
@@ -55,7 +55,7 @@ contents: |
       - --log-file=/var/log/kube-apiserver.log
       command:
       - /usr/local/bin/kube-apiserver
-      image: k8s.gcr.io/kube-apiserver-amd64:v1.22.0
+      image: registry.k8s.io/kube-apiserver-amd64:v1.22.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
@@ -55,7 +55,7 @@ contents: |
       - --log-file=/var/log/kube-apiserver.log
       command:
       - /usr/local/bin/kube-apiserver
-      image: k8s.gcr.io/kube-apiserver-arm64:v1.22.0
+      image: registry.k8s.io/kube-apiserver-arm64:v1.22.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
@@ -36,7 +36,7 @@ contents: |
       - --log-file=/var/log/kube-controller-manager.log
       command:
       - /usr/local/bin/kube-controller-manager
-      image: k8s.gcr.io/kube-controller-manager-amd64:v1.22.0
+      image: registry.k8s.io/kube-controller-manager-amd64:v1.22.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
@@ -36,7 +36,7 @@ contents: |
       - --log-file=/var/log/kube-controller-manager.log
       command:
       - /usr/local/bin/kube-controller-manager
-      image: k8s.gcr.io/kube-controller-manager-arm64:v1.22.0
+      image: registry.k8s.io/kube-controller-manager-arm64:v1.22.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-amd64.yaml
@@ -23,7 +23,7 @@ contents: |
       - --log-file=/var/log/kube-proxy.log
       command:
       - /usr/local/bin/kube-proxy
-      image: k8s.gcr.io/kube-proxy-amd64:v1.22.0
+      image: registry.k8s.io/kube-proxy-amd64:v1.22.0
       name: kube-proxy
       resources:
         requests:

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-arm64.yaml
@@ -23,7 +23,7 @@ contents: |
       - --log-file=/var/log/kube-proxy.log
       command:
       - /usr/local/bin/kube-proxy
-      image: k8s.gcr.io/kube-proxy-arm64:v1.22.0
+      image: registry.k8s.io/kube-proxy-arm64:v1.22.0
       name: kube-proxy
       resources:
         requests:

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-amd64.yaml
@@ -23,7 +23,7 @@ contents: |
       - --log-file=/var/log/kube-scheduler.log
       command:
       - /usr/local/bin/kube-scheduler
-      image: k8s.gcr.io/kube-scheduler-amd64:v1.22.0
+      image: registry.k8s.io/kube-scheduler-amd64:v1.22.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-arm64.yaml
@@ -23,7 +23,7 @@ contents: |
       - --log-file=/var/log/kube-scheduler.log
       command:
       - /usr/local/bin/kube-scheduler
-      image: k8s.gcr.io/kube-scheduler-arm64:v1.22.0
+      image: registry.k8s.io/kube-scheduler-arm64:v1.22.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -143,7 +143,7 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 		CanonicalLocation: image,
 	}
 
-	if strings.HasPrefix(image, "k8s.gcr.io/kops/dns-controller:") || strings.HasPrefix(image, "registry.k8s.io/kops/dns-controller:") {
+	if strings.HasPrefix(image, "registry.k8s.io/kops/dns-controller:") {
 		// To use user-defined DNS Controller:
 		// 1. DOCKER_REGISTRY=[your docker hub repo] make dns-controller-push
 		// 2. export DNSCONTROLLER_IMAGE=[your docker hub repo]
@@ -154,7 +154,7 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 		}
 	}
 
-	if strings.HasPrefix(image, "k8s.gcr.io/kops/kops-controller:") || strings.HasPrefix(image, "registry.k8s.io/kops/kops-controller:") {
+	if strings.HasPrefix(image, "registry.k8s.io/kops/kops-controller:") {
 		// To use user-defined DNS Controller:
 		// 1. DOCKER_REGISTRY=[your docker hub repo] make kops-controller-push
 		// 2. export KOPSCONTROLLER_IMAGE=[your docker hub repo]
@@ -165,7 +165,7 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 		}
 	}
 
-	if strings.HasPrefix(image, "k8s.gcr.io/kops/kube-apiserver-healthcheck:") || strings.HasPrefix(image, "registry.k8s.io/kops/kube-apiserver-healthcheck:") {
+	if strings.HasPrefix(image, "registry.k8s.io/kops/kube-apiserver-healthcheck:") {
 		override := os.Getenv("KUBE_APISERVER_HEALTHCHECK_IMAGE")
 		if override != "" {
 			image = override
@@ -177,7 +177,7 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 		normalized := image
 
 		// If the image name contains only a single / we need to determine if the image is located on docker-hub or if it's using a convenient URL,
-		// like k8s.gcr.io/<image-name> or registry.k8s.io/<image-name>
+		// like registry.k8s.io/<image-name> or registry.k8s.io/<image-name>
 		// In case of a hub image it should be sufficient to just prepend the proxy url, producing eg docker-proxy.example.com/weaveworks/weave-kube
 		if strings.Count(normalized, "/") <= 1 && !strings.ContainsAny(strings.Split(normalized, "/")[0], ".:") {
 			normalized = containerProxy + "/" + normalized
@@ -197,7 +197,6 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 		normalized := image
 
 		// Remove the 'standard' kubernetes image prefixes, just for sanity
-		normalized = strings.TrimPrefix(normalized, "k8s.gcr.io/")
 		normalized = strings.TrimPrefix(normalized, "registry.k8s.io/")
 
 		// When assembling the cluster spec, kops may call the option more then once until the config converges

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 10cdb84ad4055ddadd11022796c90676417e60c1d34f6740d9e275051f2c5e7a
+    manifestHash: 5b18a0e4a56168a792e1366d4bd57fe7c232a0e78baf91241ba61ffcbeb79bf5
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -45,7 +45,7 @@ spec:
       containers:
       - args:
         - -addr=169.254.169.252:988
-        image: k8s.gcr.io/metadata-proxy:v0.1.12
+        image: registry.k8s.io/metadata-proxy:v0.1.12
         name: metadata-proxy
         resources:
           limits:
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: registry.k8s.io/prometheus-to-sd:v0.5.0
         name: prometheus-to-sd-exporter
         resources:
           limits:
@@ -99,7 +99,7 @@ spec:
           ip addr add dev lo 169.254.169.252/32
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
-        image: k8s.gcr.io/k8s-custom-iptables:1.0
+        image: registry.k8s.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables
         securityContext:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -126,7 +126,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 10cdb84ad4055ddadd11022796c90676417e60c1d34f6740d9e275051f2c5e7a
+    manifestHash: 5b18a0e4a56168a792e1366d4bd57fe7c232a0e78baf91241ba61ffcbeb79bf5
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -45,7 +45,7 @@ spec:
       containers:
       - args:
         - -addr=169.254.169.252:988
-        image: k8s.gcr.io/metadata-proxy:v0.1.12
+        image: registry.k8s.io/metadata-proxy:v0.1.12
         name: metadata-proxy
         resources:
           limits:
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: registry.k8s.io/prometheus-to-sd:v0.5.0
         name: prometheus-to-sd-exporter
         resources:
           limits:
@@ -99,7 +99,7 @@ spec:
           ip addr add dev lo 169.254.169.252/32
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
-        image: k8s.gcr.io/k8s-custom-iptables:1.0
+        image: registry.k8s.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables
         securityContext:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 10cdb84ad4055ddadd11022796c90676417e60c1d34f6740d9e275051f2c5e7a
+    manifestHash: 5b18a0e4a56168a792e1366d4bd57fe7c232a0e78baf91241ba61ffcbeb79bf5
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -45,7 +45,7 @@ spec:
       containers:
       - args:
         - -addr=169.254.169.252:988
-        image: k8s.gcr.io/metadata-proxy:v0.1.12
+        image: registry.k8s.io/metadata-proxy:v0.1.12
         name: metadata-proxy
         resources:
           limits:
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: registry.k8s.io/prometheus-to-sd:v0.5.0
         name: prometheus-to-sd-exporter
         resources:
           limits:
@@ -99,7 +99,7 @@ spec:
           ip addr add dev lo 169.254.169.252/32
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
-        image: k8s.gcr.io/k8s-custom-iptables:1.0
+        image: registry.k8s.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables
         securityContext:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 10cdb84ad4055ddadd11022796c90676417e60c1d34f6740d9e275051f2c5e7a
+    manifestHash: 5b18a0e4a56168a792e1366d4bd57fe7c232a0e78baf91241ba61ffcbeb79bf5
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -45,7 +45,7 @@ spec:
       containers:
       - args:
         - -addr=169.254.169.252:988
-        image: k8s.gcr.io/metadata-proxy:v0.1.12
+        image: registry.k8s.io/metadata-proxy:v0.1.12
         name: metadata-proxy
         resources:
           limits:
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: registry.k8s.io/prometheus-to-sd:v0.5.0
         name: prometheus-to-sd-exporter
         resources:
           limits:
@@ -99,7 +99,7 @@ spec:
           ip addr add dev lo 169.254.169.252/32
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
-        image: k8s.gcr.io/k8s-custom-iptables:1.0
+        image: registry.k8s.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables
         securityContext:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 10cdb84ad4055ddadd11022796c90676417e60c1d34f6740d9e275051f2c5e7a
+    manifestHash: 5b18a0e4a56168a792e1366d4bd57fe7c232a0e78baf91241ba61ffcbeb79bf5
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -45,7 +45,7 @@ spec:
       containers:
       - args:
         - -addr=169.254.169.252:988
-        image: k8s.gcr.io/metadata-proxy:v0.1.12
+        image: registry.k8s.io/metadata-proxy:v0.1.12
         name: metadata-proxy
         resources:
           limits:
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: registry.k8s.io/prometheus-to-sd:v0.5.0
         name: prometheus-to-sd-exporter
         resources:
           limits:
@@ -99,7 +99,7 @@ spec:
           ip addr add dev lo 169.254.169.252/32
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
-        image: k8s.gcr.io/k8s-custom-iptables:1.0
+        image: registry.k8s.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables
         securityContext:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 10cdb84ad4055ddadd11022796c90676417e60c1d34f6740d9e275051f2c5e7a
+    manifestHash: 5b18a0e4a56168a792e1366d4bd57fe7c232a0e78baf91241ba61ffcbeb79bf5
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -45,7 +45,7 @@ spec:
       containers:
       - args:
         - -addr=169.254.169.252:988
-        image: k8s.gcr.io/metadata-proxy:v0.1.12
+        image: registry.k8s.io/metadata-proxy:v0.1.12
         name: metadata-proxy
         resources:
           limits:
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: registry.k8s.io/prometheus-to-sd:v0.5.0
         name: prometheus-to-sd-exporter
         resources:
           limits:
@@ -99,7 +99,7 @@ spec:
           ip addr add dev lo 169.254.169.252/32
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
-        image: k8s.gcr.io/k8s-custom-iptables:1.0
+        image: registry.k8s.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables
         securityContext:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 10cdb84ad4055ddadd11022796c90676417e60c1d34f6740d9e275051f2c5e7a
+    manifestHash: 5b18a0e4a56168a792e1366d4bd57fe7c232a0e78baf91241ba61ffcbeb79bf5
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -45,7 +45,7 @@ spec:
       containers:
       - args:
         - -addr=169.254.169.252:988
-        image: k8s.gcr.io/metadata-proxy:v0.1.12
+        image: registry.k8s.io/metadata-proxy:v0.1.12
         name: metadata-proxy
         resources:
           limits:
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: registry.k8s.io/prometheus-to-sd:v0.5.0
         name: prometheus-to-sd-exporter
         resources:
           limits:
@@ -99,7 +99,7 @@ spec:
           ip addr add dev lo 169.254.169.252/32
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
-        image: k8s.gcr.io/k8s-custom-iptables:1.0
+        image: registry.k8s.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables
         securityContext:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 10cdb84ad4055ddadd11022796c90676417e60c1d34f6740d9e275051f2c5e7a
+    manifestHash: 5b18a0e4a56168a792e1366d4bd57fe7c232a0e78baf91241ba61ffcbeb79bf5
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -45,7 +45,7 @@ spec:
       containers:
       - args:
         - -addr=169.254.169.252:988
-        image: k8s.gcr.io/metadata-proxy:v0.1.12
+        image: registry.k8s.io/metadata-proxy:v0.1.12
         name: metadata-proxy
         resources:
           limits:
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: registry.k8s.io/prometheus-to-sd:v0.5.0
         name: prometheus-to-sd-exporter
         resources:
           limits:
@@ -99,7 +99,7 @@ spec:
           ip addr add dev lo 169.254.169.252/32
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
-        image: k8s.gcr.io/k8s-custom-iptables:1.0
+        image: registry.k8s.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables
         securityContext:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: hcloud-csi-driver.addons.k8s.io/k8s-1.22.yaml
-    manifestHash: 8e3f5a90da912e2ce39a53fbcfd76c39c1fa52cec43678cf1286e37690028c66
+    manifestHash: d5ccf385e0b90b1ff175c0a6feaf454dd8f4bda4dedb8ddc61b040807c1300e4
     name: hcloud-csi-driver.addons.k8s.io
     selector:
       k8s-addon: hcloud-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-csi-driver.addons.k8s.io-k8s-1.22_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-csi-driver.addons.k8s.io-k8s-1.22_content
@@ -271,12 +271,12 @@ spec:
         kops.k8s.io/managed-by: kops
     spec:
       containers:
-      - image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+      - image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
         name: csi-attacher
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+      - image: registry.k8s.io/sig-storage/csi-resizer:v1.2.0
         name: csi-resizer
         volumeMounts:
         - mountPath: /run/csi
@@ -284,7 +284,7 @@ spec:
       - args:
         - --feature-gates=Topology=true
         - --default-fstype=ext4
-        image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
         name: csi-provisioner
         volumeMounts:
         - mountPath: /run/csi
@@ -328,7 +328,7 @@ spec:
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+      - image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:
@@ -375,7 +375,7 @@ spec:
       containers:
       - args:
         - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
         name: csi-node-driver-registrar
         volumeMounts:
         - mountPath: /run/csi
@@ -418,7 +418,7 @@ spec:
           name: plugin-dir
         - mountPath: /dev
           name: device-dir
-      - image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+      - image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:

--- a/upup/models/cloudup/resources/addons/digitalocean-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
@@ -801,7 +801,7 @@ spec:
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--default-fstype=ext4"
@@ -814,7 +814,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -828,7 +828,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -840,7 +840,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.5.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=30s"
@@ -1088,7 +1088,7 @@ spec:
               mountPath: /etc/udev/rules.d/
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -1230,7 +1230,7 @@ spec:
       serviceAccountName: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: k8s.gcr.io/sig-storage/snapshot-controller:v6.0.1
+          image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
           args:
             - "--v=5"
           imagePullPolicy: IfNotPresent

--- a/upup/models/cloudup/resources/addons/hcloud-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/hcloud-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
@@ -219,12 +219,12 @@ spec:
         app: hcloud-csi-controller
     spec:
       containers:
-      - image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+      - image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
         name: csi-attacher
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+      - image: registry.k8s.io/sig-storage/csi-resizer:v1.2.0
         name: csi-resizer
         volumeMounts:
         - mountPath: /run/csi
@@ -232,7 +232,7 @@ spec:
       - args:
         - --feature-gates=Topology=true
         - --default-fstype=ext4
-        image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
         name: csi-provisioner
         volumeMounts:
         - mountPath: /run/csi
@@ -276,7 +276,7 @@ spec:
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+      - image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:
@@ -315,7 +315,7 @@ spec:
       containers:
       - args:
         - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
         name: csi-node-driver-registrar
         volumeMounts:
         - mountPath: /run/csi
@@ -358,7 +358,7 @@ spec:
           name: plugin-dir
         - mountPath: /dev
           name: device-dir
-      - image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+      - image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:

--- a/upup/models/cloudup/resources/addons/metadata-proxy.addons.k8s.io/v0.1.12.yaml
+++ b/upup/models/cloudup/resources/addons/metadata-proxy.addons.k8s.io/v0.1.12.yaml
@@ -48,7 +48,7 @@ spec:
       - name: update-ipdtables
         securityContext:
           privileged: true
-        image: k8s.gcr.io/k8s-custom-iptables:1.0
+        image: registry.k8s.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         command:
         - "/bin/sh"
@@ -77,7 +77,7 @@ spec:
           type: Directory
       containers:
       - name: metadata-proxy
-        image: k8s.gcr.io/metadata-proxy:v0.1.12
+        image: registry.k8s.io/metadata-proxy:v0.1.12
         securityContext:
           privileged: true
         args:
@@ -92,7 +92,7 @@ spec:
             cpu: "30m"
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: registry.k8s.io/prometheus-to-sd:v0.5.0
         # Request and limit resources to get guaranteed QoS.
         resources:
           requests:


### PR DESCRIPTION
Cherry pick of #15134 on release-1.26.

#15134: Use registry.k8s.io for legacy addons

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```