### PR TITLE
Automated cherry pick of #15110: gce: Always apply the metadata-proxy-ready node label


### DIFF
--- a/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
@@ -88,6 +88,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -135,6 +135,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1
@@ -155,6 +157,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1
@@ -175,6 +179,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/minimal-1.26-gce-dns-none/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-gce-dns-none/expected-v1alpha2.yaml
@@ -87,6 +87,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/minimal-1.26-gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-gce/expected-v1alpha2.yaml
@@ -87,6 +87,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -121,6 +121,8 @@ spec:
   machineType: e2-medium
   maxSize: 1
   minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
   role: Node
   subnets:
   - us-test1

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1023,6 +1023,13 @@ func setupNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetMap ma
 			}
 		}
 
+		if cloudProvider == api.CloudProviderGCE {
+			if g.Spec.NodeLabels == nil {
+				g.Spec.NodeLabels = make(map[string]string)
+			}
+			g.Spec.NodeLabels["cloud.google.com/metadata-proxy-ready"] = "true"
+		}
+
 		g.Spec.MachineType = opt.NodeSize
 		g.Spec.Image = opt.NodeImage
 


### PR DESCRIPTION
Cherry pick of #15110 on release-1.26

#15110:gce: Always apply the metadata-proxy-ready node label
