### PR TITLE
scaleway: none DNS option available

### DIFF
--- a/docs/getting_started/scaleway.md
+++ b/docs/getting_started/scaleway.md
@@ -63,6 +63,8 @@ Note that for now you can only create a kops cluster in a single availability zo
 # The default cluster uses ubuntu images on DEV1-M machines with cilium as Container Network Interface
   # This creates a cluster with the gossip DNS in zone fr-par-1
 kops create cluster --cloud=scaleway --name=mycluster.k8s.local --zones=fr-par-1 --yes
+  # This creates a cluster with no DNS in zone nl-ams-2
+kops create cluster --cloud=scaleway --name=my.cluster --zones=nl-ams-2 --yes
 ```
 
 ### Editing your cluster

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -525,7 +525,7 @@ func validateTopology(c *kops.Cluster, topology *kops.TopologySpec, fieldPath *f
 
 		if topology.DNS == kops.DNSTypeNone {
 			switch cloud {
-			case kops.CloudProviderOpenstack, kops.CloudProviderHetzner, kops.CloudProviderAWS, kops.CloudProviderGCE, kops.CloudProviderDO:
+			case kops.CloudProviderOpenstack, kops.CloudProviderHetzner, kops.CloudProviderAWS, kops.CloudProviderGCE, kops.CloudProviderDO, kops.CloudProviderScaleway:
 			// ok
 			default:
 				allErrs = append(allErrs, field.Invalid(fieldPath.Child("dns", "type"), topology.DNS, fmt.Sprintf("not supported for %q", c.Spec.GetCloudProvider())))

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1435,7 +1435,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 				}
 			}
 
-		case kops.CloudProviderDO:
+		case kops.CloudProviderDO, kops.CloudProviderScaleway:
 			// Use any IP address that is found (including public ones)
 			for _, additionalIP := range apiserverAdditionalIPs {
 				bootConfig.APIServerIPs = append(bootConfig.APIServerIPs, additionalIP)


### PR DESCRIPTION
This PR adds the possibility for Scaleway clusters to use no DNS.