### PR TITLE
feat(hetzner): bump cloud-controller-manager and csi-driver

### DIFF
--- a/pkg/model/components/hetznercloudcontrollermanager.go
+++ b/pkg/model/components/hetznercloudcontrollermanager.go
@@ -53,7 +53,7 @@ func (b *HetznerCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}
 	eccm.ConfigureCloudRoutes = fi.PtrTo(false)
 
 	if eccm.Image == "" {
-		eccm.Image = "hetznercloud/hcloud-cloud-controller-manager:v1.13.2"
+		eccm.Image = "hetznercloud/hcloud-cloud-controller-manager:v1.15.0"
 	}
 
 	return nil

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     cloudProvider: hcloud
     clusterCIDR: 100.64.0.0/10
     configureCloudRoutes: false
-    image: hetznercloud/hcloud-cloud-controller-manager:v1.13.2
+    image: hetznercloud/hcloud-cloud-controller-manager:v1.15.0
     leaderElection:
       leaderElect: false
   cloudProvider: hetzner

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -34,14 +34,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml
-    manifestHash: 8f83c3847967c9e2946669e26758201efb04f8ed9ed4ecf2368446d3fc7c3866
+    manifestHash: 334e7ace1e27a9dd9ae8636d3e658524f568818a2add425f242c880f346c77a9
     name: hcloud-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: hcloud-cloud-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.22
     manifest: hcloud-csi-driver.addons.k8s.io/k8s-1.22.yaml
-    manifestHash: d5ccf385e0b90b1ff175c0a6feaf454dd8f4bda4dedb8ddc61b040807c1300e4
+    manifestHash: f86445654ced20b614f6031d14a5fea5cf61fdc98f39968407af67a0ddb258e9
     name: hcloud-csi-driver.addons.k8s.io
     selector:
       k8s-addon: hcloud-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
@@ -96,7 +96,7 @@ spec:
             secretKeyRef:
               key: network
               name: hcloud
-        image: hetznercloud/hcloud-cloud-controller-manager:v1.13.2
+        image: hetznercloud/hcloud-cloud-controller-manager:v1.15.0
         name: hcloud-cloud-controller-manager
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-csi-driver.addons.k8s.io-k8s-1.22_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-csi-driver.addons.k8s.io-k8s-1.22_content
@@ -212,7 +212,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: hcloud-csi-driver.addons.k8s.io
-    app: hcloud-csi
+    app: hcloud-csi-controller
     app.kubernetes.io/managed-by: kops
     k8s-addon: hcloud-csi-driver.addons.k8s.io
   name: hcloud-csi-controller-metrics
@@ -271,12 +271,14 @@ spec:
         kops.k8s.io/managed-by: kops
     spec:
       containers:
-      - image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
+      - args:
+        - --default-fstype=ext4
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.1.0
         name: csi-attacher
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: registry.k8s.io/sig-storage/csi-resizer:v1.2.0
+      - image: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
         name: csi-resizer
         volumeMounts:
         - mountPath: /run/csi
@@ -284,7 +286,7 @@ spec:
       - args:
         - --feature-gates=Topology=true
         - --default-fstype=ext4
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
         name: csi-provisioner
         volumeMounts:
         - mountPath: /run/csi
@@ -308,7 +310,7 @@ spec:
             secretKeyRef:
               key: token
               name: hcloud-csi
-        image: hetznercloud/hcloud-csi-driver:2.0.0
+        image: hetznercloud/hcloud-csi-driver:v2.3.2
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
@@ -328,7 +330,7 @@ spec:
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
+      - image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:
@@ -375,7 +377,7 @@ spec:
       containers:
       - args:
         - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
         name: csi-node-driver-registrar
         volumeMounts:
         - mountPath: /run/csi
@@ -391,7 +393,7 @@ spec:
           value: 0.0.0.0:9189
         - name: ENABLE_METRICS
           value: "true"
-        image: hetznercloud/hcloud-csi-driver:2.0.0
+        image: hetznercloud/hcloud-csi-driver:v2.3.2
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
@@ -418,7 +420,7 @@ spec:
           name: plugin-dir
         - mountPath: /dev
           name: device-dir
-      - image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
+      - image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:

--- a/upup/models/cloudup/resources/addons/hcloud-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/hcloud-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
@@ -177,7 +177,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: hcloud-csi
+    app: hcloud-csi-controller
   name: hcloud-csi-controller-metrics
   namespace: kube-system
 spec:
@@ -219,12 +219,14 @@ spec:
         app: hcloud-csi-controller
     spec:
       containers:
-      - image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
+      - args:
+        - --default-fstype=ext4
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.1.0
         name: csi-attacher
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: registry.k8s.io/sig-storage/csi-resizer:v1.2.0
+      - image: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
         name: csi-resizer
         volumeMounts:
         - mountPath: /run/csi
@@ -232,7 +234,7 @@ spec:
       - args:
         - --feature-gates=Topology=true
         - --default-fstype=ext4
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
         name: csi-provisioner
         volumeMounts:
         - mountPath: /run/csi
@@ -256,7 +258,7 @@ spec:
             secretKeyRef:
               key: token
               name: hcloud-csi
-        image: hetznercloud/hcloud-csi-driver:2.0.0
+        image: hetznercloud/hcloud-csi-driver:v2.3.2
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
@@ -276,7 +278,7 @@ spec:
         volumeMounts:
         - mountPath: /run/csi
           name: socket-dir
-      - image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
+      - image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:
@@ -315,7 +317,7 @@ spec:
       containers:
       - args:
         - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
         name: csi-node-driver-registrar
         volumeMounts:
         - mountPath: /run/csi
@@ -331,7 +333,7 @@ spec:
           value: 0.0.0.0:9189
         - name: ENABLE_METRICS
           value: "true"
-        image: hetznercloud/hcloud-csi-driver:2.0.0
+        image: hetznercloud/hcloud-csi-driver:v2.3.2
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
@@ -358,7 +360,7 @@ spec:
           name: plugin-dir
         - mountPath: /dev
           name: device-dir
-      - image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
+      - image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
         imagePullPolicy: Always
         name: liveness-probe
         volumeMounts:


### PR DESCRIPTION
This pull request bumps the default version of the Hetzner `cloud-controller-manager` and `csi-driver`. Hetzner has recently released ARM instances and these versions have multi arch support.