### PR TITLE
docs(cilium): fix several broken links

### DIFF
--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -29,7 +29,7 @@ kops create cluster \
 
 {{ kops_feature_table(kops_added_beta='1.18', kops_added_default='1.26') }}
 
-By default, Cilium will use CRDs for synchronizing agent state. This can cause performance problems on larger clusters. As of kOps 1.18, kOps can manage an etcd cluster using etcd-manager dedicated for cilium agent state sync. The [Cilium docs](https://docs.cilium.io/en/v1.12/gettingstarted/k8s-install-external-etcd/) contains recommendations for when this must be enabled.
+By default, Cilium will use CRDs for synchronizing agent state. This can cause performance problems on larger clusters. As of kOps 1.18, kOps can manage an etcd cluster using etcd-manager dedicated for cilium agent state sync. The [Cilium docs](https://docs.cilium.io/en/v1.13/installation/k8s-install-external-etcd/) contains recommendations for when this must be enabled.
 
 For new clusters you can use the `cilium-etcd` networking provider:
 
@@ -85,7 +85,7 @@ Then enable etcd as kvstore:
 As of kOps 1.19, BPF NodePort is enabled by default for new clusters if the kubernetes version is 1.12 or newer. It can be safely enabled as of kOps 1.18.
 
 In this mode, the cluster is fully functional without kube-proxy, with Cilium replacing kube-proxy's NodePort implementation using BPF.
-Read more about this in the [Cilium docs - kubeproxy free](https://docs.cilium.io/en/v1.12/gettingstarted/kubeproxy-free/) and [Cilium docs - NodePort](https://docs.cilium.io/en/v1.12/gettingstarted/kubeproxy-free/#nodeport-devices)
+Read more about this in the [Cilium docs - kubeproxy free](https://docs.cilium.io/en/v1.13/network/kubernetes/kubeproxy-free/) and [Cilium docs - NodePort](https://docs.cilium.io/en/v1.13/network/kubernetes/kubeproxy-free/#nodeport-devices-port-and-bind-settings)
 
 Be aware that you need to use an AMI with at least Linux 4.19.57 for this feature to work.
 

--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -29,7 +29,7 @@ kops create cluster \
 
 {{ kops_feature_table(kops_added_beta='1.18', kops_added_default='1.26') }}
 
-By default, Cilium will use CRDs for synchronizing agent state. This can cause performance problems on larger clusters. As of kOps 1.18, kOps can manage an etcd cluster using etcd-manager dedicated for cilium agent state sync. The [Cilium docs](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-external-etcd/) contains recommendations for when this must be enabled.
+By default, Cilium will use CRDs for synchronizing agent state. This can cause performance problems on larger clusters. As of kOps 1.18, kOps can manage an etcd cluster using etcd-manager dedicated for cilium agent state sync. The [Cilium docs](https://docs.cilium.io/en/v1.12/gettingstarted/k8s-install-external-etcd/) contains recommendations for when this must be enabled.
 
 For new clusters you can use the `cilium-etcd` networking provider:
 
@@ -85,7 +85,7 @@ Then enable etcd as kvstore:
 As of kOps 1.19, BPF NodePort is enabled by default for new clusters if the kubernetes version is 1.12 or newer. It can be safely enabled as of kOps 1.18.
 
 In this mode, the cluster is fully functional without kube-proxy, with Cilium replacing kube-proxy's NodePort implementation using BPF.
-Read more about this in the [Cilium docs - kubeproxy free](https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/) and [Cilium docs - NodePort](https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/#nodeport-devices)
+Read more about this in the [Cilium docs - kubeproxy free](https://docs.cilium.io/en/v1.12/gettingstarted/kubeproxy-free/) and [Cilium docs - NodePort](https://docs.cilium.io/en/v1.12/gettingstarted/kubeproxy-free/#nodeport-devices)
 
 Be aware that you need to use an AMI with at least Linux 4.19.57 for this feature to work.
 
@@ -203,7 +203,7 @@ Hubble UI brings a dashboard on top of Hubble observability layer. It allows vie
 
 When Cilium is intalled and managed by kOps, Cilium cli should not be used as the configuration it produces conflicts with the configuration managed by kOps (certificates are not managed the same way). For this reason, deploying Hubble UI can be tricky.
 
-Fortunately, recent versions of the Cilium Helm chart allow standalone install of Hubble UI. See `Helm (Standalone install)` tab in [Hubble UI documentation](https://docs.cilium.io/en/stable/gettingstarted/hubble/).
+Fortunately, recent versions of the Cilium Helm chart allow standalone install of Hubble UI. See `Helm (Standalone install)` tab in [Hubble UI documentation](https://docs.cilium.io/en/v1.13/gettingstarted/hubble/).
 
 Basically, it requires to disable all components in the chart (they are already managed by kOps) except Hubble UI, and setting `hubble.ui.standalone.enabled` to `true`.
 


### PR DESCRIPTION
## Summary

Fix some broken links on the Cilium docs page

## Details

- `stable` route no longer has some of the links, so instead used a specific version of the Cilium docs
  - follows the convention in the rest of this doc to use versions
  - I used the latest version that has the link available

## Review Notes

I updated anything with `stable` but left already versioned ones. The versioned ones still work, but some could be updated to newer versions of the docs. I can do that if wanted, but not sure if y'all would prefer it be an older link closer in time to when the features were added. **EDIT**: See #15583 which updates the rest of the links that were already versioned
  
## Misc

I had started this and some other docs changes a while ago, finally got to them while making other docs PRs 😅 