### PR TITLE
Automated cherry pick of #15564: Revert "Remove obsolete etcd versions"

### DIFF
--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -67,8 +67,15 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 
 var etcdSupportedImages = map[string]string{
 	"3.2.24": "registry.k8s.io/etcd:3.2.24-1",
+	"3.3.10": "registry.k8s.io/etcd:3.3.10-0",
 	"3.3.17": "registry.k8s.io/etcd:3.3.17-0",
+	"3.4.3":  "registry.k8s.io/etcd:3.4.3-0",
 	"3.4.13": "registry.k8s.io/etcd:3.4.13-0",
+	"3.5.0":  "registry.k8s.io/etcd:3.5.0-0",
+	"3.5.1":  "registry.k8s.io/etcd:3.5.1-0",
+	"3.5.3":  "registry.k8s.io/etcd:3.5.3-0",
+	"3.5.4":  "registry.k8s.io/etcd:3.5.4-0",
+	"3.5.6":  "registry.k8s.io/etcd:3.5.6-0",
 	"3.5.7":  "registry.k8s.io/etcd:3.5.7-0",
 	"3.5.9":  "registry.k8s.io/etcd:3.5.9-0",
 }

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -134,6 +134,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.3.10
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.3.17
       command:
       - /opt/bin/kops-utils-cp
@@ -151,6 +163,78 @@ Contents: |
       - /opt/bin/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.4.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.0
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.1
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.4
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.6
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -279,6 +363,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.3.10
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.3.17
       command:
       - /opt/bin/kops-utils-cp
@@ -296,6 +392,78 @@ Contents: |
       - /opt/bin/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.4.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.0
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.1
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.4
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.6
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -133,6 +133,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.3.10
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.3.17
       command:
       - /opt/bin/kops-utils-cp
@@ -150,6 +162,78 @@ Contents: |
       - /opt/bin/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.4.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.0
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.1
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.4
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.6
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -277,6 +361,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.3.10
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.3.17
       command:
       - /opt/bin/kops-utils-cp
@@ -294,6 +390,78 @@ Contents: |
       - /opt/bin/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.4.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.0
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.1
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.4
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.6
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -136,6 +136,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.3.10
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.3.17
       command:
       - /opt/bin/kops-utils-cp
@@ -153,6 +165,78 @@ Contents: |
       - /opt/bin/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.4.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.0
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.1
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.4
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.6
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -283,6 +367,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.3.10
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.3.17
       command:
       - /opt/bin/kops-utils-cp
@@ -300,6 +396,78 @@ Contents: |
       - /opt/bin/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.4.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.0
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.1
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.4
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.6
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -142,6 +142,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.3.10
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.3.17
       command:
       - /opt/bin/kops-utils-cp
@@ -159,6 +171,78 @@ Contents: |
       - /opt/bin/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.4.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.0
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.1
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.4
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.6
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
       resources: {}
       volumeMounts:
       - mountPath: /opt
@@ -295,6 +379,18 @@ Contents: |
     - args:
       - /usr/local/bin/etcd
       - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.3.10
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.3.10-0
+      name: init-etcd-3-3-10
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
       - /opt/etcd-v3.3.17
       command:
       - /opt/bin/kops-utils-cp
@@ -312,6 +408,78 @@ Contents: |
       - /opt/bin/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.4.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.4.3-0
+      name: init-etcd-3-4-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.0
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.0-0
+      name: init-etcd-3-5-0
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.1
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.1-0
+      name: init-etcd-3-5-1
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.3
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.3-0
+      name: init-etcd-3-5-3
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.4
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.4-0
+      name: init-etcd-3-5-4
+      resources: {}
+      volumeMounts:
+      - mountPath: /opt
+        name: opt
+    - args:
+      - /usr/local/bin/etcd
+      - /usr/local/bin/etcdctl
+      - /opt/etcd-v3.5.6
+      command:
+      - /opt/bin/kops-utils-cp
+      image: registry.k8s.io/etcd:3.5.6-0
+      name: init-etcd-3-5-6
       resources: {}
       volumeMounts:
       - mountPath: /opt

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -72,6 +72,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -89,6 +101,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -72,6 +72,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -89,6 +101,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -72,6 +72,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -89,6 +101,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -71,6 +71,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -88,6 +100,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -71,6 +71,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -88,6 +100,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -73,6 +73,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -90,6 +102,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -73,6 +73,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -90,6 +102,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -70,6 +70,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -87,6 +99,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -69,6 +69,18 @@ spec:
   - args:
     - /usr/local/bin/etcd
     - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.3.10
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.3.10-0
+    name: init-etcd-3-3-10
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
     - /opt/etcd-v3.3.17
     command:
     - /opt/bin/kops-utils-cp
@@ -86,6 +98,78 @@ spec:
     - /opt/bin/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.4.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.4.3-0
+    name: init-etcd-3-4-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.0
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.0-0
+    name: init-etcd-3-5-0
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.1
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.1-0
+    name: init-etcd-3-5-1
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.3
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.3-0
+    name: init-etcd-3-5-3
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.4
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.4-0
+    name: init-etcd-3-5-4
+    resources: {}
+    volumeMounts:
+    - mountPath: /opt
+      name: opt
+  - args:
+    - /usr/local/bin/etcd
+    - /usr/local/bin/etcdctl
+    - /opt/etcd-v3.5.6
+    command:
+    - /opt/bin/kops-utils-cp
+    image: registry.k8s.io/etcd:3.5.6-0
+    name: init-etcd-3-5-6
     resources: {}
     volumeMounts:
     - mountPath: /opt


### PR DESCRIPTION
Cherry pick of #15564 on release-1.27.

#15564: Revert "Remove obsolete etcd versions"

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```