### PR TITLE
[DigitalOcean] support terraform provider for DO

### DIFF
--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -94,6 +94,8 @@ var (
 	// - the feature won't do anything when the node OS does not support SELinux.
 	// TODO(jsafrane): add to all CSI drivers installed by kops.
 	SELinuxMount = new("SELinuxMount", Bool(false))
+	// DO Terraform toggles the DO terraform support.
+	DOTerraform = new("DOTerraform", Bool(false))
 )
 
 // FeatureFlag defines a feature flag

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -168,6 +168,9 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		if !found {
 			return fmt.Errorf("cloud provider %v does not support the terraform target", c.Cloud.ProviderID())
 		}
+		if c.Cloud.ProviderID() == kops.CloudProviderDO && !featureflag.DOTerraform.Enabled() {
+			return fmt.Errorf("DO Terraform requires the DOTerraform feature flag to be enabled")
+		}
 	}
 	if c.InstanceGroups == nil {
 		list, err := c.Clientset.InstanceGroupsFor(c.Cluster).List(ctx, metav1.ListOptions{})

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -92,6 +92,7 @@ var TerraformCloudProviders = []kops.CloudProviderID{
 	kops.CloudProviderGCE,
 	kops.CloudProviderHetzner,
 	kops.CloudProviderScaleway,
+	kops.CloudProviderDO,
 }
 
 type ApplyClusterCmd struct {

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/do"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 	_ "k8s.io/kops/upup/pkg/fi/cloudup/terraform"
 )
 
@@ -218,4 +219,33 @@ func (_ *Droplet) CheckChanges(a, e, changes *Droplet) error {
 		}
 	}
 	return nil
+}
+
+type terraformDropletOptions struct {
+	Image    *string  `cty:"image"`
+	Size     *string  `cty:"size"`
+	Region   *string  `cty:"region"`
+	Name     *string  `cty:"name"`
+	Tags     []string `cty:"tags"`
+	SSHKey   []string `cty:"ssh_keys"`
+	UserData *string  `cty:"user_data"`
+	VPCUUID  *string  `cty:"vpc_uuid"`
+}
+
+func (_ *Droplet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Droplet) error {
+	tf := &terraformDropletOptions{
+		Image:  e.Image,
+		Size:   e.Size,
+		Region: e.Region,
+		Name:   e.Name,
+		Tags:   e.Tags,
+	}
+
+	userData, err := fi.ResourceAsString(e.UserData)
+	if err != nil {
+		return err
+	}
+	tf.UserData = &userData
+
+	return t.RenderResource("digitalocean_droplet", *e.Name, tf)
 }

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -240,7 +240,7 @@ func (_ *Droplet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *D
 		Region: e.Region,
 		Name:   e.Name,
 		Tags:   e.Tags,
-		SSHKey: []string{fi.ValueOf(e.SSHKey)},
+		SSHKey: []string{fi.ValueOf(e.SSHKey.KeyFingerprint)},
 	}
 
 	if e.UserData != nil {

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -239,6 +239,7 @@ func (_ *Droplet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *D
 		Region: e.Region,
 		Name:   e.Name,
 		Tags:   e.Tags,
+		SSHKey: []string{fi.ValueOf(e.SSHKey)},
 	}
 
 	userData, err := fi.ResourceAsString(e.UserData)

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -235,12 +235,16 @@ type terraformDropletOptions struct {
 
 func (_ *Droplet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Droplet) error {
 	tf := &terraformDropletOptions{
-		Image:  e.Image,
-		Size:   e.Size,
-		Region: e.Region,
-		Name:   e.Name,
-		Tags:   e.Tags,
-		SSHKey: []string{fi.ValueOf(e.SSHKey.KeyFingerprint)},
+		Image:   e.Image,
+		Size:    e.Size,
+		Region:  e.Region,
+		Name:    e.Name,
+		Tags:    e.Tags,
+		VPCUUID: e.VPCUUID,
+	}
+
+	if e.SSHKey != nil {
+		tf.SSHKey = []string{fi.ValueOf(e.SSHKey.KeyFingerprint)}
 	}
 
 	if e.UserData != nil {

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -246,12 +246,12 @@ func (_ *Droplet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *D
 	if e.UserData != nil {
 		d, err := fi.ResourceAsBytes(e.UserData)
 		if err != nil {
-			return err
+			return fmt.Errorf("Error retrieving droplet from resource bytes: %w", err)
 		}
 		if d != nil {
 			tf.UserData, err = t.AddFileBytes("digitalocean_droplet", fi.ValueOf(e.Name), "user_data", d, false)
 			if err != nil {
-				return err
+				return fmt.Errorf("Error adding user data bytes to terraform resource: %w", err)
 			}
 		}
 	}

--- a/upup/pkg/fi/cloudup/dotasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/dotasks/sshkey.go
@@ -163,7 +163,7 @@ func (_ *SSHKey) RenderDO(t *do.DOAPITarget, a, e, changes *SSHKey) error {
 }
 
 type terraformSSHKey struct {
-	Name      *string                  `cty:"key_name"`
+	Name      *string                  `cty:"name"`
 	PublicKey *terraformWriter.Literal `cty:"public_key"`
 }
 

--- a/upup/pkg/fi/cloudup/dotasks/volume.go
+++ b/upup/pkg/fi/cloudup/dotasks/volume.go
@@ -132,16 +132,26 @@ func (_ *Volume) RenderDO(t *do.DOAPITarget, a, e, changes *Volume) error {
 // terraformVolume represents the digitalocean_volume resource in terraform
 // https://www.terraform.io/docs/providers/do/r/volume.html
 type terraformVolume struct {
-	Name   *string `cty:"name"`
-	SizeGB *int64  `cty:"size"`
-	Region *string `cty:"region"`
+	Name   *string  `cty:"name"`
+	SizeGB *int64   `cty:"size"`
+	Region *string  `cty:"region"`
+	Tags   []string `cty:"tags"`
 }
 
 func (_ *Volume) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Volume) error {
+	tagArray := []string{}
+
+	for k, v := range e.Tags {
+		// DO tags don't accept =. Separate the key and value with an ":"
+		klog.V(10).Infof("DO - Join the volume tag - %s", fmt.Sprintf("%s:%s", k, v))
+		tagArray = append(tagArray, fmt.Sprintf("%s:%s", k, v))
+	}
+
 	tf := &terraformVolume{
 		Name:   e.Name,
 		SizeGB: e.SizeGB,
 		Region: e.Region,
+		Tags:   tagArray,
 	}
 	return t.RenderResource("digitalocean_volume", *e.Name, tf)
 }

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -122,7 +122,7 @@ func (t *TerraformTarget) writeProviders(buf *bytes.Buffer) {
 	if t.Cloud.ProviderID() == kops.CloudProviderGCE {
 		providerBody["project"] = t.Project
 	}
-	if t.Cloud.ProviderID() != kops.CloudProviderHetzner {
+	if t.Cloud.ProviderID() != kops.CloudProviderHetzner && t.Cloud.ProviderID() != kops.CloudProviderDO {
 		providerBody["region"] = t.Cloud.Region()
 	}
 	for k, v := range tfGetProviderExtraConfig(t.clusterSpecTarget) {

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -52,7 +52,51 @@ func (t *TerraformTarget) finishHCL2() error {
 
 	t.writeDataSources(buf, dataSourcesByType)
 
+<<<<<<< HEAD
 	t.writeTerraform(buf)
+=======
+			element.Write(buf, 0, fmt.Sprintf("data %q %q", dataSourceType, dataSourceName))
+			buf.WriteString("\n")
+		}
+	}
+
+	buf.WriteString("terraform {\n")
+	buf.WriteString("  required_version = \">= 0.15.0\"\n")
+	buf.WriteString("  required_providers {\n")
+
+	if t.Cloud.ProviderID() == kops.CloudProviderGCE {
+		writeMap(buf, 4, "google", map[string]*terraformWriter.Literal{
+			"source":  terraformWriter.LiteralFromStringValue("hashicorp/google"),
+			"version": terraformWriter.LiteralFromStringValue(">= 2.19.0"),
+		})
+	} else if t.Cloud.ProviderID() == kops.CloudProviderHetzner {
+		writeMap(buf, 4, "hcloud", map[string]*terraformWriter.Literal{
+			"source":  terraformWriter.LiteralFromStringValue("hetznercloud/hcloud"),
+			"version": terraformWriter.LiteralFromStringValue(">= 1.35.1"),
+		})
+	} else if t.Cloud.ProviderID() == kops.CloudProviderAWS {
+		configurationAlias := terraformWriter.LiteralTokens("aws", "files")
+		writeMap(buf, 4, "aws", map[string]*terraformWriter.Literal{
+			"source":                terraformWriter.LiteralFromStringValue("hashicorp/aws"),
+			"version":               terraformWriter.LiteralFromStringValue(">= 4.0.0"),
+			"configuration_aliases": terraformWriter.LiteralListExpression(configurationAlias),
+		})
+		if featureflag.Spotinst.Enabled() {
+			writeMap(buf, 4, "spotinst", map[string]*terraformWriter.Literal{
+				"source":  terraformWriter.LiteralFromStringValue("spotinst/spotinst"),
+				"version": terraformWriter.LiteralFromStringValue(">= 1.33.0"),
+			})
+		}
+	} else if t.Cloud.ProviderID() == kops.CloudProviderDO {
+		writeMap(buf, 4, "digitalocean", map[string]*terraformWriter.Literal{
+			"source":  terraformWriter.LiteralFromStringValue("digitalocean/digitalocean"),
+			"version": terraformWriter.LiteralFromStringValue("~> 2.0"),
+		})
+	}
+
+	buf.WriteString("  }\n")
+	buf.WriteString("}\n")
+>>>>>>> 58d3d04107 (Initial changes for terraform support)
 
 	t.Files["kubernetes.tf"] = buf.Bytes()
 

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -52,51 +52,7 @@ func (t *TerraformTarget) finishHCL2() error {
 
 	t.writeDataSources(buf, dataSourcesByType)
 
-<<<<<<< HEAD
 	t.writeTerraform(buf)
-=======
-			element.Write(buf, 0, fmt.Sprintf("data %q %q", dataSourceType, dataSourceName))
-			buf.WriteString("\n")
-		}
-	}
-
-	buf.WriteString("terraform {\n")
-	buf.WriteString("  required_version = \">= 0.15.0\"\n")
-	buf.WriteString("  required_providers {\n")
-
-	if t.Cloud.ProviderID() == kops.CloudProviderGCE {
-		writeMap(buf, 4, "google", map[string]*terraformWriter.Literal{
-			"source":  terraformWriter.LiteralFromStringValue("hashicorp/google"),
-			"version": terraformWriter.LiteralFromStringValue(">= 2.19.0"),
-		})
-	} else if t.Cloud.ProviderID() == kops.CloudProviderHetzner {
-		writeMap(buf, 4, "hcloud", map[string]*terraformWriter.Literal{
-			"source":  terraformWriter.LiteralFromStringValue("hetznercloud/hcloud"),
-			"version": terraformWriter.LiteralFromStringValue(">= 1.35.1"),
-		})
-	} else if t.Cloud.ProviderID() == kops.CloudProviderAWS {
-		configurationAlias := terraformWriter.LiteralTokens("aws", "files")
-		writeMap(buf, 4, "aws", map[string]*terraformWriter.Literal{
-			"source":                terraformWriter.LiteralFromStringValue("hashicorp/aws"),
-			"version":               terraformWriter.LiteralFromStringValue(">= 4.0.0"),
-			"configuration_aliases": terraformWriter.LiteralListExpression(configurationAlias),
-		})
-		if featureflag.Spotinst.Enabled() {
-			writeMap(buf, 4, "spotinst", map[string]*terraformWriter.Literal{
-				"source":  terraformWriter.LiteralFromStringValue("spotinst/spotinst"),
-				"version": terraformWriter.LiteralFromStringValue(">= 1.33.0"),
-			})
-		}
-	} else if t.Cloud.ProviderID() == kops.CloudProviderDO {
-		writeMap(buf, 4, "digitalocean", map[string]*terraformWriter.Literal{
-			"source":  terraformWriter.LiteralFromStringValue("digitalocean/digitalocean"),
-			"version": terraformWriter.LiteralFromStringValue("~> 2.0"),
-		})
-	}
-
-	buf.WriteString("  }\n")
-	buf.WriteString("}\n")
->>>>>>> 58d3d04107 (Initial changes for terraform support)
 
 	t.Files["kubernetes.tf"] = buf.Bytes()
 
@@ -265,6 +221,8 @@ func (t *TerraformTarget) writeTerraform(buf *bytes.Buffer) {
 		if featureflag.Spotinst.Enabled() {
 			providers["spotinst"] = true
 		}
+	} else if t.Cloud.ProviderID() == kops.CloudProviderDO {
+		providers["digitalocean"] = true
 	}
 
 	for _, tfProvider := range t.TerraformWriter.Providers {
@@ -296,6 +254,10 @@ func (t *TerraformTarget) writeTerraform(buf *bytes.Buffer) {
 			"scaleway": {
 				"source":  "scaleway/scaleway",
 				"version": ">= 2.2.1",
+			},
+			"digitalocean": {
+				"source":  "digitalocean/digitalocean",
+				"version": "~>2.0",
 			},
 		}
 

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -599,13 +600,13 @@ func (p *S3Path) RenderTerraform(w *terraformWriter.TerraformWriter, name string
 
 		content, err := w.AddFileBytes("digitalocean_spaces_bucket_object", name, "content", bytes, false)
 		if err != nil {
-			return fmt.Errorf("rendering DO file: %v", err)
+			return fmt.Errorf("error rendering DO file: %w", err)
 		}
 
 		// retrieve space region from endpoint
 		endpoint := os.Getenv("S3_ENDPOINT")
 		if endpoint == "" {
-			return fmt.Errorf("S3 Endpoint is empty")
+			return errors.New("S3 Endpoint is empty")
 		}
 		region := strings.Split(endpoint, ".")[0]
 


### PR DESCRIPTION
Initial work to get the terraform support for DO.

- Tested by creating a cluster with `--out terraform` like below.

```
kops create cluster --cloud=digitalocean --name=dev6.****.co.in --node-count=2 --networking=calico --zones=sfo3 --ssh-public-key=~/.ssh/id_ed25519.pub --target=terraform --out=./terraform-test -v=6
```

- kubernetes.tf file gets created with digitial ocean specific resources. snippet below.
```

output "cluster_name" {
  value = "dev6.test.co.in"
}

output "region" {
  value = "sfo3"
}

provider "digitalocean" {
}

resource "digitalocean_droplet" "control-plane-sfo3-1-masters-dev6-test-co-in" {
  image     = "ubuntu-20-04-x64"
  name      = "control-plane-sfo3-1.masters.dev6.test.co.in"
  region    = "sfo3"
  size      = "s-2vcpu-4gb"
  ssh_keys  = ["c5:e2:db:15:b1:36:5f:f4:21:13:1a:59:cf:a4:39:05"]
  tags      = ["KubernetesCluster:dev6-test-co-in", "k8s-index:etcd-1", "KubernetesCluster-Master:dev6-test-co-in", "kops-instancegroup:control-plane-sfo3-1"]
  user_data = file("${path.module}/data/digitalocean_droplet_control-plane-sfo3-1.masters.dev6.test.co.in_user_data")
}

resource "digitalocean_droplet" "nodes-sfo3-dev6-test-co-in" {
  image     = "ubuntu-20-04-x64"
  name      = "nodes-sfo3.dev6.test.co.in"
  region    = "sfo3"
  size      = "s-2vcpu-4gb"
  ssh_keys  = ["c5:e2:db:15:b1:36:5f:f4:21:13:1a:59:cf:a4:39:05"]
  tags      = ["KubernetesCluster:dev6-test-co-in", "kops-instancegroup:nodes-sfo3"]
  user_data = file("${path.module}/data/digitalocean_droplet_nodes-sfo3.dev6.test.co.in_user_data")
}

resource "digitalocean_spaces_bucket_object" "cluster-completed-spec" {
  bucket  = "sri-kops-space"
  content = file("${path.module}/data/digitalocean_spaces_bucket_object_cluster-completed.spec_content")
  key     = "dev6.test.co.in/cluster-completed.spec"
  region  = "sfo2"
}

```

- terraform init/plan/apply works as expected.
- able to see the cluster created as expected.


