### PR TITLE
[docs] Fix External IAM Policy Docs

### DIFF
--- a/docs/iam_roles.md
+++ b/docs/iam_roles.md
@@ -59,9 +59,9 @@ iam:
 
 {{ kops_feature_table(kops_added_default='1.18') }}
 
-At times, you may want to attach policies shared to you by another AWS account or that are maintained by an outside application. You can specify managed policies through the `policyOverrides` spec field.
+At times, you may want to attach policies shared to you by another AWS account or that are maintained by an outside application. You can specify managed policies through the `externalPolicies` spec field.
 
-Policy Overrides are specified by their ARN on AWS and are grouped by their role type. See the example below:
+External Policies are specified by their ARN on AWS and are grouped by their role type. See the example below:
 
 ```yaml
 spec:


### PR DESCRIPTION
This feature was renamed during its [development](https://github.com/kubernetes/kops/pull/7837) and a remnant of that original name was in the docs. Fixing this because it confused me enough to have to look up what the correct config was in the code.