### PR TITLE
Document setting cluster name flag for OCCM and Cinder CSI plugin

### DIFF
--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -53,6 +53,10 @@ error is encountered while updating an InstanceGroup.
 
 * Clusters can be created without DNS or Gossip, by using the `--dns=none` flag.
 
+## OpenStack
+
+* When creating new clusters kOps now sets the cluster name flag for the [external OpenStack cloud controller (OCCM)](https://github.com/kubernetes/kops/pull/15139) and the [Cinder CSI plugin](https://github.com/kubernetes/kops/pull/15095).
+
 # Other changes of note
 
 * containerd config is now written to `/etc/containerd/config.toml`.


### PR DESCRIPTION
This adds a release note documenting setting the cluster name flags for OCCM and Cinder CSI plugin.

For reference:
* https://github.com/kubernetes/kops/pull/15139
* https://github.com/kubernetes/kops/pull/15095