### PR TITLE
add removeAll to vfs

### DIFF
--- a/pkg/client/simple/vfsclientset/clientset.go
+++ b/pkg/client/simple/vfsclientset/clientset.go
@@ -175,27 +175,9 @@ func DeleteAllClusterState(basePath vfs.Path) error {
 		return fmt.Errorf("refusing to delete: unknown file found: %s", path)
 	}
 
-	for _, path := range paths {
-		err = path.Remove()
-		if err != nil {
-			return fmt.Errorf("error deleting cluster file %s: %v", path, err)
-		}
-	}
-
-	return nil
-}
-
-func deleteAllPaths(basePath vfs.Path) error {
-	paths, err := basePath.ReadTree()
+	err = basePath.RemoveAll()
 	if err != nil {
-		return fmt.Errorf("error listing files in state store: %v", err)
-	}
-
-	for _, path := range paths {
-		err = path.Remove()
-		if err != nil {
-			return fmt.Errorf("error deleting cluster file %s: %v", path, err)
-		}
+		return fmt.Errorf("error deleting cluster files in %s: %w", basePath, err)
 	}
 
 	return nil
@@ -227,7 +209,7 @@ func (c *VFSClientset) DeleteCluster(ctx context.Context, cluster *kops.Cluster)
 		if err != nil {
 			return err
 		}
-		err = deleteAllPaths(path)
+		err = path.RemoveAll()
 		if err != nil {
 			return err
 		}
@@ -239,7 +221,7 @@ func (c *VFSClientset) DeleteCluster(ctx context.Context, cluster *kops.Cluster)
 		if err != nil {
 			return err
 		}
-		err = deleteAllPaths(path)
+		err = path.RemoveAll()
 		if err != nil {
 			return err
 		}

--- a/upup/models/vfs.go
+++ b/upup/models/vfs.go
@@ -145,6 +145,10 @@ func (p *AssetPath) Remove() error {
 	return ReadOnlyError
 }
 
+func (p *AssetPath) RemoveAll() error {
+	return ReadOnlyError
+}
+
 func (p *AssetPath) RemoveAllVersions() error {
 	return p.Remove()
 }

--- a/util/pkg/vfs/azureblob.go
+++ b/util/pkg/vfs/azureblob.go
@@ -219,6 +219,22 @@ func (p *AzureBlobPath) Remove() error {
 	return err
 }
 
+func (p *AzureBlobPath) RemoveAll() error {
+	tree, err := p.ReadTree()
+	if err != nil {
+		return err
+	}
+
+	for _, blobPath := range tree {
+		err := blobPath.Remove()
+		if err != nil {
+			return fmt.Errorf("error removing file %s: %w", blobPath, err)
+		}
+	}
+
+	return nil
+}
+
 func (p *AzureBlobPath) RemoveAllVersions() error {
 	ctx := context.TODO()
 

--- a/util/pkg/vfs/fs.go
+++ b/util/pkg/vfs/fs.go
@@ -195,6 +195,22 @@ func (p *FSPath) Remove() error {
 	return os.Remove(p.location)
 }
 
+func (p *FSPath) RemoveAll() error {
+	tree, err := p.ReadTree()
+	if err != nil {
+		return err
+	}
+
+	for _, filePath := range tree {
+		err := filePath.Remove()
+		if err != nil {
+			return fmt.Errorf("error removing file %s: %w", filePath, err)
+		}
+	}
+
+	return nil
+}
+
 func (p *FSPath) RemoveAllVersions() error {
 	return p.Remove()
 }

--- a/util/pkg/vfs/gsfs.go
+++ b/util/pkg/vfs/gsfs.go
@@ -143,6 +143,22 @@ func (p *GSPath) Remove() error {
 	}
 }
 
+func (p *GSPath) RemoveAll() error {
+	tree, err := p.ReadTree()
+	if err != nil {
+		return err
+	}
+
+	for _, objectPath := range tree {
+		err := objectPath.Remove()
+		if err != nil {
+			return fmt.Errorf("error removing file %s: %w", objectPath, err)
+		}
+	}
+
+	return nil
+}
+
 func (p *GSPath) RemoveAllVersions() error {
 	return p.Remove()
 }

--- a/util/pkg/vfs/k8sfs.go
+++ b/util/pkg/vfs/k8sfs.go
@@ -71,6 +71,10 @@ func (p *KubernetesPath) Remove() error {
 	return fmt.Errorf("KubernetesPath::Remove not supported")
 }
 
+func (p *KubernetesPath) RemoveAll() error {
+	return fmt.Errorf("KubernetesPath::RemoveAll not supported")
+}
+
 func (p *KubernetesPath) RemoveAllVersions() error {
 	return p.Remove()
 }

--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -188,6 +188,22 @@ func (p *MemFSPath) Remove() error {
 	return nil
 }
 
+func (p *MemFSPath) RemoveAll() error {
+	tree, err := p.ReadTree()
+	if err != nil {
+		return err
+	}
+
+	for _, filePath := range tree {
+		err := filePath.Remove()
+		if err != nil {
+			return fmt.Errorf("error removing file %s: %w", filePath, err)
+		}
+	}
+
+	return nil
+}
+
 func (p *MemFSPath) RemoveAllVersions() error {
 	return p.Remove()
 }

--- a/util/pkg/vfs/sshfs.go
+++ b/util/pkg/vfs/sshfs.go
@@ -116,6 +116,22 @@ func (p *SSHPath) Remove() error {
 	return nil
 }
 
+func (p *SSHPath) RemoveAll() error {
+	tree, err := p.ReadTree()
+	if err != nil {
+		return err
+	}
+
+	for _, filePath := range tree {
+		err := filePath.Remove()
+		if err != nil {
+			return fmt.Errorf("error removing file %s: %w", filePath, err)
+		}
+	}
+
+	return nil
+}
+
 func (p *SSHPath) RemoveAllVersions() error {
 	return p.Remove()
 }

--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -57,6 +57,9 @@ type Path interface {
 	// Remove deletes the file
 	Remove() error
 
+	// RemoveAll deletes all files recursively, deletes only files as returned per ReadTree
+	RemoveAll() error
+
 	// RemoveAllVersions completely deletes the file (with all its versions and markers).
 	RemoveAllVersions() error
 


### PR DESCRIPTION
Adds `RemoveAll` to vfs interface.
The goal of this method is to avoid deleting files one by one if the implementation allows it.
When deleting a cluster that ran for a while, it can take a very long time to delete all backups.

I personally use s3 as state-store, I tried to implement it for other providers when I could find useful methods in their APIs. For other providers I resolved to use a loop, it does not change from the current implementation and it could be improved later on.

For the swift implementation, I used the default 10k bulk items but I'm not sure about this one as this seems to be configurable per swift instance. 

I also found partially the same code with `RemoveAllVersion` although this only target object versions/snapshots. But this one does not seems to be used elsewhere in the code.


