### PR TITLE
Update audit configuration in cluster_spec.md

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -431,10 +431,10 @@ spec:
     auditLogMaxBackups: 1
     auditLogMaxSize: 100
     auditLogPath: /var/log/kube-apiserver-audit.log
-    auditPolicyFile: /etc/kubernetes/audit/policy-config.yaml
+    auditPolicyFile: /srv/kubernetes/kube-apiserver/audit/policy-config.yaml
   fileAssets:
   - name: audit-policy-config
-    path: /etc/kubernetes/audit/policy-config.yaml
+    path: /srv/kubernetes/kube-apiserver/audit/policy-config.yaml
     roles:
     - Master
     content: |
@@ -458,10 +458,10 @@ Webhook backend sends audit events to a remote API, which is assumed to be the s
 spec:
   kubeAPIServer:
     auditWebhookBatchMaxWait: 5s
-    auditWebhookConfigFile: /etc/kubernetes/audit/webhook-config.yaml
+    auditWebhookConfigFile: /srv/kubernetes/kube-apiserver/audit/webhook-config.yaml
   fileAssets:
   - name: audit-webhook-config
-    path: /etc/kubernetes/audit/webhook-config.yaml
+    path: /srv/kubernetes/kube-apiserver/audit/webhook-config.yaml
     roles:
     - Master
     content: |


### PR DESCRIPTION
Since [1.22](https://github.com/kubernetes/kops/blob/ff5b06586d99e86c9dcf1680022e7a0e626305f1/docs/releases/1.22-NOTES.md#control-plane-pods-no-longer-mount-srvkubernetes) pods only mount specific hostPaths that are reachable for kube-apiserver which means the audit policy config also has to be stored under that path if we want it to be reachable by the pod. This has not been reflected in the documentation