### PR TITLE
kubetest2-kops: update tests for new zones

### DIFF
--- a/tests/e2e/kubetest2-kops/aws/zones_test.go
+++ b/tests/e2e/kubetest2-kops/aws/zones_test.go
@@ -30,7 +30,10 @@ func TestRandomZones(t *testing.T) {
 		{1, nil},
 		{2, nil},
 		{3, nil},
-		{4, ErrNoEligibleRegion},
+		{4, nil}, // us-east-1 currently has 6 zones
+		{5, nil}, // us-east-1 currently has 6 zones
+		{6, nil}, // us-east-1 currently has 6 zones
+		{7, ErrNoEligibleRegion},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%v zones", tt.count), func(t *testing.T) {


### PR DESCRIPTION
We previously tested that we could not generate 4 zones in a region,
but now us-east-1 has 6 zones, so we need to update the tests to fail
only when even more zones are requested.
