### PR TITLE
kops-controller: Return `http.StatusConflict` when node already exists

### DIFF
--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -181,7 +181,7 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 		err := s.uncachedClient.Get(ctx, types.NamespacedName{Name: id.NodeName}, node)
 		if err == nil {
 			klog.Infof("bootstrap %s node %q already exists; denying to avoid node-impersonation attacks", r.RemoteAddr, id.NodeName)
-			w.WriteHeader(http.StatusForbidden)
+			w.WriteHeader(http.StatusConflict)
 			_, _ = w.Write([]byte("node already registered"))
 			return
 		}


### PR DESCRIPTION
As @justinsb commented in https://github.com/kubernetes/kops/pull/15138#discussion_r1107168105, `kops-controller` should return `http.StatusConflict` when node already exits.

Also, for reference, https://github.com/kubernetes/kops/pull/15351#issuecomment-1527644755.

Due to this mismatch, some tests are failing for Karpenter:
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/15144/pull-kops-e2e-aws-karpenter/1662005360124235776

/cc @zetaab @justinsb