### PR TITLE
Automated cherry pick of #15635: openstack: Open hubble port 4244

### DIFF
--- a/pkg/model/openstackmodel/firewall.go
+++ b/pkg/model/openstackmodel/firewall.go
@@ -459,6 +459,9 @@ func (b *FirewallModelBuilder) addCNIRules(c *fi.CloudupModelBuilderContext, sgM
 	if b.Cluster.Spec.Networking.Cilium != nil {
 		udpPorts = append(udpPorts, 8472)
 		tcpPorts = append(tcpPorts, 4240)
+		if b.Cluster.Spec.Networking.Cilium.Hubble != nil && fi.ValueOf(b.Cluster.Spec.Networking.Cilium.Hubble.Enabled) {
+			tcpPorts = append(tcpPorts, 4244)
+		}
 	}
 
 	if b.Cluster.Spec.Networking.Weave != nil {


### PR DESCRIPTION
Cherry pick of #15635 on release-1.27.

#15635: open hubble port 4244

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```