### PR TITLE
aws: Set local.vpc_ipv6_cidr_block only for IPv6 managed clusters

### DIFF
--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -21,7 +21,6 @@ locals {
   vpc_cidr_block                    = data.aws_vpc.private-shared-ip-example-com.cidr_block
   vpc_id                            = "vpc-12345678"
   vpc_ipv6_cidr_block               = data.aws_vpc.private-shared-ip-example-com.ipv6_cidr_block
-  vpc_ipv6_cidr_length              = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 output "bastion_autoscaling_group_ids" {
@@ -110,10 +109,6 @@ output "vpc_id" {
 
 output "vpc_ipv6_cidr_block" {
   value = data.aws_vpc.private-shared-ip-example-com.ipv6_cidr_block
-}
-
-output "vpc_ipv6_cidr_length" {
-  value = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 provider "aws" {

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -20,7 +20,6 @@ locals {
   vpc_cidr_block                = data.aws_vpc.private-shared-subnet-example-com.cidr_block
   vpc_id                        = "vpc-12345678"
   vpc_ipv6_cidr_block           = data.aws_vpc.private-shared-subnet-example-com.ipv6_cidr_block
-  vpc_ipv6_cidr_length          = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 output "bastion_autoscaling_group_ids" {
@@ -105,10 +104,6 @@ output "vpc_id" {
 
 output "vpc_ipv6_cidr_block" {
   value = data.aws_vpc.private-shared-subnet-example-com.ipv6_cidr_block
-}
-
-output "vpc_ipv6_cidr_length" {
-  value = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 provider "aws" {

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -21,7 +21,6 @@ locals {
   vpc_cidr_block                    = data.aws_vpc.privatedns2-example-com.cidr_block
   vpc_id                            = "vpc-12345678"
   vpc_ipv6_cidr_block               = data.aws_vpc.privatedns2-example-com.ipv6_cidr_block
-  vpc_ipv6_cidr_length              = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 output "bastion_autoscaling_group_ids" {
@@ -110,10 +109,6 @@ output "vpc_id" {
 
 output "vpc_ipv6_cidr_block" {
   value = data.aws_vpc.privatedns2-example-com.ipv6_cidr_block
-}
-
-output "vpc_ipv6_cidr_length" {
-  value = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 provider "aws" {

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -15,7 +15,6 @@ locals {
   vpc_cidr_block               = data.aws_vpc.sharedsubnet-example-com.cidr_block
   vpc_id                       = "vpc-12345678"
   vpc_ipv6_cidr_block          = data.aws_vpc.sharedsubnet-example-com.ipv6_cidr_block
-  vpc_ipv6_cidr_length         = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 output "cluster_name" {
@@ -80,10 +79,6 @@ output "vpc_id" {
 
 output "vpc_ipv6_cidr_block" {
   value = data.aws_vpc.sharedsubnet-example-com.ipv6_cidr_block
-}
-
-output "vpc_ipv6_cidr_length" {
-  value = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 provider "aws" {

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -15,7 +15,6 @@ locals {
   vpc_cidr_block               = data.aws_vpc.sharedvpc-example-com.cidr_block
   vpc_id                       = "vpc-12345678"
   vpc_ipv6_cidr_block          = data.aws_vpc.sharedvpc-example-com.ipv6_cidr_block
-  vpc_ipv6_cidr_length         = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 output "cluster_name" {
@@ -80,10 +79,6 @@ output "vpc_id" {
 
 output "vpc_ipv6_cidr_block" {
   value = data.aws_vpc.sharedvpc-example-com.ipv6_cidr_block
-}
-
-output "vpc_ipv6_cidr_length" {
-  value = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 provider "aws" {

--- a/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
@@ -22,7 +22,6 @@ locals {
   vpc_cidr_block                    = data.aws_vpc.minimal-ipv6-example-com.cidr_block
   vpc_id                            = "vpc-12345678"
   vpc_ipv6_cidr_block               = data.aws_vpc.minimal-ipv6-example-com.ipv6_cidr_block
-  vpc_ipv6_cidr_length              = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 output "cluster_name" {
@@ -115,10 +114,6 @@ output "vpc_id" {
 
 output "vpc_ipv6_cidr_block" {
   value = data.aws_vpc.minimal-ipv6-example-com.ipv6_cidr_block
-}
-
-output "vpc_ipv6_cidr_length" {
-  value = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 provider "aws" {

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -21,7 +21,6 @@ locals {
   vpc_cidr_block                = data.aws_vpc.unmanaged-example-com.cidr_block
   vpc_id                        = "vpc-12345678"
   vpc_ipv6_cidr_block           = data.aws_vpc.unmanaged-example-com.ipv6_cidr_block
-  vpc_ipv6_cidr_length          = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 output "bastion_autoscaling_group_ids" {
@@ -110,10 +109,6 @@ output "vpc_id" {
 
 output "vpc_ipv6_cidr_block" {
   value = data.aws_vpc.unmanaged-example-com.ipv6_cidr_block
-}
-
-output "vpc_ipv6_cidr_length" {
-  value = local.vpc_ipv6_cidr_block == null ? null : tonumber(regex(".*/(\\d+)", local.vpc_ipv6_cidr_block)[0])
 }
 
 provider "aws" {

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -296,19 +296,21 @@ func (_ *VPC) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPC) 
 		return err
 	}
 
-	cidrPrefixLengthCaptureList := terraformWriter.LiteralFunctionExpression("regex",
-		terraformWriter.LiteralFromStringValue(".*/(\\\\d+)"),
-		terraformWriter.LiteralTokens("local", "vpc_ipv6_cidr_block"),
-	)
-	cidrPrefixLengthString := terraformWriter.LiteralIndexExpression(
-		cidrPrefixLengthCaptureList,
-		terraformWriter.LiteralFromIntValue(0),
-	)
-	if err := t.AddOutputVariable("vpc_ipv6_cidr_length", terraformWriter.LiteralNullConditionalExpression(
-		terraformWriter.LiteralTokens("local", "vpc_ipv6_cidr_block"),
-		terraformWriter.LiteralFunctionExpression("tonumber", cidrPrefixLengthString),
-	)); err != nil {
-		return err
+	if fi.ValueOf(e.AmazonIPv6) {
+		cidrPrefixLengthCaptureList := terraformWriter.LiteralFunctionExpression("regex",
+			terraformWriter.LiteralFromStringValue(".*/(\\\\d+)"),
+			terraformWriter.LiteralTokens("local", "vpc_ipv6_cidr_block"),
+		)
+		cidrPrefixLengthString := terraformWriter.LiteralIndexExpression(
+			cidrPrefixLengthCaptureList,
+			terraformWriter.LiteralFromIntValue(0),
+		)
+		if err := t.AddOutputVariable("vpc_ipv6_cidr_length", terraformWriter.LiteralNullConditionalExpression(
+			terraformWriter.LiteralTokens("local", "vpc_ipv6_cidr_block"),
+			terraformWriter.LiteralFunctionExpression("tonumber", cidrPrefixLengthString),
+		)); err != nil {
+			return err
+		}
 	}
 
 	shared := fi.ValueOf(e.Shared)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/15245

/cc @rifelpet @johngmyers 