### PR TITLE
etcd-manager: Add back etcd v3.5.7 binaries

### DIFF
--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -69,6 +69,7 @@ var etcdSupportedImages = map[string]string{
 	"3.2.24": "registry.k8s.io/etcd:3.2.24-1",
 	"3.3.17": "registry.k8s.io/etcd:3.3.17-0",
 	"3.4.13": "registry.k8s.io/etcd:3.4.13-0",
+	"3.5.7":  "registry.k8s.io/etcd:3.5.7-0",
 	"3.5.9":  "registry.k8s.io/etcd:3.5.9-0",
 }
 

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -158,6 +158,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.7
+      command:
+      - /opt/bin/kops-copy
+      image: registry.k8s.io/etcd:3.5.7-0
+      name: init-etcd-3-5-7
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.5.9
       command:
       - /opt/bin/kops-copy
@@ -284,6 +296,18 @@ Contents: |
       - /opt/bin/kops-copy
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.7
+      command:
+      - /opt/bin/kops-copy
+      image: registry.k8s.io/etcd:3.5.7-0
+      name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -157,6 +157,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.7
+      command:
+      - /opt/bin/kops-copy
+      image: registry.k8s.io/etcd:3.5.7-0
+      name: init-etcd-3-5-7
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.5.9
       command:
       - /opt/bin/kops-copy
@@ -282,6 +294,18 @@ Contents: |
       - /opt/bin/kops-copy
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.7
+      command:
+      - /opt/bin/kops-copy
+      image: registry.k8s.io/etcd:3.5.7-0
+      name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -160,6 +160,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.7
+      command:
+      - /opt/bin/kops-copy
+      image: registry.k8s.io/etcd:3.5.7-0
+      name: init-etcd-3-5-7
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.5.9
       command:
       - /opt/bin/kops-copy
@@ -288,6 +300,18 @@ Contents: |
       - /opt/bin/kops-copy
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.7
+      command:
+      - /opt/bin/kops-copy
+      image: registry.k8s.io/etcd:3.5.7-0
+      name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -166,6 +166,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.7
+      command:
+      - /opt/bin/kops-copy
+      image: registry.k8s.io/etcd:3.5.7-0
+      name: init-etcd-3-5-7
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.5.9
       command:
       - /opt/bin/kops-copy
@@ -300,6 +312,18 @@ Contents: |
       - /opt/bin/kops-copy
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.7
+      command:
+      - /opt/bin/kops-copy
+      image: registry.k8s.io/etcd:3.5.7-0
+      name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -96,6 +96,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -96,6 +96,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -95,6 +95,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -97,6 +97,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -95,6 +95,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -97,6 +97,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -96,6 +96,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -98,6 +98,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -96,6 +96,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -98,6 +98,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -95,6 +95,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -97,6 +97,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -95,6 +95,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -97,6 +97,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -95,6 +95,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -97,6 +97,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -95,6 +95,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -97,6 +97,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -96,6 +96,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -95,6 +95,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -95,6 +95,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -97,6 +97,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -97,6 +97,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -96,6 +96,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -98,6 +98,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -96,6 +96,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -98,6 +98,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -96,6 +96,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -98,6 +98,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -96,6 +96,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -98,6 +98,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -94,6 +94,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -93,6 +93,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.7
+    command:
+    - /opt/bin/kops-copy
+    image: registry.k8s.io/etcd:3.5.7-0
+    name: init-etcd-3-5-7
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.5.9
     command:
     - /opt/bin/kops-copy


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kops/pull/15466#issuecomment-1575587094
```
I0604 11:08:01.771997    5736 s3fs.go:338] Reading file "s3://k8s-kops-prow/e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io/backups/etcd/main/control/etcd-cluster-created"
I0604 11:08:02.117890    5736 controller.go:391] spec member_count:3 etcd_version:"3.5.9" 
I0604 11:08:02.117947    5736 controller.go:439] mismatched version for peer peer{id:"etcd-ca-central-1a" endpoints:"172.20.0.155:3996" }: want "3.5.9", have "3.5.7"
I0604 11:08:02.117976    5736 controller.go:439] mismatched version for peer peer{id:"etcd-ca-central-1b" endpoints:"172.20.1.216:3996" }: want "3.5.9", have "3.5.7"
I0604 11:08:02.117993    5736 controller.go:439] mismatched version for peer peer{id:"etcd-ca-central-1d" endpoints:"172.20.2.26:3996" }: want "3.5.9", have "3.5.7"
I0604 11:08:02.118014    5736 controller.go:511] etcd has unhealthy members, but no idle peers ready to join, so won't remove unhealthy members
I0604 11:08:02.118038    5736 controller.go:539] detected that we need to upgrade/downgrade etcd
I0604 11:08:02.118043    5736 upgrade.go:139] doing in-place upgrade to "3.5.9"
W0604 11:08:02.118051    5736 controller.go:161] unexpected error running etcd cluster reconciliation loop: cannot upgrade/downgrade cluster when not all members are healthy
I0604 11:08:11.513410    5736 etcdserver.go:577] starting etcd with state cluster:<cluster_token:"CVL3ZNC1xLR8t3IG-Bq5eg" nodes:<name:"etcd-ca-central-1a" peer_urls:"https://etcd-ca-central-1a.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io:2380" client_urls:"https://etcd-ca-central-1a.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io:4001" quarantined_client_urls:"https://etcd-ca-central-1a.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io:3994" tls_enabled:true > nodes:<name:"etcd-ca-central-1b" peer_urls:"https://etcd-ca-central-1b.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io:2380" client_urls:"https://etcd-ca-central-1b.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io:4001" quarantined_client_urls:"https://etcd-ca-central-1b.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io:3994" tls_enabled:true > nodes:<name:"etcd-ca-central-1d" peer_urls:"https://etcd-ca-central-1d.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io:2380" client_urls:"https://etcd-ca-central-1d.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io:4001" quarantined_client_urls:"https://etcd-ca-central-1d.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io:3994" tls_enabled:true > > etcd_version:"3.5.7" 
I0604 11:08:11.513487    5736 etcdserver.go:586] starting etcd with datadir /rootfs/mnt/master-vol-066ffa9d62b56fd71/data/CVL3ZNC1xLR8t3IG-Bq5eg
I0604 11:08:11.513740    5736 pki.go:56] adding peerClientIPs [172.20.0.155]
I0604 11:08:11.513771    5736 pki.go:64] generating peer keypair for etcd: {CommonName:etcd-ca-central-1a Organization:[] AltNames:{DNSNames:[etcd-ca-central-1a etcd-ca-central-1a.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io] IPs:[172.20.0.155 127.0.0.1 ::1]} Usages:[2 1]}
I0604 11:08:11.513947    5736 certs.go:151] existing certificate not valid after 2025-06-03T11:08:01Z; will regenerate
I0604 11:08:11.513957    5736 certs.go:207] generating certificate for "etcd-ca-central-1a"
I0604 11:08:11.516055    5736 pki.go:106] building client-serving certificate: {CommonName:etcd-ca-central-1a Organization:[] AltNames:{DNSNames:[etcd-ca-central-1a etcd-ca-central-1a.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io etcd-ca-central-1a.internal.e2e-7c187fd25f-bb719.test-cncf-aws.k8s.io] IPs:[127.0.0.1 ::1]} Usages:[1 2]}
I0604 11:08:11.516196    5736 certs.go:151] existing certificate not valid after 2025-06-03T11:08:01Z; will regenerate
I0604 11:08:11.516206    5736 certs.go:207] generating certificate for "etcd-ca-central-1a"
I0604 11:08:11.684724    5736 certs.go:207] generating certificate for "etcd-ca-central-1a"
W0604 11:08:11.686466    5736 etcdserver.go:116] error running etcd: unknown etcd version v3.5.7: not found in [/opt/etcd-v3.5.7]
```