### PR TITLE
Fix AWS CCM defaults for IPAM to match KCM

### DIFF
--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.27.2

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: eaac3475bfd301cbce7dc31d1b3ebffc956580c879bcd84690ecb82c88641855
+    manifestHash: 0ff974e13ec519948db39a69d054f65ce4404b17b19206e7e7fcf28de958d80c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
@@ -20,7 +20,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -163,7 +163,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 97b946fdac709c8f174e6719555910cffff4e26ca5b7028bf3007570e397b427
+    manifestHash: f8cc45fc5a0b2201f2811e4b21c9a4237a322fc2cf14c5322c9aeae061897cc1
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=bastionuserdata.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 4221d7d4646366d1b1077aa216df095836881b1dd6be8b9c627cc15d3232bbb7
+    manifestHash: f6b072cfa1a9134ca0106e856b2a70b2f0dca749991583de4cd3f87ccc7dccd3
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: bastionuserdata.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -34,7 +34,7 @@ spec:
       - args:
         - --allocate-node-cidrs=true
         - --cloud-provider=aws
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=cas-priority-expander-custom.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 18804ce8c98f30e1bfae1d47557d18e2641cfb4eb4b5112130815ef590686c1e
+    manifestHash: 399257cb8c9aa2d7401eb4e3e12aede61a31d40434718f61dec8763854b01857
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -17,7 +17,7 @@ spec:
   cloudControllerManager:
     allocateNodeCIDRs: true
     cloudProvider: aws
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: cas-priority-expander-custom.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -34,7 +34,7 @@ spec:
       - args:
         - --allocate-node-cidrs=true
         - --cloud-provider=aws
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=cas-priority-expander.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 1b6d82becbcf78a301a886a0a1e1f0f9b4f0ce3908feae5bf01a2684d8ca859a
+    manifestHash: 645e8940c7771bdf712ce127b84e68baa44097cffc8f905ac42bb2d1e284c0b5
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
@@ -17,7 +17,7 @@ spec:
   cloudControllerManager:
     allocateNodeCIDRs: true
     cloudProvider: aws
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: cas-priority-expander.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -34,7 +34,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: complex.example.com
     configureCloudRoutes: false
     enableLeaderMigration: true

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=complex.example.com
         - --configure-cloud-routes=false
         - --enable-leader-migration=true

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 6ffef86e2c71c3ff619faf398b8e8330d0b513aaa238e4356aca7ce9289d2e8a
+    manifestHash: 9f2124a3cd64512b87897b80a3e8eea5bd3bff91ff77102394b1fdcb86c98686
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: compress.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=compress.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 91255c7cb32728919a1e8bb018c11449b60108f45ad784aaecfea15e6f7546ca
+    manifestHash: 3cacb886dcc54c79396c05b19c3fe7c66842571156a3dda71e6f28a2b5d66bb9
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: containerd.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=containerd.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 090f13557812c33392a17c0479ad7a5ee061049d8a6b3fa1160a3875e59f83bb
+    manifestHash: 48e0169d461e7b741442985ca61df93aee9f678a5072c350ffee2226ea22aa6c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: containerd.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=containerd.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 090f13557812c33392a17c0479ad7a5ee061049d8a6b3fa1160a3875e59f83bb
+    manifestHash: 48e0169d461e7b741442985ca61df93aee9f678a5072c350ffee2226ea22aa6c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=123.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: de417125cdf704070e3d6a4b68a419b88c630bc11177ef8bbab2c38c6844dd49
+    manifestHash: 423d0e938aaa568717523a529e3dada7d2c5d4b43dbea36266bdf658991fd9b1
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: 123.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: existing-iam.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=existing-iam.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: d825d567335503cd6cf8eff2a215dd4a274ae2278c948fab5fe7dd02812153cf
+    manifestHash: 90172ec59c913aec647fd51bc2341c6d74ba74656655978e2e66982ed4d22cec
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
@@ -19,7 +19,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: existingsg.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=existingsg.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 5cb8090e61f28e0b60a2e32f46fee0c5c1f31272b1248419ce3e5942a0710033
+    manifestHash: 0c3538b4938e12f7f63ee5da668ba2ae8789e10b067a52b44cd0f85bccc35ae6
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 97b946fdac709c8f174e6719555910cffff4e26ca5b7028bf3007570e397b427
+    manifestHash: f8cc45fc5a0b2201f2811e4b21c9a4237a322fc2cf14c5322c9aeae061897cc1
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: externallb.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=externallb.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 5b3de0310582c3542a274c756286d950d0e679a1a4e2273c5da19ed04ad824e6
+    manifestHash: 7260106b6e7ecd95bcbe5103d88d0405bd58a5a18dd841888092d01a1461bd55
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: externalpolicies.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=externalpolicies.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: c9eff183a89f7883596efd5f375a0a847b7dfdefb9d0930770392d8661b5d19f
+    manifestHash: d25f26354370f22981085e0b254f3328cac6bd60ba891ebd24d2654f17fa27f7
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: ha.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=ha.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9b5e777ee30b796cad97bf147cbe1385d48408ab4abc316a8f783821b38cc7d7
+    manifestHash: 8d7859ee77cd3a3e07d084cf48eb64d9232554859f0225be5df0fbfeb6f209f0
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -163,7 +163,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: dcd605e354aff1e3bbb866f38f52cc4b5daa327a22eee543a38af824a2233453
+    manifestHash: 4760a1ac5de7056dc7865c904f2717b800d66b7f46e6337687c2c1b3d14c344a
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
   cloudControllerManager:
     allocateNodeCIDRs: true
     cloudProvider: aws
-    clusterCIDR: 172.20.0.0/16
+    clusterCIDR: 172.20.128.0/17
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -34,7 +34,7 @@ spec:
       - args:
         - --allocate-node-cidrs=true
         - --cloud-provider=aws
-        - --cluster-cidr=172.20.0.0/16
+        - --cluster-cidr=172.20.128.0/17
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -186,7 +186,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7f568c3bb4686dcafba3c2676e97848bf9936e4af5f1acd64d224a4553d2c046
+    manifestHash: 1e499302a8a1314eb02093ad0ee3d085025cd2ec47a57e6738676ea742f29671
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
   cloudControllerManager:
     allocateNodeCIDRs: true
     cloudProvider: aws
-    clusterCIDR: 172.20.0.0/16
+    clusterCIDR: 172.20.128.0/17
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.17

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -34,7 +34,7 @@ spec:
       - args:
         - --allocate-node-cidrs=true
         - --cloud-provider=aws
-        - --cluster-cidr=172.20.0.0/16
+        - --cluster-cidr=172.20.128.0/17
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -193,7 +193,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: ea5dacadd85ab3b76aa141cb94c5a155695093723152974b75d89ce0b978e65a
+    manifestHash: 53634dcc4def3594db7290fb77ad925c830209d585b2308b7f39da9d2b16f97e
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
   cloudControllerManager:
     allocateNodeCIDRs: true
     cloudProvider: aws
-    clusterCIDR: 172.20.0.0/16
+    clusterCIDR: 172.20.128.0/17
     clusterName: minimal.example.com
     configureCloudRoutes: false
     enableLeaderMigration: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -34,7 +34,7 @@ spec:
       - args:
         - --allocate-node-cidrs=true
         - --cloud-provider=aws
-        - --cluster-cidr=172.20.0.0/16
+        - --cluster-cidr=172.20.128.0/17
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --enable-leader-migration=true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -193,7 +193,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 410acbecc5577bece65217cd27be1d0a307cbacd5e7a9d274a54a76e4bec242d
+    manifestHash: 0e04eebc3901d062585b8aa954f3bfc875b321e6bbf68b72d53a28e14dc8fc4b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
   cloudControllerManager:
     allocateNodeCIDRs: true
     cloudProvider: aws
-    clusterCIDR: 172.20.0.0/16
+    clusterCIDR: 172.20.128.0/17
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -34,7 +34,7 @@ spec:
       - args:
         - --allocate-node-cidrs=true
         - --cloud-provider=aws
-        - --cluster-cidr=172.20.0.0/16
+        - --cluster-cidr=172.20.128.0/17
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -193,7 +193,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 616536ab198d8686569086349f666ef092c24d35ad69e8d49224fa4bcef8b3cc
+    manifestHash: 389dca50e8dba75c84709bf7048ef7249b8aeb550426dfbced7b5cc8a0688fe2
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
   cloudControllerManager:
     allocateNodeCIDRs: true
     cloudProvider: aws
-    clusterCIDR: 172.20.0.0/16
+    clusterCIDR: 172.20.128.0/17
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -34,7 +34,7 @@ spec:
       - args:
         - --allocate-node-cidrs=true
         - --cloud-provider=aws
-        - --cluster-cidr=172.20.0.0/16
+        - --cluster-cidr=172.20.128.0/17
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -194,7 +194,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7f568c3bb4686dcafba3c2676e97848bf9936e4af5f1acd64d224a4553d2c046
+    manifestHash: 1e499302a8a1314eb02093ad0ee3d085025cd2ec47a57e6738676ea742f29671
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
   cloudControllerManager:
     allocateNodeCIDRs: true
     cloudProvider: aws
-    clusterCIDR: 172.20.0.0/16
+    clusterCIDR: 172.20.128.0/17
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -34,7 +34,7 @@ spec:
       - args:
         - --allocate-node-cidrs=true
         - --cloud-provider=aws
-        - --cluster-cidr=172.20.0.0/16
+        - --cluster-cidr=172.20.128.0/17
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -186,7 +186,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7fdd9a9031a4d1918cf34eb784504fa60e4929db4c6627b06685d72875f8f3ff
+    manifestHash: 8b8cf7626c8822663942d5624f8e95b4689d15bd1da1bac3fa1050ccc1082e03
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -20,7 +20,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 172.20.0.0/16
+    clusterCIDR: 172.20.128.0/17
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=172.20.0.0/16
+        - --cluster-cidr=172.20.128.0/17
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -186,7 +186,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 656bb9874cea453dae552963c82751b734464caf77bb5b75d18a648a765523e4
+    manifestHash: 55d45ed42fb1eddc545dd5e64ba4d38f138a64689d04f19c8a247eef64f41ccb
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     enableLeaderMigration: true

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --enable-leader-migration=true

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3b8c826de1e94374b938cd2a264c0171a14ffa8b8a15bd97ba329e004be7a08e
+    manifestHash: 87dd4d1bf305fe6d6324f85668e65eeed8b5d2ccbf99b4e43d867b7cd3ec8a84
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 678ff2bf4b436233e78f734512bdaac4715a94b8653b248a826019943872afc6
+    manifestHash: 719a27c700bbadd1ccce11f14211be614bd85969b88d89cb272412196384d6ec
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.27.2

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: eaac3475bfd301cbce7dc31d1b3ebffc956580c879bcd84690ecb82c88641855
+    manifestHash: 0ff974e13ec519948db39a69d054f65ce4404b17b19206e7e7fcf28de958d80c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -92,7 +92,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal-etcd.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal-etcd.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 79e87e72ff6f872c5f6a710dbe9c05711f3037185d9bbd19e66861a7ca5b2b4a
+    manifestHash: 3091ebe1ccd690995dc4be515e3c61b12ce8cafc78ee0e953a4d8f68b4f45b40
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
@@ -20,8 +20,7 @@ spec:
     - ipv6
     - ipv4
   cloudControllerManager:
-    allocateNodeCIDRs: true
-    clusterCIDR: ::/0
+    allocateNodeCIDRs: false
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -32,8 +32,7 @@ spec:
                 operator: Exists
       containers:
       - args:
-        - --allocate-node-cidrs=true
-        - --cluster-cidr=::/0
+        - --allocate-node-cidrs=false
         - --cluster-name=minimal-ipv6.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -161,7 +161,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 03c09c29b9c572ee968d93076784ad4b6328251a30c727ec263baf7893ec57c2
+    manifestHash: 95efc4ba2e63a9042dccde1c65b1d88a1d4d43407929bd6d40e8a511ddd9c0e5
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -20,8 +20,7 @@ spec:
     - ipv6
     - ipv4
   cloudControllerManager:
-    allocateNodeCIDRs: true
-    clusterCIDR: ::/0
+    allocateNodeCIDRs: false
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -32,8 +32,7 @@ spec:
                 operator: Exists
       containers:
       - args:
-        - --allocate-node-cidrs=true
-        - --cluster-cidr=::/0
+        - --allocate-node-cidrs=false
         - --cluster-name=minimal-ipv6.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 03c09c29b9c572ee968d93076784ad4b6328251a30c727ec263baf7893ec57c2
+    manifestHash: 95efc4ba2e63a9042dccde1c65b1d88a1d4d43407929bd6d40e8a511ddd9c0e5
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
@@ -20,8 +20,7 @@ spec:
     - ipv6
     - ipv4
   cloudControllerManager:
-    allocateNodeCIDRs: true
-    clusterCIDR: ::/0
+    allocateNodeCIDRs: false
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -32,8 +32,7 @@ spec:
                 operator: Exists
       containers:
       - args:
-        - --allocate-node-cidrs=true
-        - --cluster-cidr=::/0
+        - --allocate-node-cidrs=false
         - --cluster-name=minimal-ipv6.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 03c09c29b9c572ee968d93076784ad4b6328251a30c727ec263baf7893ec57c2
+    manifestHash: 95efc4ba2e63a9042dccde1c65b1d88a1d4d43407929bd6d40e8a511ddd9c0e5
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -20,8 +20,7 @@ spec:
     - ipv6
     - ipv4
   cloudControllerManager:
-    allocateNodeCIDRs: true
-    clusterCIDR: ::/0
+    allocateNodeCIDRs: false
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -32,8 +32,7 @@ spec:
                 operator: Exists
       containers:
       - args:
-        - --allocate-node-cidrs=true
-        - --cluster-cidr=::/0
+        - --allocate-node-cidrs=false
         - --cluster-name=minimal-ipv6.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 03c09c29b9c572ee968d93076784ad4b6328251a30c727ec263baf7893ec57c2
+    manifestHash: 95efc4ba2e63a9042dccde1c65b1d88a1d4d43407929bd6d40e8a511ddd9c0e5
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: this.is.truly.a.really.really.long.cluster-name.minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=this.is.truly.a.really.really.long.cluster-name.minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 1c8163953e09ccab47fd27e0da6a6460329648e37567895651341e0fe787d3b4
+    manifestHash: ea63afe8c34a9b833eb708b1db46cb070d60fc5d9ae0a921ff8ef905507a1029
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal-warmpool.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal-warmpool.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -107,7 +107,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 32a83831f770a4688c73f1b931f96856604fdb801ec11013fb46b2f5c524e176
+    manifestHash: a4ad6608613713833c39b9dd77cd09fa2a1402723e2bcbf1a853086b44d88872
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.27.2

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: eaac3475bfd301cbce7dc31d1b3ebffc956580c879bcd84690ecb82c88641855
+    manifestHash: 0ff974e13ec519948db39a69d054f65ce4404b17b19206e7e7fcf28de958d80c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.k8s.local
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.k8s.local
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 6e7d9d7a646251ffc8806d5538affb2caf870ec5a4f30042c37b65d1a7be25d8
+    manifestHash: 3d56488013054b09c1122be00bef19904bbd3e2f442c706fbc32827b5f8221c2
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.k8s.local
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.k8s.local
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7a3d7d42f0563e7a8c3c3396b84ecb3f1e1f0b58c36dd15158a51a5d730b45af
+    manifestHash: 553a189f6ae421ae3318f8b55e123dff39f70fb1ca6e6074ca4d91cbbf7572f0
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: mixedinstances.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=mixedinstances.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2e8d1aadb9d4c313795876f09598d8325c6f3a9062d0b840a443ec9ece2410d6
+    manifestHash: e004ea06aa9c5a29f0f59ff38ee25e47d4711baade710fb8c638a11d578d8179
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: mixedinstances.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=mixedinstances.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2e8d1aadb9d4c313795876f09598d8325c6f3a9062d0b840a443ec9ece2410d6
+    manifestHash: e004ea06aa9c5a29f0f59ff38ee25e47d4711baade710fb8c638a11d578d8179
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: nthimdsprocessor.longclustername.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=nthimdsprocessor.longclustername.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -97,7 +97,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2b1695116e5ce944adcc9f168d58ec8a8605c6925cf4a8de0087ca4618423d54
+    manifestHash: aa5901c27ae717564d59ac31e9da454486265311b471f2f39a2a4853b46e3285
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: nthimdsprocessor.longclustername.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=nthimdsprocessor.longclustername.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -97,7 +97,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: fdf80c656cd8ee31f926b7c6d3dbb7354b4f0698663d8fe0eaeebfc861eb5c48
+    manifestHash: 920182ad52f6db22c7122cbcecf26c065d1614ceedbaa5ff21cc6856832635d2
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: private-shared-ip.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=private-shared-ip.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 884e544255fa0cabf6f5bb8d01d1c83ac868f9c514d65ad487b75e1b75956165
+    manifestHash: 02603dd41bccc6f4cceb95534c43159d46ee2cdd4f3d9f2f47a4b3e287e06451
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: private-shared-subnet.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=private-shared-subnet.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 32e459fcdc780694c53b1a80fd23a73f7677378d922675391a7f96feda5230e6
+    manifestHash: dd022b9885343a90cb851de8b6f826f23cf253e929d2805877d5e1097d70e2c2
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: privatecalico.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=privatecalico.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -161,7 +161,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2b6f92e59d77da8a5dfbe7047cf9c95dc8d9ae7e5939199b33956368d189b420
+    manifestHash: 974e0015038a6b1fcfcfe928c6d978baa23b86f76a06cf45e1ec82ca43e7606d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: privatecanal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=privatecanal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -161,7 +161,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 080ee26fd2f543ef1efb3b8e85d5787d424b99ce1d18db57934f49a32b933a47
+    manifestHash: dcb1c1d5169f22e938a0ee84d450d215d58af06489a2c51bb0ab6d9fd63343ca
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: privatecilium.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=privatecilium.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -107,7 +107,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9ab32c6caa3f73135e636d5630a7433a5c125871215a7e00226d590cb0f3adbd
+    manifestHash: da8ffe21fc41690af44c1d14ba1d878a97533719df2db85428b5e337e1e8c0de
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: privatecilium.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=privatecilium.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -107,7 +107,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9ab32c6caa3f73135e636d5630a7433a5c125871215a7e00226d590cb0f3adbd
+    manifestHash: da8ffe21fc41690af44c1d14ba1d878a97533719df2db85428b5e337e1e8c0de
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -20,7 +20,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: privatecilium.example.com
     configureCloudRoutes: false
     enableLeaderMigration: true

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=privatecilium.example.com
         - --configure-cloud-routes=false
         - --enable-leader-migration=true

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -171,7 +171,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 61e00b3148b40d3b935c514913bb32025b4ff7eab6228be32bcda847da758778
+    manifestHash: dd4f0fa2f3bf5d2e48df978ee6986450631797a565c7a109fac0b7c72c808668
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: privateciliumadvanced.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=privateciliumadvanced.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -107,7 +107,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 75d25b15dc8f2083634e8d4e80cfd77e87f82fb79635cd0cc091471174739905
+    manifestHash: 6e8307b2152373a0787dbc17a7d6200723800211fd89944f8d17426d1fac7e11
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: privatedns1.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.27.2

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=privatedns1.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e1656140c31cc51ab2fdeb669202f744f97c6a16ba4bde127506eee9d06d346f
+    manifestHash: 1a4eb06534cd8be922412ce8b406e55febfbd3dfd0f7195f820dddab7b77efd9
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: privatedns2.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=privatedns2.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: cdb83ea9ed6c8b50087dcdd5cdc8006197cf2915a6bc43a0d97e1d274bc593f0
+    manifestHash: 34726f3ba9c704b2d1645f59d0f23df2f794ac65bf0e053a9c3641b896833d80
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: privateflannel.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=privateflannel.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -157,7 +157,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e1fa6b98ede10a5322bac9102e7269b94fe9d00dfad59d9d32212c392633dc65
+    manifestHash: c405cba58beea2a27fc205d72306b358b12284580ce2802544bf2939dfbb445c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: privatekopeio.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=privatekopeio.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -148,7 +148,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: f7a4106a12abfb4d8e38ae602793c10948c384d18142e336166f6a49bba3e779
+    manifestHash: 541675560364f6062b7635a6260f7fe493a908ccbc576d4d4999e303930e28e5
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     enableLeaderMigration: true

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --enable-leader-migration=true

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 219f8f304408b2efd0e5194931ad47bf48dfbb587e7c48a5ed6415a77aad1674
+    manifestHash: d4706b3c682b2e2006812dcb3b54142030a62c65f47542c9db466ea75bff5ece
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: sharedsubnet.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=sharedsubnet.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 48f5db81df25006aaba00f278bd39d2aed7ba7b63e58cc30e2f398e34450acbf
+    manifestHash: d7ddb5ba716e63e66a4bc8c634bf8de594134e9994cf94972676a4fef526a928
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: sharedvpc.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=sharedvpc.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 4cf3e4550636747a2d14764e3e61e7c33dac0ced968fb42956a7eb4e9e1dffcd
+    manifestHash: eaf75a97119c9d0a8aeba095ae5a18d30568aec9e95b345238e854cef7cba808
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -20,8 +20,7 @@ spec:
     - ipv6
     - ipv4
   cloudControllerManager:
-    allocateNodeCIDRs: true
-    clusterCIDR: ::/0
+    allocateNodeCIDRs: false
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -32,8 +32,7 @@ spec:
                 operator: Exists
       containers:
       - args:
-        - --allocate-node-cidrs=true
-        - --cluster-cidr=::/0
+        - --allocate-node-cidrs=false
         - --cluster-name=minimal-ipv6.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 03c09c29b9c572ee968d93076784ad4b6328251a30c727ec263baf7893ec57c2
+    manifestHash: 95efc4ba2e63a9042dccde1c65b1d88a1d4d43407929bd6d40e8a511ddd9c0e5
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
@@ -18,7 +18,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: unmanaged.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=unmanaged.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 649c7a0ecc76de9c1ec593f65205d11df4592ab70ccc431f5405aba76cc5f2b3
+    manifestHash: 7ab679b1a8ac6bbdbc0005d2b704f74327c4bb8fc9b4636f821ebc0a551b3b02
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true
-    clusterCIDR: 100.64.0.0/10
+    clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --allocate-node-cidrs=true
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -107,7 +107,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -107,7 +107,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -34,7 +34,7 @@ spec:
       - args:
         - --allocate-node-cidrs=true
         - --cloud-provider=aws
-        - --cluster-cidr=100.64.0.0/10
+        - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
         - --leader-elect=true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 70f11212fd187344ec26c5ef9ad423d826a5164774fabaa518ff8e3b5625be62
+    manifestHash: a50d171901db45242328234ceef5e9a2939f3d85360969752f125abfcaaf744c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -107,7 +107,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: eaac3475bfd301cbce7dc31d1b3ebffc956580c879bcd84690ecb82c88641855
+    manifestHash: 0ff974e13ec519948db39a69d054f65ce4404b17b19206e7e7fcf28de958d80c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 13393edaa0d1b4849ab74cf8f6173bc340d158195e681d40901841661563a8d9
+    manifestHash: ced67ebf4c5a1d92a09a1e95039e9a78ee9f9baf86c652eb49a59f5458c3ba00
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 7664ee5608865dda8b51b660348c7724eaaae1c2dec58f7031c75fd10d202d15
+    manifestHash: eff0c442541bc156d4c1d3e1632794c90f1c31e92a88f129d4b0e30baf7bc920
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
When reviewing #15623 we noticed that AWS CCM was incorrectly defaulting ClusterCIDR to NonMasqueradeCIDR. Updating the CCM code to match that for KCM.

GCP networking doesn't work on AWS, so removing that code.

I'm not sure whether we should default UseServiceAccountCredentials to true like KCM does.

/cc @hakman 