### PR TITLE
scaleway: refactoring: utils functions to get info from tags

### DIFF
--- a/pkg/nodeidentity/scaleway/identify.go
+++ b/pkg/nodeidentity/scaleway/identify.go
@@ -100,20 +100,16 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 	}
 
 	labels := map[string]string{}
-	for _, tag := range server.Tags {
-		if strings.HasPrefix(tag, scaleway.TagNameRolePrefix) {
-			role := strings.TrimPrefix(tag, scaleway.TagNameRolePrefix+"=")
-			switch kops.InstanceGroupRole(role) {
-			case kops.InstanceGroupRoleControlPlane:
-				labels[nodelabels.RoleLabelControlPlane20] = ""
-			case kops.InstanceGroupRoleNode:
-				labels[nodelabels.RoleLabelNode16] = ""
-			case kops.InstanceGroupRoleAPIServer:
-				labels[nodelabels.RoleLabelAPIServer16] = ""
-			default:
-				klog.Warningf("Unknown node role %q for server %s(%d)", role, server.Name, server.ID)
-			}
-		}
+	role := scaleway.InstanceRoleFromTags(server.Tags)
+	switch kops.InstanceGroupRole(role) {
+	case kops.InstanceGroupRoleControlPlane:
+		labels[nodelabels.RoleLabelControlPlane20] = ""
+	case kops.InstanceGroupRoleNode:
+		labels[nodelabels.RoleLabelNode16] = ""
+	case kops.InstanceGroupRoleAPIServer:
+		labels[nodelabels.RoleLabelAPIServer16] = ""
+	default:
+		klog.Warningf("Unknown node role %q for server %s(%d)", role, server.Name, server.ID)
 	}
 
 	info := &nodeidentity.Info{

--- a/protokube/pkg/protokube/scaleway_volumes.go
+++ b/protokube/pkg/protokube/scaleway_volumes.go
@@ -19,7 +19,6 @@ package protokube
 import (
 	"fmt"
 	"net"
-	"strings"
 
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -108,11 +107,8 @@ func (s ScwCloudProvider) InstanceInternalIP() net.IP {
 }
 
 func (s *ScwCloudProvider) GossipSeeds() (gossip.SeedProvider, error) {
-	for _, tag := range s.server.Tags {
-		if !strings.HasPrefix(tag, scaleway.TagClusterName) {
-			continue
-		}
-		clusterName := strings.TrimPrefix(tag, scaleway.TagClusterName+"=")
+	clusterName := scaleway.ClusterNameFromTags(s.server.Tags)
+	if clusterName != "" {
 		return gossipscw.NewSeedProvider(s.scwClient, clusterName)
 	}
 	return nil, fmt.Errorf("failed to find cluster name label for running server: %v", s.server.Tags)

--- a/upup/pkg/fi/cloudup/scaleway/cloud.go
+++ b/upup/pkg/fi/cloudup/scaleway/cloud.go
@@ -147,12 +147,7 @@ func NewScwCloud(tags map[string]string) (ScwCloud, error) {
 }
 
 func (s *scwCloudImplementation) ClusterName(tags []string) string {
-	for _, tag := range tags {
-		if strings.HasPrefix(tag, TagClusterName) {
-			return strings.TrimPrefix(tag, TagClusterName+"=")
-		}
-	}
-	return ""
+	return ClusterNameFromTags(tags)
 }
 
 func (s *scwCloudImplementation) DNS() (dnsprovider.Interface, error) {
@@ -345,13 +340,7 @@ func findServerGroups(s *scwCloudImplementation, clusterName string) (map[string
 
 	serverGroups := make(map[string][]*instance.Server)
 	for _, server := range servers {
-		igName := ""
-		for _, tag := range server.Tags {
-			if strings.HasPrefix(tag, TagInstanceGroup) {
-				igName = strings.TrimPrefix(tag, TagInstanceGroup+"=")
-				break
-			}
-		}
+		igName := InstanceGroupNameFromTags(server.Tags)
 		serverGroups[igName] = append(serverGroups[igName], server)
 	}
 
@@ -376,11 +365,7 @@ func buildCloudGroup(ig *kops.InstanceGroup, sg []*instance.Server, nodeMap map[
 		}
 		cloudInstance.State = cloudinstances.State(server.State)
 		cloudInstance.MachineType = server.CommercialType
-		for _, tag := range server.Tags {
-			if strings.HasPrefix(tag, TagNameRolePrefix) {
-				cloudInstance.Roles = append(cloudInstance.Roles, strings.TrimPrefix(tag, TagNameRolePrefix))
-			}
-		}
+		cloudInstance.Roles = append(cloudInstance.Roles, InstanceRoleFromTags(server.Tags))
 		if server.PrivateIP != nil {
 			cloudInstance.PrivateIP = *server.PrivateIP
 		}

--- a/upup/pkg/fi/cloudup/scaleway/utils.go
+++ b/upup/pkg/fi/cloudup/scaleway/utils.go
@@ -68,6 +68,33 @@ func ParseRegionFromZone(zone scw.Zone) (region scw.Region, err error) {
 	return region, nil
 }
 
+func ClusterNameFromTags(tags []string) string {
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, TagClusterName) {
+			return strings.TrimPrefix(tag, TagClusterName+"=")
+		}
+	}
+	return ""
+}
+
+func InstanceGroupNameFromTags(tags []string) string {
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, TagInstanceGroup) {
+			return strings.TrimPrefix(tag, TagInstanceGroup+"=")
+		}
+	}
+	return ""
+}
+
+func InstanceRoleFromTags(tags []string) string {
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, TagNameRolePrefix) {
+			return strings.TrimPrefix(tag, TagNameRolePrefix+"=")
+		}
+	}
+	return ""
+}
+
 func getScalewayProfile() (*scw.Profile, error) {
 	scwProfileName := os.Getenv("SCW_PROFILE")
 	if scwProfileName == "" {

--- a/upup/pkg/fi/cloudup/scaleway/verifier.go
+++ b/upup/pkg/fi/cloudup/scaleway/verifier.go
@@ -105,16 +105,9 @@ func (v scalewayVerifier) VerifyToken(ctx context.Context, rawRequest *http.Requ
 		challengeEndPoints = append(challengeEndPoints, net.JoinHostPort(server.IPv6.Address.String(), strconv.Itoa(wellknownports.NodeupChallenge)))
 	}
 
-	igName := ""
-	for _, tag := range server.Tags {
-		if strings.HasPrefix(tag, TagInstanceGroup) {
-			igName = strings.TrimPrefix(tag, TagInstanceGroup+"=")
-		}
-	}
-
 	result := &bootstrap.VerifyResult{
 		NodeName:          server.Name,
-		InstanceGroupName: igName,
+		InstanceGroupName: InstanceGroupNameFromTags(server.Tags),
 		CertificateNames:  addresses,
 		ChallengeEndpoint: challengeEndPoints[0],
 	}


### PR DESCRIPTION
This PR adds 3 new utils functions to get:
- the cluster's name
- the instance's role
- the instance's instance group name

from the given tags.

This avoids a few `for _, tag := range tags` type loops.