### PR TITLE
Automated cherry pick of #15069: openstack verifier: support IPv6
#15138: exit gracefully if server already exists in k8s

### DIFF
--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -142,6 +142,12 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 
 	id, err := s.verifier.VerifyToken(ctx, r, r.Header.Get("Authorization"), body, s.opt.Server.UseInstanceIDForNodeName)
 	if err != nil {
+		// means that we should exit nodeup gracefully
+		if err == bootstrap.ErrAlreadyExists {
+			w.WriteHeader(http.StatusNoContent)
+			klog.Infof("%s: %v", r.RemoteAddr, err)
+			return
+		}
 		klog.Infof("bootstrap %s verify err: %v", r.RemoteAddr, err)
 		w.WriteHeader(http.StatusForbidden)
 		// don't return the error; this allows us to have richer errors without security implications

--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -144,7 +144,7 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// means that we should exit nodeup gracefully
 		if err == bootstrap.ErrAlreadyExists {
-			w.WriteHeader(http.StatusNoContent)
+			w.WriteHeader(http.StatusConflict)
 			klog.Infof("%s: %v", r.RemoteAddr, err)
 			return
 		}

--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -144,7 +144,8 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		klog.Infof("bootstrap %s verify err: %v", r.RemoteAddr, err)
 		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(fmt.Sprintf("failed to verify token: %v", err)))
+		// don't return the error; this allows us to have richer errors without security implications
+		_, _ = w.Write([]byte("failed to verify token"))
 		return
 	}
 

--- a/pkg/bootstrap/authenticate.go
+++ b/pkg/bootstrap/authenticate.go
@@ -18,8 +18,11 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"net/http"
 )
+
+var ErrAlreadyExists = errors.New("node already exists")
 
 // Authenticator generates authentication credentials for requests.
 type Authenticator interface {

--- a/pkg/kopscontrollerclient/client.go
+++ b/pkg/kopscontrollerclient/client.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"time"
 
@@ -148,6 +149,12 @@ func (b *Client) Query(ctx context.Context, req any, resp any) error {
 	}
 	if response.Body != nil {
 		defer response.Body.Close()
+	}
+
+	// if we receive StatusNoContent it means that we should exit gracefully
+	if response.StatusCode == http.StatusNoContent {
+		klog.Infof("kops-controller returned status code %d", response.StatusCode)
+		os.Exit(0)
 	}
 
 	if response.StatusCode != http.StatusOK {

--- a/pkg/kopscontrollerclient/client.go
+++ b/pkg/kopscontrollerclient/client.go
@@ -151,8 +151,8 @@ func (b *Client) Query(ctx context.Context, req any, resp any) error {
 		defer response.Body.Close()
 	}
 
-	// if we receive StatusNoContent it means that we should exit gracefully
-	if response.StatusCode == http.StatusNoContent {
+	// if we receive StatusConflict it means that we should exit gracefully
+	if response.StatusCode == http.StatusConflict {
 		klog.Infof("kops-controller returned status code %d", response.StatusCode)
 		os.Exit(0)
 	}

--- a/upup/pkg/fi/cloudup/openstack/verifier.go
+++ b/upup/pkg/fi/cloudup/openstack/verifier.go
@@ -154,7 +154,7 @@ func (o openstackVerifier) VerifyToken(ctx context.Context, rawRequest *http.Req
 	// check from kubernetes API does the instance already exist
 	_, err = o.kubeClient.CoreV1().Nodes().Get(ctx, instance.Name, v1.GetOptions{})
 	if err == nil {
-		return nil, fmt.Errorf("server %q is already joined to kubernetes cluster", instance.Name)
+		return nil, bootstrap.ErrAlreadyExists
 	}
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, fmt.Errorf("got error while querying kubernetes api: %w", err)


### PR DESCRIPTION
Cherry pick of #15069 #15138 on release-1.26.

#15069: openstack verifier: support IPv6
#15138: exit gracefully if server already exists in k8s

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```