### PR TITLE
Automated cherry pick of #15244: Fix behaviour for `kops export kubeconfig --internal`

### DIFF
--- a/pkg/kubeconfig/create_kubecfg.go
+++ b/pkg/kubeconfig/create_kubecfg.go
@@ -44,34 +44,34 @@ func BuildKubecfg(cluster *kops.Cluster, keyStore fi.Keystore, secretStore fi.Se
 		} else {
 			server = "https://api." + clusterName
 		}
-	}
 
-	// If a load balancer exists we use it, except for when an SSL certificate is set.
-	// This should avoid a lot of pain with DNS pre-creation.
-	if cluster.Spec.API.LoadBalancer != nil && (cluster.Spec.API.LoadBalancer.SSLCertificate == "" || admin != 0) {
-		ingresses, err := cloud.GetApiIngressStatus(cluster)
-		if err != nil {
-			return nil, fmt.Errorf("error getting ingress status: %v", err)
-		}
+		// If a load balancer exists we use it, except for when an SSL certificate is set.
+		// This should avoid a lot of pain with DNS pre-creation.
+		if cluster.Spec.API.LoadBalancer != nil && (cluster.Spec.API.LoadBalancer.SSLCertificate == "" || admin != 0) {
+			ingresses, err := cloud.GetApiIngressStatus(cluster)
+			if err != nil {
+				return nil, fmt.Errorf("error getting ingress status: %v", err)
+			}
 
-		var targets []string
-		for _, ingress := range ingresses {
-			if ingress.Hostname != "" {
-				targets = append(targets, ingress.Hostname)
+			var targets []string
+			for _, ingress := range ingresses {
+				if ingress.Hostname != "" {
+					targets = append(targets, ingress.Hostname)
+				}
+				if ingress.IP != "" {
+					targets = append(targets, ingress.IP)
+				}
 			}
-			if ingress.IP != "" {
-				targets = append(targets, ingress.IP)
-			}
-		}
 
-		sort.Strings(targets)
-		if len(targets) == 0 {
-			klog.Warningf("Did not find API endpoint; may not be able to reach cluster")
-		} else {
-			if len(targets) != 1 {
-				klog.Warningf("Found multiple API endpoints (%v), choosing arbitrarily", targets)
+			sort.Strings(targets)
+			if len(targets) == 0 {
+				klog.Warningf("Did not find API endpoint; may not be able to reach cluster")
+			} else {
+				if len(targets) != 1 {
+					klog.Warningf("Found multiple API endpoints (%v), choosing arbitrarily", targets)
+				}
+				server = "https://" + targets[0]
 			}
-			server = "https://" + targets[0]
 		}
 	}
 

--- a/pkg/kubeconfig/create_kubecfg_test.go
+++ b/pkg/kubeconfig/create_kubecfg_test.go
@@ -346,6 +346,38 @@ func TestBuildKubecfg(t *testing.T) {
 			},
 			wantClientCert: true,
 		},
+		{
+			name: "Test Kube Config Data for Public cluster with admin and internal option",
+			args: args{
+				cluster:  publicCluster,
+				status:   fakeStatus,
+				admin:    DefaultKubecfgAdminLifetime,
+				internal: true,
+			},
+			want: &KubeconfigBuilder{
+				Context: "testcluster",
+				Server:  "https://api.internal.testcluster",
+				CACerts: []byte(nextCertificate + certData),
+				User:    "testcluster",
+			},
+			wantClientCert: true,
+		},
+		{
+			name: "Test Kube Config Data for Public cluster without admin and with internal option",
+			args: args{
+				cluster:  publicCluster,
+				status:   fakeStatus,
+				admin:    0,
+				internal: true,
+			},
+			want: &KubeconfigBuilder{
+				Context: "testcluster",
+				Server:  "https://api.internal.testcluster",
+				CACerts: []byte(nextCertificate + certData),
+				User:    "testcluster",
+			},
+			wantClientCert: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #15244 on release-1.26.

#15244: Fix behaviour for `kops export kubeconfig --internal`

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```