### PR TITLE
gce: Set labels on ForwardingRules

### DIFF
--- a/cloudmock/gce/mockcompute/forwarding_rule.go
+++ b/cloudmock/gce/mockcompute/forwarding_rule.go
@@ -71,6 +71,26 @@ func (c *forwardingRuleClient) Insert(project, region string, fr *compute.Forwar
 	return doneOperation(), nil
 }
 
+func (c *forwardingRuleClient) SetLabels(ctx context.Context, project, region, name string, req *compute.RegionSetLabelsRequest) (*compute.Operation, error) {
+	c.Lock()
+	defer c.Unlock()
+	regions, ok := c.forwardingRules[project]
+	if !ok {
+		return nil, notFoundError()
+	}
+	frs, ok := regions[region]
+	if !ok {
+		return nil, notFoundError()
+	}
+	fr, ok := frs[name]
+	if !ok {
+		return nil, notFoundError()
+	}
+
+	fr.Labels = req.Labels
+	return doneOperation(), nil
+}
+
 func (c *forwardingRuleClient) Delete(project, region, name string) (*compute.Operation, error) {
 	c.Lock()
 	defer c.Unlock()

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -476,8 +476,9 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 		case kops.CloudProviderGCE:
 			config.VolumeProvider = "gce"
 
+			clusterLabel := gce.LabelForCluster(b.Cluster.Name)
 			config.VolumeTag = []string{
-				gce.GceLabelNameKubernetesCluster + "=" + gce.SafeClusterName(b.Cluster.Name),
+				clusterLabel.Key + "=" + clusterLabel.Value,
 				gce.GceLabelNameEtcdClusterPrefix + etcdCluster.Name,
 				gce.GceLabelNameRolePrefix + "master=master",
 			}

--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -70,6 +70,8 @@ func (b *APILoadBalancerBuilder) createPublicLB(c *fi.CloudupModelBuilderContext
 	}
 	c.AddTask(ipAddress)
 
+	clusterLabel := gce.LabelForCluster(b.ClusterName())
+
 	c.AddTask(&gcetasks.ForwardingRule{
 		Name:       s(b.NameForForwardingRule("api")),
 		Lifecycle:  b.Lifecycle,
@@ -78,8 +80,8 @@ func (b *APILoadBalancerBuilder) createPublicLB(c *fi.CloudupModelBuilderContext
 		IPAddress:  ipAddress,
 		IPProtocol: "TCP",
 		Labels: map[string]string{
-			gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(b.ClusterName()),
-			"name":                            "api",
+			clusterLabel.Key: clusterLabel.Value,
+			"name":           "api",
 		},
 	})
 	if b.Cluster.UsesNoneDNS() {
@@ -91,8 +93,8 @@ func (b *APILoadBalancerBuilder) createPublicLB(c *fi.CloudupModelBuilderContext
 			IPAddress:  ipAddress,
 			IPProtocol: "TCP",
 			Labels: map[string]string{
-				gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(b.ClusterName()),
-				"name":                            "kops-controller",
+				clusterLabel.Key: clusterLabel.Value,
+				"name":           "kops-controller",
 			},
 		})
 	}
@@ -145,6 +147,8 @@ func (b *APILoadBalancerBuilder) addFirewallRules(c *fi.CloudupModelBuilderConte
 // GCP this entails creating a health check, backend service, and one forwarding rule
 // per specified subnet pointing to that backend service.
 func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderContext) error {
+	clusterLabel := gce.LabelForCluster(b.ClusterName())
+
 	hc := &gcetasks.HealthCheck{
 		Name:      s(b.NameForHealthCheck("api")),
 		Port:      wellknownports.KubeAPIServer,
@@ -213,8 +217,8 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 			Network:             network,
 			Subnetwork:          subnet,
 			Labels: map[string]string{
-				gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(b.ClusterName()),
-				"name":                            "api-" + sn.Name,
+				clusterLabel.Key: clusterLabel.Value,
+				"name":           "api-" + sn.Name,
 			},
 		})
 		if b.Cluster.UsesNoneDNS() {
@@ -229,8 +233,8 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 				Network:             network,
 				Subnetwork:          subnet,
 				Labels: map[string]string{
-					gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(b.ClusterName()),
-					"name":                            "kops-controller-" + sn.Name,
+					clusterLabel.Key: clusterLabel.Value,
+					"name":           "kops-controller-" + sn.Name,
 				},
 			})
 		}

--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -77,6 +77,10 @@ func (b *APILoadBalancerBuilder) createPublicLB(c *fi.CloudupModelBuilderContext
 		TargetPool: targetPool,
 		IPAddress:  ipAddress,
 		IPProtocol: "TCP",
+		Labels: map[string]string{
+			gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(b.ClusterName()),
+			"name":                            "api",
+		},
 	})
 	if b.Cluster.UsesNoneDNS() {
 		c.AddTask(&gcetasks.ForwardingRule{
@@ -86,6 +90,10 @@ func (b *APILoadBalancerBuilder) createPublicLB(c *fi.CloudupModelBuilderContext
 			TargetPool: targetPool,
 			IPAddress:  ipAddress,
 			IPProtocol: "TCP",
+			Labels: map[string]string{
+				gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(b.ClusterName()),
+				"name":                            "kops-controller",
+			},
 		})
 	}
 
@@ -204,6 +212,10 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 			LoadBalancingScheme: s("INTERNAL"),
 			Network:             network,
 			Subnetwork:          subnet,
+			Labels: map[string]string{
+				gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(b.ClusterName()),
+				"name":                            "api-" + sn.Name,
+			},
 		})
 		if b.Cluster.UsesNoneDNS() {
 			c.AddTask(&gcetasks.ForwardingRule{
@@ -216,6 +228,10 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 				LoadBalancingScheme: s("INTERNAL"),
 				Network:             network,
 				Subnetwork:          subnet,
+				Labels: map[string]string{
+					gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(b.ClusterName()),
+					"name":                            "kops-controller-" + sn.Name,
+				},
 			})
 		}
 	}

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -175,11 +175,12 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 			case kops.InstanceGroupRoleBastion:
 				t.Tags = append(t.Tags, b.GCETagForRole(kops.InstanceGroupRoleBastion))
 			}
+			clusterLabel := gce.LabelForCluster(b.ClusterName())
 			roleLabel := gce.GceLabelNameRolePrefix + ig.Spec.Role.ToLowerString()
 			t.Labels = map[string]string{
-				gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(b.ClusterName()),
-				roleLabel:                         "",
-				gce.GceLabelNameInstanceGroup:     ig.ObjectMeta.Name,
+				clusterLabel.Key:              clusterLabel.Value,
+				roleLabel:                     "",
+				gce.GceLabelNameInstanceGroup: ig.ObjectMeta.Name,
 			}
 			if ig.Spec.Role == kops.InstanceGroupRoleControlPlane {
 				t.Labels[gce.GceLabelNameRolePrefix+"master"] = ""

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -272,9 +272,11 @@ func (b *MasterVolumeBuilder) addGCEVolume(c *fi.CloudupModelBuilderContext, pre
 	// This is the configuration of the etcd cluster
 	clusterSpec := m.Name + "/" + strings.Join(allMembers, ",")
 
+	clusterLabel := gce.LabelForCluster(b.ClusterName())
+
 	// The tags are how protokube knows to mount the volume and use it for etcd
 	tags := make(map[string]string)
-	tags[gce.GceLabelNameKubernetesCluster] = gce.SafeClusterName(b.ClusterName())
+	tags[clusterLabel.Key] = clusterLabel.Value
 	tags[gce.GceLabelNameRolePrefix+"master"] = "master" // Can't start with a number
 	tags[gce.GceLabelNameEtcdClusterPrefix+etcd.Name] = gce.EncodeGCELabel(clusterSpec)
 

--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -299,7 +299,7 @@ func (d *clusterDiscoveryGCE) listManagedInstances(igm *compute.InstanceGroupMan
 func (d *clusterDiscoveryGCE) findGCEDisks() ([]*compute.Disk, error) {
 	c := d.gceCloud
 
-	clusterTag := gce.SafeClusterName(d.clusterName)
+	clusterLabel := gce.LabelForCluster(d.clusterName)
 
 	var matches []*compute.Disk
 
@@ -316,8 +316,8 @@ func (d *clusterDiscoveryGCE) findGCEDisks() ([]*compute.Disk, error) {
 		for _, d := range list.Disks {
 			match := false
 			for k, v := range d.Labels {
-				if k == gce.GceLabelNameKubernetesCluster {
-					if v == clusterTag {
+				if k == clusterLabel.Key {
+					if v == clusterLabel.Value {
 						match = true
 					} else {
 						match = false

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -449,9 +449,13 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-example-com
 }
 
 resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-example-com" {
-  backend_service       = google_compute_backend_service.api-minimal-gce-example-com.id
-  ip_address            = google_compute_address.api-us-test1-minimal-gce-example-com.address
-  ip_protocol           = "TCP"
+  backend_service = google_compute_backend_service.api-minimal-gce-example-com.id
+  ip_address      = google_compute_address.api-us-test1-minimal-gce-example-com.address
+  ip_protocol     = "TCP"
+  labels = {
+    "k8s-io-cluster-name" = "minimal-gce-example-com"
+    "name"                = "api-us-test1"
+  }
   load_balancing_scheme = "INTERNAL"
   name                  = "api-us-test1-minimal-gce-example-com"
   network               = google_compute_network.minimal-gce-example-com.name
@@ -460,9 +464,13 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-example-com"
 }
 
 resource "google_compute_forwarding_rule" "kops-controller-us-test1-minimal-gce-example-com" {
-  backend_service       = google_compute_backend_service.api-minimal-gce-example-com.id
-  ip_address            = google_compute_address.api-us-test1-minimal-gce-example-com.address
-  ip_protocol           = "TCP"
+  backend_service = google_compute_backend_service.api-minimal-gce-example-com.id
+  ip_address      = google_compute_address.api-us-test1-minimal-gce-example-com.address
+  ip_protocol     = "TCP"
+  labels = {
+    "k8s-io-cluster-name" = "minimal-gce-example-com"
+    "name"                = "kops-controller-us-test1"
+  }
   load_balancing_scheme = "INTERNAL"
   name                  = "kops-controller-us-test1-minimal-gce-example-com"
   network               = google_compute_network.minimal-gce-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -433,9 +433,13 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-ilb-example
 }
 
 resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-ilb-example-com" {
-  backend_service       = google_compute_backend_service.api-minimal-gce-ilb-example-com.id
-  ip_address            = google_compute_address.api-us-test1-minimal-gce-ilb-example-com.address
-  ip_protocol           = "TCP"
+  backend_service = google_compute_backend_service.api-minimal-gce-ilb-example-com.id
+  ip_address      = google_compute_address.api-us-test1-minimal-gce-ilb-example-com.address
+  ip_protocol     = "TCP"
+  labels = {
+    "k8s-io-cluster-name" = "minimal-gce-ilb-example-com"
+    "name"                = "api-us-test1"
+  }
   load_balancing_scheme = "INTERNAL"
   name                  = "api-us-test1-minimal-gce-ilb-example-com"
   network               = google_compute_network.minimal-gce-ilb-example-com.name

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -433,9 +433,13 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-with-a-very
 }
 
 resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi" {
-  backend_service       = google_compute_backend_service.api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.id
-  ip_address            = google_compute_address.api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi.address
-  ip_protocol           = "TCP"
+  backend_service = google_compute_backend_service.api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.id
+  ip_address      = google_compute_address.api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi.address
+  ip_protocol     = "TCP"
+  labels = {
+    "k8s-io-cluster-name" = "minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
+    "name"                = "api-us-test1"
+  }
   load_balancing_scheme = "INTERNAL"
   name                  = "api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi"
   network               = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -422,9 +422,13 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-plb-example
 resource "google_compute_forwarding_rule" "api-minimal-gce-plb-example-com" {
   ip_address  = google_compute_address.api-minimal-gce-plb-example-com.address
   ip_protocol = "TCP"
-  name        = "api-minimal-gce-plb-example-com"
-  port_range  = "443-443"
-  target      = google_compute_target_pool.api-minimal-gce-plb-example-com.self_link
+  labels = {
+    "k8s-io-cluster-name" = "minimal-gce-plb-example-com"
+    "name"                = "api"
+  }
+  name       = "api-minimal-gce-plb-example-com"
+  port_range = "443-443"
+  target     = google_compute_target_pool.api-minimal-gce-plb-example-com.self_link
 }
 
 resource "google_compute_http_health_check" "api-minimal-gce-plb-example-com" {

--- a/upup/pkg/fi/cloudup/gce/compute.go
+++ b/upup/pkg/fi/cloudup/gce/compute.go
@@ -366,6 +366,7 @@ type ForwardingRuleClient interface {
 	Delete(project, region, name string) (*compute.Operation, error)
 	Get(project, region, name string) (*compute.ForwardingRule, error)
 	List(ctx context.Context, project, region string) ([]*compute.ForwardingRule, error)
+	SetLabels(ctx context.Context, project, region, resource string, request *compute.RegionSetLabelsRequest) (*compute.Operation, error)
 }
 
 type forwardingRuleClientImpl struct {
@@ -384,6 +385,10 @@ func (c *forwardingRuleClientImpl) Delete(project, region, name string) (*comput
 
 func (c *forwardingRuleClientImpl) Get(project, region, name string) (*compute.ForwardingRule, error) {
 	return c.srv.Get(project, region, name).Do()
+}
+
+func (c *forwardingRuleClientImpl) SetLabels(ctx context.Context, project string, region string, resource string, request *compute.RegionSetLabelsRequest) (*compute.Operation, error) {
+	return c.srv.SetLabels(project, region, resource, request).Context(ctx).Do()
 }
 
 func (c *forwardingRuleClientImpl) List(ctx context.Context, project, region string) ([]*compute.ForwardingRule, error) {

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -327,10 +327,17 @@ func (c *gceCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]f
 		}
 	}
 
+	clusterLabel := LabelForCluster(cluster.Name)
+
 	for _, forwardingRule := range forwardingRules {
 		if !strings.HasPrefix(forwardingRule.Name, "api-") {
 			continue
 		}
+
+		if clusterLabel.Value != forwardingRule.Labels[clusterLabel.Key] {
+			continue
+		}
+
 		if forwardingRule.IPAddress == "" {
 			return nil, fmt.Errorf("found forward rule %q, but it did not have an IPAddress", forwardingRule.Name)
 		}

--- a/upup/pkg/fi/cloudup/gce/labels.go
+++ b/upup/pkg/fi/cloudup/gce/labels.go
@@ -27,7 +27,8 @@ import (
 
 const (
 	// The tag name we use to differentiate multiple logically independent clusters running in the same region
-	GceLabelNameKubernetesCluster = "k8s-io-cluster-name"
+	gceLabelNameKubernetesCluster = "k8s-io-cluster-name"
+
 	GceLabelNameInstanceGroup     = "k8s-io-instance-group"
 	GceLabelNameRolePrefix        = "k8s-io-role-"
 	GceLabelNameEtcdClusterPrefix = "k8s-io-etcd-"

--- a/upup/pkg/fi/cloudup/gce/utils.go
+++ b/upup/pkg/fi/cloudup/gce/utils.go
@@ -99,6 +99,17 @@ func SafeClusterName(clusterName string) string {
 	return safeClusterName
 }
 
+type Label struct {
+	Key   string
+	Value string
+}
+
+// LabelForCluster returns the GCE label we use for resources for this cluster.
+func LabelForCluster(clusterName string) Label {
+	v := SafeClusterName(clusterName)
+	return Label{Key: gceLabelNameKubernetesCluster, Value: v}
+}
+
 // SafeTruncatedClusterName returns a safe and truncated cluster name
 func SafeTruncatedClusterName(clusterName string, maxLength int) string {
 	// GCE does not support . in tags / names

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -57,7 +57,8 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 				return nil, fmt.Errorf("project is required for GCE - try gcloud config get-value project")
 			}
 
-			labels := map[string]string{gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(cluster.ObjectMeta.Name)}
+			clusterLabel := gce.LabelForCluster(cluster.ObjectMeta.Name)
+			labels := map[string]string{clusterLabel.Key: clusterLabel.Value}
 
 			gceCloud, err := gce.NewGCECloud(region, project, labels)
 			if err != nil {


### PR DESCRIPTION
We add the cluster-name label, now that labels are supported on
ForwardingRules.
