### PR TITLE
Skip new endpoint port/protocol e2e test on cilium

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -64,6 +64,8 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|external.IP.is.not.assigned.to.a.node"
 		// https://github.com/cilium/cilium/issues/14287
 		skipRegex += "|same.port.number.but.different.protocols|same.hostPort.but.different.hostIP.and.protocol"
+		// https://github.com/cilium/cilium/issues/9207
+		skipRegex += "|serve.endpoints.on.same.port.and.different.protocols"
 		if k8sVersion.Minor >= 22 {
 			// ref:
 			// https://github.com/kubernetes/kubernetes/issues/96717


### PR DESCRIPTION
This new test will fail until cilium fixes their bug. 

https://kubernetes.slack.com/archives/C8MKE2G5P/p1678912338617759