### PR TITLE
kubetest2-kops: add support for boskos-resource-type flag

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -8,6 +8,7 @@ replace k8s.io/kops => ../../.
 replace k8s.io/client-go => k8s.io/client-go v0.31.0
 
 require (
+	github.com/aws/aws-sdk-go v1.44.283
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/octago/sflags v0.2.0

--- a/tests/e2e/kubetest2-kops/aws/s3.go
+++ b/tests/e2e/kubetest2-kops/aws/s3.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"k8s.io/klog/v2"
+)
+
+// We need to pick some region to query the AWS APIs through, even if we are not running on AWS.
+const defaultRegion = "us-east-2"
+
+type awsClient struct {
+	sts *sts.STS
+	s3  *s3.S3
+}
+
+func newAWSClient(ctx context.Context, creds *credentials.Credentials) (*awsClient, error) {
+	awsConfig := aws.NewConfig().WithRegion(defaultRegion).WithUseDualStack(true)
+	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
+	if creds != nil {
+		awsConfig = awsConfig.WithCredentials(creds)
+	}
+
+	awsSession, err := session.NewSessionWithOptions(session.Options{
+		Config:            *awsConfig,
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error starting new AWS session: %v", err)
+	}
+
+	return &awsClient{
+		sts: sts.New(awsSession, awsConfig),
+		s3:  s3.New(awsSession, awsConfig),
+	}, nil
+}
+
+// AWSBucketName constructs a bucket name that is unique to the AWS account.
+func AWSBucketName(ctx context.Context, creds *credentials.Credentials) (string, error) {
+	client, err := newAWSClient(ctx, creds)
+	if err != nil {
+		return "", err
+	}
+
+	callerIdentity, err := client.sts.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", fmt.Errorf("error getting AWS caller identity from STS: %w", err)
+	}
+	bucket := "kops-test-" + aws.StringValue(callerIdentity.Account)
+	return bucket, nil
+}
+
+// EnsureAWSBucket creates a bucket if it does not exist in the account.
+// If a different account has already created the bucket, that is treated as an error to prevent "preimage" attacks.
+func EnsureAWSBucket(ctx context.Context, creds *credentials.Credentials, bucketName string) error {
+	// These don't need to be in the same region, so we pick a region arbitrarily
+	location := "us-east-2"
+
+	client, err := newAWSClient(ctx, creds)
+	if err != nil {
+		return err
+	}
+
+	// Note that this lists only our buckets, so we know that someone else hasn't created the bucket
+	buckets, err := client.s3.ListBucketsWithContext(ctx, &s3.ListBucketsInput{})
+	if err != nil {
+		return fmt.Errorf("error listing buckets: %w", err)
+	}
+
+	var existingBucket *s3.Bucket
+	for _, bucket := range buckets.Buckets {
+		if aws.StringValue(bucket.Name) == bucketName {
+			existingBucket = bucket
+		}
+	}
+
+	if existingBucket == nil {
+		klog.Infof("creating S3 bucket s3://%s", bucketName)
+		if _, err := client.s3.CreateBucketWithContext(ctx, &s3.CreateBucketInput{
+			Bucket: &bucketName,
+			CreateBucketConfiguration: &s3.CreateBucketConfiguration{
+				LocationConstraint: &location,
+			},
+		}); err != nil {
+			return fmt.Errorf("error creating bucket s3://%v: %w", bucketName, err)
+		}
+	}
+
+	return nil
+}
+
+// DeleteAWSBucket deletes an AWS bucket.
+func DeleteAWSBucket(ctx context.Context, creds *credentials.Credentials, bucketName string) error {
+	client, err := newAWSClient(ctx, creds)
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("deleting S3 bucket s3://%s", bucketName)
+	if _, err := client.s3.DeleteBucketWithContext(ctx, &s3.DeleteBucketInput{Bucket: &bucketName}); err != nil {
+		return fmt.Errorf("error deleting bucket: %w", err)
+	}
+	return nil
+}

--- a/tests/e2e/kubetest2-kops/deployer/boskos.go
+++ b/tests/e2e/kubetest2-kops/deployer/boskos.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/boskos/client"
+	"sigs.k8s.io/boskos/common"
+	"sigs.k8s.io/kubetest2/pkg/boskos"
+)
+
+type boskosHelper struct {
+	// boskos holds the client we use for boskos communication.
+	boskos *client.Client
+
+	// this channel serves as a signal channel for the boskos heartbeat goroutine
+	// so that it can be explicitly closed
+	boskosHeartbeatClose chan struct{}
+
+	// resources tracks acquired resources so they can be freed in Cleanup.
+	resources []*common.Resource
+}
+
+func (h *boskosHelper) Acquire(ctx context.Context, resourceType string) (*common.Resource, error) {
+	if h.boskos == nil {
+		h.boskosHeartbeatClose = make(chan struct{})
+
+		boskosURL := os.Getenv("BOSKOS_HOST")
+		if boskosURL == "" {
+			boskosURL = "http://boskos.test-pods.svc.cluster.local."
+		}
+		boskosClient, err := boskos.NewClient(boskosURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to make boskos client for %q: %w", boskosURL, err)
+		}
+		h.boskos = boskosClient
+	}
+
+	resource, err := boskos.Acquire(
+		h.boskos,
+		resourceType,
+		5*time.Minute,
+		5*time.Minute,
+		h.boskosHeartbeatClose,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %q resource from boskos: %w", resourceType, err)
+	}
+	h.resources = append(h.resources, resource)
+
+	return resource, nil
+}
+
+// Cleanup releases any resources acquired from boskos
+func (h *boskosHelper) Cleanup(ctx context.Context) error {
+	if h.boskos != nil {
+		var resourceNames []string
+		for _, resource := range h.resources {
+			klog.V(2).Info("releasing boskos resource %v %q", resource.Type, resource.Name)
+			resourceNames = append(resourceNames, resource.Name)
+		}
+		err := boskos.Release(
+			h.boskos,
+			resourceNames,
+			h.boskosHeartbeatClose,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to release boskos resources %v: %w", resourceNames, err)
+		}
+	}
+
+	return nil
+}

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -100,7 +100,18 @@ type deployer struct {
 	// this channel serves as a signal channel for the hearbeat goroutine
 	// so that it can be explicitly closed
 	boskosHeartbeatClose chan struct{}
+	// BoskosResourceType string `flag:"boskos-resource-type" desc:"Resource type to acquire from boskos, for credentials"`
+
+	// boskos boskosHelper
+
+	// // awsStaticCredentials holds credentials for AWS loaded from boskos
+	// awsStaticCredentials *awsStaticCredentials
 }
+
+// type awsStaticCredentials struct {
+// 	AccessKeyID     string
+// 	SecretAccessKey string
+// }
 
 // assert that New implements types.NewDeployer
 var _ types.NewDeployer = New

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -59,8 +59,15 @@ type deployer struct {
 	KubernetesFeatureGates string   `flag:"kubernetes-feature-gates" desc:"Feature Gates to enable on Kubernetes components"`
 	createBucket           bool     `flag:"-"`
 
-	// ControlPlaneCount specifies the number of VMs in the control-plane.
-	ControlPlaneCount int `flag:"control-plane-count" desc:"Number of control-plane instances"`
+	// // ControlPlaneCount specifies the number of VMs in the control-plane.
+	// ControlPlaneCount int `flag:"control-plane-count" desc:"Number of control-plane instances"`
+	// ClusterName      string   `flag:"cluster-name" desc:"The FQDN to use for the cluster name"`
+	// ControlPlaneSize int      `flag:"control-plane-size" desc:"Number of control plane instances"`
+	// CloudProvider    string   `flag:"cloud-provider" desc:"Which cloud provider to use"`
+	// GCPProject       string   `flag:"gcp-project" desc:"Which GCP Project to use when --cloud-provider=gce"`
+	// Env              []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`
+	// CreateArgs       string   `flag:"create-args" desc:"Extra space-separated arguments passed to 'kops create cluster'"`
+	// KopsBinaryPath   string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
 
 	ControlPlaneIGOverrides []string `flag:"control-plane-instance-group-overrides" desc:"overrides for the control plane instance groups"`
 	NodeIGOverrides         []string `flag:"node-instance-group-overrides" desc:"overrides for the node instance groups"`
@@ -104,6 +111,13 @@ type deployer struct {
 
 	// boskos boskosHelper
 
+	// // awsCredentials holds credentials for AWS loaded from boskos
+	// awsCredentials *credentials.Credentials
+
+	// // stateStore holds the kops state-store URL
+	// stateStore string
+
+	// createStateStoreBucket bool `flag:"-"`
 	// // awsStaticCredentials holds credentials for AWS loaded from boskos
 	// awsStaticCredentials *awsStaticCredentials
 }

--- a/tests/e2e/kubetest2-kops/deployer/down.go
+++ b/tests/e2e/kubetest2-kops/deployer/down.go
@@ -17,17 +17,18 @@ limitations under the License.
 package deployer
 
 import (
-	"fmt"
+	"context"
 	"strings"
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/gce"
 	"k8s.io/kops/tests/e2e/pkg/kops"
-	"sigs.k8s.io/kubetest2/pkg/boskos"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
 func (d *deployer) Down() error {
+	ctx := context.TODO()
+
 	if err := d.init(); err != nil {
 		return err
 	}
@@ -77,16 +78,8 @@ func (d *deployer) Down() error {
 		gce.DeleteGCSBucket(d.stagingStore(), d.GCPProject)
 	}
 
-	if d.boskos != nil {
-		klog.V(2).Info("releasing boskos project")
-		err := boskos.Release(
-			d.boskos,
-			[]string{d.GCPProject},
-			d.boskosHeartbeatClose,
-		)
-		if err != nil {
-			return fmt.Errorf("down failed to release boskos project: %s", err)
-		}
+	if err := d.boskos.Cleanup(ctx); err != nil {
+		return err
 	}
 	return nil
 }

--- a/tests/e2e/kubetest2-kops/deployer/template.go
+++ b/tests/e2e/kubetest2-kops/deployer/template.go
@@ -80,6 +80,7 @@ func (d *deployer) templateValues(zones []string, publicIP string) (map[string]i
 		"publicIP":          publicIP,
 		"stateStore":        d.stateStore(),
 		"discoveryStore":    d.discoveryStore(),
+		"stateStore":        d.stateStore,
 		"zones":             zones,
 		"sshPublicKey":      string(publicKey),
 	}, nil


### PR DESCRIPTION
This will cause AWS tests to acquire an aws-account from boskos (when
set to aws-account), and run the tests with those credentials.
