### PR TITLE
GCP Terraform: enable create_before_destroy in instance templates

### DIFF
--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -581,6 +581,9 @@ resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-co
     "k8s-io-role-control-plane" = ""
     "k8s-io-role-master"        = ""
   }
+  lifecycle {
+    create_before_destroy = true
+  }
   machine_type = "e2-medium"
   metadata = {
     "cluster-name"                    = "ha-gce.example.com"
@@ -629,6 +632,9 @@ resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-co
     "k8s-io-instance-group"     = "master-us-test1-b"
     "k8s-io-role-control-plane" = ""
     "k8s-io-role-master"        = ""
+  }
+  lifecycle {
+    create_before_destroy = true
   }
   machine_type = "e2-medium"
   metadata = {
@@ -679,6 +685,9 @@ resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-co
     "k8s-io-role-control-plane" = ""
     "k8s-io-role-master"        = ""
   }
+  lifecycle {
+    create_before_destroy = true
+  }
   machine_type = "e2-medium"
   metadata = {
     "cluster-name"                    = "ha-gce.example.com"
@@ -726,6 +735,9 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
     "k8s-io-cluster-name"   = "ha-gce-example-com"
     "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
+  }
+  lifecycle {
+    create_before_destroy = true
   }
   machine_type = "e2-medium"
   metadata = {

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -469,6 +469,9 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-example-c
     "k8s-io-role-control-plane" = ""
     "k8s-io-role-master"        = ""
   }
+  lifecycle {
+    create_before_destroy = true
+  }
   machine_type = "e2-medium"
   metadata = {
     "cluster-name"                    = "minimal.example.com"
@@ -516,6 +519,9 @@ resource "google_compute_instance_template" "nodes-minimal-example-com" {
     "k8s-io-cluster-name"   = "minimal-example-com"
     "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
+  }
+  lifecycle {
+    create_before_destroy = true
   }
   machine_type = "e2-medium"
   metadata = {

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -445,6 +445,9 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-examp
     "k8s-io-role-control-plane" = ""
     "k8s-io-role-master"        = ""
   }
+  lifecycle {
+    create_before_destroy = true
+  }
   machine_type = "e2-medium"
   metadata = {
     "cluster-name"                    = "minimal-gce.example.com"
@@ -492,6 +495,9 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
     "k8s-io-cluster-name"   = "minimal-gce-example-com"
     "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
+  }
+  lifecycle {
+    create_before_destroy = true
   }
   machine_type = "e2-medium"
   metadata = {

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -450,6 +450,9 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-examp
     "k8s-io-role-control-plane" = ""
     "k8s-io-role-master"        = ""
   }
+  lifecycle {
+    create_before_destroy = true
+  }
   machine_type = "e2-medium"
   metadata = {
     "cluster-name"                    = "minimal-gce.example.com"
@@ -495,6 +498,9 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
     "k8s-io-cluster-name"   = "minimal-gce-example-com"
     "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
+  }
+  lifecycle {
+    create_before_destroy = true
   }
   machine_type = "e2-medium"
   metadata = {

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -448,6 +448,9 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-ilb-e
     "k8s-io-role-control-plane" = ""
     "k8s-io-role-master"        = ""
   }
+  lifecycle {
+    create_before_destroy = true
+  }
   machine_type = "e2-medium"
   metadata = {
     "cluster-name"                    = "minimal-gce-ilb.example.com"
@@ -493,6 +496,9 @@ resource "google_compute_instance_template" "nodes-minimal-gce-ilb-example-com" 
     "k8s-io-cluster-name"   = "minimal-gce-ilb-example-com"
     "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
+  }
+  lifecycle {
+    create_before_destroy = true
   }
   machine_type = "e2-medium"
   metadata = {

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -448,6 +448,9 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-with-
     "k8s-io-role-control-plane" = ""
     "k8s-io-role-master"        = ""
   }
+  lifecycle {
+    create_before_destroy = true
+  }
   machine_type = "e2-medium"
   metadata = {
     "cluster-name"                    = "minimal-gce-with-a-very-very-very-very-very-long-name.example.com"
@@ -493,6 +496,9 @@ resource "google_compute_instance_template" "nodes-minimal-gce-with-a-very-very-
     "k8s-io-cluster-name"   = "minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
     "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
+  }
+  lifecycle {
+    create_before_destroy = true
   }
   machine_type = "e2-medium"
   metadata = {

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -445,6 +445,9 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-with-
     "k8s-io-role-control-plane" = ""
     "k8s-io-role-master"        = ""
   }
+  lifecycle {
+    create_before_destroy = true
+  }
   machine_type = "e2-medium"
   metadata = {
     "cluster-name"                    = "minimal-gce-with-a-very-very-very-very-very-long-name.example.com"
@@ -492,6 +495,9 @@ resource "google_compute_instance_template" "nodes-minimal-gce-with-a-very-very-
     "k8s-io-cluster-name"   = "minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
     "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
+  }
+  lifecycle {
+    create_before_destroy = true
   }
   machine_type = "e2-medium"
   metadata = {

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -464,6 +464,9 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-plb-e
     "k8s-io-role-control-plane" = ""
     "k8s-io-role-master"        = ""
   }
+  lifecycle {
+    create_before_destroy = true
+  }
   machine_type = "e2-medium"
   metadata = {
     "cluster-name"                    = "minimal-gce-plb.example.com"
@@ -509,6 +512,9 @@ resource "google_compute_instance_template" "nodes-minimal-gce-plb-example-com" 
     "k8s-io-cluster-name"   = "minimal-gce-plb-example-com"
     "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
+  }
+  lifecycle {
+    create_before_destroy = true
   }
   machine_type = "e2-medium"
   metadata = {

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -445,6 +445,9 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-priva
     "k8s-io-role-control-plane" = ""
     "k8s-io-role-master"        = ""
   }
+  lifecycle {
+    create_before_destroy = true
+  }
   machine_type = "e2-medium"
   metadata = {
     "cluster-name"                    = "minimal-gce-private.example.com"
@@ -490,6 +493,9 @@ resource "google_compute_instance_template" "nodes-minimal-gce-private-example-c
     "k8s-io-cluster-name"   = "minimal-gce-private-example-com"
     "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
+  }
+  lifecycle {
+    create_before_destroy = true
   }
   machine_type = "e2-medium"
   metadata = {

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -489,6 +489,7 @@ func (_ *InstanceTemplate) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Instanc
 }
 
 type terraformInstanceTemplate struct {
+	Lifecycle             *terraform.Lifecycle                     `cty:"lifecycle"`
 	NamePrefix            string                                   `cty:"name_prefix"`
 	CanIPForward          bool                                     `cty:"can_ip_forward"`
 	MachineType           string                                   `cty:"machine_type"`
@@ -623,6 +624,7 @@ func (_ *InstanceTemplate) RenderTerraform(t *terraform.TerraformTarget, a, e, c
 	name := fi.ValueOf(e.Name)
 
 	tf := &terraformInstanceTemplate{
+		Lifecycle:  &terraform.Lifecycle{CreateBeforeDestroy: fi.PtrTo(true)},
 		NamePrefix: fi.ValueOf(e.NamePrefix) + "-",
 	}
 


### PR DESCRIPTION
Add a `lifecycle` block that enables `create_before_destroy` in the generated Terraform code for GCP instance templates, similar to the AWS launch template counterpart, and following [Terraform recommendations](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template#using-with-instance-group-manager).