### PR TITLE
Fix Amazon ECR endpoint in China

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -463,7 +463,7 @@ providers:
   - name: ecr-credential-provider
     matchImages:
       - "*.dkr.ecr.*.amazonaws.com"
-      - "*.dkr.ecr.*.amazonaws.cn"
+      - "*.dkr.ecr.*.amazonaws.com.cn"
       - "*.dkr.ecr-fips.*.amazonaws.com"
       - "*.dkr.ecr.us-iso-east-1.c2s.ic.gov"
       - "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"


### PR DESCRIPTION
We were trying to set up a Kubernetes cluster in AWS China and kept getting Unauthorized errors when pulling images. After some digging, we found that the current hard-coded Amazon ECR endpoint in China is not correct (see the [offical docs](https://docs.aws.amazon.com/general/latest/gr/ecr.html)).

With this fix, we can now pull images from our private ECR normally in China. This should also fix #13494