### PR TITLE
Fix long auth helper cache file name

### DIFF
--- a/pkg/commands/helpers/kubectl_auth.go
+++ b/pkg/commands/helpers/kubectl_auth.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -173,7 +174,11 @@ func cacheFilePath(kopsStateStore string, clusterName string) string {
 	b.WriteString(clusterName)
 	b.WriteByte(0)
 
-	hash := fmt.Sprintf("%x", sha256.Sum256(b.Bytes()))
+	var i big.Int
+	hb := sha256.Sum224(b.Bytes())
+	i.SetBytes(hb[:])
+
+	hash := i.Text(62)
 	return filepath.Join(homedir.HomeDir(), ".kube", "cache", "kops-authentication", hash)
 }
 

--- a/pkg/commands/helpers/kubectl_auth.go
+++ b/pkg/commands/helpers/kubectl_auth.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -174,20 +173,8 @@ func cacheFilePath(kopsStateStore string, clusterName string) string {
 	b.WriteString(clusterName)
 	b.WriteByte(0)
 
-	hash := fmt.Sprintf("%x", sha256.New().Sum(b.Bytes()))
-	sanitizedName := strings.Map(func(r rune) rune {
-		switch {
-		case r >= 'a' && r <= 'z':
-			return r
-		case r >= 'A' && r <= 'Z':
-			return r
-		case r >= '0' && r <= '9':
-			return r
-		default:
-			return '_'
-		}
-	}, clusterName)
-	return filepath.Join(homedir.HomeDir(), ".kube", "cache", "kops-authentication", sanitizedName+"_"+hash)
+	hash := fmt.Sprintf("%x", sha256.Sum256(b.Bytes()))
+	return filepath.Join(homedir.HomeDir(), ".kube", "cache", "kops-authentication", hash)
 }
 
 func loadCachedExecCredential(cacheFilePath string) (*ExecCredential, error) {

--- a/pkg/commands/helpers/kubectl_auth_test.go
+++ b/pkg/commands/helpers/kubectl_auth_test.go
@@ -1,0 +1,28 @@
+package helpers
+
+import (
+	"path"
+	"testing"
+)
+
+func Test_cacheFilePath(t *testing.T) {
+	inputs := []struct {
+		kopsStateStore string
+		clusterName    string
+	}{
+		{
+			kopsStateStore: "s3://abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk",
+			clusterName: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde." +
+				"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk." +
+				"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk." +
+				"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+		},
+	}
+
+	output1 := cacheFilePath(inputs[0].kopsStateStore, inputs[0].clusterName)
+	_, file := path.Split(output1)
+
+	if len(file) > 64 {
+		t.Errorf("cacheFilePath() got %v, too long(%v)", output1, len(file))
+	}
+}

--- a/pkg/commands/helpers/kubectl_auth_test.go
+++ b/pkg/commands/helpers/kubectl_auth_test.go
@@ -38,7 +38,7 @@ func Test_cacheFilePath(t *testing.T) {
 	output1 := cacheFilePath(inputs[0].kopsStateStore, inputs[0].clusterName)
 	_, file := path.Split(output1)
 
-	if len(file) > 38 {
+	if len(file) > 71 {
 		t.Errorf("cacheFilePath() got %v, too long(%v)", output1, len(file))
 	}
 }

--- a/pkg/commands/helpers/kubectl_auth_test.go
+++ b/pkg/commands/helpers/kubectl_auth_test.go
@@ -38,7 +38,7 @@ func Test_cacheFilePath(t *testing.T) {
 	output1 := cacheFilePath(inputs[0].kopsStateStore, inputs[0].clusterName)
 	_, file := path.Split(output1)
 
-	if len(file) > 64 {
+	if len(file) > 38 {
 		t.Errorf("cacheFilePath() got %v, too long(%v)", output1, len(file))
 	}
 }

--- a/pkg/commands/helpers/kubectl_auth_test.go
+++ b/pkg/commands/helpers/kubectl_auth_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package helpers
 
 import (


### PR DESCRIPTION
The `kops helpers kubectl-auth` command tries to create a cache file that is long in proportion to the length of the `cluster` and `state` parameters, and outputs the following message. This PR corrects this behavior so that it always generates cache file names of the same length.


> I0623 12:21:51.479433    8889 kubectl_auth.go:114] cached credential "/home/vscode/.kube/cache/kops-authentication/my_kops_cluster_test_my_domain_net_73333a2f2f6d792d6b6f70732d73746174652d6d792d6177732d6163636f756e742d69642d61702d6e6f727468656173742d31006d792d6b6f70732d636c75737465722e746573742e6d792d646f6d61696e2e6e657400e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" was not valid: open /home/vscode/.kube/cache/kops-authentication/my_kops_cluster_test_my_domain_net_73333a2f2f6d792d6b6f70732d73746174652d6d792d6177732d6163636f756e742d69642d61702d6e6f727468656173742d31006d792d6b6f70732d636c75737465722e746573742e6d792d646f6d61696e2e6e657400e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855: input/output error
