### PR TITLE
Automated cherry pick of #15180: set node status update freq to 60min in OpenStack

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -650,6 +650,10 @@ spec:
                   master:
                     description: Master is the url for the kube api master.
                     type: string
+                  nodeStatusUpdateFrequency:
+                    description: 'NodeStatusUpdateFrequency is the duration between
+                      node status updates. (default: 5m)'
+                    type: string
                   useServiceAccountCredentials:
                     description: UseServiceAccountCredentials controls whether we
                       use individual service account credentials for each controller.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -696,6 +696,8 @@ type CloudControllerManagerConfig struct {
 	// CPURequest of NodeTerminationHandler container.
 	// Default: 200m
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// NodeStatusUpdateFrequency is the duration between node status updates. (default: 5m)
+	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"node-status-update-frequency"`
 }
 
 // KubeSchedulerConfig is the configuration for the kube-scheduler

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -695,6 +695,8 @@ type CloudControllerManagerConfig struct {
 	// CPURequest of CloudControllerManager container.
 	// Default: 200m
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// NodeStatusUpdateFrequency is the duration between node status updates. (default: 5m)
+	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"node-status-update-frequency"`
 }
 
 // KubeSchedulerConfig is the configuration for the kube-scheduler

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2161,6 +2161,7 @@ func autoConvert_v1alpha2_CloudControllerManagerConfig_To_kops_CloudControllerMa
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
 	out.EnableLeaderMigration = in.EnableLeaderMigration
 	out.CPURequest = in.CPURequest
+	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
 	return nil
 }
 
@@ -2193,6 +2194,7 @@ func autoConvert_kops_CloudControllerManagerConfig_To_v1alpha2_CloudControllerMa
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
 	out.EnableLeaderMigration = in.EnableLeaderMigration
 	out.CPURequest = in.CPURequest
+	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -811,6 +811,11 @@ func (in *CloudControllerManagerConfig) DeepCopyInto(out *CloudControllerManager
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.NodeStatusUpdateFrequency != nil {
+		in, out := &in.NodeStatusUpdateFrequency, &out.NodeStatusUpdateFrequency
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -693,6 +693,8 @@ type CloudControllerManagerConfig struct {
 	// CPURequest of NodeTerminationHandler container.
 	// Default: 200m
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// NodeStatusUpdateFrequency is the duration between node status updates. (default: 5m)
+	NodeStatusUpdateFrequency *metav1.Duration `json:"nodeStatusUpdateFrequency,omitempty" flag:"node-status-update-frequency"`
 }
 
 // KubeSchedulerConfig is the configuration for the kube-scheduler

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2213,6 +2213,7 @@ func autoConvert_v1alpha3_CloudControllerManagerConfig_To_kops_CloudControllerMa
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
 	out.EnableLeaderMigration = in.EnableLeaderMigration
 	out.CPURequest = in.CPURequest
+	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
 	return nil
 }
 
@@ -2245,6 +2246,7 @@ func autoConvert_kops_CloudControllerManagerConfig_To_v1alpha3_CloudControllerMa
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
 	out.EnableLeaderMigration = in.EnableLeaderMigration
 	out.CPURequest = in.CPURequest
+	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -733,6 +733,11 @@ func (in *CloudControllerManagerConfig) DeepCopyInto(out *CloudControllerManager
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.NodeStatusUpdateFrequency != nil {
+		in, out := &in.NodeStatusUpdateFrequency, &out.NodeStatusUpdateFrequency
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -830,6 +830,11 @@ func (in *CloudControllerManagerConfig) DeepCopyInto(out *CloudControllerManager
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.NodeStatusUpdateFrequency != nil {
+		in, out := &in.NodeStatusUpdateFrequency, &out.NodeStatusUpdateFrequency
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Cherry pick of #15180 on release-1.26.

#15180: set node status update freq to 60min in OpenStack

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```