### PR TITLE
docs: remove `kube-dns-autoscaler` when upgrading to CoreDNS

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -244,7 +244,7 @@ etcdClusters:
 ### etcd backups retention
 {{ kops_feature_table(kops_added_default='1.18') }}
 
-As of kOps 1.27, the default etcd backup retention duration is 90 days.  
+As of kOps 1.27, the default etcd backup retention duration is 90 days.
 You can adjust the retention duration using the `backupRetentionDays` parameter:
 
 ```yaml
@@ -847,12 +847,13 @@ This block contains configurations for [CoreDNS](https://coredns.io/).
 
 For Kubernetes version >= 1.20, `CoreDNS` will be installed as the default DNS server.
 
- ```yaml
+```yaml
  spec:
    kubeDNS:
      provider: CoreDNS
 ```
 OR
+
 ```yaml
 spec:
    kubeDNS:
@@ -860,7 +861,7 @@ spec:
 
 Specifying KubeDNS will install kube-dns as the default service discovery instead of [CoreDNS](https://coredns.io/).
 
- ```yaml
+```yaml
  spec:
    kubeDNS:
      provider: KubeDNS
@@ -902,7 +903,7 @@ spec:
         }
 ```
 
-**Note:** If you are upgrading to CoreDNS, kube-dns will be left in place and must be removed manually (you can scale the kube-dns and kube-dns-autoscaler deployments in the `kube-system` namespace to 0 as a starting point). The `kube-dns` Service itself should be left in place, as this retains the ClusterIP and eliminates the possibility of DNS outages in your cluster. If you would like to continue autoscaling, update the `kube-dns-autoscaler` Deployment container command for `--target=Deployment/kube-dns` to be `--target=Deployment/coredns`.
+**Note:** If you are upgrading to CoreDNS, kube-dns will be left in place and must be removed manually. You can scale the kube-dns and kube-dns-autoscaler deployments in the `kube-system` namespace to 0 as a starting point, and then remove both deployments. The `kube-dns` Service itself should be left in place, as this retains the ClusterIP and eliminates the possibility of DNS outages in your cluster.
 
 For larger clusters you may need to set custom resource requests and limits. For the CoreDNS provider you can set
 


### PR DESCRIPTION
## Summary

Per https://github.com/kubernetes/kops/issues/6318#issuecomment-830490064 and related comments, the `kube-dns-autoscaler` is no longer needed when upgrading to CoreDNS.

## Details

- there is a separate `coredns-autoscaler` that is spun up in more recent kOps versions
  - so the `kube-dns-autoscaler` is no longer needed after an upgrade to CoreDNS - and possibly could conflict if they both targeted the same deployment

- updating the `kube-dns-autoscaler` was the most confusing part, so this simplifies things a good bit!

- also fix some minor inconsistent spacing in this doc

## Misc

Was teaching folks about k8s DNS so came back to the issue to see what the progress was w/ CoreDNS as I had to do this upgrade a couple years ago