### PR TITLE
Default to dns=none for hetzner and digitalocean

### DIFF
--- a/tests/integration/create_cluster/minimal_hetzner/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal_hetzner/expected-v1alpha2.yaml
@@ -51,7 +51,7 @@ spec:
     zone: fsn1
   topology:
     dns:
-      type: Private
+      type: None
     masters: public
     nodes: public
 

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1323,12 +1323,16 @@ func setupTopology(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.S
 func setupDNSTopology(opt *NewClusterOptions, cluster *api.Cluster) error {
 	switch strings.ToLower(opt.DNSType) {
 	case "":
-		if cluster.UsesLegacyGossip() {
-			cluster.Spec.Networking.Topology.DNS = api.DNSTypePrivate
-		} else if cluster.Spec.GetCloudProvider() == api.CloudProviderHetzner {
+		switch cluster.Spec.GetCloudProvider() {
+		case api.CloudProviderHetzner, api.CloudProviderDO:
+			// Use dns=none if not specified
 			cluster.Spec.Networking.Topology.DNS = api.DNSTypeNone
-		} else {
-			cluster.Spec.Networking.Topology.DNS = api.DNSTypePublic
+		default:
+			if cluster.UsesLegacyGossip() {
+				cluster.Spec.Networking.Topology.DNS = api.DNSTypePrivate
+			} else {
+				cluster.Spec.Networking.Topology.DNS = api.DNSTypePublic
+			}
 		}
 	case "public":
 		cluster.Spec.Networking.Topology.DNS = api.DNSTypePublic


### PR DESCRIPTION
For new clusters only, default to dns=none on hetzner and
digitalocean.

Hetzner previously used dns=private (with the same behaviour), but
dns=none is more specific.

DigitalOcean previously defaulted to peer-to-peer gossip, but dns=none
is simpler and requires fewer permissions.
