### PR TITLE
Add a mutex lock to 'awsCloudInstances' map

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -275,8 +275,8 @@ func getCloudInstancesFromRegion(region string) AWSCloud {
 	cloud, ok := awsCloudInstances.regionMap[region]
 	if !ok {
 		return nil
-
 	}
+
 	return cloud
 }
 

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -268,8 +268,20 @@ func updateAwsCloudInstances(region string, cloud AWSCloud) {
 	awsCloudInstances.mutex.Unlock()
 }
 
+func getCloudInstancesFromRegion(region string) AWSCloud {
+	awsCloudInstances.mutex.Lock()
+	defer awsCloudInstances.mutex.Unlock()
+
+	cloud, ok := awsCloudInstances.regionMap[region]
+	if !ok {
+		return nil
+
+	}
+	return cloud
+}
+
 func NewAWSCloud(region string, tags map[string]string) (AWSCloud, error) {
-	raw := awsCloudInstances.regionMap[region]
+	raw := getCloudInstancesFromRegion(region)
 
 	if raw == nil {
 		c := &awsCloudImplementation{

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -55,7 +55,7 @@ var _ fi.Cloud = (*MockAWSCloud)(nil)
 
 func InstallMockAWSCloud(region string, zoneLetters string) *MockAWSCloud {
 	i := BuildMockAWSCloud(region, zoneLetters)
-	awsCloudInstances[region] = i
+	updateAwsCloudInstances(region, i)
 	allRegions = []*ec2.Region{
 		{RegionName: aws.String(region)},
 	}


### PR DESCRIPTION
We're using terraform kops provider to manage our AWS kops clusters. Time to time we hit a race condition with the stack trace points to `awsup.NewAWSCloud` function, when writing to a concurrent map, that maintains a map between regions and `AWSCloud` objects.

This PR changes this to variable so it belongs to a new type, that wraps the map into its own struct where access is controlled by a mutex lock.

Let me know if that makes sense to you all.

Thanks for building this awesome project!