### PR TITLE
gce: set ip address family on all FirewallRule tasks

### DIFF
--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -107,6 +107,7 @@ func createPublicLB(b *APILoadBalancerBuilder, c *fi.CloudupModelBuilderContext)
 				Name:         s(b.NameForFirewallRule("pod-cidrs-to-https-api")),
 				Lifecycle:    b.Lifecycle,
 				Network:      network,
+				Family:       gcetasks.AddressFamilyIPv4, // ip alias is always ipv4
 				SourceRanges: []string{b.Cluster.Spec.Networking.PodCIDR},
 				TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleControlPlane)},
 				Allowed:      []string{"tcp:" + strconv.Itoa(wellknownports.KubeAPIServer)},

--- a/pkg/model/gcemodel/external_access.go
+++ b/pkg/model/gcemodel/external_access.go
@@ -121,6 +121,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.CloudupModelBuilderContext) err
 				Name:         s(b.NameForFirewallRule("pod-cidrs-to-https-api")),
 				Lifecycle:    b.Lifecycle,
 				Network:      network,
+				Family:       gcetasks.AddressFamilyIPv4, // ip alias is always ipv4
 				SourceRanges: []string{b.Cluster.Spec.Networking.PodCIDR},
 				TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleControlPlane)},
 				Allowed:      []string{"tcp:" + strconv.Itoa(wellknownports.KubeAPIServer)},


### PR DESCRIPTION
We had missed a few code paths previously.
