### PR TITLE
Automated cherry pick of #15523: Fix promotion of `kops-utils-cp` - cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
   - DOCKER_REGISTRY=$_DOCKER_REGISTRY
   - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
   args:
-  - kops-utils-cp
+  - kops-utils-cp-push
   - kops-controller-push
   - dns-controller-push
   - kube-apiserver-healthcheck-push


### PR DESCRIPTION
Cherry pick of #15523 on release-1.27.

#15523: Fix promotion of `kops-utils-cp` - cloudbuild

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```