### PR TITLE
remove cgroup slice suffix

### DIFF
--- a/docs/releases/1.26-NOTES.md
+++ b/docs/releases/1.26-NOTES.md
@@ -19,6 +19,8 @@ eviction errors), proceeding to the next InstanceGroup after timing out.
 As of kOps 1.26, rolling updates will not proceed if a cluster validation
 error is encountered while updating an InstanceGroup.
 
+* `kubelet.kubeletCgroups` and `kubelet.runtimeCgroups` will not automatically append `.slice` to the cgroup name. Ensure that both fields are suffixed with `.slice` if you are using systemd cgroups (example: `/podruntime.slice`). This resolves an issue where kubelet's container manager would reference the wrong cgroup
+
 ## AWS
 
 * Clusters can be created without DNS or Gossip, by using the `--dns=none` flag.

--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -233,7 +233,7 @@ func (b *ContainerdBuilder) buildSystemdService(sv semver.Version) *nodetasks.Se
 	if b.NodeupConfig.KubeletConfig.CgroupDriver == "systemd" {
 		cgroup := b.NodeupConfig.KubeletConfig.RuntimeCgroups
 		if cgroup != "" {
-			manifest.Set("Service", "Slice", strings.Trim(cgroup, "/")+".slice")
+			manifest.Set("Service", "Slice", strings.Trim(cgroup, "/"))
 		}
 	}
 

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -381,7 +381,7 @@ func (b *KubeletBuilder) buildSystemdService() *nodetasks.Service {
 	if b.NodeupConfig.KubeletConfig.CgroupDriver == "systemd" && b.NodeupConfig.ContainerRuntime == "containerd" {
 		cgroup := b.NodeupConfig.KubeletConfig.KubeletCgroups
 		if cgroup != "" {
-			manifest.Set("Service", "Slice", strings.Trim(cgroup, "/")+".slice")
+			manifest.Set("Service", "Slice", strings.Trim(cgroup, "/"))
 		}
 	}
 
@@ -700,7 +700,7 @@ func (b *KubeletBuilder) buildCgroupService(name string) *nodetasks.Service {
 	manifestString := manifest.Render()
 
 	service := &nodetasks.Service{
-		Name:       name + ".slice",
+		Name:       name,
 		Definition: s(manifestString),
 	}
 


### PR DESCRIPTION
This is a breaking change. 

This change ensures that the cgroup names provisioned and used for kubelet/containerd are the same as the cgroups passed to kubelet. 

Fixes https://github.com/kubernetes/kops/issues/15167