### PR TITLE
DigitalOcean support for node bootstrap

### DIFF
--- a/cmd/kops-controller/pkg/config/options.go
+++ b/cmd/kops-controller/pkg/config/options.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	gcetpm "k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
@@ -65,10 +66,11 @@ type ServerOptions struct {
 }
 
 type ServerProviderOptions struct {
-	AWS       *awsup.AWSVerifierOptions           `json:"aws,omitempty"`
-	GCE       *gcetpm.TPMVerifierOptions          `json:"gce,omitempty"`
-	Hetzner   *hetzner.HetznerVerifierOptions     `json:"hetzner,omitempty"`
-	OpenStack *openstack.OpenStackVerifierOptions `json:"openstack,omitempty"`
+	AWS          *awsup.AWSVerifierOptions           `json:"aws,omitempty"`
+	GCE          *gcetpm.TPMVerifierOptions          `json:"gce,omitempty"`
+	Hetzner      *hetzner.HetznerVerifierOptions     `json:"hetzner,omitempty"`
+	OpenStack    *openstack.OpenStackVerifierOptions `json:"openstack,omitempty"`
+	DigitalOcean *do.DigitalOceanVerifierOptions     `json:"do,omitempty"`
 }
 
 // DiscoveryOptions configures our support for discovery, particularly gossip DNS (i.e. k8s.local)

--- a/nodeup/pkg/model/bootstrap_client.go
+++ b/nodeup/pkg/model/bootstrap_client.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce/gcediscovery"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm/gcetpmsigner"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
@@ -75,6 +76,13 @@ func (b BootstrapClientBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		authenticator = a
 	case kops.CloudProviderOpenstack:
 		a, err := openstack.NewOpenstackAuthenticator()
+		if err != nil {
+			return err
+		}
+		authenticator = a
+
+	case kops.CloudProviderDO:
+		a, err := do.NewAuthenticator()
 		if err != nil {
 			return err
 		}

--- a/pkg/apis/kops/model/features.go
+++ b/pkg/apis/kops/model/features.go
@@ -31,6 +31,8 @@ func UseKopsControllerForNodeBootstrap(cluster *kops.Cluster) bool {
 		return true
 	case kops.CloudProviderOpenstack:
 		return true
+	case kops.CloudProviderDO:
+		return true
 	default:
 		return false
 	}
@@ -40,6 +42,8 @@ func UseKopsControllerForNodeBootstrap(cluster *kops.Cluster) bool {
 func UseChallengeCallback(cloudProvider kops.CloudProviderID) bool {
 	switch cloudProvider {
 	case kops.CloudProviderHetzner:
+		return true
+	case kops.CloudProviderDO:
 		return true
 	default:
 		return false

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -522,8 +522,14 @@ func validateTopology(c *kops.Cluster, topology *kops.TopologySpec, fieldPath *f
 	if topology.DNS != "" {
 		cloud := c.Spec.GetCloudProvider()
 		allErrs = append(allErrs, IsValidValue(fieldPath.Child("dns", "type"), &topology.DNS, kops.SupportedDnsTypes)...)
-		if topology.DNS == kops.DNSTypeNone && cloud != kops.CloudProviderOpenstack && cloud != kops.CloudProviderHetzner && cloud != kops.CloudProviderAWS && cloud != kops.CloudProviderGCE {
-			allErrs = append(allErrs, field.Invalid(fieldPath.Child("dns", "type"), topology.DNS, fmt.Sprintf("not supported for %q", c.Spec.GetCloudProvider())))
+
+		if topology.DNS == kops.DNSTypeNone {
+			switch cloud {
+			case kops.CloudProviderOpenstack, kops.CloudProviderHetzner, kops.CloudProviderAWS, kops.CloudProviderGCE, kops.CloudProviderDO:
+			// ok
+			default:
+				allErrs = append(allErrs, field.Invalid(fieldPath.Child("dns", "type"), topology.DNS, fmt.Sprintf("not supported for %q", c.Spec.GetCloudProvider())))
+			}
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1435,6 +1435,12 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 				}
 			}
 
+		case kops.CloudProviderDO:
+			// Use any IP address that is found (including public ones)
+			for _, additionalIP := range apiserverAdditionalIPs {
+				bootConfig.APIServerIPs = append(bootConfig.APIServerIPs, additionalIP)
+			}
+
 		case kops.CloudProviderGCE:
 			// Use any IP address that is found (including public ones)
 			for _, additionalIP := range apiserverAdditionalIPs {

--- a/upup/pkg/fi/cloudup/do/authenticator.go
+++ b/upup/pkg/fi/cloudup/do/authenticator.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"k8s.io/kops/pkg/bootstrap"
+)
+
+const DOAuthenticationTokenPrefix = "x-digitalocean-droplet-id "
+
+type doAuthenticator struct {
+}
+
+var _ bootstrap.Authenticator = &doAuthenticator{}
+
+func NewAuthenticator() (bootstrap.Authenticator, error) {
+	return &doAuthenticator{}, nil
+}
+
+func (o *doAuthenticator) CreateToken(body []byte) (string, error) {
+	dropletID, err := getMetadataDropletID()
+	if err != nil {
+		return "", fmt.Errorf("unable to fetch droplet id: %w", err)
+	}
+	return DOAuthenticationTokenPrefix + dropletID, nil
+}
+
+const (
+	dropletIDMetadataURL = "http://169.254.169.254/metadata/v1/id"
+)
+
+func getMetadataDropletID() (string, error) {
+	return getMetadata(dropletIDMetadataURL)
+}
+
+func getMetadata(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("error querying droplet metadata: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("droplet metadata returned non-200 status code: %d", resp.StatusCode)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading droplet metadata: %w", err)
+	}
+
+	return string(bodyBytes), nil
+}

--- a/upup/pkg/fi/cloudup/do/verifier.go
+++ b/upup/pkg/fi/cloudup/do/verifier.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"golang.org/x/oauth2"
+	"k8s.io/kops/pkg/bootstrap"
+	"k8s.io/kops/pkg/wellknownports"
+)
+
+type DigitalOceanVerifierOptions struct {
+}
+
+type digitalOceanVerifier struct {
+	doClient *godo.Client
+}
+
+var _ bootstrap.Verifier = &digitalOceanVerifier{}
+
+func NewVerifier(ctx context.Context, opt *DigitalOceanVerifierOptions) (bootstrap.Verifier, error) {
+	accessToken := os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
+	if accessToken == "" {
+		return nil, errors.New("DIGITALOCEAN_ACCESS_TOKEN is required")
+	}
+
+	tokenSource := &TokenSource{
+		AccessToken: accessToken,
+	}
+
+	oauthClient := oauth2.NewClient(ctx, tokenSource)
+	doClient := godo.NewClient(oauthClient)
+
+	return &digitalOceanVerifier{
+		doClient: doClient,
+	}, nil
+}
+
+func (o digitalOceanVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request, token string, body []byte, useInstanceIDForNodeName bool) (*bootstrap.VerifyResult, error) {
+	if !strings.HasPrefix(token, DOAuthenticationTokenPrefix) {
+		return nil, fmt.Errorf("incorrect authorization type")
+	}
+	serverIDString := strings.TrimPrefix(token, DOAuthenticationTokenPrefix)
+
+	serverID, err := strconv.Atoi(serverIDString)
+	if err != nil {
+		return nil, fmt.Errorf("invalid authorization token")
+	}
+
+	droplet, _, err := o.doClient.Droplets.Get(ctx, serverID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get info for server %v: %w", token, err)
+	}
+
+	var addresses []string
+	var challengeEndpoints []string
+	if droplet.Networks != nil {
+		for _, nic := range droplet.Networks.V4 {
+			if nic.Type == "private" {
+				addresses = append(addresses, nic.IPAddress)
+				challengeEndpoints = append(challengeEndpoints, net.JoinHostPort(nic.IPAddress, strconv.Itoa(wellknownports.NodeupChallenge)))
+			}
+		}
+		for _, nic := range droplet.Networks.V6 {
+			if nic.Type == "private" {
+				addresses = append(addresses, nic.IPAddress)
+				challengeEndpoints = append(challengeEndpoints, net.JoinHostPort(nic.IPAddress, strconv.Itoa(wellknownports.NodeupChallenge)))
+			}
+		}
+	}
+
+	// Note: we use TLS passthrough, so we lose the client IP address.
+	// We therefore don't have a great way to verify the request.
+	// We do at least prevent duplicate node registrations, preventing some attacks here.
+
+	// The node challenge is important here though, verifying the caller has control of the IP address.
+
+	nodeName := ""
+	if len(addresses) == 0 {
+		// Name seems a better default than the first IP, but we have to match what other components are expecting
+		nodeName = droplet.Name
+	} else {
+		nodeName = addresses[0]
+	}
+
+	if len(challengeEndpoints) == 0 {
+		return nil, fmt.Errorf("cannot determine challenge endpoint for server %q", serverID)
+	}
+
+	result := &bootstrap.VerifyResult{
+		NodeName:          nodeName,
+		CertificateNames:  addresses,
+		ChallengeEndpoint: challengeEndpoints[0],
+	}
+
+	for _, tag := range droplet.Tags {
+		if strings.HasPrefix(tag, TagKubernetesInstanceGroup+":") {
+			result.InstanceGroupName = strings.TrimPrefix(tag, TagKubernetesInstanceGroup+":")
+		}
+	}
+	return result, nil
+}

--- a/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/util/pkg/vfs"
@@ -129,6 +130,13 @@ func (_ *LoadBalancer) RenderDO(t *do.DOAPITarget, a, e, changes *LoadBalancer) 
 			EntryPort:      80,
 			TargetProtocol: "http",
 			TargetPort:     80,
+		},
+		{
+			EntryProtocol:  "https",
+			EntryPort:      wellknownports.KopsControllerPort,
+			TargetProtocol: "https",
+			TargetPort:     wellknownports.KopsControllerPort,
+			TlsPassthrough: true,
 		},
 	}
 

--- a/upup/pkg/fi/cloudup/openstack/verifier.go
+++ b/upup/pkg/fi/cloudup/openstack/verifier.go
@@ -87,7 +87,7 @@ func NewOpenstackVerifier(opt *OpenStackVerifierOptions) (bootstrap.Verifier, er
 
 	kubeClient, err := newClientSet()
 	if err != nil {
-		return nil, fmt.Errorf("error building kubernetes client: %v", err)
+		return nil, fmt.Errorf("error building kubernetes client: %w", err)
 	}
 
 	return &openstackVerifier{

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -62,6 +62,7 @@ import (
 	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	gcetpm "k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
@@ -730,6 +731,9 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 
 		case kops.CloudProviderOpenstack:
 			config.Server.Provider.OpenStack = &openstack.OpenStackVerifierOptions{}
+
+		case kops.CloudProviderDO:
+			config.Server.Provider.DigitalOcean = &do.DigitalOceanVerifierOptions{}
 
 		default:
 			return "", fmt.Errorf("unsupported cloud provider %s", cluster.Spec.GetCloudProvider())

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/do"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce/gcediscovery"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm/gcetpmsigner"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
@@ -761,6 +762,14 @@ func getNodeConfigFromServers(ctx context.Context, bootConfig *nodeup.BootConfig
 			return nil, err
 		}
 		authenticator = a
+
+	case api.CloudProviderDO:
+		a, err := do.NewAuthenticator()
+		if err != nil {
+			return nil, err
+		}
+		authenticator = a
+
 	default:
 		return nil, fmt.Errorf("unsupported cloud provider for node configuration %s", bootConfig.CloudProvider)
 	}


### PR DESCRIPTION
Update DigitalOcean to support bootstrapping nodes through kops-controller.

This means we no longer need to put the DO credentials onto the nodes.