### PR TITLE
Remap all init container images of etcd-manager

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -273,13 +273,16 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 					},
 				},
 			}
-			// Remap image via AssetBuilder
-			remapped, err := b.AssetBuilder.RemapImage(initContainer.Image)
-			if err != nil {
-				return nil, fmt.Errorf("unable to remap container image %q: %w", initContainer.Image, err)
-			}
-			initContainer.Image = remapped
 			pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
+		}
+
+		// Remap all init container images via AssetBuilder
+		for i, container := range pod.Spec.InitContainers {
+			remapped, err := b.AssetBuilder.RemapImage(container.Image)
+			if err != nil {
+				return nil, fmt.Errorf("unable to remap init container image %q: %w", container.Image, err)
+			}
+			pod.Spec.InitContainers[i].Image = remapped
 		}
 	}
 


### PR DESCRIPTION
I was testing out kops v1.27.0-beta.1 and noticed that the new `kops-utils-cp` init container image for etcd-manager hasn't been remapped via the asset builder and thus not copied to our custom container proxy when we run `kops get assets --copy`. 

This PR adds the missing code to remap the `kops-utils-cp` image.