### PR TITLE
Fix ASG dependencies, use AWS SDK native struct for warmpool options

### DIFF
--- a/cloudmock/aws/mockautoscaling/warmpool.go
+++ b/cloudmock/aws/mockautoscaling/warmpool.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package mockautoscaling
 
-import "github.com/aws/aws-sdk-go/service/autoscaling"
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+)
 
 func (m *MockAutoscaling) DescribeWarmPool(input *autoscaling.DescribeWarmPoolInput) (*autoscaling.DescribeWarmPoolOutput, error) {
 	instances, found := m.WarmPoolInstances[*input.AutoScalingGroupName]
@@ -31,4 +34,11 @@ func (m *MockAutoscaling) DescribeWarmPool(input *autoscaling.DescribeWarmPoolIn
 
 func (m *MockAutoscaling) DeleteWarmPool(*autoscaling.DeleteWarmPoolInput) (*autoscaling.DeleteWarmPoolOutput, error) {
 	return &autoscaling.DeleteWarmPoolOutput{}, nil
+}
+
+func (m *MockAutoscaling) PutWarmPool(input *autoscaling.PutWarmPoolInput) (*autoscaling.PutWarmPoolOutput, error) {
+	if _, found := m.Groups[*input.AutoScalingGroupName]; !found {
+		return nil, awserr.New("ValidationError", "AutoScalingGroup not found", nil)
+	}
+	return &autoscaling.PutWarmPoolOutput{}, nil
 }

--- a/cmd/kops/lifecycle_integration_test.go
+++ b/cmd/kops/lifecycle_integration_test.go
@@ -179,6 +179,15 @@ func TestLifecycleManyAddons(t *testing.T) {
 	})
 }
 
+// TestLifecycleManyAddons runs the test on a cluster with requisite resources for NTH Queue Processor and other addons.
+func TestLifecycleWarmPool(t *testing.T) {
+	runLifecycleTestAWS(&LifecycleTestOptions{
+		t:           t,
+		SrcDir:      "minimal-warmpool",
+		ClusterName: "minimal-warmpool.example.com",
+	})
+}
+
 func runLifecycleTest(h *testutils.IntegrationTestHarness, o *LifecycleTestOptions, cloud *awsup.MockAWSCloud) {
 	ctx := context.Background()
 

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -100,8 +100,8 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 			}
 			if warmPool.IsEnabled() {
 				warmPoolTask.WarmPoolConfig = &autoscaling.WarmPoolConfiguration{
-					MaxGroupPreparedCapacity:	warmPool.MaxSize,
-					MinSize:			&warmPool.MinSize,
+					MaxGroupPreparedCapacity: warmPool.MaxSize,
+					MinSize:                  &warmPool.MinSize,
 				}
 				tsk.WarmPoolConfig = warmPoolTask.WarmPoolConfig
 			} else {

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
@@ -98,11 +99,13 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 				Enabled:   enabled,
 			}
 			if warmPool.IsEnabled() {
-				warmPoolTask.MinSize = warmPool.MinSize
-				warmPoolTask.MaxSize = warmPool.MaxSize
-				tsk.WarmPool = warmPoolTask
+				warmPoolTask.WarmPoolConfig = &autoscaling.WarmPoolConfiguration{
+					MaxGroupPreparedCapacity:	warmPool.MaxSize,
+					MinSize:			&warmPool.MinSize,
+				}
+				tsk.WarmPoolConfig = warmPoolTask.WarmPoolConfig
 			} else {
-				tsk.WarmPool = nil
+				tsk.WarmPoolConfig = nil
 			}
 			c.AddTask(warmPoolTask)
 

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -46,15 +46,15 @@ const (
 var _ fi.CloudupHasDependencies = &AutoscalingGroup{}
 
 func (e *AutoscalingGroup) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
-        var deps []fi.CloudupTask
-        for _, task := range tasks {
-                if _, ok := task.(*Subnet); ok {
-                        deps = append(deps, task)
-                }
-                if _, ok := task.(*LaunchTemplate); ok {
-                        deps = append(deps, task)
-                }
-        }
+	var deps []fi.CloudupTask
+	for _, task := range tasks {
+		if _, ok := task.(*Subnet); ok {
+			deps = append(deps, task)
+		}
+		if _, ok := task.(*LaunchTemplate); ok {
+			deps = append(deps, task)
+		}
+	}
 	return deps
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -343,8 +343,8 @@ terraform {
 				MixedOnDemandAboveBase:      fi.PtrTo(int64(30)),
 				MixedSpotAllocationStrategy: fi.PtrTo("capacity-optimized"),
 				WarmPoolConfig: &autoscaling.WarmPoolConfiguration{
-					MaxGroupPreparedCapacity:       fi.PtrTo(int64(5)),
-					MinSize:                        fi.PtrTo(int64(3)),
+					MaxGroupPreparedCapacity: fi.PtrTo(int64(5)),
+					MinSize:                  fi.PtrTo(int64(3)),
 				},
 				Subnets: []*Subnet{
 					{

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -342,10 +342,9 @@ terraform {
 				MixedOnDemandBase:           fi.PtrTo(int64(4)),
 				MixedOnDemandAboveBase:      fi.PtrTo(int64(30)),
 				MixedSpotAllocationStrategy: fi.PtrTo("capacity-optimized"),
-				WarmPool: &WarmPool{
-					Enabled: fi.PtrTo(true),
-					MinSize: 3,
-					MaxSize: fi.PtrTo(int64(5)),
+				WarmPoolConfig: &autoscaling.WarmPoolConfiguration{
+					MaxGroupPreparedCapacity:       fi.PtrTo(int64(5)),
+					MinSize:                        fi.PtrTo(int64(3)),
 				},
 				Subnets: []*Subnet{
 					{

--- a/upup/pkg/fi/cloudup/awstasks/warmpool.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool.go
@@ -35,14 +35,14 @@ type WarmPool struct {
 
 	Enabled *bool
 
-	WarmPoolConfig *autoscaling.WarmPoolConfiguration
+	WarmPoolConfig   *autoscaling.WarmPoolConfiguration
 	AutoscalingGroup *AutoscalingGroup
 }
 
 var _ fi.CloudupHasDependencies = &WarmPool{}
 
 func (e *WarmPool) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
-        return nil
+	return nil
 }
 
 // Find is used to discover the ASG in the cloud provider.
@@ -67,9 +67,9 @@ func (e *WarmPool) Find(c *fi.CloudupContext) (*WarmPool, error) {
 	}
 
 	actual := &WarmPool{
-		Name:      e.Name,
-		Lifecycle: e.Lifecycle,
-		Enabled:   fi.PtrTo(true),
+		Name:           e.Name,
+		Lifecycle:      e.Lifecycle,
+		Enabled:        fi.PtrTo(true),
 		WarmPoolConfig: warmPool.WarmPoolConfiguration,
 	}
 	return actual, nil


### PR DESCRIPTION
Addresses https://github.com/kubernetes/kops/issues/15289
Uses AWS SDK builtin struct, so it will be easier to add additional options, and will the struct will contain any future options that AWS might add to the warmpool.