### PR TITLE
bump k8s versions in alpha following May releases

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -87,17 +87,17 @@ spec:
     networking:
       kubenet: {}
   kubernetesVersions:
-  - range: ">=1.27.0"
+  - range: ">=1.27.2"
     recommendedVersion: 1.27.2
-    requiredVersion: 1.27.0
+    requiredVersion: 1.27.2
   - range: ">=1.26.0"
-    recommendedVersion: 1.26.5
+    recommendedVersion: 1.26.6
     requiredVersion: 1.26.0
   - range: ">=1.25.0"
-    recommendedVersion: 1.25.10
+    recommendedVersion: 1.25.11
     requiredVersion: 1.25.0
   - range: ">=1.24.0"
-    recommendedVersion: 1.24.14
+    recommendedVersion: 1.24.15
     requiredVersion: 1.24.0
   - range: ">=1.23.0"
     recommendedVersion: 1.23.17
@@ -145,15 +145,15 @@ spec:
   - range: ">=1.26.0-alpha.1"
     recommendedVersion: "1.26.2"
     #requiredVersion: 1.26.0
-    kubernetesVersion: 1.26.5
+    kubernetesVersion: 1.26.6
   - range: ">=1.25.0-alpha.1"
     recommendedVersion: "1.26.2"
     #requiredVersion: 1.25.0
-    kubernetesVersion: 1.25.10
+    kubernetesVersion: 1.25.11
   - range: ">=1.24.0-alpha.1"
     recommendedVersion: "1.26.2"
     #requiredVersion: 1.24.0
-    kubernetesVersion: 1.24.14
+    kubernetesVersion: 1.24.15
   - range: ">=1.23.0-alpha.1"
     recommendedVersion: "1.26.2"
     #requiredVersion: 1.23.0


### PR DESCRIPTION
<!--
Thanks for contributing to kubernetes/kops!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines:

 https://git.k8s.io/kops/CONTRIBUTING.md

2. Also, you'll probably want to checkout our development documentation:

https://git.k8s.io/kops/docs/development

3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

4. Finally, make sure all verifications and tests pass by running:
```
 make pr
```
-->

**What this PR does / why we need it**:
Bumping k8s versions in Alpha following recent releases

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
- https://github.com/kubernetes/kubernetes/releases/tag/v1.24.14
- https://github.com/kubernetes/kubernetes/releases/tag/v1.25.10
- https://github.com/kubernetes/kubernetes/releases/tag/v1.26.5
- https://github.com/kubernetes/kubernetes/releases/tag/v1.27.2