### PR TITLE
Create func to reset awsCloudInstances

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -234,10 +234,14 @@ func (c *awsCloudImplementation) Region() string {
 	return c.region
 }
 
-var awsCloudInstances map[string]AWSCloud = make(map[string]AWSCloud)
+var AWSCloudInstances = NewAWSCloudInstances()
+
+func NewAWSCloudInstances() map[string]AWSCloud {
+	return make(map[string]AWSCloud)
+}
 
 func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
-	raw := awsCloudInstances[region]
+	raw := AWSCloudInstances[region]
 	if raw == nil {
 		c := &awsCloudImplementation{
 			region: region,
@@ -375,7 +379,7 @@ func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
 		c.ssm.Handlers.Send.PushFront(requestLogger)
 		c.addHandlers(region, &c.ssm.Handlers)
 
-		awsCloudInstances[region] = c
+		AWSCloudInstances[region] = c
 		raw = c
 	}
 

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -234,14 +234,14 @@ func (c *awsCloudImplementation) Region() string {
 	return c.region
 }
 
-var aWSCloudInstances map[string]AWSCloud = make(map[string]AWSCloud)
+var awsCloudInstances map[string]AWSCloud = make(map[string]AWSCloud)
 
 func ResetAWSCloudInstances() {
-	aWSCloudInstances = make(map[string]AWSCloud)
+	awsCloudInstances = make(map[string]AWSCloud)
 }
 
 func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
-	raw := aWSCloudInstances[region]
+	raw := awsCloudInstances[region]
 	if raw == nil {
 		c := &awsCloudImplementation{
 			region: region,
@@ -379,7 +379,7 @@ func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
 		c.ssm.Handlers.Send.PushFront(requestLogger)
 		c.addHandlers(region, &c.ssm.Handlers)
 
-		aWSCloudInstances[region] = c
+		awsCloudInstances[region] = c
 		raw = c
 	}
 

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -234,14 +234,14 @@ func (c *awsCloudImplementation) Region() string {
 	return c.region
 }
 
-var AWSCloudInstances = NewAWSCloudInstances()
+var aWSCloudInstances map[string]AWSCloud = make(map[string]AWSCloud)
 
-func NewAWSCloudInstances() map[string]AWSCloud {
-	return make(map[string]AWSCloud)
+func ResetAWSCloudInstances() {
+	aWSCloudInstances = make(map[string]AWSCloud)
 }
 
 func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
-	raw := AWSCloudInstances[region]
+	raw := aWSCloudInstances[region]
 	if raw == nil {
 		c := &awsCloudImplementation{
 			region: region,
@@ -379,7 +379,7 @@ func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
 		c.ssm.Handlers.Send.PushFront(requestLogger)
 		c.addHandlers(region, &c.ssm.Handlers)
 
-		AWSCloudInstances[region] = c
+		aWSCloudInstances[region] = c
 		raw = c
 	}
 

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -55,7 +55,7 @@ var _ fi.Cloud = (*MockAWSCloud)(nil)
 
 func InstallMockAWSCloud(region string, zoneLetters string) *MockAWSCloud {
 	i := BuildMockAWSCloud(region, zoneLetters)
-	aWSCloudInstances[region] = i
+	awsCloudInstances[region] = i
 	allRegions = []*ec2.Region{
 		{RegionName: aws.String(region)},
 	}

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -55,7 +55,7 @@ var _ fi.Cloud = (*MockAWSCloud)(nil)
 
 func InstallMockAWSCloud(region string, zoneLetters string) *MockAWSCloud {
 	i := BuildMockAWSCloud(region, zoneLetters)
-	AWSCloudInstances[region] = i
+	aWSCloudInstances[region] = i
 	allRegions = []*ec2.Region{
 		{RegionName: aws.String(region)},
 	}

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -55,7 +55,7 @@ var _ fi.Cloud = (*MockAWSCloud)(nil)
 
 func InstallMockAWSCloud(region string, zoneLetters string) *MockAWSCloud {
 	i := BuildMockAWSCloud(region, zoneLetters)
-	awsCloudInstances[region] = i
+	AWSCloudInstances[region] = i
 	allRegions = []*ec2.Region{
 		{RegionName: aws.String(region)},
 	}


### PR DESCRIPTION
Since we use kops as lib, we need to reset this variable so that we can create clients with another AWS account.

Here is an example that also follows the same idea and was recently changed:

https://github.com/kubernetes/kops/blob/v1.26.2/util/pkg/vfs/context.go#L65