### PR TITLE
fix(cilium): cilium-operator must be able to patch K8S nodes resources

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
@@ -441,6 +441,14 @@ rules:
   verbs:
   - list
   - watch
+# to set NetworkUnavailable false on startup and remove cilium taint
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - patch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
# Description

As per the cilium recommended installation, the cilium-operator is in charge of removing the `node.cilium.io/agent-not-ready` that is put on nodes upon startup. As such the operator needs the PATCH permission on the node ressource.

# Reference

* kops upstream issue: https://github.com/kubernetes/kops/issues/15464
* kops upstream PR: https://github.com/kubernetes/kops/pull/15470