### PR TITLE
Automated cherry pick of #15458: Support intstr.IntOrString type

### DIFF
--- a/cmd/kops/edit_instancegroup_test.go
+++ b/cmd/kops/edit_instancegroup_test.go
@@ -66,7 +66,7 @@ func TestEditInstanceGroup(t *testing.T) {
 		editOptions := &EditInstanceGroupOptions{
 			ClusterName: clusterName,
 			GroupName:   "nodes",
-			Sets:        []string{"spec.maxSize=10"},
+			Sets:        []string{"spec.maxSize=10", "spec.rollingUpdate.maxUnavailable=50%"},
 		}
 		err := RunEditInstanceGroup(ctx, factory, &stdout, editOptions)
 		if err != nil {

--- a/cmd/kops/test/edit_instance_group.yaml
+++ b/cmd/kops/test/edit_instance_group.yaml
@@ -10,6 +10,8 @@ spec:
   image: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404
   maxSize: 10
   role: Node
+  rollingUpdate:
+    maxUnavailable: 50%
   subnets:
   - subnet-us-test-1a
   taints:

--- a/util/pkg/reflectutils/access.go
+++ b/util/pkg/reflectutils/access.go
@@ -161,7 +161,6 @@ func setType(v reflect.Value, newValue string) error {
 		default:
 			panic("missing case in switch")
 		}
-	
 	case "intstr.IntOrString":
 		newV = reflect.ValueOf(intstr.Parse(newValue))
 


### PR DESCRIPTION
Cherry pick of #15458 on release-1.27.

#15458: Support intstr.IntOrString type

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```