### PR TITLE
OpenStack: Use interface attach when reconciling server ports 

### DIFF
--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/doc.go
@@ -1,0 +1,52 @@
+/*
+Package attachinterfaces provides the ability to retrieve and manage network
+interfaces through Nova.
+
+Example of Listing a Server's Interfaces
+
+	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
+	allPages, err := attachinterfaces.List(computeClient, serverID).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allInterfaces, err := attachinterfaces.ExtractInterfaces(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, interface := range allInterfaces {
+		fmt.Printf("%+v\n", interface)
+	}
+
+Example to Get a Server's Interface
+
+	portID = "0dde1598-b374-474e-986f-5b8dd1df1d4e"
+	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
+	interface, err := attachinterfaces.Get(computeClient, serverID, portID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a new Interface attachment on the Server
+
+	networkID := "8a5fe506-7e9f-4091-899b-96336909d93c"
+	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
+	attachOpts := attachinterfaces.CreateOpts{
+		NetworkID: networkID,
+	}
+	interface, err := attachinterfaces.Create(computeClient, serverID, attachOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete an Interface attachment from the Server
+
+	portID = "0dde1598-b374-474e-986f-5b8dd1df1d4e"
+	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
+	err := attachinterfaces.Delete(computeClient, serverID, portID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package attachinterfaces

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/requests.go
@@ -1,0 +1,75 @@
+package attachinterfaces
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// List makes a request against the nova API to list the server's interfaces.
+func List(client *gophercloud.ServiceClient, serverID string) pagination.Pager {
+	return pagination.NewPager(client, listInterfaceURL(client, serverID), func(r pagination.PageResult) pagination.Page {
+		return InterfacePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Get requests details on a single interface attachment by the server and port IDs.
+func Get(client *gophercloud.ServiceClient, serverID, portID string) (r GetResult) {
+	resp, err := client.Get(getInterfaceURL(client, serverID, portID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToAttachInterfacesCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters of a new interface attachment.
+type CreateOpts struct {
+	// PortID is the ID of the port for which you want to create an interface.
+	// The NetworkID and PortID parameters are mutually exclusive.
+	// If you do not specify the PortID parameter, the OpenStack Networking API
+	// v2.0 allocates a port and creates an interface for it on the network.
+	PortID string `json:"port_id,omitempty"`
+
+	// NetworkID is the ID of the network for which you want to create an interface.
+	// The NetworkID and PortID parameters are mutually exclusive.
+	// If you do not specify the NetworkID parameter, the OpenStack Networking
+	// API v2.0 uses the network information cache that is associated with the instance.
+	NetworkID string `json:"net_id,omitempty"`
+
+	// Slice of FixedIPs. If you request a specific FixedIP address without a
+	// NetworkID, the request returns a Bad Request (400) response code.
+	// Note: this uses the FixedIP struct, but only the IPAddress field can be used.
+	FixedIPs []FixedIP `json:"fixed_ips,omitempty"`
+}
+
+// ToAttachInterfacesCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToAttachInterfacesCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "interfaceAttachment")
+}
+
+// Create requests the creation of a new interface attachment on the server.
+func Create(client *gophercloud.ServiceClient, serverID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToAttachInterfacesCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(createInterfaceURL(client, serverID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete makes a request against the nova API to detach a single interface from the server.
+// It needs server and port IDs to make a such request.
+func Delete(client *gophercloud.ServiceClient, serverID, portID string) (r DeleteResult) {
+	resp, err := client.Delete(deleteInterfaceURL(client, serverID, portID), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/results.go
@@ -1,0 +1,84 @@
+package attachinterfaces
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type attachInterfaceResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any attachInterfaceResult as an Interface, if possible.
+func (r attachInterfaceResult) Extract() (*Interface, error) {
+	var s struct {
+		Interface *Interface `json:"interfaceAttachment"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Interface, err
+}
+
+// GetResult is the response from a Get operation. Call its Extract
+// method to interpret it as an Interface.
+type GetResult struct {
+	attachInterfaceResult
+}
+
+// CreateResult is the response from a Create operation. Call its Extract
+// method to interpret it as an Interface.
+type CreateResult struct {
+	attachInterfaceResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// FixedIP represents a Fixed IP Address.
+// This struct is also used when creating an attachment,
+// but it is not possible to specify a SubnetID.
+type FixedIP struct {
+	SubnetID  string `json:"subnet_id,omitempty"`
+	IPAddress string `json:"ip_address"`
+}
+
+// Interface represents a network interface on a server.
+type Interface struct {
+	PortState string    `json:"port_state"`
+	FixedIPs  []FixedIP `json:"fixed_ips"`
+	PortID    string    `json:"port_id"`
+	NetID     string    `json:"net_id"`
+	MACAddr   string    `json:"mac_addr"`
+}
+
+// InterfacePage abstracts the raw results of making a List() request against
+// the API.
+//
+// As OpenStack extensions may freely alter the response bodies of structures
+// returned to the client, you may only safely access the data provided through
+// the ExtractInterfaces call.
+type InterfacePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if an InterfacePage contains no interfaces.
+func (r InterfacePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	interfaces, err := ExtractInterfaces(r)
+	return len(interfaces) == 0, err
+}
+
+// ExtractInterfaces interprets the results of a single page from a List() call,
+// producing a slice of Interface structs.
+func ExtractInterfaces(r pagination.Page) ([]Interface, error) {
+	var s struct {
+		Interfaces []Interface `json:"interfaceAttachments"`
+	}
+	err := (r.(InterfacePage)).ExtractInto(&s)
+	return s.Interfaces, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/urls.go
@@ -1,0 +1,18 @@
+package attachinterfaces
+
+import "github.com/gophercloud/gophercloud"
+
+func listInterfaceURL(client *gophercloud.ServiceClient, serverID string) string {
+	return client.ServiceURL("servers", serverID, "os-interface")
+}
+
+func getInterfaceURL(client *gophercloud.ServiceClient, serverID, portID string) string {
+	return client.ServiceURL("servers", serverID, "os-interface", portID)
+}
+
+func createInterfaceURL(client *gophercloud.ServiceClient, serverID string) string {
+	return client.ServiceURL("servers", serverID, "os-interface")
+}
+func deleteInterfaceURL(client *gophercloud.ServiceClient, serverID, portID string) string {
+	return client.ServiceURL("servers", serverID, "os-interface", portID)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -489,6 +489,7 @@ github.com/googleapis/gax-go/v2/internal
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes
+github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs


### PR DESCRIPTION
This makes use of the interface attach method when reconciling server ports.

The difference between just setting the `DeviceID` on the Port and this is that with the attachment process the server is also validated. Which means for example that a Port cannot be attached to a server in `ERROR`
state.