### PR TITLE
fix(firewall): open node to master ICMP security group

### DIFF
--- a/pkg/model/awsmodel/firewall.go
+++ b/pkg/model/awsmodel/firewall.go
@@ -196,13 +196,12 @@ func (b *FirewallModelBuilder) applyNodeToMasterBlockSpecificPorts(c *fi.Cloudup
 			}
 			for _, protocol := range protocols {
 				awsName := strconv.Itoa(int(protocol))
-				name := awsName
 
 				switch protocol {
 				case ProtocolIPIP:
-					name = "ipip"
+					awsName = "ipip"
 					t := &awstasks.SecurityGroupRule{
-						Name:          fi.PtrTo(fmt.Sprintf("node-to-master-protocol-%s%s", name, suffix)),
+						Name:          fi.PtrTo(fmt.Sprintf("node-to-master-protocol-%s%s", awsName, suffix)),
 						Lifecycle:     b.Lifecycle,
 						SecurityGroup: masterGroup.Task,
 						SourceGroup:   nodeGroup.Task,
@@ -210,9 +209,9 @@ func (b *FirewallModelBuilder) applyNodeToMasterBlockSpecificPorts(c *fi.Cloudup
 					}
 					AddDirectionalGroupRule(c, t)
 				case ProtocolICMP:
-					name = "icmp"
+					awsName = "icmp"
 					t := &awstasks.SecurityGroupRule{
-						Name:          fi.PtrTo(fmt.Sprintf("node-to-master-protocol-%s%s", name, suffix)),
+						Name:          fi.PtrTo(fmt.Sprintf("node-to-master-protocol-%s%s", awsName, suffix)),
 						Lifecycle:     b.Lifecycle,
 						SecurityGroup: masterGroup.Task,
 						SourceGroup:   nodeGroup.Task,

--- a/pkg/model/awsmodel/firewall.go
+++ b/pkg/model/awsmodel/firewall.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"golang.org/x/net/ipv4"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
@@ -215,9 +216,9 @@ func (b *FirewallModelBuilder) applyNodeToMasterBlockSpecificPorts(c *fi.Cloudup
 						Lifecycle:     b.Lifecycle,
 						SecurityGroup: masterGroup.Task,
 						SourceGroup:   nodeGroup.Task,
-						FromPort:      fi.PtrTo(int64(8)),
+						FromPort:      fi.PtrTo(int64(ipv4.ICMPTypeEcho)),
 						Protocol:      fi.PtrTo(awsName),
-						ToPort:        fi.PtrTo(int64(8)),
+						ToPort:        fi.PtrTo(int64(ipv4.ICMPTypeEcho)),
 					}
 					AddDirectionalGroupRule(c, t)
 				default:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
@@ -1020,21 +1020,21 @@ resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-egress-a
   type              = "egress"
 }
 
-resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-4-0to0-masters-minimal-ipv6-example-com" {
-  from_port                = 0
-  protocol                 = "4"
-  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
-  source_security_group_id = aws_security_group.nodes-minimal-ipv6-example-com.id
-  to_port                  = 65535
-  type                     = "ingress"
-}
-
 resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-all-0to0-nodes-minimal-ipv6-example-com" {
   from_port                = 0
   protocol                 = "-1"
   security_group_id        = aws_security_group.nodes-minimal-ipv6-example-com.id
   source_security_group_id = aws_security_group.nodes-minimal-ipv6-example-com.id
   to_port                  = 0
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-ipip-0to0-masters-minimal-ipv6-example-com" {
+  from_port                = 0
+  protocol                 = "ipip"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.nodes-minimal-ipv6-example-com.id
+  to_port                  = 65535
   type                     = "ingress"
 }
 

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
@@ -1029,6 +1029,15 @@ resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-
   type                     = "ingress"
 }
 
+resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-icmp-8to8-masters-minimal-ipv6-example-com" {
+  from_port                = 8
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.nodes-minimal-ipv6-example-com.id
+  to_port                  = 8
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-tcp-1to2379-masters-minimal-ipv6-example-com" {
   from_port                = 1
   protocol                 = "tcp"

--- a/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
@@ -761,6 +761,15 @@ resource "aws_security_group_rule" "from-nodes-minimal-warmpool-example-com-ingr
   type                     = "ingress"
 }
 
+resource "aws_security_group_rule" "from-nodes-minimal-warmpool-example-com-ingress-icmp-8to8-masters-minimal-warmpool-example-com" {
+  from_port                = 8
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-minimal-warmpool-example-com.id
+  source_security_group_id = aws_security_group.nodes-minimal-warmpool-example-com.id
+  to_port                  = 8
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "from-nodes-minimal-warmpool-example-com-ingress-tcp-1to2379-masters-minimal-warmpool-example-com" {
   from_port                = 1
   protocol                 = "tcp"

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -1134,21 +1134,21 @@ resource "aws_security_group_rule" "from-nodes-privatecalico-example-com-egress-
   type              = "egress"
 }
 
-resource "aws_security_group_rule" "from-nodes-privatecalico-example-com-ingress-4-0to0-masters-privatecalico-example-com" {
-  from_port                = 0
-  protocol                 = "4"
-  security_group_id        = aws_security_group.masters-privatecalico-example-com.id
-  source_security_group_id = aws_security_group.nodes-privatecalico-example-com.id
-  to_port                  = 65535
-  type                     = "ingress"
-}
-
 resource "aws_security_group_rule" "from-nodes-privatecalico-example-com-ingress-all-0to0-nodes-privatecalico-example-com" {
   from_port                = 0
   protocol                 = "-1"
   security_group_id        = aws_security_group.nodes-privatecalico-example-com.id
   source_security_group_id = aws_security_group.nodes-privatecalico-example-com.id
   to_port                  = 0
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "from-nodes-privatecalico-example-com-ingress-ipip-0to0-masters-privatecalico-example-com" {
+  from_port                = 0
+  protocol                 = "ipip"
+  security_group_id        = aws_security_group.masters-privatecalico-example-com.id
+  source_security_group_id = aws_security_group.nodes-privatecalico-example-com.id
+  to_port                  = 65535
   type                     = "ingress"
 }
 

--- a/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
@@ -1121,6 +1121,15 @@ resource "aws_security_group_rule" "from-nodes-privatecilium-example-com-ingress
   type                     = "ingress"
 }
 
+resource "aws_security_group_rule" "from-nodes-privatecilium-example-com-ingress-icmp-8to8-masters-privatecilium-example-com" {
+  from_port                = 8
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-privatecilium-example-com.id
+  source_security_group_id = aws_security_group.nodes-privatecilium-example-com.id
+  to_port                  = 8
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "from-nodes-privatecilium-example-com-ingress-tcp-1to2379-masters-privatecilium-example-com" {
   from_port                = 1
   protocol                 = "tcp"

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -1121,6 +1121,15 @@ resource "aws_security_group_rule" "from-nodes-privatecilium-example-com-ingress
   type                     = "ingress"
 }
 
+resource "aws_security_group_rule" "from-nodes-privatecilium-example-com-ingress-icmp-8to8-masters-privatecilium-example-com" {
+  from_port                = 8
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-privatecilium-example-com.id
+  source_security_group_id = aws_security_group.nodes-privatecilium-example-com.id
+  to_port                  = 8
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "from-nodes-privatecilium-example-com-ingress-tcp-1to2379-masters-privatecilium-example-com" {
   from_port                = 1
   protocol                 = "tcp"

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -1137,6 +1137,15 @@ resource "aws_security_group_rule" "from-nodes-privatecilium-example-com-ingress
   type                     = "ingress"
 }
 
+resource "aws_security_group_rule" "from-nodes-privatecilium-example-com-ingress-icmp-8to8-masters-privatecilium-example-com" {
+  from_port                = 8
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-privatecilium-example-com.id
+  source_security_group_id = aws_security_group.nodes-privatecilium-example-com.id
+  to_port                  = 8
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "from-nodes-privatecilium-example-com-ingress-tcp-1to2379-masters-privatecilium-example-com" {
   from_port                = 1
   protocol                 = "tcp"

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -1154,6 +1154,15 @@ resource "aws_security_group_rule" "from-nodes-privateciliumadvanced-example-com
   type                     = "ingress"
 }
 
+resource "aws_security_group_rule" "from-nodes-privateciliumadvanced-example-com-ingress-icmp-8to8-masters-privateciliumadvanced-example-com" {
+  from_port                = 8
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-privateciliumadvanced-example-com.id
+  source_security_group_id = aws_security_group.nodes-privateciliumadvanced-example-com.id
+  to_port                  = 8
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "from-nodes-privateciliumadvanced-example-com-ingress-tcp-1to2379-masters-privateciliumadvanced-example-com" {
   from_port                = 1
   protocol                 = "tcp"


### PR DESCRIPTION
Fixes #15329.

Cilium health check mechanism requires ICMP and TCP/4240 port to be opened between every nodes in the cluster, including control plane nodes. If one of these 2 checks fails the node is considered as unreachable.

We only open ICMP echo request (type 8) from node to master.