### PR TITLE
docs(release): add improved security of `metrics-server` note to 1.19

### DIFF
--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -72,6 +72,7 @@ has been updated by a newer version of kOps unless it is given the `--allow-kops
 ### Addons
 
 * Metrics Server is now available as a configurable addon. Add `spec.metricsServer.enabled: true` to the cluster spec to enable.
+  * This new addon is **more secure** than installing directly via the `metrics-server` Helm chart as kOps automatically provisions and sets TLS certs, avoiding the need to use the `--kubelet-insecure-tls` flag. See [#6879](https://github.com/kubernetes/kops/issues/6879) for more details.
 
 * Cluster Autoscaler is now availalble as a configurable addon. Add `spec.clusterAutoscaler.enabled: true` to the cluster spec to enable.
 

--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -72,7 +72,7 @@ has been updated by a newer version of kOps unless it is given the `--allow-kops
 ### Addons
 
 * Metrics Server is now available as a configurable addon. Add `spec.metricsServer.enabled: true` to the cluster spec to enable.
-  * This new addon is **more secure** than installing directly via the `metrics-server` Helm chart as kOps automatically provisions and sets TLS certs, avoiding the need to use the `--kubelet-insecure-tls` flag. See [#6879](https://github.com/kubernetes/kops/issues/6879) for more details.
+  * With this change, one no longer has to set the `--kubelet-insecure-tls` flag, making any `metrics-server` installation **more secure**. See [#6879](https://github.com/kubernetes/kops/issues/6879) for more details.
 
 * Cluster Autoscaler is now availalble as a configurable addon. Add `spec.clusterAutoscaler.enabled: true` to the cluster spec to enable.
 


### PR DESCRIPTION
## Summary

Note that the change to the kubelet serving cert allows one to avoid `--kubelet-insecure-tls` usage with _any_ installation of `metrics-server`

## Details & References

- I had brought attention to this issue in https://github.com/kubernetes/kops/issues/6879#issuecomment-642966333 and https://github.com/kubernetes-sigs/metrics-server/issues/541 (but did not know how to fix it myself -- big thanks to Ole again!). I also mentioned the lack of security details in https://github.com/kubernetes/kops/pull/10022#discussion_r608871128
  - was requested to submit a PR for this note as well, finally got to pushing this up 😅
  - this is good encouragement for folks to remove `--kubelet-insecure-tls` from their code for better security
  
## Misc

Same as #15326 and #15325 , I had started this and some other docs changes a while ago, finally got to them while making other docs PRs 😅 
