### PR TITLE
upload helper: support upload to S3 buckets that block ACLs

### DIFF
--- a/hack/upload
+++ b/hack/upload
@@ -21,7 +21,13 @@ if [[ -z "${DEST}" ]]; then
 fi
 
 if [[ "${DEST:0:5}" == "s3://" ]]; then
-  aws s3 sync ${PUBLIC:+--acl public-read} ${SRC} ${DEST}
+  acl_flag="${PUBLIC:+--acl public-read}"
+  bucket=$(echo "${DEST}" | cut -d/ -f3)
+  # S3 buckets with BucketOwnerEnforced error on attempts to set ACLs
+  if aws s3api get-bucket-ownership-controls --bucket "${bucket}" | grep -q "BucketOwnerEnforced" 2>/dev/null; then
+    acl_flag=""
+  fi
+  aws s3 sync ${acl_flag} ${SRC} ${DEST}
   exit 0
 fi
 


### PR DESCRIPTION
Similar to GCS with UBLA, S3 is now encouraging buckets that block
ACLs.  When we upload to one of these buckets, we cannot set ACLs.

When we detect one of these buckets, we simply skip setting the ACL,
assuming the object ACLs are instead managed at the bucket level, when
the bucket was created.
