### PR TITLE
Add RHEL9 support

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -46,6 +46,7 @@ The following table provides the support status for various distros with regards
 | Kope.io                                 |            - |      - |       1.18 |    1.23 |
 | RHEL 7                                  |            - |    1.5 |       1.21 |    1.23 |
 | [RHEL 8](#rhel-8)                       |         1.15 |   1.18 |          - |       - |
+| [RHEL 9](#rhel-9)                       |         1.27 |      - |          - |       - |
 | [Rocky 8](#rocky-8)                     |       1.23.2 |   1.24 |          - |       - |
 | Ubuntu 16.04                            |          1.5 |   1.10 |       1.17 |    1.20 |
 | [Ubuntu 18.04](#ubuntu-1804-bionic)     |         1.10 |   1.16 |       1.26 |       - |
@@ -170,6 +171,19 @@ aws ec2 describe-images --region us-east-1 --output table \
   --owners 309956199498 \
   --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
   --filters "Name=name,Values=RHEL-8.*x86_64*"
+```
+
+### RHEL 9
+
+RHEL 9 is based on Kernel version **5.15** which fixes all the known major Kernel bugs.
+
+Available images can be listed using:
+
+```bash
+aws ec2 describe-images --region us-east-1 --output table \
+  --owners 309956199498 \
+  --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
+  --filters "Name=name,Values=RHEL-9.*x86_64*"
 ```
 
 ### Rocky 8

--- a/nodeup/pkg/model/miscutils.go
+++ b/nodeup/pkg/model/miscutils.go
@@ -46,7 +46,7 @@ func (b *MiscUtilsBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if b.Distribution.IsRHELFamily() {
 		// TODO: These packages have been auto-installed for a long time, and likely we don't need all of them any longer
 		packages = append(packages, "wget")
-		if b.Distribution != distributions.DistributionAmazonLinux2023 {
+		if b.Distribution != distributions.DistributionAmazonLinux2023 && b.Distribution != distributions.DistributionRhel9 {
 			packages = append(packages, "curl")
 			packages = append(packages, "python2")
 		}

--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -61,18 +61,19 @@ func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})
 		c.AddTask(&nodetasks.Package{Name: "ethtool"})
 		c.AddTask(&nodetasks.Package{Name: "iptables"})
-		c.AddTask(&nodetasks.Package{Name: "libcgroup"})
 		c.AddTask(&nodetasks.Package{Name: "libseccomp"})
 		c.AddTask(&nodetasks.Package{Name: "libtool-ltdl"})
 		c.AddTask(&nodetasks.Package{Name: "socat"})
 		c.AddTask(&nodetasks.Package{Name: "util-linux"})
 		// Handle some packages differently for each distro
-		switch b.Distribution {
-		case distributions.DistributionAmazonLinux2:
-			// Amazon Linux 2 doesn't have SELinux enabled by default
-		default:
+		// Amazon Linux 2 doesn't have SELinux enabled by default
+		if b.Distribution != distributions.DistributionAmazonLinux2 {
 			c.AddTask(&nodetasks.Package{Name: "container-selinux"})
 			c.AddTask(&nodetasks.Package{Name: "pigz"})
+		}
+		// RHEL9 does not have libcgroup
+		if b.Distribution != distributions.DistributionRhel9 {
+			c.AddTask(&nodetasks.Package{Name: "libcgroup"})
 		}
 		// Additional packages
 		for _, additionalPackage := range b.NodeupConfig.Packages {

--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -326,7 +326,7 @@ func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) erro
 			args = []string{"apt-get", "install", "--yes", "--no-install-recommends"}
 			env = append(env, "DEBIAN_FRONTEND=noninteractive")
 		} else if d.IsRHELFamily() {
-			if d == distributions.DistributionRhel8 || d == distributions.DistributionRocky8 {
+			if d == distributions.DistributionRhel8 || d == distributions.DistributionRocky8 || d == distributions.DistributionRhel9 {
 				args = []string{"/usr/bin/dnf", "install", "-y", "--setopt=install_weak_deps=False"}
 			} else {
 				args = []string{"/usr/bin/yum", "install", "-y"}

--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -49,6 +49,7 @@ var (
 	DistributionAmazonLinux2    = Distribution{packageFormat: "rpm", project: "amazonlinux2", id: "amazonlinux2", version: 0}
 	DistributionAmazonLinux2023 = Distribution{packageFormat: "rpm", project: "amazonlinux2023", id: "amzn", version: 2023}
 	DistributionRhel8           = Distribution{packageFormat: "rpm", project: "rhel", id: "rhel8", version: 8}
+	DistributionRhel9           = Distribution{packageFormat: "rpm", project: "rhel", id: "rhel9", version: 9}
 	DistributionRocky8          = Distribution{packageFormat: "rpm", project: "rocky", id: "rocky8", version: 8}
 	DistributionFlatcar         = Distribution{packageFormat: "", project: "flatcar", id: "flatcar", version: 0}
 	DistributionContainerOS     = Distribution{packageFormat: "", project: "containeros", id: "containeros", version: 0}

--- a/util/pkg/distributions/identify.go
+++ b/util/pkg/distributions/identify.go
@@ -82,6 +82,9 @@ func FindDistribution(rootfs string) (Distribution, error) {
 	if strings.HasPrefix(distro, "rhel-8.") {
 		return DistributionRhel8, nil
 	}
+	if strings.HasPrefix(distro, "rhel-9.") {
+		return DistributionRhel9, nil
+	}
 	if strings.HasPrefix(distro, "rocky-8.") {
 		return DistributionRocky8, nil
 	}

--- a/util/pkg/distributions/identify_test.go
+++ b/util/pkg/distributions/identify_test.go
@@ -100,6 +100,11 @@ func TestFindDistribution(t *testing.T) {
 			expected: DistributionRhel8,
 		},
 		{
+			rootfs:   "rhel9",
+			err:      nil,
+			expected: DistributionRhel9,
+		},
+		{
 			rootfs:   "rocky8",
 			err:      nil,
 			expected: DistributionRocky8,

--- a/util/pkg/distributions/tests/rhel9/etc/os-release
+++ b/util/pkg/distributions/tests/rhel9/etc/os-release
@@ -1,0 +1,18 @@
+NAME="Red Hat Enterprise Linux"
+VERSION="9.1 (Plow)"
+ID="rhel"
+ID_LIKE="fedora"
+VERSION_ID="9.1"
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="Red Hat Enterprise Linux 9.1 (Plow)"
+ANSI_COLOR="0;31"
+LOGO="fedora-logo-icon"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
+HOME_URL="https://www.redhat.com/"
+DOCUMENTATION_URL="https://access.redhat.com/documentation/red_hat_enterprise_linux/9/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
+REDHAT_BUGZILLA_PRODUCT_VERSION=9.1
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="9.1"


### PR DESCRIPTION
Add support for RHEL 9.

RHEL 9 does not ship python2 and libcgroup. I am able to create a RHEL9 cluster with this PR, I did not check any older distro.