### PR TITLE
Add optional SELinux support to RHEL clusters

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -896,6 +896,9 @@ spec:
                         description: Version used to pick the runc package.
                         type: string
                     type: object
+                  selinuxEnabled:
+                    description: SelinuxEnabled enables SELinux support
+                    type: boolean
                   skipInstall:
                     description: SkipInstall prevents kOps from installing and modifying
                       containerd in any way (default "false").

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -199,6 +199,9 @@ spec:
                         description: Version used to pick the runc package.
                         type: string
                     type: object
+                  selinuxEnabled:
+                    description: SelinuxEnabled enables SELinux support
+                    type: boolean
                   skipInstall:
                     description: SkipInstall prevents kOps from installing and modifying
                       containerd in any way (default "false").

--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -479,6 +479,9 @@ func (b *ContainerdBuilder) buildContainerdConfig() (string, error) {
 
 	config, _ := toml.Load("")
 	config.SetPath([]string{"version"}, int64(2))
+	if containerd.SeLinuxEnabled {
+		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "enable_selinux"}, true)
+	}
 	if b.NodeupConfig.KubeletConfig.PodInfraContainerImage != "" {
 		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}, b.NodeupConfig.KubeletConfig.PodInfraContainerImage)
 	}

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -739,6 +739,8 @@ func (b *KubeAPIServerBuilder) buildPod(ctx context.Context, kubeAPIServer *kops
 	kubemanifest.MarkPodAsCritical(pod)
 	kubemanifest.MarkPodAsClusterCritical(pod)
 
+	kubemanifest.AddHostPathSELinuxContext(pod, b.NodeupConfig)
+
 	if useHealthcheckProxy {
 		if err := b.addHealthcheckSidecar(ctx, pod); err != nil {
 			return nil, err

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -273,5 +273,7 @@ func (b *KubeControllerManagerBuilder) buildPod(kcm *kops.KubeControllerManagerC
 	kubemanifest.MarkPodAsCritical(pod)
 	kubemanifest.MarkPodAsClusterCritical(pod)
 
+	kubemanifest.AddHostPathSELinuxContext(pod, b.NodeupConfig)
+
 	return pod, nil
 }

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -239,6 +239,8 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	// PodPriority is enabled.
 	kubemanifest.MarkPodAsNodeCritical(pod)
 
+	kubemanifest.AddHostPathSELinuxContext(pod, b.NodeupConfig)
+
 	return pod, nil
 }
 

--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -287,5 +287,7 @@ func (b *KubeSchedulerBuilder) buildPod(kubeScheduler *kops.KubeSchedulerConfig)
 	kubemanifest.MarkPodAsCritical(pod)
 	kubemanifest.MarkPodAsClusterCritical(pod)
 
+	kubemanifest.AddHostPathSELinuxContext(pod, b.NodeupConfig)
+
 	return pod, nil
 }

--- a/pkg/apis/kops/containerdconfig.go
+++ b/pkg/apis/kops/containerdconfig.go
@@ -43,6 +43,8 @@ type ContainerdConfig struct {
 	NvidiaGPU *NvidiaGPUConfig `json:"nvidiaGPU,omitempty"`
 	// Runc configures the runc runtime.
 	Runc *Runc `json:"runc,omitempty"`
+	// SelinuxEnabled enables SELinux support
+	SeLinuxEnabled bool `json:"selinuxEnabled,omitempty"`
 }
 
 type NvidiaGPUConfig struct {

--- a/pkg/apis/kops/v1alpha2/containerdconfig.go
+++ b/pkg/apis/kops/v1alpha2/containerdconfig.go
@@ -40,6 +40,8 @@ type ContainerdConfig struct {
 	NvidiaGPU *NvidiaGPUConfig `json:"nvidiaGPU,omitempty"`
 	// Runc configures the runc runtime.
 	Runc *Runc `json:"runc,omitempty"`
+	// SelinuxEnabled enables SELinux support
+	SeLinuxEnabled bool `json:"selinuxEnabled,omitempty"`
 }
 
 type NvidiaGPUConfig struct {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3114,6 +3114,7 @@ func autoConvert_v1alpha2_ContainerdConfig_To_kops_ContainerdConfig(in *Containe
 	} else {
 		out.Runc = nil
 	}
+	out.SeLinuxEnabled = in.SeLinuxEnabled
 	return nil
 }
 
@@ -3158,6 +3159,7 @@ func autoConvert_kops_ContainerdConfig_To_v1alpha2_ContainerdConfig(in *kops.Con
 	} else {
 		out.Runc = nil
 	}
+	out.SeLinuxEnabled = in.SeLinuxEnabled
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/containerdconfig.go
+++ b/pkg/apis/kops/v1alpha3/containerdconfig.go
@@ -40,6 +40,8 @@ type ContainerdConfig struct {
 	NvidiaGPU *NvidiaGPUConfig `json:"nvidiaGPU,omitempty"`
 	// Runc configures the runc runtime.
 	Runc *Runc `json:"runc,omitempty"`
+	// SelinuxEnabled enables SELinux support
+	SeLinuxEnabled bool `json:"selinuxEnabled,omitempty"`
 }
 
 type NvidiaGPUConfig struct {

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -3325,6 +3325,7 @@ func autoConvert_v1alpha3_ContainerdConfig_To_kops_ContainerdConfig(in *Containe
 	} else {
 		out.Runc = nil
 	}
+	out.SeLinuxEnabled = in.SeLinuxEnabled
 	return nil
 }
 
@@ -3369,6 +3370,7 @@ func autoConvert_kops_ContainerdConfig_To_v1alpha3_ContainerdConfig(in *kops.Con
 	} else {
 		out.Runc = nil
 	}
+	out.SeLinuxEnabled = in.SeLinuxEnabled
 	return nil
 }
 

--- a/pkg/kubemanifest/selinux.go
+++ b/pkg/kubemanifest/selinux.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubemanifest
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kops/pkg/apis/nodeup"
+)
+
+// AddHostPathSELinuxContext allows a non-privileged pod to access any file on
+// the Host via HostPath volumes when SELinux is enabled.
+func AddHostPathSELinuxContext(pod *v1.Pod, cfg *nodeup.Config) {
+	if cfg.ContainerdConfig == nil || !cfg.ContainerdConfig.SeLinuxEnabled {
+		return
+	}
+
+	if pod.Spec.SecurityContext == nil {
+		pod.Spec.SecurityContext = &v1.PodSecurityContext{}
+	}
+
+	// This context basically disables all SELinux checks for the pod.
+	// Among other things, it allows the pod to access HostPath volumes.
+	// The option is ignored on non-selinux systems.
+	pod.Spec.SecurityContext.SELinuxOptions = &v1.SELinuxOptions{
+		Type:  "spc_t",
+		Level: "s0",
+	}
+}

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -69,7 +69,6 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 		// Set default log level to INFO
 		containerd.LogLevel = fi.PtrTo("info")
-
 	} else if clusterSpec.ContainerRuntime == "docker" {
 		// Docker version should always be available
 		dockerVersion := fi.ValueOf(clusterSpec.Docker.Version)

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3f329cfc37ea852a3f8e75e7aefd07f08b334bad7742502764404e40f6c7a00e
+    manifestHash: e705cd815f784d42f1e5c8e0ede6f1ebf7e79054c6a5b1f7295a8424ae09eb8e
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -285,7 +285,6 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
-      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3f329cfc37ea852a3f8e75e7aefd07f08b334bad7742502764404e40f6c7a00e
+    manifestHash: e705cd815f784d42f1e5c8e0ede6f1ebf7e79054c6a5b1f7295a8424ae09eb8e
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -285,7 +285,6 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
-      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3f329cfc37ea852a3f8e75e7aefd07f08b334bad7742502764404e40f6c7a00e
+    manifestHash: e705cd815f784d42f1e5c8e0ede6f1ebf7e79054c6a5b1f7295a8424ae09eb8e
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -285,7 +285,6 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
-      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3f329cfc37ea852a3f8e75e7aefd07f08b334bad7742502764404e40f6c7a00e
+    manifestHash: e705cd815f784d42f1e5c8e0ede6f1ebf7e79054c6a5b1f7295a8424ae09eb8e
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -285,7 +285,6 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
-      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -186,7 +186,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3f329cfc37ea852a3f8e75e7aefd07f08b334bad7742502764404e40f6c7a00e
+    manifestHash: e705cd815f784d42f1e5c8e0ede6f1ebf7e79054c6a5b1f7295a8424ae09eb8e
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -285,7 +285,6 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
-      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3f329cfc37ea852a3f8e75e7aefd07f08b334bad7742502764404e40f6c7a00e
+    manifestHash: e705cd815f784d42f1e5c8e0ede6f1ebf7e79054c6a5b1f7295a8424ae09eb8e
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -285,7 +285,6 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
-      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3f329cfc37ea852a3f8e75e7aefd07f08b334bad7742502764404e40f6c7a00e
+    manifestHash: e705cd815f784d42f1e5c8e0ede6f1ebf7e79054c6a5b1f7295a8424ae09eb8e
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -285,7 +285,6 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
-      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -140,6 +140,12 @@ spec:
       nodeSelector:
         {{ APIServerNodeRole }}: ""
       priorityClassName: system-node-critical
+{{ if ContainerdSELinuxEnabled }}
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
+          level: s0
+{{ end }}
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -179,7 +185,6 @@ spec:
             - ALL
           runAsUser: 10000
           runAsGroup: 10000
-
         resources:
           requests:
             memory: {{ or .Authentication.AWS.MemoryRequest "20Mi" }}

--- a/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
@@ -38,6 +38,12 @@ spec:
         effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+{{ if ContainerdSELinuxEnabled }}
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
+          level: s0
+{{ end }}
       serviceAccountName: aws-cloud-controller-manager
       containers:
       - name: aws-cloud-controller-manager

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -190,6 +190,11 @@ spec:
             drop:
             - all
           readOnlyRootFilesystem: true
+{{ if ContainerdSELinuxEnabled }}
+          seLinuxOptions:
+            type: spc_t
+            level: s0
+{{ end }}
         livenessProbe:
           httpGet:
             path: /health

--- a/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
@@ -39,6 +39,12 @@ spec:
         effect: NoSchedule
       - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
+{{ if ContainerdSELinuxEnabled }}
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
+          level: s0
+{{ end }}
       serviceAccountName: cloud-controller-manager
       containers:
       - name: cloud-controller-manager

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -99,6 +99,11 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 10011
+{{ if ContainerdSELinuxEnabled }}
+          seLinuxOptions:
+            type: spc_t
+            level: s0
+{{ end }}
       volumes:
 {{ if .UseHostCertificates }}
       - hostPath:

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -143,8 +143,12 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
         - operator: Exists
+{{ if ContainerdSELinuxEnabled }}
       securityContext:
-        {}
+        seLinuxOptions:
+          type: spc_t
+          level: s0
+{{ end }}
       containers:
         - name: aws-node
           image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.6" }}"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
@@ -888,6 +888,12 @@ spec:
             memory: 100Mi
       restartPolicy: Always
       priorityClassName: system-node-critical
+{{ if ContainerdSELinuxEnabled }}
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
+          level: s0
+{{ end }}
       serviceAccount: cilium
       serviceAccountName: cilium
       terminationGracePeriodSeconds: 1
@@ -1072,6 +1078,12 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-cluster-critical
+{{ if ContainerdSELinuxEnabled }}
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
+          level: s0
+{{ end }}
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
       tolerations:

--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
@@ -213,6 +213,11 @@ spec:
           privileged: false
           capabilities:
             add: ["NET_ADMIN", "NET_RAW"]
+{{ if ContainerdSELinuxEnabled }}
+          seLinuxOptions:
+            type: spc_t
+            level: s0
+{{ end }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.25.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.25.yaml.template
@@ -170,6 +170,11 @@ spec:
           privileged: false
           capabilities:
             add: ["NET_ADMIN", "NET_RAW"]
+{{ if ContainerdSELinuxEnabled }}
+          seLinuxOptions:
+            type: spc_t
+            level: s0
+{{ end }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -53,6 +53,12 @@ spec:
         tier: node
     spec:
       priorityClassName: system-node-critical
+{{ if ContainerdSELinuxEnabled }}
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
+          level: s0
+{{ end }}
       serviceAccountName: kube-router
       containers:
       - name: kube-router

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -313,6 +313,11 @@ spec:
             readOnlyRootFilesystem: true
             runAsGroup: 1000
             runAsNonRoot: true
+{{ if ContainerdSELinuxEnabled }}
+            seLinuxOptions:
+              type: spc_t
+              level: s0
+{{ end }}
           image: public.ecr.aws/aws-ec2/aws-node-termination-handler:{{ .Version }}
           imagePullPolicy: IfNotPresent
           env:

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -163,6 +163,11 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+{{ if ContainerdSELinuxEnabled }}
+          seLinuxOptions:
+            type: spc_t
+            level: s0
+{{ end }}
         ports:
         - containerPort: 53
           name: dns

--- a/upup/models/cloudup/resources/addons/nvidia.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/nvidia.addons.k8s.io/k8s-1.16.yaml.template
@@ -24,6 +24,11 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+{{ if ContainerdSELinuxEnabled }}
+          seLinuxOptions:
+            type: spc_t
+            level: s0
+{{ end }}
         volumeMounts:
           - name: device-plugin
             mountPath: /var/lib/kubelet/device-plugins
@@ -252,6 +257,11 @@ spec:
             - SYS_ADMIN
           runAsNonRoot: false
           runAsUser: 0
+{{ if ContainerdSELinuxEnabled }}
+          seLinuxOptions:
+            type: spc_t
+            level: s0
+{{ end }}
         image: "nvcr.io/nvidia/k8s/dcgm-exporter:2.4.6-2.6.10-ubuntu20.04"
         imagePullPolicy: "IfNotPresent"
         args: 

--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
@@ -212,6 +212,11 @@ spec:
       nodeSelector: null
       securityContext:
         runAsUser: 1001
+{{ if ContainerdSELinuxEnabled }}
+        seLinuxOptions:
+          type: spc_t
+          level: s0
+{{ end }}
       serviceAccountName: cloud-controller-manager
       tolerations:
       - effect: NoSchedule

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -412,6 +412,13 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["KopsFeatureEnabled"] = tf.kopsFeatureEnabled
 	dest["KopsVersion"] = func() string { return kopsroot.KOPS_RELEASE_VERSION }
 
+	dest["ContainerdSELinuxEnabled"] = func() bool {
+		if cluster.Spec.Containerd != nil {
+			return cluster.Spec.Containerd.SeLinuxEnabled
+		}
+		return false
+	}
+
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: f52de79d02b9fd76d89668ba627d143b9c520429272006a6e591da87dd0961b7
+    manifestHash: 89500f972b8275a9e8d233dfa1fd501de7844d731c7721f3f011383b156beed6
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -287,7 +287,6 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
-      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: f52de79d02b9fd76d89668ba627d143b9c520429272006a6e591da87dd0961b7
+    manifestHash: 89500f972b8275a9e8d233dfa1fd501de7844d731c7721f3f011383b156beed6
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -287,7 +287,6 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
-      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:


### PR DESCRIPTION
Add `cluster.containerd.selinuxEnabled` field that enables SELinux support in containerd on RHEL8/9 (and perhaps other distros). In the end, it adds `enable_selinux=true` in containerd config file.

Unless specified in a Kubernetes Pod, the container runtime then allocates a unique random SELinux label, for example `system_u:system_r:container_t:s0:c152,c241` and runs the Pod containers with that label. If a container process then escapes its containment (which would be a serious CVE in the container runtime), SELinux will prevent the rogue process accessing files of other Pods (because they will have different `cXXX,cYYY` numbers) and on the host.

There is a glitch though - with SELinux enabled in the container runtime, unprivileged containers cannot access anything on the host. Since kops runs all Kubernetes components and etcd as static Pods, these Pods can't e.g. read `/etc` and write to `/var/log/`. Therefore I added `securityOptions: seLinuxOptions: type: spc_t` to most static Pods and all addons that use HostPath volumes. Containers running with `spc_t` (abrev. of "super privileged containers") can access any file on the host. (Regular UID/GID checks are still in effect)

With the changes here, I am able to run a cluster with cillium on RHEL8+9. I did not check other distros nor network plugins.

WIP:
~* needs https://github.com/kubernetes/kops/pull/15496 merged first~
