### PR TITLE
azure: Verify node identity using VMSS name instead of tags

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -737,7 +737,9 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 			config.Server.Provider.Scaleway = &scaleway.ScalewayVerifierOptions{}
 
 		case kops.CloudProviderAzure:
-			config.Server.Provider.Azure = &azure.AzureVerifierOptions{}
+			config.Server.Provider.Azure = &azure.AzureVerifierOptions{
+				ClusterName: tf.ClusterName(),
+			}
 
 		default:
 			return "", fmt.Errorf("unsupported cloud provider %s", cluster.Spec.GetCloudProvider())


### PR DESCRIPTION
Continue discussion from https://github.com/kubernetes/kops/pull/15627#discussion_r1264531162.

/cc @rifelpet @justinsb @johngmyers 