### PR TITLE
Automated cherry pick of #15238: aws: Use `control-plane` for additional policies instead of

### DIFF
--- a/pkg/model/awsmodel/iam.go
+++ b/pkg/model/awsmodel/iam.go
@@ -350,8 +350,11 @@ func (b *IAMModelBuilder) buildIAMTasks(role iam.Subject, iamName string, c *fi.
 				additionalPolicy := ""
 				if b.Cluster.Spec.AdditionalPolicies != nil {
 					additionalPolicies := *(b.Cluster.Spec.AdditionalPolicies)
-
-					additionalPolicy = additionalPolicies[roleKey]
+					key := roleKey
+					if key == "master" {
+						key = "control-plane"
+					}
+					additionalPolicy = additionalPolicies[key]
 				}
 
 				additionalPolicyName := "additional." + iamName


### PR DESCRIPTION
Cherry pick of #15238 on release-1.26.

#15238: aws: Use `control-plane` for additional policies instead of

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```