### PR TITLE
Automated cherry pick of #15689: Print error message when digest image fails

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -227,7 +227,7 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 
 	digest, err := crane.Digest(image, crane.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
-		klog.Warningf("failed to digest image %q", image)
+		klog.Warningf("failed to digest image %q: %s", image, err)
 		return image, nil
 	}
 


### PR DESCRIPTION
Cherry pick of #15689 on release-1.27.

#15689: Print error message when digest image fails

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```