### PR TITLE
[doc] Update s3api command to create OIDC bucket

### DIFF
--- a/docs/getting_started/aws.md
+++ b/docs/getting_started/aws.md
@@ -228,7 +228,7 @@ with the cluster's DNS.
 
 **Please DO NOT MOVE ON until you have validated your NS records! This is not required if a gossip-based cluster is created.**
 
-## Cluster State storage
+## Cluster State store
 
 In order to store the state of your cluster, and the representation of your
 cluster, we need to create a dedicated S3 bucket for `kops` to use.  This
@@ -254,6 +254,7 @@ to revert or recover a previous state store.
 aws s3api put-bucket-versioning --bucket prefix-example-com-state-store  --versioning-configuration Status=Enabled
 ```
 
+## Cluster OIDC store
 In order for ServiceAccounts to use external permissions (aka IAM Roles for ServiceAccounts), you also need a bucket for hosting the OIDC documents.
 While you can reuse the bucket above if you grant it a public ACL, we do recommend a separate bucket for these files.
 

--- a/docs/getting_started/aws.md
+++ b/docs/getting_started/aws.md
@@ -263,6 +263,12 @@ The ACL must be public so that the AWS STS service can access them.
 aws s3api create-bucket \
     --bucket prefix-example-com-oidc-store \
     --region us-east-1 \
+    --object-ownership BucketOwnerPreferred
+aws s3api put-public-access-block \
+    --bucket prefix-example-com-oidc-store \
+    --public-access-block-configuration BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false
+aws s3api put-bucket-acl \
+    --bucket prefix-example-com-oidc-store \
     --acl public-read
 ```
 


### PR DESCRIPTION
Refs: https://github.com/kubernetes/kops/issues/15454

Recently AWS disabled ACLs by default (see: https://aws.amazon.com/jp/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/), so we need to update s3 commands to create public buckets. 
I update the s3api command in the document.