### PR TITLE
Default to dns=none for k8s.local clusters, on a few clouds

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -902,6 +902,15 @@ func (c *Cluster) UsesNoneDNS() bool {
 	if c.Spec.Networking.Topology != nil && c.Spec.Networking.Topology.DNS == DNSTypeNone {
 		return true
 	}
+
+	if dns.IsGossipClusterName(c.Name) {
+		// Default implementation of k8s.local clusters is now "dns=none" for a few clouds
+		switch c.Spec.GetCloudProvider() {
+		case CloudProviderDO, CloudProviderHetzner, CloudProviderGCE:
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/tests/integration/create_cluster/minimal_hetzner/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal_hetzner/expected-v1alpha2.yaml
@@ -51,7 +51,7 @@ spec:
     zone: fsn1
   topology:
     dns:
-      type: Private
+      type: None
     masters: public
     nodes: public
 


### PR DESCRIPTION
For DigitalOcean, Hetzner and GCE (initially), we treat k8s.local as
dns=none, instead of using the heavier gossip mechanism.
