### PR TITLE
Automated cherry pick of #15655: Fix modifying backupRetentionDays

### DIFF
--- a/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_master-us-test-1a.masters.minimal-etcd.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_master-us-test-1a.masters.minimal-etcd.example.com_user_data
@@ -132,7 +132,7 @@ etcdClusters:
     - name: us-test-1a
       volumeSize: 20
     manager:
-      backupRetentionDays: 90
+      backupRetentionDays: 30
       env:
       - name: ETCD_MANAGER_HOURLY_BACKUPS_RETENTION
         value: 1d

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
@@ -55,7 +55,7 @@ spec:
       name: us-test-1a
       volumeSize: 20
     manager:
-      backupRetentionDays: 90
+      backupRetentionDays: 30
       env:
       - name: ETCD_MANAGER_HOURLY_BACKUPS_RETENTION
         value: 1d

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -21,7 +21,7 @@ spec:
       2>&1
     env:
     - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
-      value: 90d
+      value: 30d
     - name: ETCD_MANAGER_HOURLY_BACKUPS_RETENTION
       value: 1d
     image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc

--- a/upup/pkg/fi/cloudup/defaults.go
+++ b/upup/pkg/fi/cloudup/defaults.go
@@ -48,7 +48,9 @@ func PerformAssignments(c *kops.Cluster, cloud fi.Cloud) error {
 		if etcdCluster.Manager == nil {
 			etcdCluster.Manager = &kops.EtcdManagerSpec{}
 		}
-		etcdCluster.Manager.BackupRetentionDays = fi.PtrTo[uint32](90)
+		if etcdCluster.Manager.BackupRetentionDays == nil {
+			etcdCluster.Manager.BackupRetentionDays = fi.PtrTo[uint32](90)
+		}
 	}
 
 	// Topology support


### PR DESCRIPTION
Cherry pick of #15655 on release-1.27.

#15655: Fix modifying backupRetentionDays

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```