### PR TITLE
Automated cherry pick of #15360: If the Cluster Name is not default the hubble relay shows TLS

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
@@ -1190,7 +1190,7 @@ metadata:
   namespace: kube-system
 spec:
   dnsNames:
-  - "*.default.hubble-grpc.cilium.io"
+  - "*.{{ .ClusterName }}.hubble-grpc.cilium.io"
   issuerRef:
     kind: Issuer
     name: networking.cilium.io


### PR DESCRIPTION
Cherry pick of #15360 on release-1.26.

#15360: If the Cluster Name is not default the hubble relay shows TLS

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```