### PR TITLE
openstack designate fixes

### DIFF
--- a/dns-controller/cmd/dns-controller/main.go
+++ b/dns-controller/cmd/dns-controller/main.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/aws/route53"
 	_ "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/do"
 	_ "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/google/clouddns"
+	_ "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/openstack/designate"
 	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/protokube/pkg/gossip"
 	gossipdns "k8s.io/kops/protokube/pkg/gossip/dns"
@@ -66,7 +67,7 @@ func main() {
 	flags.BoolVar(&watchIngress, "watch-ingress", true, "Configure hostnames found in ingress resources")
 	flags.StringSliceVar(&gossipSeeds, "gossip-seed", gossipSeeds, "If set, will enable gossip zones and seed using the provided addresses")
 	flags.StringSliceVarP(&zones, "zone", "z", []string{}, "Configure permitted zones and their mappings")
-	flags.StringVar(&dnsProviderID, "dns", "aws-route53", "DNS provider we should use (aws-route53, google-clouddns, digitalocean, gossip)")
+	flags.StringVar(&dnsProviderID, "dns", "aws-route53", "DNS provider we should use (aws-route53, google-clouddns, digitalocean, gossip, openstack-designate)")
 	flag.StringVar(&gossipProtocol, "gossip-protocol", "mesh", "mesh/memberlist")
 	flags.StringVar(&gossipListen, "gossip-listen", fmt.Sprintf("0.0.0.0:%d", wellknownports.DNSControllerGossipWeaveMesh), "The address on which to listen if gossip is enabled")
 	flags.StringVar(&gossipSecret, "gossip-secret", gossipSecret, "Secret to use to secure gossip")

--- a/dnsprovider/pkg/dnsprovider/providers/openstack/designate/designate.go
+++ b/dnsprovider/pkg/dnsprovider/providers/openstack/designate/designate.go
@@ -42,16 +42,15 @@ func init() {
 
 func newDesignate(_ io.Reader) (*Interface, error) {
 	oc := vfs.OpenstackConfig{}
+	region, err := oc.GetRegion()
+	if err != nil {
+		return nil, fmt.Errorf("error finding openstack region: %v", err)
+	}
+
 	ao, err := oc.GetCredential()
 	if err != nil {
 		return nil, err
 	}
-
-	/*
-		pc, err := openstack.AuthenticatedClient(ao)
-		if err != nil {
-			return nil, fmt.Errorf("error building openstack authenticated client: %v", err)
-		}*/
 
 	provider, err := openstack.NewClient(ao.IdentityEndpoint)
 	if err != nil {
@@ -76,11 +75,10 @@ func newDesignate(_ io.Reader) (*Interface, error) {
 		return nil, fmt.Errorf("error building openstack authenticated client: %v", err)
 	}
 
-	endpointOpt, err := oc.GetServiceConfig("Designate")
-	if err != nil {
-		return nil, err
-	}
-	sc, err := openstack.NewDNSV2(provider, endpointOpt)
+	sc, err := openstack.NewDNSV2(provider, gophercloud.EndpointOpts{
+		Type:   "dns",
+		Region: region,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating a ServiceClient: %v", err)
 	}

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -56,6 +56,10 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: "127.0.0.1"
+{{ range $name, $value := DNSControllerEnvs }}
+        - name: {{ $name }}
+          value: {{ $value }}
+{{ end }}
 {{- if .Networking.EgressProxy }}
 {{ range $name, $value := ProxyEnv }}
         - name: {{ $name }}

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -252,6 +252,8 @@ type OpenstackCloud interface {
 
 	// ListDNSRecordsets will list the DNS recordsets for the given zone id
 	ListDNSRecordsets(zoneID string, opt recordsets.ListOptsBuilder) ([]recordsets.RecordSet, error)
+	DeleteDNSRecordset(zoneID string, rrsetID string) error
+
 	GetLB(loadbalancerID string) (*loadbalancers.LoadBalancer, error)
 	GetLBStats(loadbalancerID string) (*loadbalancers.Stats, error)
 	CreateLB(opt loadbalancers.CreateOptsBuilder) (*loadbalancers.LoadBalancer, error)
@@ -412,13 +414,10 @@ func buildClients(provider *gophercloud.ProviderClient, tags map[string]string, 
 
 	var dnsClient *gophercloud.ServiceClient
 	if hasDNS {
-		// TODO: This should be replaced with the environment variable methods as done above
-		endpointOpt, err := config.GetServiceConfig("Designate")
-		if err != nil {
-			return nil, fmt.Errorf("failed to get service config: %w", err)
-		}
-
-		dnsClient, err = openstack.NewDNSV2(provider, endpointOpt)
+		dnsClient, err = openstack.NewDNSV2(provider, gophercloud.EndpointOpts{
+			Type:   "dns",
+			Region: region,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("error building dns client: %w", err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/mock_cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/mock_cloud.go
@@ -405,6 +405,10 @@ func (c *MockCloud) ListDNSRecordsets(zoneID string, opt recordsets.ListOptsBuil
 	return listDNSRecordsets(c, zoneID, opt)
 }
 
+func (c *MockCloud) DeleteDNSRecordset(zoneID string, rrsetID string) error {
+	return deleteDNSRecordset(c, zoneID, rrsetID)
+}
+
 func (c *MockCloud) ListInstances(opt servers.ListOptsBuilder) ([]servers.Server, error) {
 	return listInstances(c, opt)
 }

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -166,6 +166,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	// will return openstack external ccm image location for current kubernetes version
 	dest["OpenStackCCMTag"] = tf.OpenStackCCMTag
 	dest["OpenStackCSITag"] = tf.OpenStackCSITag
+	dest["DNSControllerEnvs"] = tf.DNSControllerEnvs
 	dest["ProxyEnv"] = tf.ProxyEnv
 
 	dest["KopsSystemEnv"] = tf.KopsSystemEnv
@@ -610,6 +611,8 @@ func (tf *TemplateFunctions) DNSControllerArgv() ([]string, error) {
 			argv = append(argv, "--dns=google-clouddns")
 		case kops.CloudProviderDO:
 			argv = append(argv, "--dns=digitalocean")
+		case kops.CloudProviderOpenstack:
+			argv = append(argv, "--dns=openstack-designate")
 
 		default:
 			return nil, fmt.Errorf("unhandled cloudprovider %q", cluster.Spec.GetCloudProvider())
@@ -805,6 +808,20 @@ func (tf *TemplateFunctions) ExternalDNSArgv() ([]string, error) {
 	}
 
 	return argv, nil
+}
+
+func (tf *TemplateFunctions) DNSControllerEnvs() map[string]string {
+	if tf.Cluster.Spec.GetCloudProvider() != kops.CloudProviderOpenstack {
+		return nil
+	}
+	envs := env.BuildSystemComponentEnvVars(&tf.Cluster.Spec)
+	out := make(map[string]string)
+	for k, v := range envs {
+		if strings.HasPrefix(k, "OS_") {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 func (tf *TemplateFunctions) ProxyEnv() map[string]string {


### PR DESCRIPTION
fixes #15337

@fchiacchiaretta this at least now makes new cluster and designate zone records are updated after masters are started.

tested in devstack, so I could not roll out full cluster to test everything - but at least master was starting.

```
./kops create cluster \
  --cloud openstack \
  --name jessetesti.foo.com \
  --state ${KOPS_STATE_STORE} \
  --zones nova \
  --network-cidr 10.2.0.0/16 \
  --image ubuntu-2004-170423-devops \
  --master-count=1 \
  --node-count=1 \
  --node-size m1.small \
  --master-size m1.medium \
  --etcd-storage-type lvmdriver-1 \
  --topology private \
  --networking calico \
  --api-loadbalancer-type public \
  --os-octavia=true \
  --os-ext-net public
```

```
openstack recordset list 316634f8-1e74-45e7-a1fe-43006d9c30c2
+--------------------------------------+----------------------------------------------+------+---------------------------------------------------------------+--------+--------+
| id                                   | name                                         | type | records                                                       | status | action |
+--------------------------------------+----------------------------------------------+------+---------------------------------------------------------------+--------+--------+
| 046b8ec2-1bc1-456e-b559-cc0dfacc94fe | foo.com.                                     | NS   | ns1.devstack.org.                                             | ACTIVE | NONE   |
| dc4107f5-bdf1-4836-9623-1918b5546343 | foo.com.                                     | SOA  | ns1.devstack.org. foo.foo.com. 1684345881 3528 600 86400 3600 | ACTIVE | NONE   |
| 144cf416-9924-46e1-a7bf-bf62f9dcfe66 | kops-controller.internal.jessetesti.foo.com. | A    | 10.2.33.207                                                   | ACTIVE | NONE   |
| 6e0a657b-e48d-420e-9ae6-b8c032dfc41c | api.internal.jessetesti.foo.com.             | A    | 10.2.33.207                                                   | ACTIVE | NONE   |
```