### PR TITLE
Automated cherry pick of #15156: Document setting cluster name flag for OCCM and Cinder CSI

### DIFF
--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -45,6 +45,10 @@ error is encountered while updating an InstanceGroup.
 
 * The default instance type is now `e2-medium` for control-plane and worker nodes, and `e2-micro` for bastions.
 
+## OpenStack
+
+* When creating new clusters kOps now sets the cluster name flag for the [external OpenStack cloud controller (OCCM)](https://github.com/kubernetes/kops/pull/15139) and the [Cinder CSI plugin](https://github.com/kubernetes/kops/pull/15095).
+
 # Breaking changes
 
 ## Other breaking changes


### PR DESCRIPTION
Cherry pick of #15156 on release-1.26.

#15156: Document setting cluster name flag for OCCM and Cinder CSI

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```