### PR TITLE
Spotinst: add feature spread nodes by count/vcpu to markets

### DIFF
--- a/docs/getting_started/spot-ocean.md
+++ b/docs/getting_started/spot-ocean.md
@@ -178,7 +178,7 @@ metadata:
 ## Cluster Metadata Labels
 ```yaml
 # cluster.yaml
-# An Cluster with Ocean configuration.
+# A Cluster with Ocean configuration.
 ---
 apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
@@ -191,10 +191,10 @@ metadata:
 ```
 
 
-| Label | Description                                                           | Default |
-|---|-----------------------------------------------------------------------|---|
-| `spotinst.io/strategy-cluster-spread-nodes-by` | Specify how Ocean will spread the nodes across markets by this value. | `count` |
-| `spotinst.io/strategy-cluster-orientation-availability-vs-cost` | Specify approach that Ocean takes while launching nodes.              | `balanced` |
+| Label | Description                                                                        | Default |
+|---|---|---|
+| `spotinst.io/strategy-cluster-spread-nodes-by` | Specify how Ocean will spread the nodes across markets by this value [vcpu,count]. | `count` |
+| `spotinst.io/strategy-cluster-orientation-availability-vs-cost` | Specify approach [cost,balanced,cheapest] that Ocean takes while launching nodes.  | `balanced` |
 
 ## Documentation
 

--- a/docs/getting_started/spot-ocean.md
+++ b/docs/getting_started/spot-ocean.md
@@ -146,7 +146,7 @@ metadata:
   ...
 ```
 
-## Metadata Labels
+## InstanceGroup Metadata Labels
 
 | Label | Description | Default |
 |---|---|---|
@@ -174,6 +174,27 @@ metadata:
 | `spotinst.io/autoscaler-resource-limits-max-vcpu` | Specify the maximum number of virtual CPUs that can be allocated to the cluster. | none |
 | `spotinst.io/autoscaler-resource-limits-max-memory` | Specify the maximum amount of total physical memory (in GiB units) that can be allocated to the cluster. | none |
 | `spotinst.io/restrict-scale-down` | Specify whether the scale-down activities should be restricted. | none |
+
+## Cluster Metadata Labels
+```yaml
+# cluster.yaml
+# An Cluster with Ocean configuration.
+---
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  name: "example"
+  labels:
+    spotinst.io/strategy-cluster-spread-nodes-by: "count"
+    spotinst.io/strategy-cluster-orientation-availability-vs-cost: "balanced"    
+  ...
+```
+
+
+| Label | Description                                                           | Default |
+|---|-----------------------------------------------------------------------|---|
+| `spotinst.io/strategy-cluster-spread-nodes-by` | Specify how Ocean will spread the nodes across markets by this value. | `count` |
+| `spotinst.io/strategy-cluster-orientation-availability-vs-cost` | Specify approach that Ocean takes while launching nodes.              | `balanced` |
 
 ## Documentation
 

--- a/pkg/model/awsmodel/spotinst.go
+++ b/pkg/model/awsmodel/spotinst.go
@@ -127,6 +127,10 @@ const (
 	// InstanceGroupLabelRestrictScaleDown is the metadata label used on the
 	// instance group to specify whether the scale-down activities should be restricted.
 	SpotInstanceGroupLabelRestrictScaleDown = "spotinst.io/restrict-scale-down"
+
+	// SpotClusterLabelSpreadNodesBy is the cloud  label used on the
+	// cluster spec to specify how Ocean will spread the nodes across markets by this value
+	SpotClusterLabelSpreadNodesBy = "spotinstSpreadNodesBy"
 )
 
 // SpotInstanceGroupModelBuilder configures SpotInstanceGroup objects
@@ -372,6 +376,13 @@ func (b *SpotInstanceGroupModelBuilder) buildOcean(c *fi.CloudupModelBuilderCont
 	}
 
 	klog.V(4).Infof("Detected default launch spec: %q", b.AutoscalingGroupName(ig))
+
+	for k, v := range b.Cluster.Labels {
+		switch k {
+		case SpotClusterLabelSpreadNodesBy:
+			ocean.SpreadNodesBy = fi.PtrTo(v)
+		}
+	}
 
 	// Image.
 	ocean.ImageID = fi.PtrTo(ig.Spec.Image)

--- a/pkg/model/awsmodel/spotinst.go
+++ b/pkg/model/awsmodel/spotinst.go
@@ -130,7 +130,11 @@ const (
 
 	// SpotClusterLabelSpreadNodesBy is the cloud  label used on the
 	// cluster spec to specify how Ocean will spread the nodes across markets by this value
-	SpotClusterLabelSpreadNodesBy = "spotinstSpreadNodesBy"
+	SpotClusterLabelSpreadNodesBy = "spotinst.io/strategy-cluster-spread-nodes-by"
+
+	// SpotClusterLabelStrategyClusterOrientationAvailabilityVsCost is the metadata label used on the
+	// instance group to specify how to optimize towards  continuity and/or cost-effective infrastructure
+	SpotClusterLabelStrategyClusterOrientationAvailabilityVsCost = "spotinst.io/strategy-cluster-orientation-availability-vs-cost"
 )
 
 // SpotInstanceGroupModelBuilder configures SpotInstanceGroup objects
@@ -381,6 +385,8 @@ func (b *SpotInstanceGroupModelBuilder) buildOcean(c *fi.CloudupModelBuilderCont
 		switch k {
 		case SpotClusterLabelSpreadNodesBy:
 			ocean.SpreadNodesBy = fi.PtrTo(v)
+		case SpotClusterLabelStrategyClusterOrientationAvailabilityVsCost:
+			ocean.AvailabilityVsCost = fi.PtrTo(string(spotinsttasks.NormalizeClusterOrientation(&v)))
 		}
 	}
 


### PR DESCRIPTION
Ocean will spread the nodes across markets by this value,"vcpu" or "count"