### PR TITLE
kubetest2: don't cache version markers

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/publish.go
+++ b/tests/e2e/kubetest2-kops/deployer/publish.go
@@ -53,7 +53,9 @@ func (d *deployer) PostTest(testErr error) error {
 	}
 
 	args := []string{
-		"gsutil", "cp",
+		"gsutil",
+		"-h", "Cache-Control:private, max-age=0, no-transform",
+		"cp",
 		tempSrc.Name(),
 		d.PublishVersionMarker,
 	}


### PR DESCRIPTION
When uploading the version marker, make sure we turn off caching.

Otherwise we see jobs using older versions than they should be
running.
