### PR TITLE
Automated cherry pick of #14952: Bump cluster autoscaler to 1.26.1

### DIFF
--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -54,9 +54,9 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
 			case 25:
 				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.0"
 			case 26:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.0"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1"
 			default:
-				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.0"
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1"
 			}
 		}
 		cas.Image = fi.PtrTo(image)

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: e041f53907e5358a4fe5514a09f022790886502eb58f2a2bc281a49de8f18740
+    manifestHash: e485760f38e39e371e1253b9ff924501e22438031e62f2c1188b0b1c7bd41d0a
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -371,7 +371,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.0
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -37,7 +37,7 @@ spec:
       - .*high.*
     enabled: true
     expander: priority
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.0
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 1d3ec5d291d4c60add9d1b7cc3ffbdfa1a0d33f9fcb9187919b815bc539de50e
+    manifestHash: bb98d9d34142130dbaf95afcd9001340e7437a21f6c0915dedff4b62132879ee
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -371,7 +371,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.0
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
@@ -30,7 +30,7 @@ spec:
     createPriorityExpanderConfig: true
     enabled: true
     expander: priority
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.0
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
@@ -33,7 +33,7 @@ spec:
     balanceSimilarNodeGroups: false
     enabled: true
     expander: random
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.0
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -49,7 +49,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 10c96e535d61975b58b27ac8beef2da578df330febaed51db73c249d545d20da
+    manifestHash: ae5578d4a54d4c7fd6d4ffc55c0b382c6b3dce39f258dd5ddc17d726d3b797db
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -344,7 +344,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/cluster-autoscaler.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.0
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -33,7 +33,7 @@ spec:
     balanceSimilarNodeGroups: false
     enabled: true
     expander: random
-    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.0
+    image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 29e89f0ab283dcfc85a07b59c452341475cd3aa88644eb1249a08d95a6038f94
+    manifestHash: d97c26afc32f2dedaa46687d789350960158fcfc7e2d016ef79ad20ea8bfa7c2
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -342,7 +342,7 @@ spec:
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4
-        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.0
+        image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
Cherry pick of #14952 on release-1.26.

#14952: Bump cluster autoscaler to 1.26.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```