### PR TITLE
Automated cherry pick of #15040: gce: When using network native pod IPs, open firewall to

### DIFF
--- a/pkg/model/gcemodel/external_access.go
+++ b/pkg/model/gcemodel/external_access.go
@@ -17,8 +17,11 @@ limitations under the License.
 package gcemodel
 
 import (
+	"strconv"
+
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gcetasks"
 )
@@ -112,6 +115,17 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			SourceRanges: b.Cluster.Spec.KubernetesAPIAccess,
 			Network:      network,
 		})
+
+		if b.NetworkingIsIPAlias() {
+			c.AddTask(&gcetasks.FirewallRule{
+				Name:         s(b.NameForFirewallRule("pod-cidrs-to-https-api")),
+				Lifecycle:    b.Lifecycle,
+				Network:      network,
+				SourceRanges: []string{b.Cluster.Spec.PodCIDR},
+				TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
+				Allowed:      []string{"tcp:" + strconv.Itoa(wellknownports.KubeAPIServer)},
+			})
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Cherry pick of #15040 on release-1.25.

#15040: gce: When using network native pod IPs, open firewall to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```