### PR TITLE
Automated cherry pick of #15145: remove s3 access from nodes if using none dns

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -465,9 +465,11 @@ func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 
 	b.addNodeupPermissions(p, r.enableLifecycleHookPermissions)
 
-	var err error
-	if p, err = b.AddS3Permissions(p); err != nil {
-		return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
+	if !b.Cluster.UsesNoneDNS() {
+		var err error
+		if p, err = b.AddS3Permissions(p); err != nil {
+			return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
+		}
 	}
 
 	if b.Cluster.Spec.IAM != nil && b.Cluster.Spec.IAM.AllowContainerRegistry {

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -2,18 +2,6 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketLocation",
-        "s3:GetEncryptionConfiguration",
-        "s3:ListBucket",
-        "s3:ListBucketVersions"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws-test:s3:::placeholder-read-bucket"
-      ]
-    },
-    {
-      "Action": [
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",


### PR DESCRIPTION
Cherry pick of #15145 on release-1.26.

#15145: remove s3 access from nodes if using none dns

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```