### PR TITLE
Automated cherry pick of #15169: update openstack csi & ccm versions

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -816,9 +816,11 @@ func (tf *TemplateFunctions) OpenStackCCMTag() string {
 		if parsed.Minor == 23 {
 			tag = "v1.23.1"
 		} else if parsed.Minor == 24 {
-			tag = "v1.24.5"
+			tag = "v1.24.6"
 		} else if parsed.Minor == 25 {
-			tag = "v1.25.3"
+			tag = "v1.25.4"
+		} else if parsed.Minor == 26 {
+			tag = "v1.26.1"
 		} else {
 			// otherwise we use always .0 ccm image, if needed that can be overrided using clusterspec
 			tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)
@@ -836,9 +838,11 @@ func (tf *TemplateFunctions) OpenStackCSITag() string {
 		tag = "latest"
 	} else {
 		if parsed.Minor == 24 {
-			tag = "v1.24.5"
+			tag = "v1.24.6"
 		} else if parsed.Minor == 25 {
-			tag = "v1.25.3"
+			tag = "v1.25.4"
+		} else if parsed.Minor == 26 {
+			tag = "v1.26.1"
 		} else {
 			// otherwise we use always .0 csi image, if needed that can be overrided using cloud config spec
 			tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)


### PR DESCRIPTION
Cherry pick of #15169 on release-1.26.

#15169: update openstack csi & ccm versions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```