### PR TITLE
docs: revise the bastion ssh guideline to mitigate permission denied errors

### DIFF
--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -113,30 +113,6 @@ On AWS, an easy way to find this DNS name is with kops toolbox:
 kops toolbox dump -ojson | grep 'bastion.*elb.amazonaws.com'
 ```
 
-### Using SSH agent to access your bastion
-
-Verify your local agent is configured correctly
-
-```
-$ ssh-add -L
-ssh-rsa <PUBLIC_RSA_HASH> /Users/kris/.ssh/id_rsa
-```
-
-If that command returns no results, add the key to `ssh-agent`
-
-```
-ssh-add ~/.ssh/id_rsa
-```
-
-Check if the key is now added using `ssh-add -L`
-
-SSH into the bastion, then into a master
-
-```
-ssh -A admin@<bastion_elb_a_record>
-ssh admin@<master_ip>
-```
-
 ### Changing your ELB idle timeout
 
 The bastion is accessed via an AWS ELB. The ELB is required to gain secure access into the private network and connect the user to the ASG that the bastion lives in. kOps will by default set the bastion ELB idle timeout to 5 minutes. This is important for SSH connections to the bastion that you plan to keep open.
@@ -162,10 +138,11 @@ ssh-add -l
 # If you need to add the key to your agent:
 ssh-add path/to/private/key
 
-# Now you can SSH into the bastion
-ssh -A admin@<bastion-ELB-address>
+# Now you can SSH into the bastion. Substitute the administrative username of the instance's OS for <username> (`ubuntu` for  Ubuntu,  `admin` for Debian, etc.) and the bastion domain for <bastion-domain>. If the bastion doesn't have a public CNAME alias, use the domain of the assigned load balancer as the bastion domain.
+ssh -A <username>@<bastion-domain>
 
-# Where <bastion-ELB-address> is usually bastion.$clustername (bastion.example.kubernetes.cluster) unless otherwise specified
+# then you can use the fowarded authentication to SSH into control-plane or worker nodes in the cluster.
+ssh <username>@<node-address>
 
 ```
 


### PR DESCRIPTION
- Updated the username variable to avoid encountering the "Permission denied (publickey)" error in different AMIs
- Removed redundant description.