### PR TITLE
Automated cherry pick of #15160: Update Go to v1.19.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.6'
 
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
@@ -36,7 +36,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
       with:
-        go-version: '1.19.5'
+        go-version: '1.19.6'
 
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       with:
@@ -53,7 +53,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
       with:
-        go-version: '1.19.5'
+        go-version: '1.19.6'
 
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       with:
@@ -70,7 +70,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.6'
 
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.6'
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Update Dependencies
         id: update_deps

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # Push the images
-- name: 'docker.io/library/golang:1.19.5-bullseye'
+- name: 'docker.io/library/golang:1.19.6-bullseye'
   id: images
   entrypoint: make
   env:
@@ -20,7 +20,7 @@ steps:
   - dns-controller-push
   - kube-apiserver-healthcheck-push
 # Push the artifacts
-- name: 'docker.io/library/golang:1.19.5-bullseye'
+- name: 'docker.io/library/golang:1.19.6-bullseye'
   id: artifacts
   entrypoint: make
   env:
@@ -35,7 +35,7 @@ steps:
   args:
   - gcs-upload-and-tag
 # Build cloudbuild artifacts (for attestation)
-- name: 'docker.io/library/golang:1.19.5-bullseye'
+- name: 'docker.io/library/golang:1.19.6-bullseye'
   id: cloudbuild-artifacts
   entrypoint: make
   env:


### PR DESCRIPTION
Cherry pick of #15160 on release-1.25.

#15160: Update Go to v1.19.6

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```