### PR TITLE
exit nodeup gracefully if server already exists in k8s

### DIFF
--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -142,6 +142,12 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 
 	id, err := s.verifier.VerifyToken(ctx, r, r.Header.Get("Authorization"), body, s.opt.Server.UseInstanceIDForNodeName)
 	if err != nil {
+		// means that we should exit nodeup gracefully
+		if err == bootstrap.ErrAlreadyExists {
+			w.WriteHeader(http.StatusNoContent)
+			klog.Infof("%s: %v", r.RemoteAddr, err)
+			return
+		}
 		klog.Infof("bootstrap %s verify err: %v", r.RemoteAddr, err)
 		w.WriteHeader(http.StatusForbidden)
 		// don't return the error; this allows us to have richer errors without security implications

--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -144,7 +144,7 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// means that we should exit nodeup gracefully
 		if err == bootstrap.ErrAlreadyExists {
-			w.WriteHeader(http.StatusNoContent)
+			w.WriteHeader(http.StatusConflict)
 			klog.Infof("%s: %v", r.RemoteAddr, err)
 			return
 		}

--- a/pkg/bootstrap/authenticate.go
+++ b/pkg/bootstrap/authenticate.go
@@ -18,8 +18,11 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"net/http"
 )
+
+var ErrAlreadyExists = errors.New("node already exists")
 
 // Authenticator generates authentication credentials for requests.
 type Authenticator interface {

--- a/pkg/kopscontrollerclient/client.go
+++ b/pkg/kopscontrollerclient/client.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"time"
 
@@ -148,6 +149,12 @@ func (b *Client) Query(ctx context.Context, req any, resp any) error {
 	}
 	if response.Body != nil {
 		defer response.Body.Close()
+	}
+
+	// if we receive StatusNoContent it means that we should exit gracefully
+	if response.StatusCode == http.StatusNoContent {
+		klog.Infof("kops-controller returned status code %d", response.StatusCode)
+		os.Exit(0)
 	}
 
 	if response.StatusCode != http.StatusOK {

--- a/pkg/kopscontrollerclient/client.go
+++ b/pkg/kopscontrollerclient/client.go
@@ -151,8 +151,8 @@ func (b *Client) Query(ctx context.Context, req any, resp any) error {
 		defer response.Body.Close()
 	}
 
-	// if we receive StatusNoContent it means that we should exit gracefully
-	if response.StatusCode == http.StatusNoContent {
+	// if we receive StatusConflict it means that we should exit gracefully
+	if response.StatusCode == http.StatusConflict {
 		klog.Infof("kops-controller returned status code %d", response.StatusCode)
 		os.Exit(0)
 	}

--- a/upup/pkg/fi/cloudup/openstack/verifier.go
+++ b/upup/pkg/fi/cloudup/openstack/verifier.go
@@ -154,7 +154,7 @@ func (o openstackVerifier) VerifyToken(ctx context.Context, rawRequest *http.Req
 	// check from kubernetes API does the instance already exist
 	_, err = o.kubeClient.CoreV1().Nodes().Get(ctx, instance.Name, v1.GetOptions{})
 	if err == nil {
-		return nil, fmt.Errorf("server %q is already joined to kubernetes cluster", instance.Name)
+		return nil, bootstrap.ErrAlreadyExists
 	}
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, fmt.Errorf("got error while querying kubernetes api: %w", err)


### PR DESCRIPTION
Original issue for this is https://github.com/kubernetes/kops/issues/15057 but it was reverted due to other issues in https://github.com/kubernetes/kops/pull/15129

some discussion available in https://github.com/kubernetes/kops/pull/15114#pullrequestreview-1287780870

I have verified that this solution works in OpenStack. When existing instance tries to join again to cluster (it does that when rebooting server OR restarting kops-configuration.service):

kops-controller log:
```
kops-controller-t4b8j kops-controller I0212 14:11:02.063861       1 server.go:148] 10.2.96.248:59480: instance already exists in kubernetes cluster
```

node log
```
Feb 12 14:11:03 nodes-helpa-fctnib nodeup[669]: I0212 14:11:03.187949     669 client.go:156] bootstrap request responded with code 204
Feb 12 14:11:03 nodes-helpa-fctnib systemd[1]: kops-configuration.service: Succeeded.
Feb 12 14:11:03 nodes-helpa-fctnib systemd[1]: Finished Run kOps bootstrap (nodeup).
```

So it works like planned. The only possible problem in this solution is that if someone do have older than 455 days https://github.com/kubernetes/kops/blob/master/cmd/kops-controller/pkg/server/server.go#L188 kubelet, the cert will expiry and it cannot renew the cert because it will be still part of the Kubernetes cluster (node is maybe in `NotReady` state). Currently the workaround for that is delete the node manually `kubectl delete node...` and restart it in cloudprovider (or kops-configuration.service in node itself). After that the node can request the new certificate. I am just hoping that people could update their clusters in time and they should NOT have 455 day old nodes in their cluster.

cc @justinsb @hakman 