### PR TITLE
Upgrade Karpenter to v0.27.5

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -469,12 +469,10 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		return pflag.NormalizedName(name)
 	})
 
-	if featureflag.Karpenter.Enabled() {
-		cmd.Flags().StringVar(&options.InstanceManager, "instance-manager", options.InstanceManager, "Instance manager to use (cloudgroups or karpenter. Default: cloudgroups)")
-		cmd.RegisterFlagCompletionFunc("instance-manager", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return []string{"cloudgroups", "karpenter"}, cobra.ShellCompDirectiveNoFileComp
-		})
-	}
+	cmd.Flags().StringVar(&options.InstanceManager, "instance-manager", options.InstanceManager, "Instance manager to use (cloudgroups or karpenter. Default: cloudgroups)")
+	cmd.RegisterFlagCompletionFunc("instance-manager", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"cloudgroups", "karpenter"}, cobra.ShellCompDirectiveNoFileComp
+	})
 	return cmd
 }
 

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -186,11 +186,6 @@ func TestCreateClusterDifferentAMIs(t *testing.T) {
 
 // TestCreateClusterKarpenter runs kops create cluster --instance-manager=karpenter
 func TestCreateClusterKarpenter(t *testing.T) {
-	featureflag.ParseFlags("+Karpenter")
-	unsetFeatureFlags := func() {
-		featureflag.ParseFlags("-Karpenter")
-	}
-	defer unsetFeatureFlags()
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/karpenter", "v1alpha2")
 }
 

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -978,12 +978,6 @@ func TestExternalDNSIRSA(t *testing.T) {
 }
 
 func TestKarpenter(t *testing.T) {
-	featureflag.ParseFlags("+Karpenter")
-	unsetFeatureFlags := func() {
-		featureflag.ParseFlags("-Karpenter")
-	}
-	defer unsetFeatureFlags()
-
 	test := newIntegrationTest("minimal.example.com", "karpenter").
 		withOIDCDiscovery().
 		withDefaults24().

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -94,6 +94,7 @@ kops create cluster [CLUSTER] [flags]
       --gce-service-account string              Service account with which the GCE VM runs. Warning: if not set, VMs will run as default compute service account.
   -h, --help                                    help for cluster
       --image string                            Machine image for all instances
+      --instance-manager string                 Instance manager to use (cloudgroups or karpenter. Default: cloudgroups) (default "cloudgroups")
       --ipv6                                    Use IPv6 for the pod network (AWS only)
       --kubernetes-feature-gates strings        List of Kubernetes feature gates to enable/disable
       --kubernetes-version string               Version of Kubernetes to run (defaults to version in channel)

--- a/docs/operations/karpenter.md
+++ b/docs/operations/karpenter.md
@@ -2,15 +2,7 @@
 
 [Karpenter](https://karpenter.sh) is a Kubernetes-native capacity manager that directly provisions Nodes and underlying instances based on Pod requirements. On AWS, kOps supports managing an InstanceGroup with either Karpenter or an AWS Auto Scaling Group (ASG).
 
-Karpenter is a fairly new project, and it is still not determined how Karpenter should work with kOps. Because of this, Karpenter is behind the `Karpenter` feature flag.
-
 ## Installing
-
-Enable the Karpenter feature flag:
-
-```sh
-export KOPS_FEATURE_FLAGS="Karpenter"
-```
 
 Karpenter requires that external permissions for ServiceAccounts be enabled for the cluster. See [AWS IAM roles for ServiceAccounts documentation](/cluster_spec#service-account-issuer-discovery-and-aws-iam-roles-for-service-accounts-irsa) for how to enable this. 
 

--- a/docs/operations/karpenter.md
+++ b/docs/operations/karpenter.md
@@ -4,6 +4,12 @@
 
 ## Installing
 
+If using kOps 1.26 or older, enable the Karpenter feature flag :
+
+```sh
+export KOPS_FEATURE_FLAGS="Karpenter"
+```
+
 Karpenter requires that external permissions for ServiceAccounts be enabled for the cluster. See [AWS IAM roles for ServiceAccounts documentation](/cluster_spec#service-account-issuer-discovery-and-aws-iam-roles-for-service-accounts-irsa) for how to enable this. 
 
 ### Existing clusters

--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -15,8 +15,6 @@ eviction errors), proceeding to the next InstanceGroup after timing out.
 As of kOps 1.26, rolling updates will not proceed if a cluster validation
 error is encountered while updating an InstanceGroup.
 
-* `Karpenter` feature flag is no more necessary and upgraded to version `0.24.0`.
-
 ## AWS
 
 * Clusters can be created without DNS or Gossip, by using the `--dns=none` flag.

--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -15,6 +15,8 @@ eviction errors), proceeding to the next InstanceGroup after timing out.
 As of kOps 1.26, rolling updates will not proceed if a cluster validation
 error is encountered while updating an InstanceGroup.
 
+* `Karpenter` feature flag is no more necessary and upgraded to version `0.24.0`.
+
 ## AWS
 
 * Clusters can be created without DNS or Gossip, by using the `--dns=none` flag.

--- a/docs/releases/1.27-NOTES.md
+++ b/docs/releases/1.27-NOTES.md
@@ -11,6 +11,8 @@ This behaviour can be overridden by setting `spec.etcdClusters[*].manager.backup
 
 * external-dns is now supported in IPv6 clusters.
 
+* `Karpenter` has been upgraded to version `0.27.x` and the feature flag is no longer necessary.
+
 ## AWS
 
 * As of Kubernetes version 1.27, all nodes will default to running with instance-metadata-service tokens required, with a max hop limit of 1.

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/kops/pkg/util/subnet"
 
 	"k8s.io/kops/pkg/apis/kops"
-	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/pkg/model/iam"
 	"k8s.io/kops/upup/pkg/fi"
@@ -277,9 +276,6 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 		fldPath := fieldPath.Child("karpenter", "enabled")
 		if !fi.ValueOf(spec.IAM.UseServiceAccountExternalPermissions) {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "Karpenter requires that service accounts use external permissions"))
-		}
-		if !featureflag.Karpenter.Enabled() {
-			allErrs = append(allErrs, field.Forbidden(fldPath, "karpenter requires the Karpenter feature flag"))
 		}
 	}
 

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -81,8 +81,6 @@ var (
 	UseAddonOperators = new("UseAddonOperators", Bool(false))
 	// TerraformManagedFiles enables rendering managed files into the Terraform configuration.
 	TerraformManagedFiles = new("TerraformManagedFiles", Bool(true))
-	// Karpenter enables karpenter-managed Instance Groups
-	Karpenter = new("Karpenter", Bool(false))
 	// ImageDigest remaps all manifests with image digests
 	ImageDigest = new("ImageDigest", Bool(true))
 	// Scaleway toggles the Scaleway Cloud support.

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -228,6 +228,10 @@ func (d *deployer) featureFlags() string {
 			return e[1]
 		}
 	}
+	// if not set by the env flag, but set in the environment, use that.
+	if e := os.Getenv("KOPS_FEATURE_FLAGS"); e != "" {
+		return e
+	}
 	return ""
 }
 

--- a/tests/e2e/scenarios/lib/common.sh
+++ b/tests/e2e/scenarios/lib/common.sh
@@ -55,7 +55,7 @@ if [[ -z "${AWS_SSH_PUBLIC_KEY_FILE-}" ]]; then
 fi
 
 KUBETEST2="kubetest2 kops -v=2 --cloud-provider=${CLOUD_PROVIDER} --cluster-name=${CLUSTER_NAME:-} --kops-root=${REPO_ROOT}"
-KUBETEST2="${KUBETEST2} --admin-access=${ADMIN_ACCESS:-} --env=KOPS_FEATURE_FLAGS=${KOPS_FEATURE_FLAGS:-}"
+KUBETEST2="${KUBETEST2} --admin-access=${ADMIN_ACCESS:-}"
 
 if [[ -n "${GCP_PROJECT-}" ]]; then
   KUBETEST2="${KUBETEST2} --gcp-project=${GCP_PROJECT}"

--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KOPS_FEATURE_FLAGS="SpecOverrideFlag,"
-
 REPO_ROOT=$(git rev-parse --show-toplevel);
 source "${REPO_ROOT}"/tests/e2e/scenarios/lib/common.sh
 

--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export KOPS_FEATURE_FLAGS="SpecOverrideFlag,"
+
 REPO_ROOT=$(git rev-parse --show-toplevel);
 source "${REPO_ROOT}"/tests/e2e/scenarios/lib/common.sh
 
@@ -78,7 +80,10 @@ else
   KOPS="${KOPS_A}"
 fi
 
-
+create_args=""
+if [[ ${KOPS_IRSA-} = true ]]; then
+  create_args="${create_args} --discovery-store=${DISCOVERY_STORE}/${CLUSTER_NAME}/discovery"
+fi
 
 ${KUBETEST2} \
     --up \
@@ -86,7 +91,7 @@ ${KUBETEST2} \
     --kubernetes-version="${K8S_VERSION_A}" \
     --control-plane-size="${KOPS_CONTROL_PLANE_SIZE:-1}" \
     --template-path="${KOPS_TEMPLATE:-}" \
-    --create-args="--networking calico"
+    --create-args="--networking calico ${KOPS_EXTRA_FLAGS:-} ${create_args}"
 
 # Export kubeconfig-a
 KUBECONFIG_A=$(mktemp -t kops.XXXXXXXXX)

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,8 +69,60 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: b6cd8f0b7dcdf48fc658eb95d9948900665562de99e317c565fdfbfbdc4481bb
+    manifestHash: 8ca1263ab9a4b7c94301164c9b5d6058de50e83c0b0491b21c23160f8446f545
     name: karpenter.sh
+    prune:
+      kinds:
+      - kind: ConfigMap
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
+      - kind: Service
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
+      - kind: ServiceAccount
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
+      - group: admissionregistration.k8s.io
+        kind: MutatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: admissionregistration.k8s.io
+        kind: ValidatingWebhookConfiguration
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: apps
+        kind: DaemonSet
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: apps
+        kind: Deployment
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
+      - group: apps
+        kind: StatefulSet
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: policy
+        kind: PodDisruptionBudget
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
+      - group: rbac.authorization.k8s.io
+        kind: ClusterRole
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: rbac.authorization.k8s.io
+        kind: ClusterRoleBinding
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+      - group: rbac.authorization.k8s.io
+        kind: Role
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
+      - group: rbac.authorization.k8s.io
+        kind: RoleBinding
+        labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
+        namespaces:
+        - kube-system
     selector:
       k8s-addon: karpenter.sh
     version: 9.99.0

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: a7fcafe317acf63b525620c1299ef21ec61eac5b8f259c8031542fe5968ac483
+    manifestHash: 0f922f2cfc90670293583bd428cd7ca393181fd8057cdd8382cbf247787f0c6c
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: 8ca1263ab9a4b7c94301164c9b5d6058de50e83c0b0491b21c23160f8446f545
+    manifestHash: 2350a3713a7963065426df13fb36b25a5ecd3c71c91c728420e5ebca39193c34
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: 2350a3713a7963065426df13fb36b25a5ecd3c71c91c728420e5ebca39193c34
+    manifestHash: a7fcafe317acf63b525620c1299ef21ec61eac5b8f259c8031542fe5968ac483
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -1225,7 +1225,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/karpenter.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/karpenter/controller:v0.27.0
+        image: public.ecr.aws/karpenter/controller:v0.27.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
@@ -44,6 +44,11 @@ spec:
               Node properties are determined from a combination of provisioner and
               pod scheduling constraints.
             properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations are applied to every node.
+                type: object
               consolidation:
                 description: Consolidation are the consolidation parameters
                 properties:
@@ -65,6 +70,10 @@ spec:
                     description: ContainerRuntime is the container runtime to be used
                       with your worker nodes.
                     type: string
+                  cpuCFSQuota:
+                    description: CPUCFSQuota enables CPU CFS quota enforcement for
+                      containers that specify CPU limits.
+                    type: boolean
                   evictionHard:
                     additionalProperties:
                       type: string
@@ -89,6 +98,27 @@ spec:
                     description: EvictionSoftGracePeriod is the map of signal names
                       to quantities that define grace periods for each eviction signal
                     type: object
+                  imageGCHighThresholdPercent:
+                    description: ImageGCHighThresholdPercent is the percent of disk
+                      usage after which image garbage collection is always run. The
+                      percent is calculated by dividing this field value by 100, so
+                      this field must be between 0 and 100, inclusive. When specified,
+                      the value must be greater than ImageGCLowThresholdPercent.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                  imageGCLowThresholdPercent:
+                    description: ImageGCLowThresholdPercent is the percent of disk
+                      usage before which image garbage collection is never run. Lowest
+                      disk usage to garbage collect to. The percent is calculated
+                      by dividing this field value by 100, so the field value must
+                      be between 0 and 100, inclusive. When specified, the value must
+                      be less than imageGCHighThresholdPercent
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   kubeReserved:
                     additionalProperties:
                       anyOf:
@@ -161,6 +191,8 @@ spec:
                   name:
                     description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                     type: string
+                required:
+                - name
                 type: object
               requirements:
                 description: Requirements are layered with Labels and applied to every
@@ -343,12 +375,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 
 ---
 
@@ -356,7 +382,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
@@ -483,6 +509,10 @@ spec:
               context:
                 description: Context is a Reserved field in EC2 APIs https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
                 type: string
+              detailedMonitoring:
+                description: DetailedMonitoring controls if detailed monitoring is
+                  enabled for instances that are launched
+                type: boolean
               instanceProfile:
                 description: InstanceProfile is the AWS identity that instances use.
                 type: string
@@ -570,17 +600,43 @@ spec:
                   being provisioned with the correct configuration.
                 type: string
             type: object
+          status:
+            description: AWSNodeTemplateStatus contains the resolved state of the
+              AWSNodeTemplate
+            properties:
+              securityGroups:
+                description: SecurityGroups contains the current Security Groups values
+                  that are available to the cluster under the SecurityGroups selectors.
+                items:
+                  description: SecurityGroupStatus contains resolved SecurityGroup
+                    selector values utilized for node launch
+                  properties:
+                    id:
+                      description: Id of the security group
+                      type: string
+                  type: object
+                type: array
+              subnets:
+                description: Subnets contains the current Subnet values that are available
+                  to the cluster under the subnet selectors.
+                items:
+                  description: SubnetStatus contains resolved Subnet selector values
+                    utilized for node launch
+                  properties:
+                    id:
+                      description: Id of the subnet
+                      type: string
+                    zone:
+                      description: The associated availability zone
+                      type: string
+                  type: object
+                type: array
+            type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 
 ---
 
@@ -606,19 +662,18 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-webhook-cert
+  name: karpenter-cert
   namespace: kube-system
 
 ---
 
 apiVersion: v1
 data:
-  loglevel.controller: debug
   loglevel.webhook: debug
   zap-logger-config: |
     {
       "level": "debug",
-      "development": true,
+      "development": false,
       "disableStacktrace": true,
       "disableCaller": true,
       "sampling": {
@@ -627,7 +682,7 @@ data:
       },
       "outputPaths": ["stdout"],
       "errorOutputPaths": ["stderr"],
-      "encoding": "console",
+      "encoding": "json",
       "encoderConfig": {
         "timeKey": "time",
         "levelKey": "level",
@@ -647,13 +702,22 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/part-of: karpenter
     k8s-addon: karpenter.sh
-  name: karpenter-config-logging
+  name: config-logging
   namespace: kube-system
 
 ---
 
 apiVersion: v1
 data:
+  aws.clusterEndpoint: https://api.internal.minimal.example.com
+  aws.clusterName: minimal.example.com
+  aws.defaultInstanceProfile: ""
+  aws.enableENILimitedPodDensity: "true"
+  aws.enablePodENI: "false"
+  aws.interruptionQueue: "false"
+  aws.isolatedVPC: "false"
+  aws.nodeNameConvention: resource-name
+  aws.vmMemoryOverheadPercent: "0.075"
   batchIdleDuration: 1s
   batchMaxDuration: 10s
 kind: ConfigMap
@@ -662,7 +726,6 @@ metadata:
   labels:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/part-of: karpenter
     k8s-addon: karpenter.sh
   name: karpenter-global-settings
   namespace: kube-system
@@ -677,7 +740,7 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-controller
+  name: karpenter-admin
 rules:
 - apiGroups:
   - karpenter.sh
@@ -688,10 +751,40 @@ rules:
   - get
   - list
   - watch
+  - create
+  - delete
+  - patch
 - apiGroups:
   - karpenter.k8s.aws
   resources:
   - awsnodetemplates
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: karpenter.sh
+  name: karpenter-core
+rules:
+- apiGroups:
+  - karpenter.sh
+  resources:
+  - provisioners
+  - provisioners/status
+  - machines
+  - machines/status
   verbs:
   - get
   - list
@@ -701,10 +794,10 @@ rules:
   resources:
   - pods
   - nodes
-  - namespaces
   - persistentvolumes
   - persistentvolumeclaims
   - replicationcontrollers
+  - namespaces
   verbs:
   - get
   - list
@@ -729,6 +822,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
@@ -740,6 +842,8 @@ rules:
   - karpenter.sh
   resources:
   - provisioners/status
+  - machines
+  - machines/status
   verbs:
   - create
   - delete
@@ -765,6 +869,23 @@ rules:
   - pods/eviction
   verbs:
   - create
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - validation.webhook.karpenter.sh
+  - validation.webhook.config.karpenter.sh
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - defaulting.webhook.karpenter.sh
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - update
 
 ---
 
@@ -776,22 +897,20 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-webhook
+  name: karpenter
 rules:
 - apiGroups:
-  - admissionregistration.k8s.io
+  - karpenter.k8s.aws
   resources:
-  - validatingwebhookconfigurations
-  - mutatingwebhookconfigurations
+  - awsnodetemplates
   verbs:
   - get
-  - watch
   - list
+  - watch
 - apiGroups:
   - admissionregistration.k8s.io
   resourceNames:
-  - validation.webhook.provisioners.karpenter.sh
-  - validation.webhook.config.karpenter.sh
+  - validation.webhook.karpenter.k8s.aws
   resources:
   - validatingwebhookconfigurations
   verbs:
@@ -799,10 +918,17 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resourceNames:
-  - defaulting.webhook.provisioners.karpenter.sh
+  - defaulting.webhook.karpenter.k8s.aws
   resources:
   - mutatingwebhookconfigurations
   verbs:
+  - update
+- apiGroups:
+  - karpenter.k8s.aws
+  resources:
+  - awsnodetemplates/status
+  verbs:
+  - patch
   - update
 
 ---
@@ -815,11 +941,11 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-controller
+  name: karpenter-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: karpenter-controller
+  name: karpenter-core
 subjects:
 - kind: ServiceAccount
   name: karpenter
@@ -835,11 +961,11 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-webhook
+  name: karpenter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: karpenter-webhook
+  name: karpenter
 subjects:
 - kind: ServiceAccount
   name: karpenter
@@ -855,7 +981,7 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-controller
+  name: karpenter
   namespace: kube-system
 rules:
 - apiGroups:
@@ -878,7 +1004,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - karpenter-webhook-cert
+  - karpenter-cert
   resources:
   - secrets
   verbs:
@@ -887,7 +1013,7 @@ rules:
   - ""
   resourceNames:
   - karpenter-global-settings
-  - karpenter-config-logging
+  - config-logging
   resources:
   - configmaps
   verbs:
@@ -930,35 +1056,17 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-webhook
+  name: karpenter-dns
   namespace: kube-system
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - kube-dns
   resources:
-  - namespaces
+  - services
   verbs:
   - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - watch
-  - create
-  - update
 
 ---
 
@@ -970,12 +1078,12 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-controller
+  name: karpenter
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: karpenter-controller
+  name: karpenter
 subjects:
 - kind: ServiceAccount
   name: karpenter
@@ -991,12 +1099,12 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-webhook
+  name: karpenter-dns
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: karpenter-webhook
+  name: karpenter-dns
 subjects:
 - kind: ServiceAccount
   name: karpenter
@@ -1012,33 +1120,21 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-metrics
+  name: karpenter
   namespace: kube-system
 spec:
   ports:
-  - port: 8080
+  - name: http-metrics
+    port: 8080
+    protocol: TCP
     targetPort: http-metrics
-  selector:
-    karpenter: controller
-
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: karpenter.sh
-    app.kubernetes.io/managed-by: kops
-    k8s-addon: karpenter.sh
-  name: karpenter-webhook
-  namespace: kube-system
-spec:
-  ports:
-  - port: 443
+  - name: https-webhook
+    port: 443
+    protocol: TCP
     targetPort: https-webhook
   selector:
     karpenter: webhook
+  type: ClusterIP
 
 ---
 
@@ -1050,151 +1146,22 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-controller
+  name: karpenter
   namespace: kube-system
 spec:
   replicas: 1
-  selector:
-    matchLabels:
-      karpenter: controller
-  strategy:
-    type: Recreate
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
-        app.kubernetes.io/name: karpenter
-        karpenter: controller
-        kops.k8s.io/managed-by: kops
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
-              - key: karpenter.sh/provisioner-name
-                operator: DoesNotExist
-      containers:
-      - env:
-        - name: AWS_ENI_LIMITED_POD_DENSITY
-          value: "true"
-        - name: AWS_NODE_NAME_CONVENTION
-          value: resource-name
-        - name: AWS_REGION
-          value: us-test-1
-        - name: CLUSTER_NAME
-          value: minimal.example.com
-        - name: CLUSTER_ENDPOINT
-          value: https://api.internal.minimal.example.com
-        - name: CONFIG_LOGGING_NAME
-          value: karpenter-config-logging
-        - name: KARPENTER_SERVICE
-          value: karpenter-webhook
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MEMORY_LIMIT
-          valueFrom:
-            resourceFieldRef:
-              containerName: controller
-              divisor: "0"
-              resource: limits.memory
-        - name: AWS_ROLE_ARN
-          value: arn:aws-test:iam::123456789012:role/karpenter.kube-system.sa.minimal.example.com
-        - name: AWS_WEB_IDENTITY_TOKEN_FILE
-          value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/karpenter/controller:v0.16.3
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-          initialDelaySeconds: 30
-          timeoutSeconds: 30
-        name: controller
-        ports:
-        - containerPort: 8080
-          name: http-metrics
-          protocol: TCP
-        - containerPort: 8081
-          name: http
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: http
-          timeoutSeconds: 30
-        resources:
-          limits:
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 1Gi
-        volumeMounts:
-        - mountPath: /var/run/secrets/amazonaws.com/
-          name: token-amazonaws-com
-          readOnly: true
-      dnsPolicy: Default
-      priorityClassName: system-cluster-critical
-      securityContext:
-        fsGroup: 10001
-      serviceAccountName: karpenter
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            karpenter: webhook
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            karpenter: webhook
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: DoNotSchedule
-      volumes:
-      - name: token-amazonaws-com
-        projected:
-          defaultMode: 420
-          sources:
-          - serviceAccountToken:
-              audience: amazonaws.com
-              expirationSeconds: 86400
-              path: token
-
----
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: karpenter.sh
-    app.kubernetes.io/managed-by: kops
-    k8s-addon: karpenter.sh
-  name: karpenter-webhook
-  namespace: kube-system
-spec:
-  replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       karpenter: webhook
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       creationTimestamp: null
       labels:
+        app.kubernetes.io/instance: karpenter
         app.kubernetes.io/name: karpenter
         karpenter: webhook
         kops.k8s.io/managed-by: kops
@@ -1221,58 +1188,73 @@ spec:
                 operator: DoesNotExist
               - key: node-role.kubernetes.io/master
                 operator: Exists
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                - karpenter
+            topologyKey: kubernetes.io/hostname
       containers:
-      - args:
-        - -port=8443
-        env:
-        - name: AWS_REGION
-          value: us-test-1
-        - name: CLUSTER_NAME
-          value: minimal.example.com
+      - env:
         - name: KUBERNETES_MIN_VERSION
           value: 1.19.0-0
-        - name: CLUSTER_ENDPOINT
-          value: https://api.internal.minimal.example.com
-        - name: CONFIG_LOGGING_NAME
-          value: karpenter-config-logging
         - name: KARPENTER_SERVICE
-          value: karpenter-webhook
+          value: karpenter
+        - name: WEBHOOK_PORT
+          value: "8443"
+        - name: METRICS_PORT
+          value: "8080"
+        - name: HEALTH_PROBE_PORT
+          value: "8081"
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: controller
+              divisor: "0"
+              resource: limits.memory
+        - name: AWS_REGION
+          value: us-test-1
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/karpenter.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/karpenter/webhook:v0.16.3
+        image: public.ecr.aws/karpenter/controller:v0.27.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            port: https-webhook
-            scheme: HTTPS
+            path: /healthz
+            port: http
           initialDelaySeconds: 30
-        name: webhook
+          timeoutSeconds: 30
+        name: controller
         ports:
+        - containerPort: 8080
+          name: http-metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: http
+          protocol: TCP
         - containerPort: 8443
           name: https-webhook
           protocol: TCP
         readinessProbe:
           httpGet:
-            port: https-webhook
-            scheme: HTTPS
+            path: /readyz
+            port: http
+          timeoutSeconds: 30
         resources:
           limits:
-            cpu: 100m
-            memory: 50Mi
+            memory: 1Gi
           requests:
-            cpu: 100m
-            memory: 50Mi
-        startupProbe:
-          failureThreshold: 6
-          httpGet:
-            port: https-webhook
-            scheme: HTTPS
+            cpu: 500m
+            memory: 1Gi
         volumeMounts:
         - mountPath: /var/run/secrets/amazonaws.com/
           name: token-amazonaws-com
@@ -1280,7 +1262,7 @@ spec:
       dnsPolicy: Default
       priorityClassName: system-cluster-critical
       securityContext:
-        fsGroup: 10001
+        fsGroup: 1000
       serviceAccountName: karpenter
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -1290,12 +1272,16 @@ spec:
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
+            app.kubernetes.io/instance: karpenter
+            app.kubernetes.io/name: karpenter
             karpenter: webhook
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
         whenUnsatisfiable: ScheduleAnyway
       - labelSelector:
           matchLabels:
+            app.kubernetes.io/instance: karpenter
+            app.kubernetes.io/name: karpenter
             karpenter: webhook
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
@@ -1320,16 +1306,93 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: defaulting.webhook.provisioners.karpenter.sh
+  name: defaulting.webhook.karpenter.k8s.aws
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: karpenter-webhook
+      name: karpenter
       namespace: kube-system
   failurePolicy: Fail
-  name: defaulting.webhook.provisioners.karpenter.sh
+  name: defaulting.webhook.karpenter.k8s.aws
+  rules:
+  - apiGroups:
+    - karpenter.k8s.aws
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsnodetemplates
+    - awsnodetemplates/status
+    scope: '*'
+  - apiGroups:
+    - karpenter.sh
+    apiVersions:
+    - v1alpha5
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - provisioners
+    - provisioners/status
+  sideEffects: None
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: karpenter.sh
+  name: defaulting.webhook.karpenter.sh
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: karpenter
+      namespace: kube-system
+  failurePolicy: Fail
+  name: defaulting.webhook.karpenter.sh
+  rules:
+  - apiGroups:
+    - karpenter.sh
+    apiVersions:
+    - v1alpha5
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - provisioners
+    - provisioners/status
+  sideEffects: None
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: karpenter.sh
+  name: validation.webhook.karpenter.k8s.aws
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: karpenter
+      namespace: kube-system
+  failurePolicy: Fail
+  name: validation.webhook.karpenter.k8s.aws
   rules:
   - apiGroups:
     - karpenter.k8s.aws
@@ -1364,29 +1427,17 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: validation.webhook.provisioners.karpenter.sh
+  name: validation.webhook.karpenter.sh
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: karpenter-webhook
+      name: karpenter
       namespace: kube-system
   failurePolicy: Fail
-  name: validation.webhook.provisioners.karpenter.sh
+  name: validation.webhook.karpenter.sh
   rules:
-  - apiGroups:
-    - karpenter.k8s.aws
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - awsnodetemplates
-    - awsnodetemplates/status
-    scope: '*'
   - apiGroups:
     - karpenter.sh
     apiVersions:
@@ -1394,7 +1445,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     resources:
     - provisioners
     - provisioners/status
@@ -1416,7 +1466,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: karpenter-webhook
+      name: karpenter
       namespace: kube-system
   failurePolicy: Fail
   name: validation.webhook.config.karpenter.sh
@@ -1436,11 +1486,29 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
   name: karpenter
+  namespace: kube-system
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: karpenter
+
+---
+
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: karpenter.sh
+  name: karpenter-nodes-default
+spec:
+  launchTemplate: karpenter-nodes-default.minimal.example.com
+  subnetSelector:
+    kops.k8s.io/instance-group/karpenter-nodes-default: '*'
+    kubernetes.io/cluster/minimal.example.com: '*'
 
 ---
 
@@ -1464,11 +1532,8 @@ spec:
     systemReserved:
       cpu: 500m
       memory: 1G
-  provider:
-    launchTemplate: karpenter-nodes-default.minimal.example.com
-    subnetSelector:
-      kops.k8s.io/instance-group/karpenter-nodes-default: '*'
-      kubernetes.io/cluster/minimal.example.com: '*'
+  providerRef:
+    name: karpenter-nodes-default
   requirements:
   - key: karpenter.sh/capacity-type
     operator: In
@@ -1489,6 +1554,23 @@ spec:
 
 ---
 
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: karpenter.sh
+  name: karpenter-nodes-single-machinetype
+spec:
+  launchTemplate: karpenter-nodes-single-machinetype.minimal.example.com
+  subnetSelector:
+    kops.k8s.io/instance-group/karpenter-nodes-single-machinetype: '*'
+    kubernetes.io/cluster/minimal.example.com: '*'
+
+---
+
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
@@ -1501,11 +1583,8 @@ metadata:
 spec:
   consolidation:
     enabled: true
-  provider:
-    launchTemplate: karpenter-nodes-single-machinetype.minimal.example.com
-    subnetSelector:
-      kops.k8s.io/instance-group/karpenter-nodes-single-machinetype: '*'
-      kubernetes.io/cluster/minimal.example.com: '*'
+  providerRef:
+    name: karpenter-nodes-single-machinetype
   requirements:
   - key: karpenter.sh/capacity-type
     operator: In

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -1217,7 +1217,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/karpenter.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/karpenter/controller:v0.27.3
+        image: public.ecr.aws/karpenter/controller:v0.27.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
@@ -382,7 +382,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
@@ -714,7 +714,7 @@ data:
   aws.defaultInstanceProfile: ""
   aws.enableENILimitedPodDensity: "true"
   aws.enablePodENI: "false"
-  aws.interruptionQueue: "false"
+  aws.interruptionQueueName: ""
   aws.isolatedVPC: "false"
   aws.nodeNameConvention: resource-name
   aws.vmMemoryOverheadPercent: "0.075"
@@ -876,14 +876,6 @@ rules:
   - validation.webhook.config.karpenter.sh
   resources:
   - validatingwebhookconfigurations
-  verbs:
-  - update
-- apiGroups:
-  - admissionregistration.k8s.io
-  resourceNames:
-  - defaulting.webhook.karpenter.sh
-  resources:
-  - mutatingwebhookconfigurations
   verbs:
   - update
 
@@ -1225,7 +1217,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/karpenter.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/karpenter/controller:v0.27.2
+        image: public.ecr.aws/karpenter/controller:v0.27.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1328,39 +1320,6 @@ webhooks:
     - awsnodetemplates
     - awsnodetemplates/status
     scope: '*'
-  - apiGroups:
-    - karpenter.sh
-    apiVersions:
-    - v1alpha5
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - provisioners
-    - provisioners/status
-  sideEffects: None
-
----
-
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: karpenter.sh
-    app.kubernetes.io/managed-by: kops
-    k8s-addon: karpenter.sh
-  name: defaulting.webhook.karpenter.sh
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: karpenter
-      namespace: kube-system
-  failurePolicy: Fail
-  name: defaulting.webhook.karpenter.sh
-  rules:
   - apiGroups:
     - karpenter.sh
     apiVersions:

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -961,7 +961,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: controller
-          image: public.ecr.aws/karpenter/controller:v0.27.3
+          image: public.ecr.aws/karpenter/controller:v0.27.5
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: provisioners.karpenter.sh
 spec:
@@ -373,12 +373,13 @@ spec:
     storage: true
     subresources:
       status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: awsnodetemplates.karpenter.k8s.aws
 spec:
@@ -697,7 +698,7 @@ data:
     "aws.enableENILimitedPodDensity": "false"
     {{ end }}
     "aws.enablePodENI": "false"
-    "aws.interruptionQueue": "false"
+    "aws.interruptionQueueName": ""
     "aws.isolatedVPC": "false"
     {{ if UsesInstanceIDForNodeName }}
     "aws.nodeNameConvention": "resource-name"
@@ -1093,32 +1094,6 @@ webhooks:
           - awsnodetemplates
           - awsnodetemplates/status
         scope: '*'
-      - apiGroups:
-          - karpenter.sh
-        apiVersions:
-          - v1alpha5
-        resources:
-          - provisioners
-          - provisioners/status
-        operations:
-          - CREATE
-          - UPDATE
----
-# Source: karpenter/templates/webhooks-core.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: defaulting.webhook.karpenter.sh
-webhooks:
-  - name: defaulting.webhook.karpenter.sh
-    admissionReviewVersions: ["v1"]
-    clientConfig:
-      service:
-        name: karpenter
-        namespace: kube-system
-    failurePolicy: Fail
-    sideEffects: None
-    rules:
       - apiGroups:
           - karpenter.sh
         apiVersions:

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: provisioners.karpenter.sh
 spec:
@@ -42,6 +42,11 @@ spec:
               Node properties are determined from a combination of provisioner and
               pod scheduling constraints.
             properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations are applied to every node.
+                type: object
               consolidation:
                 description: Consolidation are the consolidation parameters
                 properties:
@@ -63,6 +68,10 @@ spec:
                     description: ContainerRuntime is the container runtime to be used
                       with your worker nodes.
                     type: string
+                  cpuCFSQuota:
+                    description: CPUCFSQuota enables CPU CFS quota enforcement for
+                      containers that specify CPU limits.
+                    type: boolean
                   evictionHard:
                     additionalProperties:
                       type: string
@@ -87,6 +96,27 @@ spec:
                     description: EvictionSoftGracePeriod is the map of signal names
                       to quantities that define grace periods for each eviction signal
                     type: object
+                  imageGCHighThresholdPercent:
+                    description: ImageGCHighThresholdPercent is the percent of disk
+                      usage after which image garbage collection is always run. The
+                      percent is calculated by dividing this field value by 100, so
+                      this field must be between 0 and 100, inclusive. When specified,
+                      the value must be greater than ImageGCLowThresholdPercent.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                  imageGCLowThresholdPercent:
+                    description: ImageGCLowThresholdPercent is the percent of disk
+                      usage before which image garbage collection is never run. Lowest
+                      disk usage to garbage collect to. The percent is calculated
+                      by dividing this field value by 100, so the field value must
+                      be between 0 and 100, inclusive. When specified, the value must
+                      be less than imageGCHighThresholdPercent
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   kubeReserved:
                     additionalProperties:
                       anyOf:
@@ -159,6 +189,8 @@ spec:
                   name:
                     description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                     type: string
+                required:
+                - name
                 type: object
               requirements:
                 description: Requirements are layered with Labels and applied to every
@@ -341,18 +373,12 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: awsnodetemplates.karpenter.k8s.aws
 spec:
@@ -475,6 +501,10 @@ spec:
               context:
                 description: Context is a Reserved field in EC2 APIs https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
                 type: string
+              detailedMonitoring:
+                description: DetailedMonitoring controls if detailed monitoring is
+                  enabled for instances that are launched
+                type: boolean
               instanceProfile:
                 description: InstanceProfile is the AWS identity that instances use.
                 type: string
@@ -562,17 +592,43 @@ spec:
                   being provisioned with the correct configuration.
                 type: string
             type: object
+          status:
+            description: AWSNodeTemplateStatus contains the resolved state of the
+              AWSNodeTemplate
+            properties:
+              securityGroups:
+                description: SecurityGroups contains the current Security Groups values
+                  that are available to the cluster under the SecurityGroups selectors.
+                items:
+                  description: SecurityGroupStatus contains resolved SecurityGroup
+                    selector values utilized for node launch
+                  properties:
+                    id:
+                      description: Id of the security group
+                      type: string
+                  type: object
+                type: array
+              subnets:
+                description: Subnets contains the current Subnet values that are available
+                  to the cluster under the subnet selectors.
+                items:
+                  description: SubnetStatus contains resolved Subnet selector values
+                    utilized for node launch
+                  properties:
+                    id:
+                      description: Id of the subnet
+                      type: string
+                    zone:
+                      description: The associated availability zone
+                      type: string
+                  type: object
+                type: array
+            type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 # Source: karpenter/templates/serviceaccount.yaml
 apiVersion: v1
@@ -581,19 +637,19 @@ metadata:
   name: karpenter
   namespace: kube-system
 ---
-# Source: karpenter/templates/webhook/deployment.yaml
+# Source: karpenter/templates/secret-webhook-cert.yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: karpenter-webhook-cert
+  name: karpenter-cert
   namespace: kube-system
-data: {} # Injected by karpenter-webhook
+data: {} # Injected by karpenter
 ---
-# Source: karpenter/templates/100-config-logging.yaml
+# Source: karpenter/templates/configmap-logging.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: karpenter-config-logging
+  name: config-logging
   namespace: kube-system
   labels:
     app.kubernetes.io/part-of: karpenter
@@ -602,7 +658,7 @@ data:
   zap-logger-config: |
     {
       "level": "debug",
-      "development": true,
+      "development": false,
       "disableStacktrace": true,
       "disableCaller": true,
       "sampling": {
@@ -611,7 +667,7 @@ data:
       },
       "outputPaths": ["stdout"],
       "errorOutputPaths": ["stderr"],
-      "encoding": "console",
+      "encoding": "json",
       "encoderConfig": {
         "timeKey": "time",
         "levelKey": "level",
@@ -623,9 +679,7 @@ data:
         "timeEncoder": "iso8601"
       }
     }
-  # Log level overrides
-  loglevel.controller: debug
-  loglevel.webhook: debug
+  loglevel.webhook: "debug"
 ---
 # Source: karpenter/templates/configmap.yaml
 apiVersion: v1
@@ -633,261 +687,317 @@ kind: ConfigMap
 metadata:
   name: karpenter-global-settings
   namespace: kube-system
-  labels:
-    app.kubernetes.io/part-of: karpenter
-data:
-  "batchMaxDuration": "10s"
-  "batchIdleDuration": "1s"
+data:  
+    "aws.clusterEndpoint": "https://{{ APIInternalName }}"
+    "aws.clusterName": "{{ ClusterName }}"
+    "aws.defaultInstanceProfile": ""
+    {{ if not .Networking.AmazonVPC }}
+    "aws.enableENILimitedPodDensity": "true"
+    {{ else }}
+    "aws.enableENILimitedPodDensity": "false"
+    {{ end }}
+    "aws.enablePodENI": "false"
+    "aws.interruptionQueue": "false"
+    "aws.isolatedVPC": "false"
+    {{ if UsesInstanceIDForNodeName }}
+    "aws.nodeNameConvention": "resource-name"
+    {{ else }}
+    "aws.nodeNameConvention": "ip-name"
+    {{ end }}
+    "aws.vmMemoryOverheadPercent": "0.075"
+    "batchIdleDuration": "1s"
+    "batchMaxDuration": "10s"
 ---
-# Source: karpenter/templates/controller/rbac.yaml
+
+# Source: karpenter/templates/aggregate-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: karpenter-controller
+  name: karpenter-admin
 rules:
-# Read
-- apiGroups: ["karpenter.sh"]
-  resources: ["provisioners", "provisioners/status"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["karpenter.k8s.aws"]
-  resources: ["awsnodetemplates"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["pods", "nodes", "namespaces", "persistentvolumes", "persistentvolumeclaims", "replicationcontrollers"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["storage.k8s.io"]
-  resources: ["storageclasses", "csinodes"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["apps"]
-  resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
-  verbs: ["list", "watch"]
-- apiGroups: [ "policy" ]
-  resources: [ "poddisruptionbudgets" ]
-  verbs: [ "get", "list", "watch" ]
-# Write
-- apiGroups: ["karpenter.sh"]
-  resources: ["provisioners/status"]
-  verbs: ["create", "delete", "patch"]
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create", "patch"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["create", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["pods/eviction"]
-  verbs: ["create"]
+  - apiGroups: ["karpenter.sh"]
+    resources: ["provisioners", "provisioners/status"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["awsnodetemplates"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+
 ---
-# Source: karpenter/templates/webhook/rbac.yaml
+# Source: karpenter/templates/clusterrole-core.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: karpenter-webhook
+  name: karpenter-core
 rules:
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations"]
-  verbs: ["update"]
-  resourceNames: ["validation.webhook.provisioners.karpenter.sh", "validation.webhook.config.karpenter.sh"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
-  verbs: ["update"]
-  resourceNames: ["defaulting.webhook.provisioners.karpenter.sh"]
+  # Read
+  - apiGroups: ["karpenter.sh"]
+    resources: ["provisioners", "provisioners/status", "machines", "machines/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "persistentvolumes", "persistentvolumeclaims", "replicationcontrollers", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: [ "policy" ]
+    resources: [ "poddisruptionbudgets" ]
+    verbs: [ "get", "list", "watch" ]
+  # Write
+  - apiGroups: ["karpenter.sh"]
+    resources: ["provisioners/status", "machines", "machines/status"]
+    verbs: ["create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["create", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["update"]
+    resourceNames: ["validation.webhook.karpenter.sh", "validation.webhook.config.karpenter.sh"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["update"]
+    resourceNames: ["defaulting.webhook.karpenter.sh"]
+
 ---
-# Source: karpenter/templates/controller/rbac.yaml
+# Source: karpenter/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: karpenter
+rules:
+  # Read
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["awsnodetemplates"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["update"]
+    resourceNames: ["validation.webhook.karpenter.k8s.aws"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["update"]
+    resourceNames: ["defaulting.webhook.karpenter.k8s.aws"]
+  # Write
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["awsnodetemplates/status"]
+    verbs: ["patch", "update"]
+
+---
+
+# Source: karpenter/templates/clusterrole-core.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: karpenter-controller
+  name: karpenter-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: karpenter-controller
+  name: karpenter-core
 subjects:
-- kind: ServiceAccount
-  name: karpenter
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: karpenter
+    namespace: kube-system
 ---
-# Source: karpenter/templates/webhook/rbac.yaml
+# Source: karpenter/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: karpenter-webhook
+  name: karpenter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: karpenter-webhook
+  name: karpenter
 subjects:
-- kind: ServiceAccount
+  - kind: ServiceAccount
+    name: karpenter
+    namespace: kube-system
+
+---
+
+# Source: karpenter/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: karpenter
   namespace: kube-system
+rules:
+  # Read
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps", "namespaces", "secrets"]
+    verbs: ["get", "list", "watch"]
+  # Write
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["update"]
+    resourceNames: ["karpenter-cert"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["update", "patch", "delete"]
+    resourceNames:
+      - karpenter-global-settings
+      - config-logging
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["patch", "update"]
+    resourceNames:
+      - "karpenter-leader-election"
+      - "webhook.configmapwebhook.00-of-01"
+      - "webhook.defaultingwebhook.00-of-01"
+      - "webhook.validationwebhook.00-of-01"
+      - "webhook.webhookcertificates.00-of-01"
+  # Cannot specify resourceNames on create
+  # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
 ---
-# Source: karpenter/templates/controller/rbac.yaml
+# Source: karpenter/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: karpenter-controller
+  name: karpenter-dns
   namespace: kube-system
 rules:
-# Read
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch"]
-- apiGroups: [""]
-  resources: ["configmaps", "namespaces", "secrets"]
-  verbs: ["get", "list", "watch"]
-# Write
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["update"]
-  resourceNames: ["karpenter-webhook-cert"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["update", "patch", "delete"]
-  resourceNames:
-    - karpenter-global-settings
-    - karpenter-config-logging
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["patch", "update"]
-  resourceNames:
-    - "karpenter-leader-election"
-    - "webhook.configmapwebhook.00-of-01"
-    - "webhook.defaultingwebhook.00-of-01"
-    - "webhook.validationwebhook.00-of-01"
-    - "webhook.webhookcertificates.00-of-01"
-# Cannot specify resourceNames on create
-# https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["create"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["create"]
+  # Read
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["kube-dns"]
+    verbs: ["get"]
+
 ---
-# Source: karpenter/templates/webhook/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: karpenter-webhook
-  namespace: kube-system
-rules:
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "watch", "update"]
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "create", "update"]
----
-# Source: karpenter/templates/controller/rbac.yaml
+
+# Source: karpenter/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: karpenter-controller
+  name: karpenter
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: karpenter-controller
-subjects:
-- kind: ServiceAccount
   name: karpenter
-  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: karpenter
+    namespace: kube-system
 ---
-# Source: karpenter/templates/webhook/rbac.yaml
+# Source: karpenter/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: karpenter-webhook
+  name: karpenter-dns
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: karpenter-webhook
+  name: karpenter-dns
 subjects:
-- kind: ServiceAccount
-  name: karpenter
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: karpenter
+    namespace: kube-system
+
 ---
-# Source: karpenter/templates/controller/deployment.yaml
+# Source: karpenter/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: karpenter-metrics
+  name: karpenter
   namespace: kube-system
 spec:
+  type: ClusterIP
   ports:
-    - port: 8080
+    - name: http-metrics
+      port: 8080
       targetPort: http-metrics
-  selector:
-    karpenter: controller
----
-# Source: karpenter/templates/webhook/deployment.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: karpenter-webhook
-  namespace: kube-system
-spec:
-  ports:
-    - port: 443
+      protocol: TCP
+    - name: https-webhook
+      port: 443
       targetPort: https-webhook
+      protocol: TCP
   selector:
     karpenter: webhook
 ---
-# Source: karpenter/templates/controller/deployment.yaml
+# Source: karpenter/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: karpenter-controller
+  name: karpenter
   namespace: kube-system
 spec:
   replicas: {{ ControlPlaneControllerReplicas false }}
+  revisionHistoryLimit: 10
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
-      karpenter: controller
+      karpenter: webhook
   template:
     metadata:
       labels:
-        karpenter: controller
         app.kubernetes.io/name: karpenter
+        app.kubernetes.io/instance: karpenter
+        karpenter: webhook
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-      priorityClassName: system-cluster-critical
       serviceAccountName: karpenter
+      securityContext:
+        fsGroup: 1000
+      priorityClassName: "system-cluster-critical"
       dnsPolicy: Default
       containers:
         - name: controller
-          image: public.ecr.aws/karpenter/controller:v0.16.3
+          image: public.ecr.aws/karpenter/controller:v0.27.0
           imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 1Gi
+          env:
+            - name: KUBERNETES_MIN_VERSION
+              value: "1.19.0-0"
+            - name: KARPENTER_SERVICE
+              value: karpenter
+            - name: WEBHOOK_PORT
+              value: "8443"
+            - name: METRICS_PORT
+              value: "8080"
+            - name: HEALTH_PROBE_PORT
+              value: "8081"
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MEMORY_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: controller
+                  divisor: "0"
+                  resource: limits.memory
+            - name: AWS_REGION
+              value: {{ Region }}
           ports:
             - name: http-metrics
               containerPort: 8080
               protocol: TCP
             - name: http
               containerPort: 8081
+              protocol: TCP
+            - name: https-webhook
+              containerPort: 8443
               protocol: TCP
           livenessProbe:
             initialDelaySeconds: 30
@@ -900,138 +1010,23 @@ spec:
             httpGet:
               path: /readyz
               port: http
-          env:
-            {{ if not .Networking.AmazonVPC }}
-            - name: AWS_ENI_LIMITED_POD_DENSITY
-              value: "true"
-            {{ end }}
-            {{ if UsesInstanceIDForNodeName }}
-            - name: AWS_NODE_NAME_CONVENTION
-              value: "resource-name"
-            {{ end }}
-            - name: AWS_REGION
-              value: {{ Region }}
-            - name: CLUSTER_NAME
-              value: {{ ClusterName }}
-            - name: CLUSTER_ENDPOINT
-              value: https://{{ APIInternalName }}
-            - name: CONFIG_LOGGING_NAME
-              value: "karpenter-config-logging"
-            - name: KARPENTER_SERVICE
-              value: karpenter-webhook
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MEMORY_LIMIT
-              valueFrom:
-                resourceFieldRef:
-                  containerName: controller
-                  divisor: "0"
-                  resource: limits.memory
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 1Gi
+      nodeSelector: null
       affinity:
-        nodeAffinity:
+        podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                - linux
-              - key: karpenter.sh/provisioner-name
-                operator: DoesNotExist
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-      topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: "topology.kubernetes.io/zone"
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            karpenter: webhook
-      - maxSkew: 1
-        topologyKey: "kubernetes.io/hostname"
-        whenUnsatisfiable: DoNotSchedule
-        labelSelector:
-          matchLabels:
-            karpenter: webhook
-      nodeSelector: null
-
----
-# Source: karpenter/templates/webhook/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: karpenter-webhook
-  namespace: kube-system
-spec:
-  replicas: {{ ControlPlaneControllerReplicas false }}
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      karpenter: webhook
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: karpenter
-        karpenter: webhook
-    spec:
-      priorityClassName: system-cluster-critical
-      serviceAccountName: karpenter
-      dnsPolicy: Default
-      containers:
-        - name: webhook
-          image: public.ecr.aws/karpenter/webhook:v0.16.3
-          imagePullPolicy: IfNotPresent
-          args:
-            - -port=8443
-          resources: 
-            limits:
-              cpu: 100m
-              memory: 50Mi
-            requests:
-              cpu: 100m
-              memory: 50Mi
-          ports:
-            - name: https-webhook
-              containerPort: 8443
-              protocol: TCP
-          livenessProbe:
-            initialDelaySeconds: 30
-            httpGet:
-              scheme: HTTPS
-              port: https-webhook
-          readinessProbe:
-            httpGet:
-              scheme: HTTPS
-              port: https-webhook
-          startupProbe:
-            httpGet:
-              scheme: HTTPS
-              port: https-webhook
-            failureThreshold: 6
-          env:
-            - name: AWS_REGION
-              value: {{ Region }}
-            - name: CLUSTER_NAME
-              value: {{ ClusterName }}
-            - name: KUBERNETES_MIN_VERSION
-              value: "1.19.0-0"
-            - name: CLUSTER_ENDPOINT
-              value: https://{{ APIInternalName }}
-            - name: CONFIG_LOGGING_NAME
-              value: "karpenter-config-logging"
-            - name: KARPENTER_SERVICE
-              value: karpenter-webhook
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-      affinity:
+                - 'karpenter'
+            topologyKey: kubernetes.io/hostname
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -1059,113 +1054,166 @@ spec:
       - key: node-role.kubernetes.io/control-plane
         operator: Exists
       topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            karpenter: webhook
-      - maxSkew: 1
-        topologyKey: "kubernetes.io/hostname"
-        whenUnsatisfiable: DoNotSchedule
-        labelSelector:
-          matchLabels:
-            karpenter: webhook
-      nodeSelector: null
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: karpenter
+              app.kubernetes.io/instance: karpenter
+              karpenter: webhook
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: karpenter
+              app.kubernetes.io/instance: karpenter
+              karpenter: webhook
 ---
-# Source: karpenter/templates/webhook/webhooks.yaml
+# Source: karpenter/templates/webhooks.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: defaulting.webhook.provisioners.karpenter.sh
+  name: defaulting.webhook.karpenter.k8s.aws
 webhooks:
-- admissionReviewVersions: ["v1"]
-  clientConfig:
-    service:
-      name: karpenter-webhook
-      namespace: 'kube-system'
-  failurePolicy: Fail
-  sideEffects: None
-  name: defaulting.webhook.provisioners.karpenter.sh
-  rules:
-  - apiGroups:
-    - karpenter.k8s.aws
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - awsnodetemplates
-    - awsnodetemplates/status
-    scope: '*'
-  - apiGroups:
-    - karpenter.sh
-    apiVersions:
-    - v1alpha5
-    resources:
-    - provisioners
-    - provisioners/status
-    operations:
-    - CREATE
-    - UPDATE
+  - name: defaulting.webhook.karpenter.k8s.aws
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: karpenter
+        namespace: kube-system
+    failurePolicy: Fail
+    sideEffects: None
+    rules:
+      - apiGroups:
+          - karpenter.k8s.aws
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - awsnodetemplates
+          - awsnodetemplates/status
+        scope: '*'
+      - apiGroups:
+          - karpenter.sh
+        apiVersions:
+          - v1alpha5
+        resources:
+          - provisioners
+          - provisioners/status
+        operations:
+          - CREATE
+          - UPDATE
 ---
-# Source: karpenter/templates/webhook/webhooks.yaml
+# Source: karpenter/templates/webhooks-core.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: defaulting.webhook.karpenter.sh
+webhooks:
+  - name: defaulting.webhook.karpenter.sh
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: karpenter
+        namespace: kube-system
+    failurePolicy: Fail
+    sideEffects: None
+    rules:
+      - apiGroups:
+          - karpenter.sh
+        apiVersions:
+          - v1alpha5
+        resources:
+          - provisioners
+          - provisioners/status
+        operations:
+          - CREATE
+          - UPDATE
+---
+# Source: karpenter/templates/webhooks.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validation.webhook.provisioners.karpenter.sh
+  name: validation.webhook.karpenter.k8s.aws
 webhooks:
-- admissionReviewVersions: ["v1"]
-  clientConfig:
-    service:
-      name: karpenter-webhook
-      namespace: 'kube-system'
-  failurePolicy: Fail
-  sideEffects: None
-  name: validation.webhook.provisioners.karpenter.sh
-  rules:
-  - apiGroups:
-    - karpenter.k8s.aws
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - awsnodetemplates
-    - awsnodetemplates/status
-    scope: '*'
-  - apiGroups:
-    - karpenter.sh
-    apiVersions:
-    - v1alpha5
-    resources:
-    - provisioners
-    - provisioners/status
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
+  - name: validation.webhook.karpenter.k8s.aws
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: karpenter
+        namespace: kube-system
+    failurePolicy: Fail
+    sideEffects: None
+    rules:
+      - apiGroups:
+          - karpenter.k8s.aws
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - awsnodetemplates
+          - awsnodetemplates/status
+        scope: '*'
+      - apiGroups:
+          - karpenter.sh
+        apiVersions:
+          - v1alpha5
+        resources:
+          - provisioners
+          - provisioners/status
+        operations:
+          - CREATE
+          - UPDATE
 ---
-# Source: karpenter/templates/webhook/webhooks.yaml
+# Source: karpenter/templates/webhooks-core.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.karpenter.sh
+webhooks:
+  - name: validation.webhook.karpenter.sh
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: karpenter
+        namespace: kube-system
+    failurePolicy: Fail
+    sideEffects: None
+    rules:
+      - apiGroups:
+          - karpenter.sh
+        apiVersions:
+          - v1alpha5
+        resources:
+          - provisioners
+          - provisioners/status
+        operations:
+          - CREATE
+          - UPDATE
+---
+# Source: karpenter/templates/webhooks-core.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.config.karpenter.sh
 webhooks:
-- admissionReviewVersions: ["v1"]
-  clientConfig:
-    service:
-      name: karpenter-webhook
-      namespace: 'kube-system'
-  failurePolicy: Fail
-  sideEffects: None
-  name: validation.webhook.config.karpenter.sh
-  objectSelector:
-    matchLabels:
-      app.kubernetes.io/part-of: karpenter
+  - name: validation.webhook.config.karpenter.sh
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: karpenter
+        namespace: kube-system
+    failurePolicy: Fail
+    sideEffects: None
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/part-of: karpenter
 ---
 # Source: karpenter/templates/poddisruptionbudget.yaml
 {{ if IsKubernetesGTE "1.23" }}
@@ -1176,6 +1224,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: karpenter
+  namespace: kube-system
 spec:
   maxUnavailable: 1
   selector:

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -765,10 +765,6 @@ rules:
     resources: ["validatingwebhookconfigurations"]
     verbs: ["update"]
     resourceNames: ["validation.webhook.karpenter.sh", "validation.webhook.config.karpenter.sh"]
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["mutatingwebhookconfigurations"]
-    verbs: ["update"]
-    resourceNames: ["defaulting.webhook.karpenter.sh"]
 
 ---
 # Source: karpenter/templates/clusterrole.yaml
@@ -964,7 +960,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: controller
-          image: public.ecr.aws/karpenter/controller:v0.27.0
+          image: public.ecr.aws/karpenter/controller:v0.27.3
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -1234,6 +1234,16 @@ spec:
 {{ range $name, $spec := GetNodeInstanceGroups }}
 {{ if eq $spec.Manager "Karpenter" }}
 ---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: {{ $name }}
+spec:
+  subnetSelector:
+    kops.k8s.io/instance-group/{{ $name }}: "*"
+    kubernetes.io/cluster/{{ ClusterName }}: "*"
+  launchTemplate: {{ $name }}.{{ ClusterName }}
+---
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
@@ -1296,10 +1306,7 @@ spec:
     {{ $key }}: "{{ $value }}"
   {{ end }}
 {{ end }}
-  provider:
-    launchTemplate: {{ $name }}.{{ ClusterName }}
-    subnetSelector:
-      kops.k8s.io/instance-group/{{ $name }}: "*"
-      kubernetes.io/cluster/{{ ClusterName }}: "*"
+  providerRef:
+    name: {{ $name }}
 {{ end }}
 {{ end }}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -1248,7 +1248,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 		{
 			id := "k8s-1.19"
 			location := key + "/" + id + ".yaml"
-			addons.Add(&channelsapi.AddonSpec{
+			addon := addons.Add(&channelsapi.AddonSpec{
 				Name:     fi.PtrTo(key),
 				Manifest: fi.PtrTo(location),
 				Selector: map[string]string{"k8s-addon": key},
@@ -1257,6 +1257,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 			if b.UseServiceAccountExternalPermissions() {
 				serviceAccountRoles = append(serviceAccountRoles, &karpenter.ServiceAccount{})
 			}
+			addon.BuildPrune = true
 		}
 	}
 


### PR DESCRIPTION
## [feat(karpenter): Upgrade to version 0.27.0](https://github.com/kubernetes/kops/pull/15144/commits/1f1c2e9e6d933696a9a0a2e651020c019bfdb4c6)

Upgrade Karpenter to the current last stable version `0.27.0`. Templates have been updated to use the same templates as the Helm chart.

Some noticeable changes:
 - Rename `karpenter-config-logging` ConfigMap to `config-logging`
 - Some environment variables configurations are now in the `karpenter-global-settings` ConfigMap
 - Karpenter use now a common pod for the controller and webhook.

## [feat(karpenter): Use AWSNodeTemplate for launchTemplate](https://github.com/kubernetes/kops/pull/15144/commits/5bd655e09eaf6a6e2ae297edc9d6a912504eca16) 

To set Launch Templates is deprecated into the provisioner, it is recommended to use the `AWSNodeTemplate` to set it.
Ref:
 - https://karpenter.sh/v0.27.0/concepts/node-templates/

## [feat(karpenter): Drop the karpenter feature flag](https://github.com/kubernetes/kops/pull/15144/commits/1d457c438e77dd356de15b8db70ca46154bf2e97)

Drop the `Karpenter` feature flag.  it's fairly well-supported now.