### PR TITLE
WIP Add Ability to Configure Custom PriorityClasses to Be Used in Cluster Validation

### DIFF
--- a/cmd/kops/rolling-update_cluster.go
+++ b/cmd/kops/rolling-update_cluster.go
@@ -208,7 +208,7 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd.Flags().BoolVar(&options.FailOnDrainError, "fail-on-drain-error", true, "Fail if draining a node fails")
 	cmd.Flags().BoolVar(&options.FailOnValidate, "fail-on-validate-error", true, "Fail if the cluster fails to validate")
-	cmd.Flags().StringSliceVar(&options.AdditionalPriorities, "additional-priorities", options.AdditionalPriorities, "Additional priorities of Pods to consider when validating")
+	cmd.Flags().StringSliceVar(&options.AdditionalFilters, "additional-filters", options.AdditionalFilters, "Additional filters to consider when validating")
 
 	cmd.Flags().SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		switch name {
@@ -447,7 +447,7 @@ func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer
 
 	var clusterValidator validation.ClusterValidator
 	if !options.CloudOnly {
-		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, config.Host, k8sClient, options.AdditionalPriorities)
+		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, config.Host, k8sClient, options.AdditionalFilters)
 		if err != nil {
 			return fmt.Errorf("cannot create cluster validator: %v", err)
 		}

--- a/cmd/kops/rolling-update_cluster.go
+++ b/cmd/kops/rolling-update_cluster.go
@@ -208,6 +208,7 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd.Flags().BoolVar(&options.FailOnDrainError, "fail-on-drain-error", true, "Fail if draining a node fails")
 	cmd.Flags().BoolVar(&options.FailOnValidate, "fail-on-validate-error", true, "Fail if the cluster fails to validate")
+	cmd.Flags().StringSliceVar(&options.AdditionalPriorities, "additional-priorities", options.AdditionalPriorities, "Additional priorities of Pods to consider when validating")
 
 	cmd.Flags().SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		switch name {
@@ -446,7 +447,7 @@ func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer
 
 	var clusterValidator validation.ClusterValidator
 	if !options.CloudOnly {
-		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, config.Host, k8sClient)
+		clusterValidator, err = validation.NewClusterValidator(cluster, cloud, list, config.Host, k8sClient, options.AdditionalPriorities)
 		if err != nil {
 			return fmt.Errorf("cannot create cluster validator: %v", err)
 		}

--- a/docs/cli/kops_delete_instance.md
+++ b/docs/cli/kops_delete_instance.md
@@ -30,15 +30,16 @@ kops delete instance INSTANCE|NODE [flags]
 ### Options
 
 ```
-      --cloudonly                     Perform deletion update without confirming progress with Kubernetes
-      --fail-on-drain-error           Fail if draining a node fails (default true)
-      --fail-on-validate-error        Fail if the cluster fails to validate (default true)
-  -h, --help                          help for instance
-      --post-drain-delay duration     Time to wait after draining each node (default 5s)
-      --surge                         Surge by detaching the node from the ASG before deletion (default true)
-      --validate-count int32          Number of times that a cluster needs to be validated after single node update (default 2)
-      --validation-timeout duration   Maximum time to wait for a cluster to validate (default 15m0s)
-  -y, --yes                           Specify --yes to immediately delete the instance
+      --additional-priorities strings   Additional priorities of Pods to consider when validating
+      --cloudonly                       Perform deletion update without confirming progress with Kubernetes
+      --fail-on-drain-error             Fail if draining a node fails (default true)
+      --fail-on-validate-error          Fail if the cluster fails to validate (default true)
+  -h, --help                            help for instance
+      --post-drain-delay duration       Time to wait after draining each node (default 5s)
+      --surge                           Surge by detaching the node from the ASG before deletion (default true)
+      --validate-count int32            Number of times that a cluster needs to be validated after single node update (default 2)
+      --validation-timeout duration     Maximum time to wait for a cluster to validate (default 15m0s)
+  -y, --yes                             Specify --yes to immediately delete the instance
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -56,6 +56,7 @@ kops rolling-update cluster [CLUSTER] [flags]
 ### Options
 
 ```
+      --additional-priorities strings     Additional priorities of Pods to consider when validating
       --bastion-interval duration         Time to wait between restarting bastions (default 15s)
       --cloudonly                         Perform rolling update without confirming progress with Kubernetes
       --control-plane-interval duration   Time to wait between restarting control plane nodes (default 15s)

--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -29,11 +29,12 @@ kops validate cluster [CLUSTER] [flags]
 ### Options
 
 ```
-      --count int           Number of consecutive successful validations required
-  -h, --help                help for cluster
-      --kubeconfig string   Path to the kubeconfig file
-  -o, --output string       Output format. One of json|yaml|table. (default "table")
-      --wait duration       Amount of time to wait for the cluster to become ready
+      --additional-priorities strings   Additional priorities of Pods to consider when validating
+      --count int                       Number of consecutive successful validations required
+  -h, --help                            help for cluster
+      --kubeconfig string               Path to the kubeconfig file
+  -o, --output string                   Output format. One of json|yaml|table. (default "table")
+      --wait duration                   Amount of time to wait for the cluster to become ready
 ```
 
 ### Options inherited from parent commands

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -91,6 +91,10 @@ type RollingUpdateOptions struct {
 	// DeregisterControlPlaneNodes controls if we deregister control plane instances from load balacners etc before draining/terminating.
 	// When a cluster only has a single apiserver, we don't want to do this, as we can't drain after deregistering it.
 	DeregisterControlPlaneNodes bool
+
+	// AdditionalPriorities specifies that the validation will consider pods with these PriorityClassNames as well,
+	// in addition to the default system critical ones (todo: improve wording...).
+	AdditionalPriorities []string
 }
 
 func (o *RollingUpdateOptions) InitDefaults() {

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -92,9 +92,12 @@ type RollingUpdateOptions struct {
 	// When a cluster only has a single apiserver, we don't want to do this, as we can't drain after deregistering it.
 	DeregisterControlPlaneNodes bool
 
-	// AdditionalPriorities specifies that the validation will consider pods with these PriorityClassNames as well,
-	// in addition to the default system critical ones (todo: improve wording...).
-	AdditionalPriorities []string
+	// AdditionalFilters specifies filters in the form of "<key>=<value>" which are considered when validating a cluster.
+	//
+	// Currently, the flag supports the following filters:
+	//   * priority-class-name=<priority class name>
+	//   * namespace=<namespace>
+	AdditionalFilters []string
 }
 
 func (o *RollingUpdateOptions) InitDefaults() {

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -125,7 +125,7 @@ func isRelevantPriority(priority string, priorities []string) bool {
 	return false
 }
 
-func NewClusterValidator(cluster *kops.Cluster, cloud fi.Cloud, instanceGroupList *kops.InstanceGroupList, host string, k8sClient kubernetes.Interface) (ClusterValidator, error) {
+func NewClusterValidator(cluster *kops.Cluster, cloud fi.Cloud, instanceGroupList *kops.InstanceGroupList, host string, k8sClient kubernetes.Interface, additionalPriorities []string) (ClusterValidator, error) {
 	var instanceGroups []*kops.InstanceGroup
 
 	for i := range instanceGroupList.Items {
@@ -138,6 +138,10 @@ func NewClusterValidator(cluster *kops.Cluster, cloud fi.Cloud, instanceGroupLis
 	}
 
 	priorities := getDefaultPriorities()
+
+	if additionalPriorities != nil {
+		priorities = append(priorities, additionalPriorities...)
+	}
 
 	return &clusterValidatorImpl{
 		cluster:        cluster,

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -114,17 +114,6 @@ func getDefaultPriorities() []string {
 	}
 }
 
-// isRelevantPriority returns true if priority of a Pod is in priorities and false if not,
-// thus determining if the priority is relevant for validation.
-func isRelevantPriority(priority string, priorities []string) bool {
-	for _, relevantPriority := range priorities {
-		if priority == relevantPriority {
-			return true
-		}
-	}
-	return false
-}
-
 func NewClusterValidator(cluster *kops.Cluster, cloud fi.Cloud, instanceGroupList *kops.InstanceGroupList, host string, k8sClient kubernetes.Interface, additionalPriorities []string) (ClusterValidator, error) {
 	var instanceGroups []*kops.InstanceGroup
 
@@ -242,7 +231,7 @@ func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kuber
 		}
 
 		priority := pod.Spec.PriorityClassName
-		if !isRelevantPriority(priority, priorities) {
+		if !fi.ArrayContains(priorities, priority) {
 			return nil
 		}
 		if pod.Status.Phase == v1.PodSucceeded {

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -68,7 +68,7 @@ func (c *MockCloud) GetCloudGroups(cluster *kopsapi.Cluster, instancegroups []*k
 	return c.Groups, nil
 }
 
-func testValidate(t *testing.T, groups map[string]*cloudinstances.CloudInstanceGroup, objects []runtime.Object, additionalPriorities []string) (*ValidationCluster, error) {
+func testValidate(t *testing.T, groups map[string]*cloudinstances.CloudInstanceGroup, objects []runtime.Object, additionalFilters []string) (*ValidationCluster, error) {
 	cluster := &kopsapi.Cluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "testcluster.k8s.local"},
 		Spec: kopsapi.ClusterSpec{
@@ -126,7 +126,7 @@ func testValidate(t *testing.T, groups map[string]*cloudinstances.CloudInstanceG
 
 	mockcloud := BuildMockCloud(t, groups, cluster, instanceGroups)
 
-	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, "https://api.testcluster.k8s.local", fake.NewSimpleClientset(objects...), additionalPriorities)
+	validator, err := NewClusterValidator(cluster, mockcloud, &kopsapi.InstanceGroupList{Items: instanceGroups}, "https://api.testcluster.k8s.local", fake.NewSimpleClientset(objects...), additionalFilters)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, kOps  only validates pods with the priority classes `system-cluster-critical` and `system-node-critical`.

This will enable the users to specify their own priority classes kOps should consider when validating a cluster.

TODO:

- [ ] Revise naming, doc
- [ ] Add tests

TL;DRcode:

It is possible to specify `--additional-filters <key>=<value>`, multiple times with it. Where key can be `priority-class-name` and `namespace`. The latter is not implemented yet.

fixes #13150