### PR TITLE
Automated cherry pick of #15608: kops-controller: load objects with version conversion

### DIFF
--- a/cmd/kops-controller/controllers/legacy_node_controller.go
+++ b/cmd/kops-controller/controllers/legacy_node_controller.go
@@ -26,12 +26,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/kops/pkg/apis/kops"
+	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/registry"
 	"k8s.io/kops/pkg/kopscodecs"
 	"k8s.io/kops/pkg/nodeidentity"
 	"k8s.io/kops/pkg/nodelabels"
-	"k8s.io/kops/upup/pkg/fi/utils"
 	"k8s.io/kops/util/pkg/vfs"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -149,9 +148,9 @@ func (r *LegacyNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// getClusterForNode returns the kops.Cluster object for the node
+// getClusterForNode returns the api.Cluster object for the node
 // The cluster is actually loaded when we first start
-func (r *LegacyNodeReconciler) getClusterForNode(node *corev1.Node) (*kops.Cluster, error) {
+func (r *LegacyNodeReconciler) getClusterForNode(node *corev1.Node) (*api.Cluster, error) {
 	clusterPath := r.configBase.Join(registry.PathClusterCompleted)
 	cluster, err := r.loadCluster(clusterPath)
 	if err != nil {
@@ -170,8 +169,8 @@ func (r *LegacyNodeReconciler) getInstanceLifecycle(ctx context.Context, node *c
 	return identity.InstanceLifecycle, nil
 }
 
-// getInstanceGroupForNode returns the kops.InstanceGroup object for the node
-func (r *LegacyNodeReconciler) getInstanceGroupForNode(ctx context.Context, node *corev1.Node) (*kops.InstanceGroup, error) {
+// getInstanceGroupForNode returns the api.InstanceGroup object for the node
+func (r *LegacyNodeReconciler) getInstanceGroupForNode(ctx context.Context, node *corev1.Node) (*api.InstanceGroup, error) {
 	// We assume that if the instancegroup label is set, that it is correct
 	// TODO: Should we be paranoid?
 	instanceGroupName := node.Labels["kops.k8s.io/instancegroup"]
@@ -196,8 +195,8 @@ func (r *LegacyNodeReconciler) getInstanceGroupForNode(ctx context.Context, node
 	return r.loadNamedInstanceGroup(instanceGroupName)
 }
 
-// loadCluster loads a kops.Cluster object from a vfs.Path
-func (r *LegacyNodeReconciler) loadCluster(p vfs.Path) (*kops.Cluster, error) {
+// loadCluster loads a api.Cluster object from a vfs.Path
+func (r *LegacyNodeReconciler) loadCluster(p vfs.Path) (*api.Cluster, error) {
 	ttl := time.Hour
 
 	b, err := r.cache.Read(p, ttl)
@@ -209,14 +208,14 @@ func (r *LegacyNodeReconciler) loadCluster(p vfs.Path) (*kops.Cluster, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error parsing Cluster %q: %v", p, err)
 	}
-	if cluster, ok := o.(*kops.Cluster); ok {
+	if cluster, ok := o.(*api.Cluster); ok {
 		return cluster, nil
 	}
 	return nil, fmt.Errorf("unexpected object type for Cluster %q: %T", p, o)
 }
 
-// loadInstanceGroup loads a kops.InstanceGroup object from the vfs backing store
-func (r *LegacyNodeReconciler) loadNamedInstanceGroup(name string) (*kops.InstanceGroup, error) {
+// loadNamedInstanceGroup loads a api.InstanceGroup object from the vfs backing store
+func (r *LegacyNodeReconciler) loadNamedInstanceGroup(name string) (*api.InstanceGroup, error) {
 	p := r.configBase.Join("instancegroup", name)
 
 	ttl := time.Hour
@@ -225,9 +224,14 @@ func (r *LegacyNodeReconciler) loadNamedInstanceGroup(name string) (*kops.Instan
 		return nil, fmt.Errorf("error loading InstanceGroup %q: %v", p, err)
 	}
 
-	instanceGroup := &kops.InstanceGroup{}
-	if err := utils.YamlUnmarshal(b, instanceGroup); err != nil {
-		return nil, fmt.Errorf("error parsing InstanceGroup %q: %v", p, err)
+	object, _, err := kopscodecs.Decode(b, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing %s: %w", p, err)
+	}
+
+	instanceGroup, ok := object.(*api.InstanceGroup)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type, expected InstanceGroup, got %T", object)
 	}
 
 	return instanceGroup, nil

--- a/pkg/nodelabels/builder.go
+++ b/pkg/nodelabels/builder.go
@@ -17,7 +17,7 @@ limitations under the License.
 package nodelabels
 
 import (
-	"k8s.io/kops/pkg/apis/kops"
+	api "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/util/pkg/reflectutils"
 )
@@ -37,13 +37,13 @@ const (
 
 // BuildNodeLabels returns the node labels for the specified instance group
 // This moved from the kubelet to a central controller in kubernetes 1.16
-func BuildNodeLabels(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) map[string]string {
-	isControlPlane := instanceGroup.Spec.Role == kops.InstanceGroupRoleControlPlane
+func BuildNodeLabels(cluster *api.Cluster, instanceGroup *api.InstanceGroup) map[string]string {
+	isControlPlane := instanceGroup.Spec.Role == api.InstanceGroupRoleControlPlane
 
-	isAPIServer := instanceGroup.Spec.Role == kops.InstanceGroupRoleAPIServer
+	isAPIServer := instanceGroup.Spec.Role == api.InstanceGroupRoleAPIServer
 
 	// Merge KubeletConfig for NodeLabels
-	c := &kops.KubeletConfigSpec{}
+	c := &api.KubeletConfigSpec{}
 	if isControlPlane {
 		reflectutils.JSONMergeStruct(c, cluster.Spec.ControlPlaneKubelet)
 	} else {
@@ -100,7 +100,7 @@ func BuildNodeLabels(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) m
 		nodeLabels[k] = v
 	}
 
-	if instanceGroup.Spec.Manager == kops.InstanceManagerKarpenter {
+	if instanceGroup.Spec.Manager == api.InstanceManagerKarpenter {
 		nodeLabels["karpenter.sh/provisioner-name"] = instanceGroup.ObjectMeta.Name
 	}
 

--- a/upup/pkg/fi/utils/yaml.go
+++ b/upup/pkg/fi/utils/yaml.go
@@ -28,6 +28,9 @@ func YAMLToJSON(yamlBytes []byte) ([]byte, error) {
 }
 
 // YamlUnmarshal unmarshals the yaml content to an interface
+// Note: if you are loading a kops.k8s.io API object,
+// normally you want something like kopscodecs.Decode,
+// so that we can convert between apiVersions.
 func YamlUnmarshal(yamlBytes []byte, dest interface{}) error {
 	return yaml.Unmarshal(yamlBytes, dest)
 }


### PR DESCRIPTION
Cherry pick of #15608 on release-1.26.

#15608: kops-controller: load objects with version conversion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.