### PR TITLE
Automated cherry pick of #15671: Continue skipping SCTP tests for cilium until we upgrade to

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -67,8 +67,9 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|same.hostPort.but.different.hostIP.and.protocol"
 		// https://github.com/cilium/cilium/issues/9207
 		skipRegex += "|serve.endpoints.on.same.port.and.different.protocols"
-		// This may be fixed in Cilium 1.13 but skipping for now
+		// These may be fixed in Cilium 1.13 but skipping for now
 		skipRegex += "|Service.with.multiple.ports.specified.in.multiple.EndpointSlices"
+		skipRegex += "|should.create.a.Pod.with.SCTP.HostPort"
 		// https://github.com/cilium/cilium/issues/18241
 		skipRegex += "|Services.should.create.endpoints.for.unready.pods"
 		skipRegex += "|Services.should.be.able.to.connect.to.terminating.and.unready.endpoints.if.PublishNotReadyAddresses.is.true"


### PR DESCRIPTION
Cherry pick of #15671 on release-1.27.

#15671: Continue skipping SCTP tests for cilium until we upgrade to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```