### PR TITLE
Automated cherry pick of #15699: Use release version of k8s 1.27 in integration test

### DIFF
--- a/tests/integration/update_cluster/minimal/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -160,7 +160,7 @@ kubeAPIServer:
   - /events#https://127.0.0.1:4002
   featureGates:
     InTreePluginAWSUnregister: "true"
-  image: registry.k8s.io/kube-apiserver:v1.27.0-alpha.3
+  image: registry.k8s.io/kube-apiserver:v1.27.0
   kubeletPreferredAddressTypes:
   - InternalIP
   - Hostname
@@ -188,7 +188,7 @@ kubeControllerManager:
   configureCloudRoutes: false
   featureGates:
     InTreePluginAWSUnregister: "true"
-  image: registry.k8s.io/kube-controller-manager:v1.27.0-alpha.3
+  image: registry.k8s.io/kube-controller-manager:v1.27.0
   leaderElection:
     leaderElect: true
   logLevel: 2
@@ -196,7 +196,7 @@ kubeControllerManager:
 kubeScheduler:
   featureGates:
     InTreePluginAWSUnregister: "true"
-  image: registry.k8s.io/kube-scheduler:v1.27.0-alpha.3
+  image: registry.k8s.io/kube-scheduler:v1.27.0
   leaderElection:
     leaderElect: true
   logLevel: 2
@@ -245,7 +245,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Fpnr65NWckLM46Jjfpf5NOia6oLMjoIrxg6dv04NTFU=
+NodeupConfigHash: V+EuXVtggmE1qLa60D3ZBub89RptJFHHX/jHk1n6aQY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -175,7 +175,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: wDe2vIRRaH+OpMGTjXZMklLt6o/vWq89xr+AaL4iJyo=
+NodeupConfigHash: +WDFgJS3bj7L3E8LK8l/JkoYZU+Nrs4XKKTXUpjcm9s=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_cluster-completed.spec_content
@@ -82,7 +82,7 @@ spec:
     - /events#https://127.0.0.1:4002
     featureGates:
       InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-apiserver:v1.27.0-alpha.3
+    image: registry.k8s.io/kube-apiserver:v1.27.0
     kubeletPreferredAddressTypes:
     - InternalIP
     - Hostname
@@ -110,7 +110,7 @@ spec:
     configureCloudRoutes: false
     featureGates:
       InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-controller-manager:v1.27.0-alpha.3
+    image: registry.k8s.io/kube-controller-manager:v1.27.0
     leaderElection:
       leaderElect: true
     logLevel: 2
@@ -132,12 +132,12 @@ spec:
   kubeProxy:
     clusterCIDR: 100.96.0.0/11
     cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.27.0-alpha.3
+    image: registry.k8s.io/kube-proxy:v1.27.0
     logLevel: 2
   kubeScheduler:
     featureGates:
       InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-scheduler:v1.27.0-alpha.3
+    image: registry.k8s.io/kube-scheduler:v1.27.0
     leaderElection:
       leaderElect: true
     logLevel: 2
@@ -161,7 +161,7 @@ spec:
     shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: 1.27.0-alpha.3
+  kubernetesVersion: 1.27.0
   masterKubelet:
     cgroupDriver: systemd
     cgroupRoot: /

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -24,7 +24,7 @@ APIServerConfig:
     - /events#https://127.0.0.1:4002
     featureGates:
       InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-apiserver:v1.27.0-alpha.3
+    image: registry.k8s.io/kube-apiserver:v1.27.0
     kubeletPreferredAddressTypes:
     - InternalIP
     - Hostname
@@ -54,8 +54,8 @@ APIServerConfig:
     -----END RSA PUBLIC KEY-----
 Assets:
   amd64:
-  - be5e79c70e926019e588c8c5c44d93efb1042f3be6f1db0de14e707141564d29@https://dl.k8s.io/release/v1.27.0-alpha.3/bin/linux/amd64/kubelet
-  - 4d416a4bed7c1bb576e284fc6b0bb843f879c08fa8e4beb7e2376305d2dc8299@https://dl.k8s.io/release/v1.27.0-alpha.3/bin/linux/amd64/kubectl
+  - 0b4ed4fcd75d33f5dff3ba17776e6089847fc83064d3f7a3ad59a34e94e60a29@https://dl.k8s.io/release/v1.27.0/bin/linux/amd64/kubelet
+  - 71a78259d70da9c5540c4cf4cff121f443e863376f68f89a759d90cef3f51e87@https://dl.k8s.io/release/v1.27.0/bin/linux/amd64/kubectl
   - 5035d7814c95cd3cedbc5efb447ef25a4942ef05caab2159746d55ce1698c74a@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/amd64/ecr-credential-provider-linux-amd64
   - f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz
   - bb9a9ccd6517e2a54da748a9f60dc9aa9d79d19d4724663f2386812f083968e2@https://github.com/containerd/containerd/releases/download/v1.6.20/containerd-1.6.20-linux-amd64.tar.gz
@@ -63,8 +63,8 @@ Assets:
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
   arm64:
-  - 2a15e9c291dce3e07db5d9948d5c37a4e52c9884343f63287189e4f0d4c3df76@https://dl.k8s.io/release/v1.27.0-alpha.3/bin/linux/arm64/kubelet
-  - c5fad9f96ab5fe04b8927ce83ceefc4db65b032303a23b35e353276479450d2a@https://dl.k8s.io/release/v1.27.0-alpha.3/bin/linux/arm64/kubectl
+  - 37aa2edc7c0c4b3e488518c6a4b44c8aade75a55010534ee2be291220c73d157@https://dl.k8s.io/release/v1.27.0/bin/linux/arm64/kubelet
+  - f8e09630211f2b7c6a8cc38835e7dea94708d401f5c84b23a37c70c604602ddc@https://dl.k8s.io/release/v1.27.0/bin/linux/arm64/kubectl
   - b3d567bda9e2996fc1fbd9d13506bd16763d3865b5c7b0b3c4b48c6088c04481@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/arm64/ecr-credential-provider-linux-arm64
   - 525e2b62ba92a1b6f3dc9612449a84aa61652e680f7ebf4eff579795fe464b57@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-arm64-v1.2.0.tgz
   - c3e6a054b18b20fce06c7c3ed53f0989bb4b255c849bede446ebca955f07a9ce@https://github.com/containerd/containerd/releases/download/v1.6.20/containerd-1.6.20-linux-arm64.tar.gz
@@ -247,7 +247,7 @@ KeypairIDs:
 KubeProxy:
   clusterCIDR: 100.96.0.0/11
   cpuRequest: 100m
-  image: registry.k8s.io/kube-proxy:v1.27.0-alpha.3
+  image: registry.k8s.io/kube-proxy:v1.27.0
   logLevel: 2
 KubeletConfig:
   cgroupDriver: systemd
@@ -273,7 +273,7 @@ KubeletConfig:
   shutdownGracePeriodCriticalPods: 10s
   taints:
   - node-role.kubernetes.io/control-plane=:NoSchedule
-KubernetesVersion: 1.27.0-alpha.3
+KubernetesVersion: 1.27.0
 Networking:
   nonMasqueradeCIDR: 100.64.0.0/10
   serviceClusterIPRange: 100.64.0.0/13

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_nodeupconfig-nodes_content
@@ -1,14 +1,14 @@
 Assets:
   amd64:
-  - be5e79c70e926019e588c8c5c44d93efb1042f3be6f1db0de14e707141564d29@https://dl.k8s.io/release/v1.27.0-alpha.3/bin/linux/amd64/kubelet
-  - 4d416a4bed7c1bb576e284fc6b0bb843f879c08fa8e4beb7e2376305d2dc8299@https://dl.k8s.io/release/v1.27.0-alpha.3/bin/linux/amd64/kubectl
+  - 0b4ed4fcd75d33f5dff3ba17776e6089847fc83064d3f7a3ad59a34e94e60a29@https://dl.k8s.io/release/v1.27.0/bin/linux/amd64/kubelet
+  - 71a78259d70da9c5540c4cf4cff121f443e863376f68f89a759d90cef3f51e87@https://dl.k8s.io/release/v1.27.0/bin/linux/amd64/kubectl
   - 5035d7814c95cd3cedbc5efb447ef25a4942ef05caab2159746d55ce1698c74a@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/amd64/ecr-credential-provider-linux-amd64
   - f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz
   - bb9a9ccd6517e2a54da748a9f60dc9aa9d79d19d4724663f2386812f083968e2@https://github.com/containerd/containerd/releases/download/v1.6.20/containerd-1.6.20-linux-amd64.tar.gz
   - f00b144e86f8c1db347a2e8f22caade07d55382c5f76dd5c0a5b1ab64eaec8bb@https://github.com/opencontainers/runc/releases/download/v1.1.5/runc.amd64
   arm64:
-  - 2a15e9c291dce3e07db5d9948d5c37a4e52c9884343f63287189e4f0d4c3df76@https://dl.k8s.io/release/v1.27.0-alpha.3/bin/linux/arm64/kubelet
-  - c5fad9f96ab5fe04b8927ce83ceefc4db65b032303a23b35e353276479450d2a@https://dl.k8s.io/release/v1.27.0-alpha.3/bin/linux/arm64/kubectl
+  - 37aa2edc7c0c4b3e488518c6a4b44c8aade75a55010534ee2be291220c73d157@https://dl.k8s.io/release/v1.27.0/bin/linux/arm64/kubelet
+  - f8e09630211f2b7c6a8cc38835e7dea94708d401f5c84b23a37c70c604602ddc@https://dl.k8s.io/release/v1.27.0/bin/linux/arm64/kubectl
   - b3d567bda9e2996fc1fbd9d13506bd16763d3865b5c7b0b3c4b48c6088c04481@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/arm64/ecr-credential-provider-linux-arm64
   - 525e2b62ba92a1b6f3dc9612449a84aa61652e680f7ebf4eff579795fe464b57@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-arm64-v1.2.0.tgz
   - c3e6a054b18b20fce06c7c3ed53f0989bb4b255c849bede446ebca955f07a9ce@https://github.com/containerd/containerd/releases/download/v1.6.20/containerd-1.6.20-linux-arm64.tar.gz
@@ -24,7 +24,7 @@ KeypairIDs:
 KubeProxy:
   clusterCIDR: 100.96.0.0/11
   cpuRequest: 100m
-  image: registry.k8s.io/kube-proxy:v1.27.0-alpha.3
+  image: registry.k8s.io/kube-proxy:v1.27.0
   logLevel: 2
 KubeletConfig:
   cgroupDriver: systemd
@@ -46,7 +46,7 @@ KubeletConfig:
   registerSchedulable: true
   shutdownGracePeriod: 30s
   shutdownGracePeriodCriticalPods: 10s
-KubernetesVersion: 1.27.0-alpha.3
+KubernetesVersion: 1.27.0
 Networking:
   nonMasqueradeCIDR: 100.64.0.0/10
   serviceClusterIPRange: 100.64.0.0/13

--- a/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
@@ -18,7 +18,7 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  kubernetesVersion: v1.27.0-alpha.3
+  kubernetesVersion: v1.27.0
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:


### PR DESCRIPTION
Cherry pick of #15699 on release-1.27.

#15699: Use release version of k8s 1.27 in integration test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.