### PR TITLE
docs: Add note to 1.22 about the CA CN rename

### DIFF
--- a/docs/releases/1.22-NOTES.md
+++ b/docs/releases/1.22-NOTES.md
@@ -163,6 +163,9 @@ For file assets, it means adding an explicit path as shown below:
   The previous behavior of using self-signed certs may be restored by setting `kubeControllerManager.tlsCertFile` and/or
   `kubeScheduler.tlsCertFile` to `""` in the cluster spec.
 
+* kOps has changed the CN of the Kubernetes general CA from `kubernetes` to `kubernetes-ca`.
+  This change is backward-compatible, but if you were relying on the CN for some code, you will need to ensure it is compatible with both the old name and the new name as you may have older clusters with the old CN and newer clusters with the new CN.
+
 * Cilium now supports the wireguard protocol for transparent encryption.
 
 

--- a/docs/releases/1.22-NOTES.md
+++ b/docs/releases/1.22-NOTES.md
@@ -163,8 +163,7 @@ For file assets, it means adding an explicit path as shown below:
   The previous behavior of using self-signed certs may be restored by setting `kubeControllerManager.tlsCertFile` and/or
   `kubeScheduler.tlsCertFile` to `""` in the cluster spec.
 
-* kOps has changed the CN of the Kubernetes general CA from `kubernetes` to `kubernetes-ca`.
-  This change is backward-compatible, but if you were relying on the CN for some code, you will need to ensure it is compatible with both the old name and the new name as you may have older clusters with the old CN and newer clusters with the new CN.
+* kOps has changed the CN of the Kubernetes general CA from `kubernetes` to `kubernetes-ca`. This change is backward-compatible, but any tools using the CN will need to be updated.
 
 * Cilium now supports the wireguard protocol for transparent encryption.
 


### PR DESCRIPTION
## Summary

Add a note in 1.22 changelog about https://github.com/kubernetes/kops/pull/11921 et al's CA changes

## Details

- this broke some of my teams' automation code that relied on the CN, so thought it would be good to call out in case anyone else stumbles upon this in order to not spend a few hours debugging 😅 
  - this change may particularly impact Prod environments, where the cluster has not been rebuilt in some time (years), and so they will have the old CN while new clusters in lower environments will have the new CN
    - so code that relies on the CN may unexpectedly break Production while working fine in lower environments 😬 😬 😬 
      - fortunately we caught this in our QA env, but it passed Dev fine
      
## Testing Evidence

From an internal fix my team made to another team's automation:
![k8s ca change](https://user-images.githubusercontent.com/4970083/232334047-8880f06f-3a4b-432f-9be6-85ceff67d4f9.png)

(We've recommend they pull the CA from `/etc/kubernetes/pki/ca.crt` or `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` to be a bit more resilient to changes like this)

## Review Notes

Feel free to change the language / wording as you see fit or put in a different part of the release notes (I put this under "Other changes of note" right now).

I thought specifically warning about older clusters was important, as otherwise this is particularly easy to overlook