### PR TITLE
gce load balancers: set LoadBalancingScheme to EXTERNAL explicitly

### DIFF
--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -73,12 +73,13 @@ func (b *APILoadBalancerBuilder) createPublicLB(c *fi.CloudupModelBuilderContext
 	clusterLabel := gce.LabelForCluster(b.ClusterName())
 
 	c.AddTask(&gcetasks.ForwardingRule{
-		Name:       s(b.NameForForwardingRule("api")),
-		Lifecycle:  b.Lifecycle,
-		PortRange:  s(strconv.Itoa(wellknownports.KubeAPIServer) + "-" + strconv.Itoa(wellknownports.KubeAPIServer)),
-		TargetPool: targetPool,
-		IPAddress:  ipAddress,
-		IPProtocol: "TCP",
+		Name:                s(b.NameForForwardingRule("api")),
+		Lifecycle:           b.Lifecycle,
+		PortRange:           s(strconv.Itoa(wellknownports.KubeAPIServer) + "-" + strconv.Itoa(wellknownports.KubeAPIServer)),
+		TargetPool:          targetPool,
+		IPAddress:           ipAddress,
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: s("EXTERNAL"),
 		Labels: map[string]string{
 			clusterLabel.Key: clusterLabel.Value,
 			"name":           "api",
@@ -86,12 +87,13 @@ func (b *APILoadBalancerBuilder) createPublicLB(c *fi.CloudupModelBuilderContext
 	})
 	if b.Cluster.UsesNoneDNS() {
 		c.AddTask(&gcetasks.ForwardingRule{
-			Name:       s(b.NameForForwardingRule("kops-controller")),
-			Lifecycle:  b.Lifecycle,
-			PortRange:  s(strconv.Itoa(wellknownports.KopsControllerPort) + "-" + strconv.Itoa(wellknownports.KopsControllerPort)),
-			TargetPool: targetPool,
-			IPAddress:  ipAddress,
-			IPProtocol: "TCP",
+			Name:                s(b.NameForForwardingRule("kops-controller")),
+			Lifecycle:           b.Lifecycle,
+			PortRange:           s(strconv.Itoa(wellknownports.KopsControllerPort) + "-" + strconv.Itoa(wellknownports.KopsControllerPort)),
+			TargetPool:          targetPool,
+			IPAddress:           ipAddress,
+			IPProtocol:          "TCP",
+			LoadBalancingScheme: s("EXTERNAL"),
 			Labels: map[string]string{
 				clusterLabel.Key: clusterLabel.Value,
 				"name":           "kops-controller",

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -426,9 +426,10 @@ resource "google_compute_forwarding_rule" "api-minimal-gce-plb-example-com" {
     "k8s-io-cluster-name" = "minimal-gce-plb-example-com"
     "name"                = "api"
   }
-  name       = "api-minimal-gce-plb-example-com"
-  port_range = "443-443"
-  target     = google_compute_target_pool.api-minimal-gce-plb-example-com.self_link
+  load_balancing_scheme = "EXTERNAL"
+  name                  = "api-minimal-gce-plb-example-com"
+  port_range            = "443-443"
+  target                = google_compute_target_pool.api-minimal-gce-plb-example-com.self_link
 }
 
 resource "google_compute_http_health_check" "api-minimal-gce-plb-example-com" {


### PR DESCRIPTION
This avoids a spurious change being printed, and is more correct - we
actually want this to be external (vs nil, which implicitly means
"don't care").
