### PR TITLE
fix(cilium): install CNI plugin binary in an InitContainer

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
@@ -782,8 +782,10 @@ spec:
           {{- end }}
         - mountPath: /var/run/cilium
           name: cilium-run
+          {{- if not (semverCompare "~1.11.15 || ~1.12.8 || >=1.13.1" $semver) }}
         - mountPath: /host/opt/cni/bin
           name: cni-path
+          {{- end }}
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
 {{ if .EtcdManaged }}
@@ -817,6 +819,26 @@ spec:
 {{ end }}
       hostNetwork: true
       initContainers:
+      {{- if semverCompare "~1.11.15 || ~1.12.8 || >=1.13.1" $semver }}
+      - command:
+        - /install-plugin.sh
+        image: "quay.io/cilium/cilium:{{ .Version }}"
+        imagePullPolicy: IfNotPresent
+        name: install-cni-binaries
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+      {{- end }}
       - command:
         - /init-container.sh
         env:


### PR DESCRIPTION
Starting cilium version `1.12.8` and to reduces the potential security surface of the agent, Cilium removes the bind-mount of `/opt/cni/bin` into the template. Instead, write the binaries once in an initContainer.

Ref:
 - https://github.com/cilium/cilium/pull/24075