### PR TITLE
do not mount same dir twice

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -723,7 +723,9 @@ func (b *KubeAPIServerBuilder) buildPod(ctx context.Context, kubeAPIServer *kops
 	if kubeAPIServer.AuditPolicyFile != "" {
 		// The audit config dir will be used for both the audit policy and the audit webhook config
 		auditConfigDir := filepath.Dir(kubeAPIServer.AuditPolicyFile)
-		kubemanifest.AddHostPathMapping(pod, container, "auditconfigdir", auditConfigDir)
+		if pathSrvKAPI != auditConfigDir {
+			kubemanifest.AddHostPathMapping(pod, container, "auditconfigdir", auditConfigDir)
+		}
 	}
 
 	if b.NodeupConfig.APIServerConfig.Authentication != nil {


### PR DESCRIPTION
I am trying the current master and the error is

```
syslog:May 11 07:52:10 master-helpa-6hqpcj kubelet[3235]: E0511 07:52:10.874853    3235 file.go:187] "Could not process manifest file" err="invalid pod: [spec.containers[0].volumeMounts[14].mountPath: Invalid value: \"/srv/kubernetes/kube-apiserver\": must be unique]" path="/etc/kubernetes/manifests/kube-apiserver.manifest"
```

full kube-apiserver spec https://gist.github.com/zetaab/bb55d42b4a998a9ee7695b4e98d40274

like can be seen `/srv/kubernetes/kube-apiserver` is two times there. We have been using following kops spec for years:

```
    auditPolicyFile: /srv/kubernetes/kube-apiserver/policy.yaml
    auditWebhookConfigFile: /srv/kubernetes/kube-apiserver/audit.yaml
```

but now it looks like it will break the apiserver because it will try to mount the same folder twice.

```
    - mountPath: /srv/kubernetes/kube-apiserver
      name: srvkapi
      readOnly: true
    - mountPath: /srv/kubernetes/kube-apiserver
      name: auditconfigdir
      readOnly: true
...
  - hostPath:
      path: /srv/kubernetes/kube-apiserver
    name: srvkapi
  - hostPath:
      path: /srv/kubernetes/kube-apiserver
    name: auditconfigdir