### PR TITLE
WIP: prune dns-controller

### DIFF
--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/not-enabled.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/not-enabled.yaml.template
@@ -1,0 +1,143 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: dns-controller
+  namespace: kube-system
+  labels:
+    k8s-addon: dns-controller.addons.k8s.io
+    k8s-app: dns-controller
+    version: v{{ KopsVersion }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      k8s-app: dns-controller
+  template:
+    metadata:
+      labels:
+        k8s-addon: dns-controller.addons.k8s.io
+        k8s-app: dns-controller
+        version: v{{ KopsVersion }}
+    spec:
+      priorityClassName: system-cluster-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+      dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
+      hostNetwork: true
+      serviceAccount: dns-controller
+      nodeSelector: null
+      containers:
+      - name: dns-controller
+        image: registry.k8s.io/kops/dns-controller:{{ KopsVersion }}
+        args:
+{{ range $arg := DnsControllerArgv }}
+        - "{{ $arg }}"
+{{ end }}
+        command: null
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+{{ range $name, $value := DNSControllerEnvs }}
+        - name: {{ $name }}
+          value: {{ $value }}
+{{ end }}
+{{- if .Networking.EgressProxy }}
+{{ range $name, $value := ProxyEnv }}
+        - name: {{ $name }}
+          value: {{ $value }}
+{{ end }}
+{{- end }}
+{{- if eq GetCloudProvider "digitalocean" }}
+        - name: DIGITALOCEAN_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: digitalocean
+              key: access-token
+{{- end }}
+{{- if eq GetCloudProvider "scaleway" }}
+        envFrom:
+          - secretRef:
+              name: scaleway-secret
+{{- end }}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+        securityContext:
+          runAsNonRoot: true
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dns-controller
+  namespace: kube-system
+  labels:
+    k8s-addon: dns-controller.addons.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-addon: dns-controller.addons.k8s.io
+  name: kops:dns-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - ingress
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: dns-controller.addons.k8s.io
+  name: kops:dns-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kops:dns-controller
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:serviceaccount:kube-system:dns-controller

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -493,12 +493,13 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 				location := key + "/k8s-1.12.yaml"
 				id := "k8s-1.12"
 
-				addons.Add(&channelsapi.AddonSpec{
+				addon := addons.Add(&channelsapi.AddonSpec{
 					Name:     fi.PtrTo(key),
 					Selector: map[string]string{"k8s-addon": key},
 					Manifest: fi.PtrTo(location),
 					Id:       id,
 				})
+				addon.BuildPrune = true
 			}
 
 			// Generate dns-controller ServiceAccount IAM permissions.
@@ -526,6 +527,21 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 					serviceAccountRoles = append(serviceAccountRoles, &externaldns.ServiceAccount{})
 				}
 			}
+		}
+	} else {
+		// Prune the dns-controller if it was installed previously (or might have been installed previously)
+		{
+			key := "dns-controller.addons.k8s.io"
+			location := key + "/not-enabled.yaml"
+			id := "not-enabled"
+
+			addon := addons.Add(&channelsapi.AddonSpec{
+				Name:     fi.PtrTo(key),
+				Selector: map[string]string{"k8s-addon": key},
+				Manifest: fi.PtrTo(location),
+				Id:       id,
+			})
+			addon.BuildPrune = true
 		}
 	}
 


### PR DESCRIPTION
When switching from gossip to dns=none, the rolling-update fails because the dns-controller addon is still present (because it isn't removed, as we never merged #13962).  However, the configuration for the dns-controller addon still assumes gossip is running on protokube (which it isn't).

WIP because there are a few ways to tackle this: we could implement addon removal (but I would rather we did it very carefully, perhaps with explicit removal).  We could simply keep dns-controller but not install it.  Or we could do what we do here - install a different (empty) manifest.