### PR TITLE
Deprecate Canal, Flannel, and Kube-router

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -18,13 +18,13 @@ As of kOps 1.26 the default network provider is Cilium. Prior to that the defaul
 |------------------|-------------:|-------:|-----------:|----------------:|
 | AWS VPC          |          1.9 |   1.21 |          - |               - |
 | Calico           |          1.6 |   1.11 |          - |               - |
-| Canal            |         1.12 |      - |          - |               - |
+| Canal            |         1.12 |      - |       1.27 | Kubernetes 1.28 |
 | Cilium           |          1.9 |   1.15 |          - |               - |
 | Cilium ENI       |         1.18 |   1.26 |          - |               - |
-| Flannel udp      |        1.5.2 |      - |          - |               - |
-| Flannel vxlan    |        1.8.0 |      - |          - |               - |
+| Flannel udp      |        1.5.2 |      - |       1.27 | Kubernetes 1.28 |
+| Flannel vxlan    |        1.8.0 |      - |       1.27 | Kubernetes 1.28 |
 | Kopeio           |          1.5 |      - |          - |               - |
-| Kube-router      |        1.6.2 |      - |          - |               - |
+| Kube-router      |        1.6.2 |      - |       1.27 | Kubernetes 1.28 |
 | Kubenet          |          1.5 |    1.5 |          - |               - |
 | Lyft VPC         |         1.11 |      - |       1.22 |            1.23 |
 | Romana           |          1.8 |      - |       1.18 |            1.19 |

--- a/docs/networking/canal.md
+++ b/docs/networking/canal.md
@@ -1,5 +1,7 @@
 # Canal
 
+&#9888; The Canal CNI is not supported for Kubernetes 1.28 or later.
+
 [Canal](https://github.com/projectcalico/canal) is a project that combines [Flannel](https://github.com/coreos/flannel) and [Calico](http://docs.projectcalico.org/latest/getting-started/kubernetes/installation/) for CNI Networking.  It uses Flannel for networking pod traffic between hosts via VXLAN and Calico for network policy enforcement and pod to pod traffic.
 
 ## Installing

--- a/docs/networking/flannel.md
+++ b/docs/networking/flannel.md
@@ -1,5 +1,7 @@
 # Flannel
 
+&#9888; The Flannel CNI is not supported for Kubernetes 1.28 or later.
+
 ## Installing
 
 To install [flannel](https://github.com/coreos/flannel) - use `--networking flannel-vxlan` (recommended) or `--networking flannel-udp` (legacy).  `--networking flannel` now selects `flannel-vxlan`.

--- a/docs/networking/kube-router.md
+++ b/docs/networking/kube-router.md
@@ -1,5 +1,7 @@
 # Kube-router
 
+&#9888; The Kube-router CNI is not supported for Kubernetes 1.28 or later.
+
 [Kube-router](https://github.com/cloudnativelabs/kube-router) is project that provides one cohesive solution that provides CNI networking for pods, an IPVS based network service proxy and iptables based network policy enforcement.
 
 Kube-router also provides a service proxy, so kube-proxy will not be deployed in to the cluster.

--- a/docs/releases/1.27-NOTES.md
+++ b/docs/releases/1.27-NOTES.md
@@ -43,11 +43,10 @@ they would do so when the respective `topology` was set to `public`.
 
 * Support for Ubuntu 18.04 is deprecated and will be removed in kOps 1.28.
 
+* Canal, Flannel, and Kube-Router are deprecated and support will be removed for Kubernetes 1.28 and later.
+
 * Support for AWS Classic Load Balancer for API is deprecated and should not be used for newly created clusters.
 
 * All legacy addons are deprecated in favor of managed addons, including the [metrics server addon](https://github.com/kubernetes/kops/tree/master/addons/metrics-server) and the [autoscaler addon](https://github.com/kubernetes/kops/tree/master/addons/cluster-autoscaler).
 
-# Help Wanted
 
-* kOps needs maintainers for Canal, Flannel, and Kube-Router to keep versions up to date and move the integration from experimental to stable.
-If no volunteers step up by the time kOps 1.27 is released, support will be phased out.

--- a/docs/releases/1.28-NOTES.md
+++ b/docs/releases/1.28-NOTES.md
@@ -20,6 +20,8 @@ This is a document to gather the release notes prior to the release.
 
 * Support for Ubuntu 18.04 is has been removed.
 
+* Support for Canal, Flannel, and Kube-Router has been removed for Kubernetes 1.28 and later.
+
 # Deprecations
 
 * Support for Kubernetes version 1.23 is deprecated and will be removed in kOps 1.29.
@@ -29,8 +31,3 @@ This is a document to gather the release notes prior to the release.
 * Support for AWS Classic Load Balancer for API is deprecated and should not be used for newly created clusters.
 
 * All legacy addons are deprecated in favor of managed addons, including the [metrics server addon](https://github.com/kubernetes/kops/tree/master/addons/metrics-server) and the [autoscaler addon](https://github.com/kubernetes/kops/tree/master/addons/cluster-autoscaler).
-
-# Help Wanted
-
-* kOps needs maintainers for Canal, Flannel, and Kube-Router to keep versions up to date and move the integration from experimental to stable.
-If no volunteers step up by the time kOps 1.27 is released, support will be phased out.

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1066,7 +1066,11 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 		}
 		optionTaken = true
 
-		allErrs = append(allErrs, validateNetworkingFlannel(cluster, v.Flannel, fldPath.Child("flannel"))...)
+		if cluster.IsKubernetesGTE("1.28") {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("flannel"), "Flannel is not supported for Kubernetes >= 1.28"))
+		} else {
+			allErrs = append(allErrs, validateNetworkingFlannel(cluster, v.Flannel, fldPath.Child("flannel"))...)
+		}
 	}
 
 	if v.Calico != nil {
@@ -1084,7 +1088,11 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 		}
 		optionTaken = true
 
-		allErrs = append(allErrs, validateNetworkingCanal(cluster, v.Canal, fldPath.Child("canal"))...)
+		if cluster.IsKubernetesGTE("1.28") {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("canal"), "Canal is not supported for Kubernetes >= 1.28"))
+		} else {
+			allErrs = append(allErrs, validateNetworkingCanal(cluster, v.Canal, fldPath.Child("canal"))...)
+		}
 	}
 
 	if v.KubeRouter != nil {
@@ -1096,8 +1104,10 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 		}
 		optionTaken = true
 
-		if cluster.Spec.IsIPv6Only() {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kuberRouter"), "kube-router does not support IPv6"))
+		if cluster.IsKubernetesGTE("1.28") {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kubeRouter"), "kube-router is not supported for Kubernetes >= 1.28"))
+		} else if cluster.Spec.IsIPv6Only() {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kubeRouter"), "kube-router does not support IPv6"))
 		}
 	}
 

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -391,6 +391,7 @@ func Test_Validate_Networking_Flannel(t *testing.T) {
 	for _, g := range grid {
 		cluster := &kops.Cluster{
 			Spec: kops.ClusterSpec{
+				KubernetesVersion: "1.27.0",
 				Networking: kops.NetworkingSpec{
 					NetworkCIDR:           "10.0.0.0/8",
 					NonMasqueradeCIDR:     "100.64.0.0/10",


### PR DESCRIPTION
Per Office Hours discussion.

These three CNIs have been without a maintainer or updates for some time. A call for maintainers in the kOps 1.26 release notes has not resulted in any volunteers submitting updates.

This removes support for these CNIs as of Kubernetes 1.28.
