### PR TITLE
Make NLBs dualstack when they're in IPv6-capable subnets

### DIFF
--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -186,14 +186,10 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			Listeners:        nlbListeners,
 			TargetGroups:     make([]*awstasks.TargetGroup, 0),
 
-			Tags:          tags,
-			ForAPIServer:  true,
-			VPC:           b.LinkToVPC(),
-			Type:          fi.PtrTo("network"),
-			IpAddressType: fi.PtrTo("ipv4"),
-		}
-		if b.UseIPv6ForAPI() {
-			nlb.IpAddressType = fi.PtrTo("dualstack")
+			Tags:         tags,
+			ForAPIServer: true,
+			VPC:          b.LinkToVPC(),
+			Type:         fi.PtrTo("network"),
 		}
 
 		clb = &awstasks.ClassicLoadBalancer{

--- a/pkg/model/awsmodel/bastion.go
+++ b/pkg/model/awsmodel/bastion.go
@@ -333,18 +333,16 @@ func (b *BastionModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			TargetLoadBalancer: b.LinkToNLB("bastion"),
 		}
 		c.AddTask(t)
-		if *nlb.IpAddressType == "dualstack" {
-			t := &awstasks.DNSName{
-				Name:      fi.PtrTo(publicName + "-AAAA"),
-				Lifecycle: b.Lifecycle,
+		t = &awstasks.DNSName{
+			Name:      fi.PtrTo(publicName + "-AAAA"),
+			Lifecycle: b.Lifecycle,
 
-				Zone:               b.LinkToDNSZone(),
-				ResourceName:       fi.PtrTo(publicName),
-				ResourceType:       fi.PtrTo("AAAA"),
-				TargetLoadBalancer: b.LinkToNLB("bastion"),
-			}
-			c.AddTask(t)
+			Zone:               b.LinkToDNSZone(),
+			ResourceName:       fi.PtrTo(publicName),
+			ResourceType:       fi.PtrTo("AAAA"),
+			TargetLoadBalancer: b.LinkToNLB("bastion"),
 		}
+		c.AddTask(t)
 
 	}
 	return nil

--- a/pkg/model/awsmodel/dns.go
+++ b/pkg/model/awsmodel/dns.go
@@ -108,16 +108,14 @@ func (b *DNSModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				ResourceType:       fi.PtrTo("A"),
 				TargetLoadBalancer: targetLoadBalancer,
 			})
-			if b.UseIPv6ForAPI() {
-				c.AddTask(&awstasks.DNSName{
-					Name:               fi.PtrTo(b.Cluster.Spec.API.PublicName + "-AAAA"),
-					ResourceName:       fi.PtrTo(b.Cluster.Spec.API.PublicName),
-					Lifecycle:          b.Lifecycle,
-					Zone:               b.LinkToDNSZone(),
-					ResourceType:       fi.PtrTo("AAAA"),
-					TargetLoadBalancer: targetLoadBalancer,
-				})
-			}
+			c.AddTask(&awstasks.DNSName{
+				Name:               fi.PtrTo(b.Cluster.Spec.API.PublicName + "-AAAA"),
+				ResourceName:       fi.PtrTo(b.Cluster.Spec.API.PublicName),
+				Lifecycle:          b.Lifecycle,
+				Zone:               b.LinkToDNSZone(),
+				ResourceType:       fi.PtrTo("AAAA"),
+				TargetLoadBalancer: targetLoadBalancer,
+			})
 		}
 	}
 
@@ -141,16 +139,14 @@ func (b *DNSModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 					TargetLoadBalancer: targetLoadBalancer,
 				})
 			}
-			if b.UseIPv6ForAPI() {
-				c.EnsureTask(&awstasks.DNSName{
-					Name:               fi.PtrTo(b.Cluster.APIInternalName() + "-AAAA"),
-					ResourceName:       fi.PtrTo(b.Cluster.APIInternalName()),
-					Lifecycle:          b.Lifecycle,
-					Zone:               b.LinkToDNSZone(),
-					ResourceType:       fi.PtrTo("AAAA"),
-					TargetLoadBalancer: targetLoadBalancer,
-				})
-			}
+			c.EnsureTask(&awstasks.DNSName{
+				Name:               fi.PtrTo(b.Cluster.APIInternalName() + "-AAAA"),
+				ResourceName:       fi.PtrTo(b.Cluster.APIInternalName()),
+				Lifecycle:          b.Lifecycle,
+				Zone:               b.LinkToDNSZone(),
+				ResourceType:       fi.PtrTo("AAAA"),
+				TargetLoadBalancer: targetLoadBalancer,
+			})
 		}
 	}
 

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -352,25 +352,6 @@ func (b *KopsModelContext) IsIPv6Only() bool {
 	return b.Cluster.Spec.IsIPv6Only()
 }
 
-func (b *KopsModelContext) UseIPv6ForAPI() bool {
-	for _, ig := range b.InstanceGroups {
-		if ig.Spec.Role != kops.InstanceGroupRoleControlPlane && ig.Spec.Role != kops.InstanceGroupRoleAPIServer {
-			break
-		}
-		for _, igSubnetName := range ig.Spec.Subnets {
-			for _, clusterSubnet := range b.Cluster.Spec.Networking.Subnets {
-				if igSubnetName != clusterSubnet.Name {
-					continue
-				}
-				if clusterSubnet.IPv6CIDR != "" {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
 // WellKnownServiceIP returns a service ip with the service cidr
 func (b *KopsModelContext) WellKnownServiceIP(id int) (net.IP, error) {
 	return components.WellKnownServiceIP(&b.Cluster.Spec.Networking, id)

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -752,6 +752,17 @@ resource "aws_route53_record" "api-bastionuserdata-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-bastionuserdata-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-bastionuserdata-example-com.dns_name
+    zone_id                = aws_elb.api-bastionuserdata-example-com.zone_id
+  }
+  name    = "api.bastionuserdata.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "bastionuserdata-example-com" {
   tags = {
     "KubernetesCluster"                                 = "bastionuserdata.example.com"

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -652,6 +652,17 @@ resource "aws_route53_record" "api-complex-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-complex-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_lb.api-complex-example-com.dns_name
+    zone_id                = aws_lb.api-complex-example-com.zone_id
+  }
+  name    = "api.complex.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "complex-example-com" {
   tags = {
     "KubernetesCluster"                         = "complex.example.com"

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -876,6 +876,17 @@ resource "aws_route53_record" "api-existingsg-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-existingsg-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-existingsg-example-com.dns_name
+    zone_id                = aws_elb.api-existingsg-example-com.zone_id
+  }
+  name    = "api.existingsg.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "existingsg-example-com" {
   tags = {
     "KubernetesCluster"                            = "existingsg.example.com"

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -571,6 +571,17 @@ resource "aws_route53_record" "api-externalpolicies-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-externalpolicies-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-externalpolicies-example-com.dns_name
+    zone_id                = aws_elb.api-externalpolicies-example-com.zone_id
+  }
+  name    = "api.externalpolicies.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "externalpolicies-example-com" {
   tags = {
     "KubernetesCluster"                                  = "externalpolicies.example.com"

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -733,6 +733,17 @@ resource "aws_route53_record" "api-private-shared-ip-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-private-shared-ip-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-private-shared-ip-example-com.dns_name
+    zone_id                = aws_elb.api-private-shared-ip-example-com.zone_id
+  }
+  name    = "api.private-shared-ip.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "private-shared-ip-example-com" {
   tags = {
     "KubernetesCluster"                                   = "private-shared-ip.example.com"

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -700,6 +700,17 @@ resource "aws_route53_record" "api-private-shared-subnet-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-private-shared-subnet-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-private-shared-subnet-example-com.dns_name
+    zone_id                = aws_elb.api-private-shared-subnet-example-com.zone_id
+  }
+  name    = "api.private-shared-subnet.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_s3_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_cluster-completed.spec_content")

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -747,6 +747,17 @@ resource "aws_route53_record" "api-privatecalico-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-privatecalico-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-privatecalico-example-com.dns_name
+    zone_id                = aws_elb.api-privatecalico-example-com.zone_id
+  }
+  name    = "api.privatecalico.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "private-us-test-1a-privatecalico-example-com" {
   tags = {
     "KubernetesCluster"                               = "privatecalico.example.com"

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -751,6 +751,17 @@ resource "aws_route53_record" "api-privatecanal-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-privatecanal-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-privatecanal-example-com.dns_name
+    zone_id                = aws_elb.api-privatecanal-example-com.zone_id
+  }
+  name    = "api.privatecanal.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "private-us-test-1a-privatecanal-example-com" {
   tags = {
     "KubernetesCluster"                              = "privatecanal.example.com"

--- a/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
@@ -751,6 +751,17 @@ resource "aws_route53_record" "api-privatecilium-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-privatecilium-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-privatecilium-example-com.dns_name
+    zone_id                = aws_elb.api-privatecilium-example-com.zone_id
+  }
+  name    = "api.privatecilium.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "private-us-test-1a-privatecilium-example-com" {
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -751,6 +751,17 @@ resource "aws_route53_record" "api-privatecilium-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-privatecilium-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-privatecilium-example-com.dns_name
+    zone_id                = aws_elb.api-privatecilium-example-com.zone_id
+  }
+  name    = "api.privatecilium.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "private-us-test-1a-privatecilium-example-com" {
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -751,6 +751,17 @@ resource "aws_route53_record" "api-privatecilium-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-privatecilium-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-privatecilium-example-com.dns_name
+    zone_id                = aws_elb.api-privatecilium-example-com.zone_id
+  }
+  name    = "api.privatecilium.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "private-us-test-1a-privatecilium-example-com" {
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -768,6 +768,17 @@ resource "aws_route53_record" "api-privateciliumadvanced-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-privateciliumadvanced-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-privateciliumadvanced-example-com.dns_name
+    zone_id                = aws_elb.api-privateciliumadvanced-example-com.zone_id
+  }
+  name    = "api.privateciliumadvanced.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "private-us-test-1a-privateciliumadvanced-example-com" {
   tags = {
     "KubernetesCluster"                                       = "privateciliumadvanced.example.com"

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -861,6 +861,17 @@ resource "aws_route53_record" "api-privatedns1-example-com" {
   zone_id = "/hostedzone/Z2AFAKE1ZON3NO"
 }
 
+resource "aws_route53_record" "api-privatedns1-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-privatedns1-example-com.dns_name
+    zone_id                = aws_elb.api-privatedns1-example-com.zone_id
+  }
+  name    = "api.privatedns1.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z2AFAKE1ZON3NO"
+}
+
 resource "aws_route53_zone_association" "internal-example-com" {
   vpc_id  = aws_vpc.privatedns1-example-com.id
   zone_id = "/hostedzone/Z2AFAKE1ZON3NO"

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -742,6 +742,17 @@ resource "aws_route53_record" "api-privatedns2-example-com" {
   zone_id = "/hostedzone/Z3AFAKE1ZOMORE"
 }
 
+resource "aws_route53_record" "api-privatedns2-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-privatedns2-example-com.dns_name
+    zone_id                = aws_elb.api-privatedns2-example-com.zone_id
+  }
+  name    = "api.privatedns2.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z3AFAKE1ZOMORE"
+}
+
 resource "aws_route_table" "private-us-test-1a-privatedns2-example-com" {
   tags = {
     "KubernetesCluster"                             = "privatedns2.example.com"

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -751,6 +751,17 @@ resource "aws_route53_record" "api-privateflannel-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-privateflannel-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-privateflannel-example-com.dns_name
+    zone_id                = aws_elb.api-privateflannel-example-com.zone_id
+  }
+  name    = "api.privateflannel.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "private-us-test-1a-privateflannel-example-com" {
   tags = {
     "KubernetesCluster"                                = "privateflannel.example.com"

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -756,6 +756,17 @@ resource "aws_route53_record" "api-privatekopeio-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-privatekopeio-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-privatekopeio-example-com.dns_name
+    zone_id                = aws_elb.api-privatekopeio-example-com.zone_id
+  }
+  name    = "api.privatekopeio.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "private-us-test-1a-privatekopeio-example-com" {
   tags = {
     "KubernetesCluster"                               = "privatekopeio.example.com"

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -783,6 +783,17 @@ resource "aws_route53_record" "api-privateweave-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-privateweave-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-privateweave-example-com.dns_name
+    zone_id                = aws_elb.api-privateweave-example-com.zone_id
+  }
+  name    = "api.privateweave.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_route_table" "private-us-test-1a-privateweave-example-com" {
   tags = {
     "KubernetesCluster"                              = "privateweave.example.com"

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -708,6 +708,17 @@ resource "aws_route53_record" "api-unmanaged-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_route53_record" "api-unmanaged-example-com-AAAA" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_elb.api-unmanaged-example-com.dns_name
+    zone_id                = aws_elb.api-unmanaged-example-com.zone_id
+  }
+  name    = "api.unmanaged.example.com"
+  type    = "AAAA"
+  zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
+}
+
 resource "aws_s3_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_cluster-completed.spec_content")

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -479,6 +479,16 @@ func (e *NetworkLoadBalancer) Normalize(c *fi.CloudupContext) error {
 	sort.Stable(OrderSubnetMappingsByName(e.SubnetMappings))
 	sort.Stable(OrderListenersByPort(e.Listeners))
 	sort.Stable(OrderTargetGroupsByName(e.TargetGroups))
+
+	e.IpAddressType = fi.PtrTo("dualstack")
+	for _, subnet := range e.SubnetMappings {
+		for _, clusterSubnet := range c.T.Cluster.Spec.Networking.Subnets {
+			if clusterSubnet.Name == fi.ValueOf(subnet.Subnet.ShortName) && clusterSubnet.IPv6CIDR == "" {
+				e.IpAddressType = fi.PtrTo("ipv4")
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Makes NLBs be dualstack whenever possible, which is when the subnets assigned to the load balancer have IPv6 addresses. Previously kOps would try to decide based on whether the control plane or apiserver instance groups were in at least one subnet with IPv6, but a bug in that code would cause it to incorrectly make IPv4-only NLBs.

Also makes the bastion NLB dualstack when possible.

Always registers AAAA alias records for the API and bastion load balancers. There is no downside to this.
