### PR TITLE
Automated cherry pick of #15231: Initial support for Debian 12 Bookworm

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -40,6 +40,7 @@ The following table provides the support status for various distros with regards
 | Debian 9                            |          1.8 |   1.10 |       1.21 |    1.23 |
 | [Debian 10](#debian-10-buster)      |         1.13 |   1.17 |          - |       - |
 | [Debian 11](#debian-11-bullseye)    |       1.21.1 |      - |          - |       - |
+| [Debian 12](#debian-12-bookworm)    |       1.26.3 |      - |          - |       - |
 | [Flatcar](#flatcar)                 |       1.15.1 |   1.17 |          - |       - |
 | Kope.io                             |            - |      - |       1.18 |    1.23 |
 | RHEL 7                              |            - |    1.5 |       1.21 |    1.23 |
@@ -122,6 +123,12 @@ gcloud compute images list --filter debian-11-bullseye-v
 az vm image list --all --output table \
   --publisher Debian --offer debian-11 --sku 11-gen2
 ```
+
+### Debian 12 (Bookworm)
+
+Debian 12 is based on Kernel version **6.1** which has no known major Kernel bugs and fully supports all Cilium features.
+
+At the moment there is no official image published.
 
 ### Flatcar
 

--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -39,6 +39,7 @@ type Distribution struct {
 var (
 	DistributionDebian10     = Distribution{packageFormat: "deb", project: "debian", id: "buster", version: 10}
 	DistributionDebian11     = Distribution{packageFormat: "deb", project: "debian", id: "bullseye", version: 11}
+	DistributionDebian12     = Distribution{packageFormat: "deb", project: "debian", id: "bookworm", version: 12}
 	DistributionUbuntu1804   = Distribution{packageFormat: "deb", project: "ubuntu", id: "bionic", version: 18.04}
 	DistributionUbuntu2004   = Distribution{packageFormat: "deb", project: "ubuntu", id: "focal", version: 20.04}
 	DistributionUbuntu2010   = Distribution{packageFormat: "deb", project: "ubuntu", id: "groovy", version: 20.10}

--- a/util/pkg/distributions/identify.go
+++ b/util/pkg/distributions/identify.go
@@ -54,6 +54,8 @@ func FindDistribution(rootfs string) (Distribution, error) {
 		return DistributionDebian10, nil
 	case "debian-11":
 		return DistributionDebian11, nil
+	case "debian-12":
+		return DistributionDebian12, nil
 	case "ubuntu-18.04":
 		return DistributionUbuntu1804, nil
 	case "ubuntu-20.04":

--- a/util/pkg/distributions/identify_test.go
+++ b/util/pkg/distributions/identify_test.go
@@ -75,6 +75,11 @@ func TestFindDistribution(t *testing.T) {
 			expected: DistributionDebian11,
 		},
 		{
+			rootfs:   "debian12",
+			err:      nil,
+			expected: DistributionDebian12,
+		},
+		{
 			rootfs:   "flatcar",
 			err:      nil,
 			expected: DistributionFlatcar,

--- a/util/pkg/distributions/tests/debian12/etc/os-release
+++ b/util/pkg/distributions/tests/debian12/etc/os-release
@@ -1,0 +1,9 @@
+PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+NAME="Debian GNU/Linux"
+VERSION_ID="12"
+VERSION="12 (bookworm)"
+VERSION_CODENAME=bookworm
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"


### PR DESCRIPTION
Cherry pick of #15231 on release-1.26.

#15231: Initial support for Debian 12 Bookworm

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```