### PR TITLE
scaleway: fix client for protokube

### DIFF
--- a/protokube/pkg/protokube/scaleway_volumes.go
+++ b/protokube/pkg/protokube/scaleway_volumes.go
@@ -57,6 +57,12 @@ func NewScwCloudProvider() (*ScwCloudProvider, error) {
 	}
 	klog.V(4).Infof("Found zone of the running server: %v", zone)
 
+	region, err := scaleway.ParseRegionFromZone(zone)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse Scaleway region: %s", err)
+	}
+	klog.V(4).Infof("Found region of the running server: %v", region)
+
 	privateIP := metadata.PrivateIP
 	klog.V(4).Infof("Found first private net IP of the running server: %q", privateIP)
 
@@ -64,6 +70,7 @@ func NewScwCloudProvider() (*ScwCloudProvider, error) {
 		scw.WithUserAgent(scaleway.KopsUserAgentPrefix+kopsv.Version),
 		scw.WithEnv(),
 		scw.WithDefaultZone(zone),
+		scw.WithDefaultRegion(region),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %w", err)


### PR DESCRIPTION
In #15122 I removed the default region from the client options when creating a Scaleway client for protokube (as I thought it was no use since protokube only makes requests to zoned APIs). 
But it turns out I have to rollback this change because now I get this error, which I haven't encountered earlier :
`Error initializing Scaleway: "error creating client: scaleway-sdk-go: default region cannot be empty"`