### PR TITLE
Automated cherry pick of #15628: aws: Allow using the same instance ID as egress for multiple

### DIFF
--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -468,7 +468,7 @@ func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 					Tags:      nil, // We don't need to add tags here
 				}
 
-				c.AddTask(in)
+				c.EnsureTask(in)
 			} else if strings.HasPrefix(egress, "tgw-") {
 				tgwID = &egress
 			} else if egress == "External" {


### PR DESCRIPTION
Cherry pick of #15628 on release-1.27.

#15628: aws: Allow using the same instance ID as egress for multiple

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```