### PR TITLE
ipv6: containerd routes support for IPv6

### DIFF
--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
@@ -8,7 +8,7 @@ contents: |
               "ipam": {
                   "type": "host-local",
                   "ranges": [[{"subnet": "{{.PodCIDR}}"}]],
-                  "routes": [{ "dst": "0.0.0.0/0" }]
+                  "routes": [{"dst":"0.0.0.0/0"}]
               }
           },
           {

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -8,7 +8,7 @@ contents: |
               "ipam": {
                   "type": "host-local",
                   "ranges": [[{"subnet": "{{.PodCIDR}}"}]],
-                  "routes": [{ "dst": "0.0.0.0/0" }]
+                  "routes": [{"dst":"0.0.0.0/0"}]
               }
           },
           {


### PR DESCRIPTION
If using IPv6 and a kubenet-style CNI (which is more common with
IPv6), we need to support an IPv6 route on the pod, or else Pods will
be unable to reach other Pods.
