### PR TITLE
docs(release): fix broken CLI link in 1.19 notes

### DIFF
--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -53,7 +53,7 @@ See the [documentation](/cluster_spec/#load-balancer-class) for more info.
 * The `kops update cluster` command will now refuse to run on a cluster that
 has been updated by a newer version of kOps unless it is given the `--allow-kops-downgrade` flag.
 
-* New command for deleting a single instance: [kops delete instance](/docs/cli/kops_delete_instance/)
+* New command for deleting a single instance: [kops delete instance](/cli/kops_delete_instance)
 
 ### CNI
 


### PR DESCRIPTION
## Summary

Link to `kops delete instance` doc was broken

## Misc

Same as #15325 , I had started this and some other docs changes a while ago, finally got to them while making other docs PRs 😅 

Also this command is super useful! How have I not known about it for years??