### PR TITLE
OpenStack: Add network-cidr config for etcd-manager

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -478,6 +478,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 				fmt.Sprintf("%s=%s", openstack.TagClusterName, b.Cluster.Name),
 			}
 			config.VolumeNameTag = openstack.TagNameEtcdClusterPrefix + etcdCluster.Name
+			config.NetworkCIDR = fi.PtrTo(b.Cluster.Spec.Networking.NetworkCIDR)
 
 		case kops.CloudProviderScaleway:
 			config.VolumeProvider = "scaleway"
@@ -589,6 +590,7 @@ type config struct {
 	VolumeTag             []string `flag:"volume-tag,repeat"`
 	VolumeNameTag         string   `flag:"volume-name-tag"`
 	DNSSuffix             string   `flag:"dns-suffix"`
+	NetworkCIDR           *string  `flag:"network-cidr"`
 }
 
 // SelectorForCluster returns the selector that should be used to select our pods (from services)


### PR DESCRIPTION
This add the possibility of setting `--network-cidr` for etcd-manager when using OpenStack, which was introduced with https://github.com/kubernetes-sigs/etcdadm/pull/317