### PR TITLE
scaleway: use latest version of the ccm

### DIFF
--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.24
     manifest: scaleway-cloud-controller.addons.k8s.io/k8s-1.24.yaml
-    manifestHash: f6c221c3faf7d34d12c58776592cf36a6c46ba28948d19b4ca5f0d34148065d2
+    manifestHash: 62cf06c0ba8f17ad6a877108c1f4bb26a167791aac8c3c6f04804c9e2f61ddab
     name: scaleway-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: scaleway-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-scaleway-cloud-controller.addons.k8s.io-k8s-1.24_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-scaleway-cloud-controller.addons.k8s.io-k8s-1.24_content
@@ -51,7 +51,7 @@ spec:
         envFrom:
         - secretRef:
             name: scaleway-secret
-        image: scaleway/scaleway-cloud-controller-manager:v0.24.3
+        image: scaleway/scaleway-cloud-controller-manager:latest
         imagePullPolicy: Always
         name: scaleway-cloud-controller-manager
         resources:

--- a/upup/models/cloudup/resources/addons/scaleway-cloud-controller.addons.k8s.io/k8s-1.24.yaml.template
+++ b/upup/models/cloudup/resources/addons/scaleway-cloud-controller.addons.k8s.io/k8s-1.24.yaml.template
@@ -58,7 +58,7 @@ spec:
           tolerationSeconds: 300
       containers:
         - name: scaleway-cloud-controller-manager
-          image: scaleway/scaleway-cloud-controller-manager:v0.24.3
+          image: scaleway/scaleway-cloud-controller-manager:latest
           imagePullPolicy: Always
           args:
             - --cloud-provider=scaleway


### PR DESCRIPTION
We had to rollback the version of the CCM in #15333 while waiting for the next release. It is now available so we can use the latest version again.
