### PR TITLE
etcd-manager: support symlinking versions

### DIFF
--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -56,7 +56,11 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 			} else {
 				klog.Warningf("Unsupported etcd version %q detected; please update etcd version.", etcdCluster.Version)
 				klog.Warningf("Use export KOPS_FEATURE_FLAGS=SkipEtcdVersionCheck to override this check.")
-				klog.Warningf("Supported etcd versions: %s", strings.Join(etcdSupportedVersions(), ", "))
+				var versions []string
+				for _, v := range etcdSupportedVersions() {
+					versions = append(versions, v.Version)
+				}
+				klog.Warningf("Supported etcd versions: %s", strings.Join(versions, ", "))
 				return fmt.Errorf("etcd version %q is not supported with etcd-manager, please specify a supported version or remove the value to use the recommended version", etcdCluster.Version)
 			}
 		}
@@ -65,27 +69,34 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 	return nil
 }
 
-var etcdSupportedImages = map[string]string{
-	"3.2.24": "registry.k8s.io/etcd:3.2.24-1",
-	"3.3.17": "registry.k8s.io/etcd:3.3.17-0",
-	"3.4.13": "registry.k8s.io/etcd:3.4.13-0",
-	"3.5.7":  "registry.k8s.io/etcd:3.5.7-0",
-	"3.5.9":  "registry.k8s.io/etcd:3.5.9-0",
+// etcdVersion describes how we want to support each etcd version.
+type etcdVersion struct {
+	Version          string
+	Image            string
+	SymlinkToVersion string
 }
 
-func etcdSupportedVersions() []string {
-	var versions []string
-	for etcdVersion := range etcdSupportedImages {
-		versions = append(versions, etcdVersion)
-	}
-	sort.Strings(versions)
+var etcdSupportedImages = []etcdVersion{
+	{Version: "3.2.24", Image: "registry.k8s.io/etcd:3.2.24-1"},
+	{Version: "3.3.17", Image: "registry.k8s.io/etcd:3.3.17-0"},
+	{Version: "3.4.13", Image: "registry.k8s.io/etcd:3.4.13-0"},
+	{Version: "3.5.7", SymlinkToVersion: "3.5.9"},
+	{Version: "3.5.9", Image: "registry.k8s.io/etcd:3.5.9-0"},
+}
+
+func etcdSupportedVersions() []etcdVersion {
+	var versions []etcdVersion
+	versions = append(versions, etcdSupportedImages...)
+	sort.Slice(versions, func(i, j int) bool { return versions[i].Version < versions[j].Version })
 	return versions
 }
 
 func etcdVersionIsSupported(version string) bool {
 	version = strings.TrimPrefix(version, "v")
-	if _, ok := etcdSupportedImages[version]; ok {
-		return true
+	for _, etcdVersion := range etcdSupportedImages {
+		if etcdVersion.Version == version {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -109,8 +109,9 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
+      - -t
+      - /opt/kops-utils/
       - /ko-app/kops-utils-cp
-      - /opt/bin
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -120,11 +121,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -s
+      - /opt/kops-utils/kops-utils-cp
+      - /opt/kops-utils/ln
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+      name: kops-utils-symlinks
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - -t
+      - /opt/etcd-v3.2.24
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -132,11 +146,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.3.17
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -144,11 +159,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.4.13
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -156,23 +172,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
+      - -s
+      - /opt/etcd-v3.5.9
       - /opt/etcd-v3.5.7
       command:
-      - /opt/bin/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.7-0
+      - /opt/kops-utils/ln
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
       name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.5.9
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}
@@ -254,8 +271,9 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
+      - -t
+      - /opt/kops-utils/
       - /ko-app/kops-utils-cp
-      - /opt/bin
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -265,11 +283,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -s
+      - /opt/kops-utils/kops-utils-cp
+      - /opt/kops-utils/ln
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+      name: kops-utils-symlinks
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - -t
+      - /opt/etcd-v3.2.24
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -277,11 +308,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.3.17
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -289,11 +321,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.4.13
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -301,23 +334,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
+      - -s
+      - /opt/etcd-v3.5.9
       - /opt/etcd-v3.5.7
       command:
-      - /opt/bin/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.7-0
+      - /opt/kops-utils/ln
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
       name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.5.9
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -108,8 +108,9 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
+      - -t
+      - /opt/kops-utils/
       - /ko-app/kops-utils-cp
-      - /opt/bin
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -119,11 +120,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -s
+      - /opt/kops-utils/kops-utils-cp
+      - /opt/kops-utils/ln
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+      name: kops-utils-symlinks
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - -t
+      - /opt/etcd-v3.2.24
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -131,11 +145,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.3.17
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -143,11 +158,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.4.13
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -155,23 +171,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
+      - -s
+      - /opt/etcd-v3.5.9
       - /opt/etcd-v3.5.7
       command:
-      - /opt/bin/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.7-0
+      - /opt/kops-utils/ln
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
       name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.5.9
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}
@@ -252,8 +269,9 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
+      - -t
+      - /opt/kops-utils/
       - /ko-app/kops-utils-cp
-      - /opt/bin
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -263,11 +281,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -s
+      - /opt/kops-utils/kops-utils-cp
+      - /opt/kops-utils/ln
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+      name: kops-utils-symlinks
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - -t
+      - /opt/etcd-v3.2.24
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -275,11 +306,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.3.17
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -287,11 +319,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.4.13
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -299,23 +332,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
+      - -s
+      - /opt/etcd-v3.5.9
       - /opt/etcd-v3.5.7
       command:
-      - /opt/bin/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.7-0
+      - /opt/kops-utils/ln
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
       name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.5.9
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -111,8 +111,9 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
+      - -t
+      - /opt/kops-utils/
       - /ko-app/kops-utils-cp
-      - /opt/bin
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -122,11 +123,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -s
+      - /opt/kops-utils/kops-utils-cp
+      - /opt/kops-utils/ln
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+      name: kops-utils-symlinks
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - -t
+      - /opt/etcd-v3.2.24
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -134,11 +148,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.3.17
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -146,11 +161,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.4.13
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -158,23 +174,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
+      - -s
+      - /opt/etcd-v3.5.9
       - /opt/etcd-v3.5.7
       command:
-      - /opt/bin/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.7-0
+      - /opt/kops-utils/ln
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
       name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.5.9
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}
@@ -258,8 +275,9 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
+      - -t
+      - /opt/kops-utils/
       - /ko-app/kops-utils-cp
-      - /opt/bin
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -269,11 +287,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -s
+      - /opt/kops-utils/kops-utils-cp
+      - /opt/kops-utils/ln
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+      name: kops-utils-symlinks
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - -t
+      - /opt/etcd-v3.2.24
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -281,11 +312,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.3.17
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -293,11 +325,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.4.13
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -305,23 +338,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
+      - -s
+      - /opt/etcd-v3.5.9
       - /opt/etcd-v3.5.7
       command:
-      - /opt/bin/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.7-0
+      - /opt/kops-utils/ln
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
       name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.5.9
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -117,8 +117,9 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
+      - -t
+      - /opt/kops-utils/
       - /ko-app/kops-utils-cp
-      - /opt/bin
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -128,11 +129,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -s
+      - /opt/kops-utils/kops-utils-cp
+      - /opt/kops-utils/ln
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+      name: kops-utils-symlinks
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - -t
+      - /opt/etcd-v3.2.24
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -140,11 +154,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.3.17
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -152,11 +167,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.4.13
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -164,23 +180,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
+      - -s
+      - /opt/etcd-v3.5.9
       - /opt/etcd-v3.5.7
       command:
-      - /opt/bin/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.7-0
+      - /opt/kops-utils/ln
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
       name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.5.9
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}
@@ -270,8 +287,9 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
+      - -t
+      - /opt/kops-utils/
       - /ko-app/kops-utils-cp
-      - /opt/bin
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -281,11 +299,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -s
+      - /opt/kops-utils/kops-utils-cp
+      - /opt/kops-utils/ln
+      command:
+      - /opt/kops-utils/kops-utils-cp
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+      name: kops-utils-symlinks
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - -t
+      - /opt/etcd-v3.2.24
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -293,11 +324,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.3.17
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -305,11 +337,12 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.4.13
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -317,23 +350,24 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
+      - -s
+      - /opt/etcd-v3.5.9
       - /opt/etcd-v3.5.7
       command:
-      - /opt/bin/kops-utils-cp
-      image: registry.k8s.io/etcd:3.5.7-0
+      - /opt/kops-utils/ln
+      image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
       name: init-etcd-3-5-7
       resources: {}
       volumeMounts:
       - mountPath: /opt
         name: opt
     - args:
+      - -t
+      - /opt/etcd-v3.5.9
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -47,8 +47,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -58,11 +59,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +84,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -82,11 +97,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -94,23 +110,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -47,8 +47,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -58,11 +59,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +84,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -82,11 +97,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -94,23 +110,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -46,8 +46,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -57,11 +58,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -69,11 +83,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -81,11 +96,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -93,23 +109,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -48,8 +48,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -59,11 +60,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -71,11 +85,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -83,11 +98,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -95,23 +111,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -46,8 +46,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -57,11 +58,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -69,11 +83,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -81,11 +96,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -93,23 +109,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -48,8 +48,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -59,11 +60,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -71,11 +85,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -83,11 +98,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -95,23 +111,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -47,8 +47,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -58,11 +59,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +84,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -82,11 +97,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -94,23 +110,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -49,8 +49,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -60,11 +61,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -72,11 +86,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -84,11 +99,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -96,23 +112,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -47,8 +47,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -58,11 +59,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +84,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -82,11 +97,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -94,23 +110,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -49,8 +49,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -60,11 +61,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -72,11 +86,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -84,11 +99,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -96,23 +112,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -46,8 +46,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -57,11 +58,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -69,11 +83,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -81,11 +96,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -93,23 +109,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -48,8 +48,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -59,11 +60,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -71,11 +85,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -83,11 +98,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -95,23 +111,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -46,8 +46,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -57,11 +58,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -69,11 +83,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -81,11 +96,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -93,23 +109,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -48,8 +48,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -59,11 +60,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -71,11 +85,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -83,11 +98,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -95,23 +111,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -46,8 +46,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -57,11 +58,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -69,11 +83,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -81,11 +96,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -93,23 +109,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -48,8 +48,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -59,11 +60,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -71,11 +85,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -83,11 +98,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -95,23 +111,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -46,8 +46,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -57,11 +58,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -69,11 +83,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -81,11 +96,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -93,23 +109,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -48,8 +48,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -59,11 +60,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -71,11 +85,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -83,11 +98,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -95,23 +111,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -47,8 +47,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -58,11 +59,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +84,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -82,11 +97,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -94,23 +110,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -46,8 +46,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -57,11 +58,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -69,11 +83,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -81,11 +96,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -93,23 +109,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -46,8 +46,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -57,11 +58,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -69,11 +83,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -81,11 +96,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -93,23 +109,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -48,8 +48,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -59,11 +60,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -71,11 +85,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -83,11 +98,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -95,23 +111,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -48,8 +48,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -59,11 +60,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -71,11 +85,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -83,11 +98,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -95,23 +111,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -47,8 +47,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -58,11 +59,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +84,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -82,11 +97,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -94,23 +110,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -49,8 +49,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -60,11 +61,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -72,11 +86,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -84,11 +99,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -96,23 +112,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -47,8 +47,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -58,11 +59,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +84,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -82,11 +97,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -94,23 +110,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -49,8 +49,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -60,11 +61,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -72,11 +86,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -84,11 +99,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -96,23 +112,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -47,8 +47,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -58,11 +59,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +84,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -82,11 +97,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -94,23 +110,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -49,8 +49,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -60,11 +61,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -72,11 +86,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -84,11 +99,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -96,23 +112,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -47,8 +47,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -58,11 +59,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +84,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -82,11 +97,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -94,23 +110,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -49,8 +49,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -60,11 +61,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -72,11 +86,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -84,11 +99,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -96,23 +112,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -56,11 +57,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +82,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -80,11 +95,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -92,23 +108,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,9 @@ spec:
   hostPID: true
   initContainers:
   - args:
+    - -t
+    - /opt/kops-utils/
     - /ko-app/kops-utils-cp
-    - /opt/bin
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
@@ -55,11 +56,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -s
+    - /opt/kops-utils/kops-utils-cp
+    - /opt/kops-utils/ln
+    command:
+    - /opt/kops-utils/kops-utils-cp
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
+    name: kops-utils-symlinks
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - -t
+    - /opt/etcd-v3.2.24
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +81,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.3.17
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -79,11 +94,12 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.4.13
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -91,23 +107,24 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
+    - -s
+    - /opt/etcd-v3.5.9
     - /opt/etcd-v3.5.7
     command:
-    - /opt/bin/kops-utils-cp
-    image: registry.k8s.io/etcd:3.5.7-0
+    - /opt/kops-utils/ln
+    image: registry.k8s.io/kops/kops-utils-cp:1.27.0-alpha.2
     name: init-etcd-3-5-7
     resources: {}
     volumeMounts:
     - mountPath: /opt
       name: opt
   - args:
+    - -t
+    - /opt/etcd-v3.5.9
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}


### PR DESCRIPTION
This is an easy way for us to signal that certain versions are
compatible with each to etcd-manager, which is otherwise
overly-cautious when it comes to unknown versions.


We extend kops-utils to support ln commands, and try to match the
syntax more closely align with traditional unix syntax.
