### PR TITLE
Automated cherry pick of #15577: hetzner: Update CCM to v1.16.0

### DIFF
--- a/pkg/model/components/hetznercloudcontrollermanager.go
+++ b/pkg/model/components/hetznercloudcontrollermanager.go
@@ -48,12 +48,14 @@ func (b *HetznerCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}
 		LeaderElect: fi.PtrTo(false),
 	}
 
-	eccm.ClusterCIDR = clusterSpec.Networking.NonMasqueradeCIDR
+	if eccm.ClusterCIDR == "" {
+		eccm.ClusterCIDR = clusterSpec.Networking.PodCIDR
+	}
 	eccm.AllocateNodeCIDRs = fi.PtrTo(true)
 	eccm.ConfigureCloudRoutes = fi.PtrTo(false)
 
 	if eccm.Image == "" {
-		eccm.Image = "hetznercloud/hcloud-cloud-controller-manager:v1.15.0"
+		eccm.Image = "hetznercloud/hcloud-cloud-controller-manager:v1.16.0"
 	}
 
 	return nil

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
@@ -16,9 +16,9 @@ spec:
     allocateNodeCIDRs: true
     allowUntaggedCloud: true
     cloudProvider: hcloud
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     configureCloudRoutes: false
-    image: hetznercloud/hcloud-cloud-controller-manager:v1.15.0
+    image: hetznercloud/hcloud-cloud-controller-manager:v1.16.0
     leaderElection:
       leaderElect: false
   cloudProvider: hetzner

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml
-    manifestHash: 334e7ace1e27a9dd9ae8636d3e658524f568818a2add425f242c880f346c77a9
+    manifestHash: 6afe8a04e648a1df0a64e22dfe70f7f2b6b82a121c6595a3078f9bdcebbb7cd1
     name: hcloud-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: hcloud-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-hcloud-cloud-controller.addons.k8s.io-k8s-1.22_content
@@ -76,7 +76,7 @@ spec:
         - --allocate-node-cidrs=true
         - --allow-untagged-cloud=true
         - --cloud-provider=hcloud
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --configure-cloud-routes=false
         - --leader-elect=false
         - --v=2
@@ -96,14 +96,16 @@ spec:
             secretKeyRef:
               key: network
               name: hcloud
-        image: hetznercloud/hcloud-cloud-controller-manager:v1.15.0
+        image: hetznercloud/hcloud-cloud-controller-manager:v1.16.0
         name: hcloud-cloud-controller-manager
+        ports:
+        - containerPort: 8233
+          name: metrics
         resources:
           requests:
             cpu: 100m
             memory: 50Mi
       dnsPolicy: Default
-      hostNetwork: true
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
@@ -118,5 +120,5 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
         operator: Exists
-      - effect: NoSchedule
+      - effect: NoExecute
         key: node.kubernetes.io/not-ready

--- a/upup/models/cloudup/resources/addons/hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/hcloud-cloud-controller.addons.k8s.io/k8s-1.22.yaml.template
@@ -1,4 +1,5 @@
-# Pulled and modified from: https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm-networks.yaml
+# Pulled and modified using: kustomize build https://github.com/hetznercloud/hcloud-cloud-controller-manager.git/deploy
+
 ---
 apiVersion: v1
 kind: Secret
@@ -6,8 +7,8 @@ metadata:
   name: hcloud
   namespace: kube-system
 stringData:
-  token: "{{ HCLOUD_TOKEN }}"
   network: "{{ HCLOUD_NETWORK }}"
+  token: "{{ HCLOUD_TOKEN }}"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -15,8 +16,8 @@ metadata:
   name: cloud-controller-manager
   namespace: kube-system
 ---
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: system:cloud-controller-manager
 roleRef:
@@ -24,9 +25,9 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-  - kind: ServiceAccount
-    name: cloud-controller-manager
-    namespace: kube-system
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -44,51 +45,50 @@ spec:
       labels:
         app: hcloud-cloud-controller-manager
     spec:
-      serviceAccountName: cloud-controller-manager
-      dnsPolicy: Default
-      tolerations:
-        # this taint is set by all kubelets running `--cloud-provider=external`
-        # so we should tolerate it to schedule the cloud controller manager
-        - key: "node.cloudprovider.kubernetes.io/uninitialized"
-          value: "true"
-          effect: "NoSchedule"
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
-        # cloud controller manages should be able to run on masters
-        - key: "node-role.kubernetes.io/master"
-          effect: NoSchedule
-          operator: Exists
-        - key: "node-role.kubernetes.io/control-plane"
-          effect: NoSchedule
-          operator: Exists
-        - key: "node.kubernetes.io/not-ready"
-          effect: "NoSchedule"
-      hostNetwork: true
       containers:
-        - image: "{{ .ExternalCloudControllerManager.Image }}"
-          name: hcloud-cloud-controller-manager
-          command:
-            - "/bin/hcloud-cloud-controller-manager"
-            {{- range $arg := CloudControllerConfigArgv }}
-            - "{{ $arg }}"
-            {{- end }}
-          resources:
-            requests:
-              cpu: 100m
-              memory: 50Mi
-          env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: HCLOUD_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: hcloud
-                  key: token
-            - name: HCLOUD_NETWORK
-              valueFrom:
-                secretKeyRef:
-                  name: hcloud
-                  key: network
+      - command:
+        - /bin/hcloud-cloud-controller-manager
+        {{- range $arg := CloudControllerConfigArgv }}
+        - "{{ $arg }}"
+        {{- end }}
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: HCLOUD_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: hcloud
+        - name: HCLOUD_NETWORK
+          valueFrom:
+            secretKeyRef:
+              key: network
+              name: hcloud
+        image: '{{ .ExternalCloudControllerManager.Image }}'
+        name: hcloud-cloud-controller-manager
+        ports:
+        - containerPort: 8233
+          name: metrics
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      dnsPolicy: Default
       priorityClassName: system-cluster-critical
+      serviceAccountName: cloud-controller-manager
+      tolerations:
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready

--- a/upup/models/cloudup/resources/addons/hcloud-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/hcloud-csi-driver.addons.k8s.io/k8s-1.22.yaml.template
@@ -1,4 +1,4 @@
-# Pulled and modified from: https://raw.githubusercontent.com/hetznercloud/csi-driver/main/deploy/kubernetes/hcloud-csi.yml
+# Pulled and modified using: kustomize build https://github.com/hetznercloud/csi-driver.git/deploy
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Cherry pick of #15577 on release-1.27.

#15577: hetzner: Update CCM to v1.16.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```