### PR TITLE
OpenStack: Use task engine to retry failed servers

### DIFF
--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -71,6 +71,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -70,6 +70,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -70,6 +70,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/configures-allowed-address-pairs-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-allowed-address-pairs-with-annotations.yaml
@@ -72,6 +72,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
@@ -69,6 +69,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - soft-anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -129,6 +129,7 @@ ServerGroup:
   Name: cluster-master
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -217,6 +218,7 @@ ServerGroup:
   Name: cluster-master
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -305,6 +307,7 @@ ServerGroup:
   Name: cluster-master
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -384,6 +387,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -463,6 +467,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -542,6 +547,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -108,6 +108,7 @@ ServerGroup:
   Name: cluster-master-a
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -184,6 +185,7 @@ ServerGroup:
   Name: cluster-master-b
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -260,6 +262,7 @@ ServerGroup:
   Name: cluster-master-c
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -333,6 +336,7 @@ ServerGroup:
   Name: cluster-node-a
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -406,6 +410,7 @@ ServerGroup:
   Name: cluster-node-b
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -479,6 +484,7 @@ ServerGroup:
   Name: cluster-node-c
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -108,6 +108,7 @@ ServerGroup:
   Name: cluster-master-a
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -184,6 +185,7 @@ ServerGroup:
   Name: cluster-master-b
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -260,6 +262,7 @@ ServerGroup:
   Name: cluster-master-c
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -333,6 +336,7 @@ ServerGroup:
   Name: cluster-node-a
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -406,6 +410,7 @@ ServerGroup:
   Name: cluster-node-b
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -479,6 +484,7 @@ ServerGroup:
   Name: cluster-node-c
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -141,6 +141,7 @@ ServerGroup:
   Name: cluster-master-a
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -229,6 +230,7 @@ ServerGroup:
   Name: cluster-master-b
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -317,6 +319,7 @@ ServerGroup:
   Name: cluster-master-c
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -396,6 +399,7 @@ ServerGroup:
   Name: cluster-node-a
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -475,6 +479,7 @@ ServerGroup:
   Name: cluster-node-b
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -554,6 +559,7 @@ ServerGroup:
   Name: cluster-node-c
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -93,6 +93,7 @@ ServerGroup:
   Name: cluster-master-a
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -175,6 +176,7 @@ ServerGroup:
   Name: cluster-master-b
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -257,6 +259,7 @@ ServerGroup:
   Name: cluster-master-c
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -330,6 +333,7 @@ ServerGroup:
   Name: cluster-node-a
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -403,6 +407,7 @@ ServerGroup:
   Name: cluster-node-b
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -476,6 +481,7 @@ ServerGroup:
   Name: cluster-node-c
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -74,6 +74,7 @@ ServerGroup:
   Name: cluster-bastion
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -156,6 +157,7 @@ ServerGroup:
   Name: cluster-master
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -229,6 +231,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -87,6 +87,7 @@ ServerGroup:
   Name: cluster-bastion
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -169,6 +170,7 @@ ServerGroup:
   Name: cluster-master
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -242,6 +244,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -81,6 +81,7 @@ ServerGroup:
   Name: cluster-master
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -154,6 +155,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -101,6 +101,7 @@ ServerGroup:
   Name: cluster-master
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -180,6 +181,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
@@ -101,6 +101,7 @@ ServerGroup:
   Name: tom-software-dev-playground-real33-k8s-local-master
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""
@@ -180,6 +181,7 @@ ServerGroup:
   Name: tom-software-dev-playground-real33-k8s-local-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -71,6 +71,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -71,6 +71,7 @@ ServerGroup:
   Name: cluster-node
   Policies:
   - anti-affinity
+Status: null
 UserData:
   task:
     Lifecycle: ""

--- a/upup/pkg/fi/cloudup/openstack/instance.go
+++ b/upup/pkg/fi/cloudup/openstack/instance.go
@@ -101,10 +101,6 @@ func createInstance(c OpenstackCloud, opt servers.CreateOptsBuilder, portID stri
 	var server *servers.Server
 
 	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
-		if server != nil {
-			// Note: this will delete the server from the last try, even if it is now ACTIVE or still in BUILD state
-			c.DeleteInstanceWithID(server.ID)
-		}
 
 		v, err := servers.Create(c.ComputeClient(), opt).Extract()
 		if err != nil {
@@ -131,7 +127,7 @@ func createInstance(c OpenstackCloud, opt servers.CreateOptsBuilder, portID stri
 
 		err = waitForStatusActive(c, server.ID, nil)
 		if err != nil {
-			return false, fmt.Errorf("error while waiting for server '%s' to become '%s': %v", server.ID, activeStatus, err)
+			return true, err
 		}
 
 		return true, nil


### PR DESCRIPTION
This will make use of the kOps taks engine to retry failed servers.

The [former approach](https://github.com/kubernetes/kops/pull/15102) had the side effect of not making kOps fail when the last retry failed:

Because there is now a server present - although in an erroneous state - the "instance task" which the task engine retried reconciled the server (port, floating ip) instead of recreating it again.

With the approach of letting the task engine retry the failed servers this will be handled correctly.