### PR TITLE
Automated cherry pick of #15139: add clustername to ccm opts

### DIFF
--- a/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
@@ -21,6 +21,8 @@ spec:
         timeout: 10s
       router:
         externalNetwork: ""
+  cloudControllerManager:
+    clusterName: minimal.k8s.local
   cloudProvider: openstack
   configBase: memfs://tests/minimal.k8s.local
   etcdClusters:

--- a/tests/integration/create_cluster/ha_openstack_nodns/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_nodns/expected-v1alpha2.yaml
@@ -29,6 +29,8 @@ spec:
         dnsServers: 1.1.1.1
         externalNetwork: vlan1
         externalSubnet: vlan1subnet
+  cloudControllerManager:
+    clusterName: ha.example.com
   cloudProvider: openstack
   configBase: memfs://tests/ha.example.com
   etcdClusters:

--- a/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
@@ -27,6 +27,8 @@ spec:
       router:
         dnsServers: 1.1.1.1
         externalNetwork: vlan1
+  cloudControllerManager:
+    clusterName: minimal.k8s.local
   cloudProvider: openstack
   configBase: memfs://tests/minimal.k8s.local
   etcdClusters:

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1438,6 +1438,14 @@ func initializeOpenstack(opt *NewClusterOptions, cluster *api.Cluster) {
 			cluster.Spec.Networking.Topology.DNS = api.DNSTypeNone
 		}
 	}
+
+	if cluster.Spec.ExternalCloudControllerManager == nil {
+		cluster.Spec.ExternalCloudControllerManager = &api.CloudControllerManagerConfig{
+			ClusterName: opt.ClusterName,
+		}
+	} else {
+		cluster.Spec.ExternalCloudControllerManager.ClusterName = opt.ClusterName
+	}
 }
 
 func createEtcdCluster(etcdCluster string, controlPlanes []*api.InstanceGroup, encryptEtcdStorage bool, etcdStorageType string) api.EtcdClusterSpec {


### PR DESCRIPTION
Cherry pick of #15139 on release-1.26.

#15139: add clustername to ccm opts

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```