### PR TITLE
Automated cherry pick of #15573: aws: Avoid spurious changes in EBSVolume for KmsKeyId

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
@@ -90,8 +90,10 @@ func (e *EBSVolume) Find(context *fi.CloudupContext) (*EBSVolume, error) {
 
 	// Avoid spurious changes
 	actual.Lifecycle = e.Lifecycle
-
 	e.ID = actual.ID
+	if fi.ValueOf(e.Encrypted) && e.KmsKeyId == nil {
+		e.KmsKeyId = actual.KmsKeyId
+	}
 
 	return actual, nil
 }


### PR DESCRIPTION
Cherry pick of #15573 on release-1.26.

#15573: aws: Avoid spurious changes in EBSVolume for KmsKeyId

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```