### PR TITLE
aws: Use `control-plane` for additional policies instead of `master`

### DIFF
--- a/pkg/model/awsmodel/iam.go
+++ b/pkg/model/awsmodel/iam.go
@@ -348,7 +348,11 @@ func (b *IAMModelBuilder) buildIAMTasks(role iam.Subject, iamName string, c *fi.
 			{
 				additionalPolicy := ""
 				if b.Cluster.Spec.AdditionalPolicies != nil {
-					additionalPolicy = b.Cluster.Spec.AdditionalPolicies[roleKey]
+					key := roleKey
+					if key == "master" {
+						key = "control-plane"
+					}
+					additionalPolicy = b.Cluster.Spec.AdditionalPolicies[key]
 				}
 
 				additionalPolicyName := "additional." + iamName


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/15232

Same as for external policies:
https://github.com/kubernetes/kops/blob/071f9a86ad5ee2c0fcf7388206a92beeed743714/pkg/model/awsmodel/iam.go#L326-L332
