### PR TITLE
Add 1.27 release notes to docs menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
     - Ports: "contributing/ports.md"
     - Cluster Addons & Manager : "contributing/addons.md"
   - Releases:
+    - "1.27": releases/1.27-NOTES.md
     - "1.26": releases/1.26-NOTES.md
     - "1.25": releases/1.25-NOTES.md
     - "1.24": releases/1.24-NOTES.md


### PR DESCRIPTION
as mentioned in the release process:

https://github.com/kubernetes/kops/blob/691978734b56fd83984ba0a4c6ce411c5d654d31/docs/contributing/release-process.md#add-link-to-release-notes