### PR TITLE
Continue skipping SCTP tests for cilium until we upgrade to 1.13

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -67,8 +67,9 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|same.hostPort.but.different.hostIP.and.protocol"
 		// https://github.com/cilium/cilium/issues/9207
 		skipRegex += "|serve.endpoints.on.same.port.and.different.protocols"
-		// This may be fixed in Cilium 1.13 but skipping for now
+		// These may be fixed in Cilium 1.13 but skipping for now
 		skipRegex += "|Service.with.multiple.ports.specified.in.multiple.EndpointSlices"
+		skipRegex += "|should.create.a.Pod.with.SCTP.HostPort"
 		// https://github.com/cilium/cilium/issues/18241
 		skipRegex += "|Services.should.create.endpoints.for.unready.pods"
 		skipRegex += "|Services.should.be.able.to.connect.to.terminating.and.unready.endpoints.if.PublishNotReadyAddresses.is.true"


### PR DESCRIPTION
This skip was removed in https://github.com/kubernetes/kops/pull/15449 but is failing because we're still on cilium 1.12:

https://testgrid.k8s.io/kops-grid#kops-grid-cilium-eni-u2004-k25-ko26

Add it back under the comment for skips to be removed after we upgrade to 1.13.

This will need cherrypicking to release-1.27