### PR TITLE
Automated cherry pick of #15102: Retry creating failed OpenStack servers

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/instance.go
+++ b/upup/pkg/fi/cloudup/openstack/instance.go
@@ -44,6 +44,10 @@ const (
 	BOOT_FROM_VOLUME          = "osVolumeBoot"
 	BOOT_VOLUME_SIZE          = "osVolumeSize"
 	SERVER_GROUP_AFFINITY     = "serverGroupAffinity"
+
+	defaultActiveTimeout = time.Second * 120
+	activeStatus         = "ACTIVE"
+	errorStatus          = "ERROR"
 )
 
 // floatingBackoff is the backoff strategy for listing openstack floatingips
@@ -65,10 +69,42 @@ func IsPortInUse(err error) bool {
 	return false
 }
 
+// waitForStatusActive uses gopherclouds WaitFor() func to determine when the server becomes "ACTIVE".
+//
+// The function will immediately fail if the server transistions into the status "ERROR"
+// and will result in a timeout when not reaching status "ACTIVE" in time.
+func waitForStatusActive(c OpenstackCloud, serverID string, timeout *time.Duration) error {
+	if timeout == nil {
+		timeout = fi.PtrTo(defaultActiveTimeout)
+	}
+
+	return gophercloud.WaitFor(int(timeout.Seconds()), func() (bool, error) {
+		server, err := c.GetInstance(serverID)
+		if err != nil {
+			return false, err
+		}
+
+		if server.Status == errorStatus {
+			return false, fmt.Errorf("unable to create server: %v", server.Fault)
+		}
+
+		if server.Status == activeStatus {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}
+
 func createInstance(c OpenstackCloud, opt servers.CreateOptsBuilder, portID string) (*servers.Server, error) {
 	var server *servers.Server
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+		if server != nil {
+			// Note: this will delete the server from the last try, even if it is now ACTIVE or still in BUILD state
+			c.DeleteInstanceWithID(server.ID)
+		}
+
 		v, err := servers.Create(c.ComputeClient(), opt).Extract()
 		if err != nil {
 			if IsPortInUse(err) && portID != "" {
@@ -91,6 +127,12 @@ func createInstance(c OpenstackCloud, opt servers.CreateOptsBuilder, portID stri
 			return false, fmt.Errorf("error creating server %v: %v", opt, err)
 		}
 		server = v
+
+		err = waitForStatusActive(c, server.ID, nil)
+		if err != nil {
+			return false, fmt.Errorf("error while waiting for server '%s' to become '%s': %v", server.ID, activeStatus, err)
+		}
+
 		return true, nil
 	})
 	if err != nil {

--- a/upup/pkg/fi/cloudup/openstack/instance_test.go
+++ b/upup/pkg/fi/cloudup/openstack/instance_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+type WaitForStatusActiveMock struct {
+	server *servers.Server
+	OpenstackCloud
+}
+
+func (c WaitForStatusActiveMock) GetInstance(id string) (*servers.Server, error) {
+	if id == c.server.ID {
+		return c.server, nil
+	}
+
+	return nil, fmt.Errorf("Server with ID '%s' not found.", id)
+}
+
+func createWaitForStatusActiveMock(serverID string, serverStatus string) *WaitForStatusActiveMock {
+	return &WaitForStatusActiveMock{
+		server: &servers.Server{
+			ID:     serverID,
+			Status: serverStatus,
+		},
+	}
+}
+
+func Test_WaitForStatusActiveIsSuccessful(t *testing.T) {
+	serverID := "mock-id"
+	c := createWaitForStatusActiveMock(serverID, activeStatus)
+
+	err := waitForStatusActive(c, serverID, nil)
+
+	assertTestResults(t, err, nil, nil)
+}
+
+func Test_WaitForStatusActiveResultsInInstanceNotFound(t *testing.T) {
+	serverID := "mock-id"
+	c := createWaitForStatusActiveMock(serverID, activeStatus)
+
+	wrongServerID := "wrong-id"
+	actualErr := waitForStatusActive(c, wrongServerID, nil)
+
+	expectedErr := fmt.Errorf("Server with ID '%s' not found.", wrongServerID)
+	assertTestResults(t, nil, actualErr, expectedErr)
+}
+
+func Test_WaitForStatusActiveResultsInUnableToCreateServer(t *testing.T) {
+	serverID := "mock-id"
+	c := createWaitForStatusActiveMock(serverID, errorStatus)
+
+	actualErr := waitForStatusActive(c, serverID, nil)
+
+	expectedErr := fmt.Errorf("unable to create server: {0 0001-01-01 00:00:00 +0000 UTC  }")
+	assertTestResults(t, nil, actualErr, expectedErr)
+}
+
+func Test_WaitForStatusActiveResultsInTimeout(t *testing.T) {
+	serverID := "mock-id"
+	c := createWaitForStatusActiveMock(serverID, "BUILD")
+
+	actualErr := waitForStatusActive(c, serverID, fi.PtrTo(time.Second))
+
+	expectedErr := fmt.Errorf("A timeout occurred")
+	assertTestResults(t, nil, actualErr, expectedErr)
+}

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -96,11 +96,6 @@ func (e *Instance) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 
 var _ fi.CompareWithID = &Instance{}
 
-// TODO: delete this as this function is not used anywhere?
-func (e *Instance) WaitForStatusActive(t *openstack.OpenstackAPITarget) error {
-	return servers.WaitForStatus(t.Cloud.ComputeClient(), *e.ID, "ACTIVE", 120)
-}
-
 func (e *Instance) CompareWithID() *string {
 	return e.ID
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -96,6 +96,7 @@ func (e *Instance) GetDependencies(tasks map[string]fi.Task) []fi.Task {
 
 var _ fi.CompareWithID = &Instance{}
 
+// TODO: delete this as this function is not used anywhere?
 func (e *Instance) WaitForStatusActive(t *openstack.OpenstackAPITarget) error {
 	return servers.WaitForStatus(t.Cloud.ComputeClient(), *e.ID, "ACTIVE", 120)
 }


### PR DESCRIPTION
Cherry pick of #15102 on release-1.25.

#15102: Retry creating failed OpenStack servers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```