### PR TITLE
Automated cherry pick of #15249: switch to use registry.k8s.io images for openstack

### DIFF
--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
@@ -220,7 +220,7 @@ spec:
         operator: Exists
       containers:
       - name: openstack-cloud-controller-manager
-        image: "{{- if .ExternalCloudControllerManager.Image -}} {{ .ExternalCloudControllerManager.Image }} {{- else -}} docker.io/k8scloudprovider/openstack-cloud-controller-manager:{{OpenStackCCMTag}} {{- end -}}"
+        image: "{{- if .ExternalCloudControllerManager.Image -}} {{ .ExternalCloudControllerManager.Image }} {{- else -}} registry.k8s.io/provider-os/openstack-cloud-controller-manager:{{OpenStackCCMTag}} {{- end -}}"
         args:
           - /bin/openstack-cloud-controller-manager
 {{- range $arg := CloudControllerConfigArgv }}

--- a/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
@@ -321,7 +321,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: cinder-csi-plugin
-          image: "{{- if .CloudProvider.Openstack.BlockStorage.CSIPluginImage -}} {{ .CloudProvider.Openstack.BlockStorage.CSIPluginImage }} {{- else -}} docker.io/k8scloudprovider/cinder-csi-plugin:{{OpenStackCSITag}} {{- end -}}"
+          image: "{{- if .CloudProvider.Openstack.BlockStorage.CSIPluginImage -}} {{ .CloudProvider.Openstack.BlockStorage.CSIPluginImage }} {{- else -}} registry.k8s.io/provider-os/cinder-csi-plugin:{{OpenStackCSITag}} {{- end -}}"
           args:
             - /bin/cinder-csi-plugin
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -813,14 +813,12 @@ func (tf *TemplateFunctions) OpenStackCCMTag() string {
 	if err != nil {
 		tag = "latest"
 	} else {
-		if parsed.Minor == 23 {
-			tag = "v1.23.1"
-		} else if parsed.Minor == 24 {
+		if parsed.Minor == 24 {
 			tag = "v1.24.6"
 		} else if parsed.Minor == 25 {
-			tag = "v1.25.4"
+			tag = "v1.25.5"
 		} else if parsed.Minor == 26 {
-			tag = "v1.26.1"
+			tag = "v1.26.2"
 		} else {
 			// otherwise we use always .0 ccm image, if needed that can be overrided using clusterspec
 			tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)
@@ -840,9 +838,9 @@ func (tf *TemplateFunctions) OpenStackCSITag() string {
 		if parsed.Minor == 24 {
 			tag = "v1.24.6"
 		} else if parsed.Minor == 25 {
-			tag = "v1.25.4"
+			tag = "v1.25.5"
 		} else if parsed.Minor == 26 {
-			tag = "v1.26.1"
+			tag = "v1.26.2"
 		} else {
 			// otherwise we use always .0 csi image, if needed that can be overrided using cloud config spec
 			tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)


### PR DESCRIPTION
Cherry pick of #15249 on release-1.26.

#15249: switch to use registry.k8s.io images for openstack

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```