### PR TITLE
Update kube-router to v1.5.3

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -1,4 +1,4 @@
-# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.1.1/daemonset/kubeadm-kuberouter.yaml
+# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.5.3/daemonset/kubeadm-kuberouter.yaml
 
 apiVersion: v1
 kind: ConfigMap
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v1.2.3
+        image: docker.io/cloudnativelabs/kube-router:v1.5.3
         args:
         - --run-router=true
         - --run-firewall=true
@@ -97,7 +97,7 @@ spec:
           readOnly: false
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v1.2.3
+        image: docker.io/cloudnativelabs/kube-router:v1.5.3
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
Update kube-router to v1.5.3

Tried in aws provider using kops ans other components built based on master and it worked as it was in v1.2.3