### PR TITLE
Automated cherry pick of #15526: Remove duplicate Cluster field in BootstrapScriptBuilder

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup_test.go
+++ b/pkg/model/awsmodel/autoscalinggroup_test.go
@@ -72,13 +72,17 @@ func TestRootVolumeOptimizationFlag(t *testing.T) {
 		},
 		BootstrapScriptBuilder: &model.BootstrapScriptBuilder{
 			Lifecycle: fi.LifecycleSync,
-			Cluster: &kops.Cluster{
-				Spec: kops.ClusterSpec{
-					CloudProvider: kops.CloudProviderSpec{
-						AWS: &kops.AWSSpec{},
+			KopsModelContext: &model.KopsModelContext{
+				IAMModelContext: iam.IAMModelContext{
+					Cluster: &kops.Cluster{
+						Spec: kops.ClusterSpec{
+							CloudProvider: kops.CloudProviderSpec{
+								AWS: &kops.AWSSpec{},
+							},
+							Networking:        kops.NetworkingSpec{},
+							KubernetesVersion: "1.20.0",
+						},
 					},
-					Networking:        kops.NetworkingSpec{},
-					KubernetesVersion: "1.20.0",
 				},
 			},
 		},
@@ -184,7 +188,6 @@ func TestAPIServerAdditionalSecurityGroupsWithNLB(t *testing.T) {
 				InstanceGroups:  igs,
 			},
 			Lifecycle: fi.LifecycleSync,
-			Cluster:   cluster,
 		},
 		Cluster: cluster,
 	}

--- a/pkg/model/azuremodel/vmscaleset_test.go
+++ b/pkg/model/azuremodel/vmscaleset_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/defaults"
+	"k8s.io/kops/pkg/model/iam"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/fitasks"
 )
@@ -35,9 +36,13 @@ func TestVMScaleSetModelBuilder_Build(t *testing.T) {
 		AzureModelContext: newTestAzureModelContext(),
 		BootstrapScriptBuilder: &model.BootstrapScriptBuilder{
 			Lifecycle: fi.LifecycleSync,
-			Cluster: &kops.Cluster{
-				Spec: kops.ClusterSpec{
-					Networking: kops.NetworkingSpec{},
+			KopsModelContext: &model.KopsModelContext{
+				IAMModelContext: iam.IAMModelContext{
+					Cluster: &kops.Cluster{
+						Spec: kops.ClusterSpec{
+							Networking: kops.NetworkingSpec{},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -52,7 +52,6 @@ type BootstrapScriptBuilder struct {
 	Lifecycle           fi.Lifecycle
 	NodeUpAssets        map[architectures.Architecture]*mirrors.MirroredAsset
 	NodeUpConfigBuilder NodeUpConfigBuilder
-	Cluster             *kops.Cluster
 }
 
 type BootstrapScript struct {

--- a/pkg/model/bootstrapscript_test.go
+++ b/pkg/model/bootstrapscript_test.go
@@ -180,7 +180,6 @@ func TestBootstrapUserData(t *testing.T) {
 					Hash:      hashing.MustFromString("e525c28a65ff0ce4f95f9e730195b4e67fdcb15ceb1f36b5ad6921a8a4490c71"),
 				},
 			},
-			Cluster: cluster,
 		}
 
 		res, err := bs.ResourceNodeUp(c, group)

--- a/pkg/model/iam/types.go
+++ b/pkg/model/iam/types.go
@@ -43,6 +43,7 @@ type IAMModelContext struct {
 	// AWSPartition defines the partition of the AWS account, typically "aws", "aws-cn", or "aws-us-gov"
 	AWSPartition string
 
+	// Cluster holds the cluster we are working with.
 	Cluster *kops.Cluster
 }
 

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -1465,7 +1465,6 @@ func RunGoldenTest(t *testing.T, basedir string, testCase serverGroupModelBuilde
 				Hash:      hashing.MustFromString("e525c28a65ff0ce4f95f9e730195b4e67fdcb15ceb1f36b5ad6921a8a4490c71"),
 			},
 		},
-		Cluster: testCase.cluster,
 	}
 
 	builder := createBuilderForCluster(testCase.cluster, testCase.instanceGroups, clusterLifecycle, bootstrapScriptBuilder)

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -522,7 +522,6 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		Lifecycle:           clusterLifecycle,
 		NodeUpConfigBuilder: configBuilder,
 		NodeUpAssets:        c.NodeUpAssets,
-		Cluster:             cluster,
 	}
 
 	{


### PR DESCRIPTION
Cherry pick of #15526 on release-1.27.

#15526: Remove duplicate Cluster field in BootstrapScriptBuilder

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```