### PR TITLE
OpenStack: Add OCCM address sort order config

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -498,6 +498,8 @@ spec:
                       network:
                         description: OpenstackNetwork defines the config for a network
                         properties:
+                          addressSortOrder:
+                            type: string
                           availabilityZoneHints:
                             items:
                               type: string

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -817,6 +817,7 @@ type OpenstackNetwork struct {
 	IPv6SupportDisabled   *bool     `json:"ipv6SupportDisabled,omitempty"`
 	PublicNetworkNames    []*string `json:"publicNetworkNames,omitempty"`
 	InternalNetworkNames  []*string `json:"internalNetworkNames,omitempty"`
+	AddressSortOrder      *string   `json:"addressSortOrder,omitempty"`
 }
 
 // OpenstackMetadata defines config for metadata service related settings

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -823,6 +823,7 @@ type OpenstackNetwork struct {
 	IPv6SupportDisabled   *bool     `json:"ipv6SupportDisabled,omitempty"`
 	PublicNetworkNames    []*string `json:"publicNetworkNames,omitempty"`
 	InternalNetworkNames  []*string `json:"internalNetworkNames,omitempty"`
+	AddressSortOrder      *string   `json:"addressSortOrder,omitempty"`
 }
 
 // OpenstackMetadata defines config for metadata service related settings

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -6537,6 +6537,7 @@ func autoConvert_v1alpha2_OpenstackNetwork_To_kops_OpenstackNetwork(in *Openstac
 	out.IPv6SupportDisabled = in.IPv6SupportDisabled
 	out.PublicNetworkNames = in.PublicNetworkNames
 	out.InternalNetworkNames = in.InternalNetworkNames
+	out.AddressSortOrder = in.AddressSortOrder
 	return nil
 }
 
@@ -6550,6 +6551,7 @@ func autoConvert_kops_OpenstackNetwork_To_v1alpha2_OpenstackNetwork(in *kops.Ope
 	out.IPv6SupportDisabled = in.IPv6SupportDisabled
 	out.PublicNetworkNames = in.PublicNetworkNames
 	out.InternalNetworkNames = in.InternalNetworkNames
+	out.AddressSortOrder = in.AddressSortOrder
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -4887,6 +4887,11 @@ func (in *OpenstackNetwork) DeepCopyInto(out *OpenstackNetwork) {
 			}
 		}
 	}
+	if in.AddressSortOrder != nil {
+		in, out := &in.AddressSortOrder, &out.AddressSortOrder
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -814,6 +814,7 @@ type OpenstackNetwork struct {
 	IPv6SupportDisabled   *bool     `json:"ipv6SupportDisabled,omitempty"`
 	PublicNetworkNames    []*string `json:"publicNetworkNames,omitempty"`
 	InternalNetworkNames  []*string `json:"internalNetworkNames,omitempty"`
+	AddressSortOrder      *string   `json:"addressSortOrder,omitempty"`
 }
 
 // OpenstackMetadata defines config for metadata service related settings

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -6786,6 +6786,7 @@ func autoConvert_v1alpha3_OpenstackNetwork_To_kops_OpenstackNetwork(in *Openstac
 	out.IPv6SupportDisabled = in.IPv6SupportDisabled
 	out.PublicNetworkNames = in.PublicNetworkNames
 	out.InternalNetworkNames = in.InternalNetworkNames
+	out.AddressSortOrder = in.AddressSortOrder
 	return nil
 }
 
@@ -6799,6 +6800,7 @@ func autoConvert_kops_OpenstackNetwork_To_v1alpha3_OpenstackNetwork(in *kops.Ope
 	out.IPv6SupportDisabled = in.IPv6SupportDisabled
 	out.PublicNetworkNames = in.PublicNetworkNames
 	out.InternalNetworkNames = in.InternalNetworkNames
+	out.AddressSortOrder = in.AddressSortOrder
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -4808,6 +4808,11 @@ func (in *OpenstackNetwork) DeepCopyInto(out *OpenstackNetwork) {
 			}
 		}
 	}
+	if in.AddressSortOrder != nil {
+		in, out := &in.AddressSortOrder, &out.AddressSortOrder
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -5083,6 +5083,11 @@ func (in *OpenstackNetwork) DeepCopyInto(out *OpenstackNetwork) {
 			}
 		}
 	}
+	if in.AddressSortOrder != nil {
+		in, out := &in.AddressSortOrder, &out.AddressSortOrder
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -906,6 +906,9 @@ func MakeCloudConfig(spec kops.ClusterSpec) []string {
 		for _, name := range networking.InternalNetworkNames {
 			networkingLines = append(networkingLines, fmt.Sprintf("internal-network-name=%s", fi.ValueOf(name)))
 		}
+		if networking.AddressSortOrder != nil {
+			networkingLines = append(networkingLines, fmt.Sprintf("address-sort-order=%s", fi.ValueOf(networking.AddressSortOrder)))
+		}
 
 		if len(networkingLines) > 0 {
 			lines = append(lines, "[Networking]")


### PR DESCRIPTION
This will add the OCCM config to specify an address sort order:
* https://github.com/kubernetes/cloud-provider-openstack/pull/1946