### PR TITLE
verify-boilerplate: stricter error checking

### DIFF
--- a/hack/__init__.py
+++ b/hack/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2020 The Kubernetes Authors.
 #

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2015 The Kubernetes Authors.
 #

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright YEAR The Kubernetes Authors.
 #

--- a/hack/mkdocs_macros/__init__.py
+++ b/hack/mkdocs_macros/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2020 The Kubernetes Authors.
 #

--- a/hack/mkdocs_macros/feature_stability_table.py
+++ b/hack/mkdocs_macros/feature_stability_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2020 The Kubernetes Authors.
 #

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 . "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 files_need_boilerplate=()


### PR DESCRIPTION
If python isn't found, without this fix the script exits with code 0,
despite not checking boilerplate.
