### PR TITLE
set node status update freq to 60min in OpenStack

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -656,6 +656,10 @@ spec:
                   master:
                     description: Master is the url for the kube api master.
                     type: string
+                  nodeStatusUpdateFrequency:
+                    description: 'NodeStatusUpdateFrequency is the duration between
+                      node status updates. (default: 5m)'
+                    type: string
                   useServiceAccountCredentials:
                     description: UseServiceAccountCredentials controls whether we
                       use individual service account credentials for each controller.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -696,6 +696,8 @@ type CloudControllerManagerConfig struct {
 	// CPURequest of NodeTerminationHandler container.
 	// Default: 200m
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// NodeStatusUpdateFrequency is the duration between node status updates. (default: 5m)
+	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"node-status-update-frequency"`
 }
 
 // KubeSchedulerConfig is the configuration for the kube-scheduler

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -702,6 +702,8 @@ type CloudControllerManagerConfig struct {
 	// CPURequest of CloudControllerManager container.
 	// Default: 200m
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// NodeStatusUpdateFrequency is the duration between node status updates. (default: 5m)
+	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"node-status-update-frequency"`
 }
 
 // KubeSchedulerConfig is the configuration for the kube-scheduler

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2157,6 +2157,7 @@ func autoConvert_v1alpha2_CloudControllerManagerConfig_To_kops_CloudControllerMa
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
 	out.EnableLeaderMigration = in.EnableLeaderMigration
 	out.CPURequest = in.CPURequest
+	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
 	return nil
 }
 
@@ -2189,6 +2190,7 @@ func autoConvert_kops_CloudControllerManagerConfig_To_v1alpha2_CloudControllerMa
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
 	out.EnableLeaderMigration = in.EnableLeaderMigration
 	out.CPURequest = in.CPURequest
+	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -822,6 +822,11 @@ func (in *CloudControllerManagerConfig) DeepCopyInto(out *CloudControllerManager
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.NodeStatusUpdateFrequency != nil {
+		in, out := &in.NodeStatusUpdateFrequency, &out.NodeStatusUpdateFrequency
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -693,6 +693,8 @@ type CloudControllerManagerConfig struct {
 	// CPURequest of NodeTerminationHandler container.
 	// Default: 200m
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// NodeStatusUpdateFrequency is the duration between node status updates. (default: 5m)
+	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"node-status-update-frequency"`
 }
 
 // KubeSchedulerConfig is the configuration for the kube-scheduler

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2247,6 +2247,7 @@ func autoConvert_v1alpha3_CloudControllerManagerConfig_To_kops_CloudControllerMa
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
 	out.EnableLeaderMigration = in.EnableLeaderMigration
 	out.CPURequest = in.CPURequest
+	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
 	return nil
 }
 
@@ -2279,6 +2280,7 @@ func autoConvert_kops_CloudControllerManagerConfig_To_v1alpha3_CloudControllerMa
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
 	out.EnableLeaderMigration = in.EnableLeaderMigration
 	out.CPURequest = in.CPURequest
+	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -728,6 +728,11 @@ func (in *CloudControllerManagerConfig) DeepCopyInto(out *CloudControllerManager
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.NodeStatusUpdateFrequency != nil {
+		in, out := &in.NodeStatusUpdateFrequency, &out.NodeStatusUpdateFrequency
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -825,6 +825,11 @@ func (in *CloudControllerManagerConfig) DeepCopyInto(out *CloudControllerManager
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.NodeStatusUpdateFrequency != nil {
+		in, out := &in.NodeStatusUpdateFrequency, &out.NodeStatusUpdateFrequency
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
like it says in code

```
// Node status updates are happening unnecessarily often in kOps OpenStack.
// Node status updates are useful if we are updating existing node flavor type or node addresses.
// However, that will not happen when using kOps.
// see more discussion in https://github.com/kubernetes/cloud-provider-openstack/pull/2133
```