### PR TITLE
Increase verbosity level of log message about object ACLs

### DIFF
--- a/pkg/acls/gce/storage.go
+++ b/pkg/acls/gce/storage.go
@@ -62,7 +62,7 @@ func (s *gcsAclStrategy) GetACL(ctx context.Context, p vfs.Path, cluster *kops.C
 	}
 
 	if bucketPolicyOnly {
-		klog.Infof("bucket gs://%s has bucket-policy only; won't try to set ACLs", bucketName)
+		klog.V(8).Infof("bucket gs://%s has bucket-policy only; won't try to set ACLs", bucketName)
 		return nil, nil
 	}
 


### PR DESCRIPTION
This message is way too verbose to be logged on default log verbosity level, floods the output a lot, set it to a higher level.