### PR TITLE
Automated cherry pick of #15608: kops-controller: load objects with version conversion

### DIFF
--- a/pkg/nodelabels/builder.go
+++ b/pkg/nodelabels/builder.go
@@ -19,7 +19,7 @@ package nodelabels
 import (
 	"fmt"
 
-	"k8s.io/kops/pkg/apis/kops"
+	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/util/pkg/reflectutils"
 )
@@ -39,25 +39,25 @@ const (
 
 // BuildNodeLabels returns the node labels for the specified instance group
 // This moved from the kubelet to a central controller in kubernetes 1.16
-func BuildNodeLabels(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (map[string]string, error) {
+func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) (map[string]string, error) {
 	isControlPlane := false
 	isAPIServer := false
 	isNode := false
 	switch instanceGroup.Spec.Role {
-	case kops.InstanceGroupRoleControlPlane:
+	case api.InstanceGroupRoleControlPlane:
 		isControlPlane = true
-	case kops.InstanceGroupRoleAPIServer:
+	case api.InstanceGroupRoleAPIServer:
 		isAPIServer = true
-	case kops.InstanceGroupRoleNode:
+	case api.InstanceGroupRoleNode:
 		isNode = true
-	case kops.InstanceGroupRoleBastion:
+	case api.InstanceGroupRoleBastion:
 		// no labels to add
 	default:
 		return nil, fmt.Errorf("unhandled instanceGroup role %q", instanceGroup.Spec.Role)
 	}
 
 	// Merge KubeletConfig for NodeLabels
-	c := &kops.KubeletConfigSpec{}
+	c := &api.KubeletConfigSpec{}
 	if isControlPlane {
 		reflectutils.JSONMergeStruct(c, cluster.Spec.ControlPlaneKubelet)
 	} else {
@@ -116,7 +116,7 @@ func BuildNodeLabels(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (
 		nodeLabels[k] = v
 	}
 
-	if instanceGroup.Spec.Manager == kops.InstanceManagerKarpenter {
+	if instanceGroup.Spec.Manager == api.InstanceManagerKarpenter {
 		nodeLabels["karpenter.sh/provisioner-name"] = instanceGroup.ObjectMeta.Name
 	}
 

--- a/upup/pkg/fi/utils/yaml.go
+++ b/upup/pkg/fi/utils/yaml.go
@@ -28,6 +28,9 @@ func YAMLToJSON(yamlBytes []byte) ([]byte, error) {
 }
 
 // YamlUnmarshal unmarshals the yaml content to an interface
+// Note: if you are loading a kops.k8s.io API object,
+// normally you want something like kopscodecs.Decode,
+// so that we can convert between apiVersions.
 func YamlUnmarshal(yamlBytes []byte, dest interface{}) error {
 	return yaml.Unmarshal(yamlBytes, dest)
 }


### PR DESCRIPTION
Cherry pick of #15608 on release-1.27.

#15608: kops-controller: load objects with version conversion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.