### PR TITLE
Support intstr.IntOrString type  in cmd

### DIFF
--- a/cmd/kops/edit_instancegroup_test.go
+++ b/cmd/kops/edit_instancegroup_test.go
@@ -66,7 +66,7 @@ func TestEditInstanceGroup(t *testing.T) {
 		editOptions := &EditInstanceGroupOptions{
 			ClusterName: clusterName,
 			GroupName:   "nodes",
-			Sets:        []string{"spec.maxSize=10"},
+			Sets:        []string{"spec.maxSize=10", "spec.rollingUpdate.maxUnavailable=50%"},
 		}
 		err := RunEditInstanceGroup(ctx, factory, &stdout, editOptions)
 		if err != nil {

--- a/cmd/kops/test/edit_instance_group.yaml
+++ b/cmd/kops/test/edit_instance_group.yaml
@@ -10,6 +10,8 @@ spec:
   image: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404
   maxSize: 10
   role: Node
+  rollingUpdate:
+    maxUnavailable: 50%
   subnets:
   - subnet-us-test-1a
   taints:

--- a/util/pkg/reflectutils/access.go
+++ b/util/pkg/reflectutils/access.go
@@ -161,7 +161,6 @@ func setType(v reflect.Value, newValue string) error {
 		default:
 			panic("missing case in switch")
 		}
-	
 	case "intstr.IntOrString":
 		newV = reflect.ValueOf(intstr.Parse(newValue))
 


### PR DESCRIPTION
When using the **edit instancegroup with --set** option , a parsing error occurs if it is not a primitive type. The **instance group** struct has a custom type, and supporting it makes using cmd more comfortable.

e.g)
When trying to **updatespec.rollingUpdate.maxUnavailable** with edit instancegroup, a type error occurs because maxUnavailable is of type **intstr.IntOrString**.

```
./kops edit instancegroup --set 'spec.rollingUpdate.maxUnavailable=100%'
=> Unhandled type...
```

This PR supports processing the **intstr.IntOrString** type.