### PR TITLE
Automated cherry pick of #15514: Remap all init container images of etcd-manager

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -273,13 +273,16 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 					},
 				},
 			}
-			// Remap image via AssetBuilder
-			remapped, err := b.AssetBuilder.RemapImage(initContainer.Image)
-			if err != nil {
-				return nil, fmt.Errorf("unable to remap container image %q: %w", initContainer.Image, err)
-			}
-			initContainer.Image = remapped
 			pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
+		}
+
+		// Remap all init container images via AssetBuilder
+		for i, container := range pod.Spec.InitContainers {
+			remapped, err := b.AssetBuilder.RemapImage(container.Image)
+			if err != nil {
+				return nil, fmt.Errorf("unable to remap init container image %q: %w", container.Image, err)
+			}
+			pod.Spec.InitContainers[i].Image = remapped
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #15514 on release-1.27.

#15514: Remap all init container images of etcd-manager

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```