### PR TITLE
Bump k8s and kops versions used in scenario scripts

### DIFF
--- a/tests/e2e/scenarios/addon-resource-tracking/run-test.sh
+++ b/tests/e2e/scenarios/addon-resource-tracking/run-test.sh
@@ -28,7 +28,7 @@ function haveds() {
 # Start a cluster with an old version of channel
 
 export KOPS_BASE_URL
-KOPS_BASE_URL="https://artifacts.k8s.io/binaries/kops/1.22.6"
+KOPS_BASE_URL="https://artifacts.k8s.io/binaries/kops/1.26.5"
 KOPS=$(kops-download-from-base)
 
 # Start with a cluster running nodeTerminationHandler
@@ -37,7 +37,7 @@ ARGS="${ARGS} --set=cluster.spec.nodeTerminationHandler.enableSQSTerminationDrai
 
 ${KUBETEST2} \
     --up \
-    --kubernetes-version="1.22.17" \
+    --kubernetes-version="1.26.6" \
     --kops-binary-path="${KOPS}" \
     --create-args="$ARGS"
 

--- a/tests/e2e/scenarios/cilium-connectivity-test/run-test.sh
+++ b/tests/e2e/scenarios/cilium-connectivity-test/run-test.sh
@@ -41,6 +41,6 @@ ${KUBETEST2} \
 
 kubectl port-forward -n kube-system deployment/hubble-relay 4245:4245 &
 
-wget -qO- https://github.com/cilium/cilium-cli/releases/download/v0.7/cilium-linux-amd64.tar.gz | tar xz -C "${WORKSPACE}"
+wget -qO- https://github.com/cilium/cilium-cli/releases/download/v0.14.8/cilium-linux-amd64.tar.gz | tar xz -C "${WORKSPACE}"
 
 cilium connectivity test --all-flows

--- a/tests/e2e/scenarios/cilium-connectivity-test/run-test.sh
+++ b/tests/e2e/scenarios/cilium-connectivity-test/run-test.sh
@@ -35,7 +35,7 @@ fi
 
 ${KUBETEST2} \
     --up \
-    --kubernetes-version="1.21.0" \
+    --kubernetes-version="1.27.0" \
     --kops-binary-path="${KOPS}" \
     --create-args="--networking cilium $ARGS"
 

--- a/tests/e2e/scenarios/digital-ocean/run-test
+++ b/tests/e2e/scenarios/digital-ocean/run-test
@@ -41,11 +41,11 @@ kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 		--env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
 		--env JOB_NAME=pull-kops-e2e-kubernetes-do-kubetest2 \
 		--create-args "--networking=cilium --api-loadbalancer-type=public --node-count=2 --master-count=3" \
-		--kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.20/latest-ci.txt \
-		--kubernetes-version=https://dl.k8s.io/release/stable-1.20.txt \
+		--kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
+		--kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
 		--test=kops \
 		-- \
 		--ginkgo-args="--debug" \
-		--test-package-marker=stable-1.20.txt \
+		--test-package-marker=stable-1.27.txt \
 		--parallel 25 \
 		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|nfs|NFS|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*NodePort.*listening.*same.*port|TCP.CLOSE_WAIT|should.*run.*through.*the.*lifecycle.*of.*Pods.*and.*PodStatus"


### PR DESCRIPTION
Some of these were failing because the versions used were too old:

https://testgrid.k8s.io/kops-misc#kops-aws-addon-resource-tracking

```
 Error: kubernetes upgrade is required 
```

This bumps the scenario scripts to use newer versions.