### PR TITLE
spot: update docs about setting the VNG Size Limits in Launch Spec

### DIFF
--- a/docs/getting_started/spot-ocean.md
+++ b/docs/getting_started/spot-ocean.md
@@ -150,8 +150,8 @@ metadata:
       httpTokens: required
     machineType: m5.large
     #define the max and min numbers of instances in the group
-    maxSize: 1
-    minSize: 3
+    maxSize: 3
+    minSize: 1
     role: Node
     subnets:
       - us-west-2b

--- a/docs/getting_started/spot-ocean.md
+++ b/docs/getting_started/spot-ocean.md
@@ -143,7 +143,18 @@ metadata:
   labels:
     kops.k8s.io/cluster: "example"
     spotinst.io/spot-percentage: "90"
-  ...
+  spec:
+    image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20221206
+    instanceMetadata:
+      httpPutResponseHopLimit: 1
+      httpTokens: required
+    machineType: m5.large
+    #define the max and min numbers of instances in the group
+    maxSize: 1
+    minSize: 3
+    role: Node
+    subnets:
+      - us-west-2b
 ```
 
 ## InstanceGroup Metadata Labels


### PR DESCRIPTION
This PR update spot-ocean doc about setting support for VNG size limits in launch spec.

this PR is equivalent to an old PR #15355