### PR TITLE
OpenStack: Build InstanceGroup despite missing IP

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/server_group.go
+++ b/upup/pkg/fi/cloudup/openstack/server_group.go
@@ -135,7 +135,7 @@ func osBuildCloudInstanceGroup(c OpenstackCloud, cluster *kops.Cluster, ig *kops
 		generationName := fmt.Sprintf("%d-%d", cluster.GetGeneration(), ig.Generation)
 
 		status := cloudinstances.CloudInstanceStatusUpToDate
-		if generationName != observedName {
+		if generationName != observedName || server.Status == errorStatus {
 			status = cloudinstances.CloudInstanceStatusNeedsUpdate
 		}
 		cm, err := cg.NewCloudInstance(instanceId, status, nodeMap[instanceId])

--- a/upup/pkg/fi/cloudup/openstack/server_group.go
+++ b/upup/pkg/fi/cloudup/openstack/server_group.go
@@ -147,7 +147,10 @@ func osBuildCloudInstanceGroup(c OpenstackCloud, cluster *kops.Cluster, ig *kops
 			cm.MachineType = server.Flavor["original_name"].(string)
 		}
 
-		ip, _ := GetServerFixedIP(server, server.Metadata[TagKopsNetwork])
+		ip, err := GetServerFixedIP(server, server.Metadata[TagKopsNetwork])
+		if err != nil {
+			klog.Warningf("Unable to find fixed ip for %s: %v", server.Name, err)
+		}
 
 		cm.PrivateIP = ip
 

--- a/upup/pkg/fi/cloudup/openstack/server_group.go
+++ b/upup/pkg/fi/cloudup/openstack/server_group.go
@@ -147,10 +147,7 @@ func osBuildCloudInstanceGroup(c OpenstackCloud, cluster *kops.Cluster, ig *kops
 			cm.MachineType = server.Flavor["original_name"].(string)
 		}
 
-		ip, err := GetServerFixedIP(server, server.Metadata[TagKopsNetwork])
-		if err != nil {
-			return nil, fmt.Errorf("error creating cloud instance group member: %v", err)
-		}
+		ip, _ := GetServerFixedIP(server, server.Metadata[TagKopsNetwork])
 
 		cm.PrivateIP = ip
 


### PR DESCRIPTION
This will allow kOps to build an OpenStack InstanceGroup with a missing fixed IP.

In essence this will get rid of `interface name X not found` errors, when there are servers present which do not have an interface attached or are in a state (e.g. `ERROR`) which does not allow this. And will mark such a server with `NeedsUpdate`.

Currently this will happen:

```log
❯ openstack server list --status ERROR
2b2a77cc-8edb-4b21-b23c-dca515264aea worker-avjtq4    ERROR
6cf7570c-78d2-49e9-af5a-7376246d7cce worker-ijaqik    ERROR

❯ kops get instances
Error: error getting cloud instance group "worker": error creating cloud instance group member: server `6cf7570c-78d2-49e9-af5a-7376246d7cce` interface name `my-cluster-network` not found

❯ kops validate cluster
Validating cluster my-cluster.k8s.local

Error: Validation failed: unexpected error during validation: error getting cloud instance group "worker": error creating cloud instance group member: server `6cf7570c-78d2-49e9-af5a-7376246d7cce` interface name `my-cluster-network` not found
```

By ignoring the errors of `GetFixedIP()` when building the IGs the above commands will show now something more sensible (node without an IP and in e.g. `ERROR` state, validation will show node as "has not yet joined cluster").