### PR TITLE
If the Cluster Name is not default the hubble relay shows TLS errors

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
@@ -1193,7 +1193,7 @@ metadata:
   namespace: kube-system
 spec:
   dnsNames:
-  - "*.default.hubble-grpc.cilium.io"
+  - "*.{{ .ClusterName }}.hubble-grpc.cilium.io"
   issuerRef:
     kind: Issuer
     name: networking.cilium.io


### PR DESCRIPTION
This change uses the ClusterName value to correctly set the dnsName for certificate generation

Updated Files
 * Update: upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template