### PR TITLE
Skip multiple-port multiple-endpointslice e2e test with Cilium

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -66,6 +66,8 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|same.port.number.but.different.protocols|same.hostPort.but.different.hostIP.and.protocol"
 		// https://github.com/cilium/cilium/issues/9207
 		skipRegex += "|serve.endpoints.on.same.port.and.different.protocols"
+		// This may be fixed in Cilium 1.13 but skipping for now
+		skipRegex += "|Service.with.multiple.ports.specified.in.multiple.EndpointSlices"
 		if k8sVersion.Minor >= 22 {
 			// ref:
 			// https://github.com/kubernetes/kubernetes/issues/96717


### PR DESCRIPTION
This new test is failing. It was added in k8s 1.27 (currently only CI builds). All CI+cilium kops jobs are failing. [Example](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-scenario-no-irsa/1636557404302741504).

Skipping this test until we're upgraded to 1.13 to see if that fixes the failing test