### PR TITLE
Debian 12 Bookworm: Fix DNS resolution

### DIFF
--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -98,14 +98,16 @@ func (d *Distribution) DefaultUsers() ([]string, error) {
 // HasLoopbackEtcResolvConf is true if systemd-resolved has put the loopback address 127.0.0.53 as a nameserver in /etc/resolv.conf
 // See https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting-loops-in-kubernetes-clusters
 func (d *Distribution) HasLoopbackEtcResolvConf() bool {
-	if d.IsUbuntu() {
-		// Ubuntu > 16.04 has it
-		return d.version > 16.04
-	}
-	if d.project == "flatcar" {
+	switch d.project {
+	case "debian":
+		return d.version >= 12
+	case "ubuntu":
+		return d.version >= 18.04
+	case "flatcar":
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 // Version returns the (project scoped) numeric version


### PR DESCRIPTION
Debian Bookworm switched to using systemd-resolved by default which means that /etc/resolv.conf is a loopback stub. This causes issues with coredns, so apply the same fix as Ubuntu 16.10 and later. 