### PR TITLE
hetzer: update CSI driver to v2.3.2

### DIFF
--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-csi-driver.addons.k8s.io-k8s-1.22_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-csi-driver.addons.k8s.io-k8s-1.22_content
@@ -308,7 +308,7 @@ spec:
             secretKeyRef:
               key: token
               name: hcloud-csi
-        image: hetznercloud/hcloud-csi-driver:2.0.0
+        image: hetznercloud/hcloud-csi-driver:v2.3.2
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
@@ -391,7 +391,7 @@ spec:
           value: 0.0.0.0:9189
         - name: ENABLE_METRICS
           value: "true"
-        image: hetznercloud/hcloud-csi-driver:2.0.0
+        image: hetznercloud/hcloud-csi-driver:v2.3.2
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This update is needed since the old hcloud-csi-driver v.2.0.0 image lacks ARM64 support and hence, it fails to run on new hetzner ARM64 servers.