### PR TITLE
Automated cherry pick of #15336: fix(cilium): install CNI plugin binary in an InitContainer

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.11.yaml.template
@@ -726,8 +726,10 @@ spec:
           {{- end }}
         - mountPath: /var/run/cilium
           name: cilium-run
+          {{- if not (semverCompare "~1.11.15 || ~1.12.8 || >=1.13.1" $semver) }}
         - mountPath: /host/opt/cni/bin
           name: cni-path
+          {{- end }}
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
 {{ if .EtcdManaged }}
@@ -761,6 +763,26 @@ spec:
 {{ end }}
       hostNetwork: true
       initContainers:
+      {{- if semverCompare "~1.11.15 || ~1.12.8 || >=1.13.1" $semver }}
+      - command:
+        - /install-plugin.sh
+        image: "quay.io/cilium/cilium:{{ .Version }}"
+        imagePullPolicy: IfNotPresent
+        name: install-cni-binaries
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+      {{- end }}
       - command:
         - /init-container.sh
         env:


### PR DESCRIPTION
Cherry pick of #15336 on release-1.25.

#15336: fix(cilium): install CNI plugin binary in an InitContainer

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```