### PR TITLE
Increase max_map_count in sysctls.go

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -44,9 +44,9 @@ func (b *SysctlBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 			"# Kubernetes Settings",
 			"")
 
-		// A higher vm.max_map_count is great for elasticsearch, mongo, or other mmap users
+		// A higher vm.max_map_count is great for elasticsearch, mongo, arangodb or other mmap users
 		// See https://github.com/kubernetes/kops/issues/1340
-		sysctls = append(sysctls, "vm.max_map_count = 262144",
+		sysctls = append(sysctls, "vm.max_map_count = 1048576",
 			"")
 
 		// See https://github.com/kubernetes/kubernetes/pull/38001


### PR DESCRIPTION
We need to increase this value because we can't deploy Arangodb.
Logs from the pod
```
2023-04-13T07:07:14Z [1] INFO [e52b0] {general} ArangoDB 3.9.1 [linux] 64bit, using jemalloc, build tags/v3.9.1-0-g55736e046ee, VPack 0.1.35, RocksDB 6.27.0, ICU 64.2, V8 7.9.317, OpenSSL 1.1.1n  15 Mar 2022
2023-04-13T07:07:14Z [1] INFO [75ddc] {general} detected operating system: Linux version 5.4.0-135-generic (buildd@lcy02-amd64-066) (gcc version 9.4.0 (Ubuntu 9.4.0-1ubuntu1~20.04.1)) #152-Ubuntu SMP Wed Nov 23 20:19:22 UTC 2022
2023-04-13T07:07:14Z [1] INFO [25362] {memory} Available physical memory: 8343769088 bytes, available cores: 4
2023-04-13T07:07:14Z [1] INFO [144fe] {general} using storage engine 'rocksdb'
2023-04-13T07:07:14Z [1] INFO [3bb7d] {cluster} Starting up with role SINGLE
2023-04-13T07:07:14Z [1] INFO [f6e0e] {aql} memory limit per AQL query automatically set to 5006261453 bytes. to modify this value, please adjust the startup option `--query.memory-limit`
2023-04-13T07:07:14Z [1] INFO [a1c60] {syscall} file-descriptors (nofiles) hard limit is 1048576, soft limit is 1048576
```