### PR TITLE
Add missing ServiceAccount in snapshot-validation-deployment

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -200,7 +200,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: 0ee38c110ae8012a720b23bf9f4f99a977ff813643739f67cc7d9c99d5a66fef
+    manifestHash: 06a1cffd153dc7f8cf75853da3683d3a68b55411883d84b9bebf049fc746b980
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1271,6 +1271,7 @@ spec:
         - mountPath: /etc/snapshot-validation-webhook/certs
           name: snapshot-validation-webhook-certs
           readOnly: true
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -207,7 +207,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: 0ee38c110ae8012a720b23bf9f4f99a977ff813643739f67cc7d9c99d5a66fef
+    manifestHash: 06a1cffd153dc7f8cf75853da3683d3a68b55411883d84b9bebf049fc746b980
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1271,6 +1271,7 @@ spec:
         - mountPath: /etc/snapshot-validation-webhook/certs
           name: snapshot-validation-webhook-certs
           readOnly: true
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -207,7 +207,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: 0ee38c110ae8012a720b23bf9f4f99a977ff813643739f67cc7d9c99d5a66fef
+    manifestHash: 06a1cffd153dc7f8cf75853da3683d3a68b55411883d84b9bebf049fc746b980
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1271,6 +1271,7 @@ spec:
         - mountPath: /etc/snapshot-validation-webhook/certs
           name: snapshot-validation-webhook-certs
           readOnly: true
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -207,7 +207,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: 0ee38c110ae8012a720b23bf9f4f99a977ff813643739f67cc7d9c99d5a66fef
+    manifestHash: 06a1cffd153dc7f8cf75853da3683d3a68b55411883d84b9bebf049fc746b980
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1271,6 +1271,7 @@ spec:
         - mountPath: /etc/snapshot-validation-webhook/certs
           name: snapshot-validation-webhook-certs
           readOnly: true
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -208,7 +208,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: 0ee38c110ae8012a720b23bf9f4f99a977ff813643739f67cc7d9c99d5a66fef
+    manifestHash: 06a1cffd153dc7f8cf75853da3683d3a68b55411883d84b9bebf049fc746b980
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1271,6 +1271,7 @@ spec:
         - mountPath: /etc/snapshot-validation-webhook/certs
           name: snapshot-validation-webhook-certs
           readOnly: true
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -200,7 +200,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: 0ee38c110ae8012a720b23bf9f4f99a977ff813643739f67cc7d9c99d5a66fef
+    manifestHash: 06a1cffd153dc7f8cf75853da3683d3a68b55411883d84b9bebf049fc746b980
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1271,6 +1271,7 @@ spec:
         - mountPath: /etc/snapshot-validation-webhook/certs
           name: snapshot-validation-webhook-certs
           readOnly: true
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -200,7 +200,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: 0ee38c110ae8012a720b23bf9f4f99a977ff813643739f67cc7d9c99d5a66fef
+    manifestHash: 06a1cffd153dc7f8cf75853da3683d3a68b55411883d84b9bebf049fc746b980
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1271,6 +1271,7 @@ spec:
         - mountPath: /etc/snapshot-validation-webhook/certs
           name: snapshot-validation-webhook-certs
           readOnly: true
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/upup/models/cloudup/resources/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml.template
+++ b/upup/models/cloudup/resources/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml.template
@@ -1218,6 +1218,7 @@ spec:
         - name: snapshot-validation-webhook-certs
           secret:
             secretName: snapshot-validation-secret
+      serviceAccountName: snapshot-controller
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Deployment manifest of snapshot-validation-deployment was missing a service account and hence was using the default one that exists in kube-system namespace.
This caused it to log `Failed to watch *v1.VolumeSnapshotClass` errors