### PR TITLE
Automated cherry pick of #15691: Pass `S3_*` env vars to nodes when using Gossip

### DIFF
--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -135,7 +135,7 @@ func (b *BootstrapScript) buildEnvironmentVariables() (map[string]string, error)
 
 	if os.Getenv("S3_ENDPOINT") != "" {
 		passEnvs := false
-		if b.ig.IsControlPlane() || !b.builder.UseKopsControllerForNodeBootstrap() {
+		if b.ig.IsControlPlane() || cluster.UsesLegacyGossip() {
 			passEnvs = true
 		}
 


### PR DESCRIPTION
Cherry pick of #15691 on release-1.27.

#15691: Pass `S3_*` env vars to nodes when using Gossip

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```