### PR TITLE
gce: Avoid spurious changes for ForwardingRule

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
@@ -90,6 +90,24 @@ func (e *ForwardingRule) Find(c *fi.CloudupContext) (*ForwardingRule, error) {
 		}
 		actual.IPAddress = address
 	}
+	if r.BackendService != "" {
+		actual.BackendService = &BackendService{
+			Name: fi.PtrTo(lastComponent(r.BackendService)),
+		}
+	}
+	if r.LoadBalancingScheme != "" {
+		actual.LoadBalancingScheme = fi.PtrTo(r.LoadBalancingScheme)
+	}
+	if r.Network != "" {
+		actual.Network = &Network{
+			Name: fi.PtrTo(lastComponent(r.Network)),
+		}
+	}
+	if r.Subnetwork != "" {
+		actual.Subnetwork = &Subnet{
+			Name: fi.PtrTo(lastComponent(r.Subnetwork)),
+		}
+	}
 
 	// Ignore "system" fields
 	actual.Lifecycle = e.Lifecycle


### PR DESCRIPTION
```
Will modify resources:
  ForwardingRule/europe-central2-my-k8s-my-k8s
  	LoadBalancingScheme 	 <nil> -> INTERNAL
  	Network             	 <nil> -> name:my-k8s id:my-k8s
  	Subnetwork          	 <nil> -> name:europe-central2-my-k8s id:europe-central2-my-k8s
  	BackendService      	 <nil> -> name:api-my-k8s id:api-my-k8s
```

/cc @justinsb 