### PR TITLE
Automated cherry pick of #15502: Debian 12 Bookworm: Fix DNS resolution

### DIFF
--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -96,14 +96,16 @@ func (d *Distribution) DefaultUsers() ([]string, error) {
 // HasLoopbackEtcResolvConf is true if systemd-resolved has put the loopback address 127.0.0.53 as a nameserver in /etc/resolv.conf
 // See https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting-loops-in-kubernetes-clusters
 func (d *Distribution) HasLoopbackEtcResolvConf() bool {
-	if d.IsUbuntu() {
-		// Ubuntu > 16.04 has it
-		return d.version > 16.04
-	}
-	if d.project == "flatcar" {
+	switch d.project {
+	case "debian":
+		return d.version >= 12
+	case "ubuntu":
+		return d.version >= 18.04
+	case "flatcar":
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 // Version returns the (project scoped) numeric version


### PR DESCRIPTION
Cherry pick of #15502 on release-1.26.

#15502: Debian 12 Bookworm: Fix DNS resolution

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```