### PR TITLE
docs(release): fix typo in 1.22 Notes

### DIFF
--- a/docs/releases/1.22-NOTES.md
+++ b/docs/releases/1.22-NOTES.md
@@ -34,7 +34,7 @@ Currently this is only available using the AWS cloud provider.
 
 kOps can now provision instances with nvidia GPUs and configure it for container workloads without the need of hooks and operators. See [GPU support](https://kops.sigs.k8s.io/gpu/)
 
-## Breacking change in NodeLocalDNS
+## Breaking change in NodeLocalDNS
 
 Since 1.22.0 Cluster `spec.kubeDNS.nodeLocalDNS.forwardToKubeDNS` default behaviour changes from `true` to `false`.
 
@@ -43,7 +43,7 @@ Since 1.22.0 Cluster `spec.kubeDNS.nodeLocalDNS.forwardToKubeDNS` default behavi
 * New clusters on AWS will no longer provision an SSH public key by default. To provision
   an SSH public key on a new cluster, use the `--ssh-public-key` flag to `kops create cluster`.
 
-* The kOps Terraform support now renders managed files through the Terraform configuration instead 
+* The kOps Terraform support now renders managed files through the Terraform configuration instead
   of writing them to S3 directly. This defers changes to these files until the time of `terraform apply`.
   This feature may be temporarily disabled by turning off the `TerraformManagedFiles` feature flag
   using `export KOPS_FEATURE_FLAGS="-TerraformManagedFiles"`.
@@ -99,13 +99,13 @@ For file assets, it means adding an explicit path as shown below:
 * Terraform support now requires Terraform >=0.15.0.
   Users on older versions must follow Terraform's recommended upgrade path of applying one minor version at a time prior to running `kops update cluster --target terraform`.
 
-* The kOps Terraform support now renders managed files through the Terraform configuration instead 
+* The kOps Terraform support now renders managed files through the Terraform configuration instead
   of writing them to S3 directly. If, after upgrading kOps and applying a new Terraform plan,
   you subsequently downgrade to an earlier version of kOps, the generated plan will delete these
   files, breaking the cluster. Prior to applying the plan, you will need to orphan all the
   `aws_s3_bucket_object` objects the plan wants to destroy. Use `terraform state rm` on each of them.
   Then re-run `terraform plan` until there are no such objects in the plan.
-  
+
   If you applied the plan without first orphaning all of these objects, fix the cluster by re-running
   `kops update cluster --target terraform`.
 
@@ -158,7 +158,7 @@ For file assets, it means adding an explicit path as shown below:
 * There is a new command `kops get assets` for listing image and file assets used by a cluster.
   It also includes a `--copy` flag to copy the assets to local repositories.
   See the documentation on [Using local asset repositories](../operations/asset-repository.md) for more information.
-  
+
 * kOps now provisions TLS server certificates signed by the Kubernetes general CA to kube-controller-manager and kube-scheduler.
   The previous behavior of using self-signed certs may be restored by setting `kubeControllerManager.tlsCertFile` and/or
   `kubeScheduler.tlsCertFile` to `""` in the cluster spec.


### PR DESCRIPTION
## Summary

* Brea_c_king -> Breaking

## References

* Stumbled upon this while looking over the 1.22 Notes searching for a change note about https://github.com/kubernetes/kops/pull/11921
  * See my other PR: https://github.com/kubernetes/kops/pull/15324