### PR TITLE
scaleway: fix naming and typos

### DIFF
--- a/pkg/nodeidentity/scaleway/identify.go
+++ b/pkg/nodeidentity/scaleway/identify.go
@@ -137,17 +137,13 @@ func stringKeyFunc(obj interface{}) (string, error) {
 // getServer queries Scaleway for the server with the specified ID, returning an error if not found
 func (i *nodeIdentifier) getServer(ctx context.Context, id string) (*instance.Server, error) {
 	api := instance.NewAPI(i.client)
-	zone, exists := i.client.GetDefaultZone()
-	if !exists {
-		return nil, fmt.Errorf("client default zone is empty")
-	}
 	uuid := strings.Split(id, "/")
 	if len(uuid) != 3 {
 		return nil, fmt.Errorf("unexpected format for server id %s", id)
 	}
 	server, err := api.GetServer(&instance.GetServerRequest{
 		ServerID: uuid[2],
-		Zone:     scw.Zone(zone),
+		Zone:     scw.Zone(uuid[1]),
 	}, scw.WithContext(ctx))
 	if err != nil || server == nil {
 		return nil, fmt.Errorf("failed to get server %s: %w", id, err)

--- a/upup/models/cloudup/resources/addons/scaleway-cloud-controller.addons.k8s.io/k8s-1.24.yaml.template
+++ b/upup/models/cloudup/resources/addons/scaleway-cloud-controller.addons.k8s.io/k8s-1.24.yaml.template
@@ -11,9 +11,9 @@ stringData:
   SCW_SECRET_KEY: {{ SCW_SECRET_KEY }}
   # Project ID could also be an Organization ID
   SCW_DEFAULT_PROJECT_ID: {{ SCW_DEFAULT_PROJECT_ID }}
-  # Region is where your loadbalancer will be created, ex: nl-ams, nl-ams
+  # Region is where your loadbalancer will be created, ex: fr-par, nl-ams
   SCW_DEFAULT_REGION: {{ SCW_DEFAULT_REGION }}
-  # Zone is where your servers and volumes will be created, ex: nl-ams-1, nl-ams-2
+  # Zone is where your servers and volumes will be created, ex: fr-par-1, nl-ams-2
   SCW_DEFAULT_ZONE: {{ SCW_DEFAULT_ZONE }}
 ---
 apiVersion: apps/v1

--- a/upup/models/cloudup/resources/addons/scaleway-csi-driver.addons.k8s.io/k8s-1.24.yaml.template
+++ b/upup/models/cloudup/resources/addons/scaleway-csi-driver.addons.k8s.io/k8s-1.24.yaml.template
@@ -12,9 +12,9 @@ stringData:
   SCW_SECRET_KEY: {{ SCW_SECRET_KEY }}
   # Project ID could also be an Organization ID
   SCW_DEFAULT_PROJECT_ID: {{ SCW_DEFAULT_PROJECT_ID }}
-  # Region is where your load-balancer will be created, ex: nl-ams, nl-ams
+  # Region is where your load-balancer will be created, ex: fr-par, nl-ams
   SCW_DEFAULT_REGION: {{ SCW_DEFAULT_REGION }}
-  # Zone is where your servers and volumes will be created, ex: nl-ams-1, nl-ams-2
+  # Zone is where your servers and volumes will be created, ex: fr-par-1, nl-ams-2
   SCW_DEFAULT_ZONE: {{ SCW_DEFAULT_ZONE }}
 ---
 apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
This PR fixes a few details in various files:
- in the manifests for CCM and CSI: there were typos in the comments
- in node identifier: we can get the zone from the uuid instead of the client
- in GetClusterServers: the parameter serverName is not well named, I think it would be better to call it instanceGroupName instead