### PR TITLE
Automated cherry pick of #15674: kubetest2-kops: rename control-plane-size flag to

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -157,8 +157,8 @@ func (d *deployer) verifyKopsFlags() error {
 		return errors.New("missing required --kops-binary-path when --kops-version-marker is not used")
 	}
 
-	if d.ControlPlaneSize == 0 {
-		d.ControlPlaneSize = 1
+	if d.ControlPlaneCount == 0 {
+		d.ControlPlaneCount = 1
 	}
 
 	switch d.CloudProvider {

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -57,7 +57,7 @@ type deployer struct {
 	createBucket   bool     `flag:"-"`
 
 	// ControlPlaneCount specifies the number of VMs in the control-plane.
-	ControlPlaneCount int `flag:"control-plane-count" desc:"Number of control plane instances"`
+	ControlPlaneCount int `flag:"control-plane-count" desc:"Number of control-plane instances"`
 
 	ControlPlaneIGOverrides []string `flag:"control-plane-instance-group-overrides" desc:"overrides for the control plane instance groups"`
 	NodeIGOverrides         []string `flag:"node-instance-group-overrides" desc:"overrides for the node instance groups"`

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -48,14 +48,16 @@ type deployer struct {
 	KopsBaseURL          string `flag:"-"`
 	PublishVersionMarker string `flag:"publish-version-marker" desc:"The GCS path to which the --kops-version-marker is uploaded if the tests pass"`
 
-	ClusterName      string   `flag:"cluster-name" desc:"The FQDN to use for the cluster name"`
-	ControlPlaneSize int      `flag:"control-plane-size" desc:"Number of control plane instances"`
-	CloudProvider    string   `flag:"cloud-provider" desc:"Which cloud provider to use"`
-	GCPProject       string   `flag:"gcp-project" desc:"Which GCP Project to use when --cloud-provider=gce"`
-	Env              []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`
-	CreateArgs       string   `flag:"create-args" desc:"Extra space-separated arguments passed to 'kops create cluster'"`
-	KopsBinaryPath   string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
-	createBucket     bool     `flag:"-"`
+	ClusterName    string   `flag:"cluster-name" desc:"The FQDN to use for the cluster name"`
+	CloudProvider  string   `flag:"cloud-provider" desc:"Which cloud provider to use"`
+	GCPProject     string   `flag:"gcp-project" desc:"Which GCP Project to use when --cloud-provider=gce"`
+	Env            []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`
+	CreateArgs     string   `flag:"create-args" desc:"Extra space-separated arguments passed to 'kops create cluster'"`
+	KopsBinaryPath string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
+	createBucket   bool     `flag:"-"`
+
+	// ControlPlaneCount specifies the number of VMs in the control-plane.
+	ControlPlaneCount int `flag:"control-plane-count" desc:"Number of control plane instances"`
 
 	ControlPlaneIGOverrides []string `flag:"control-plane-instance-group-overrides" desc:"overrides for the control plane instance groups"`
 	NodeIGOverrides         []string `flag:"node-instance-group-overrides" desc:"overrides for the node instance groups"`
@@ -123,6 +125,17 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	// register flags for klog
 	klog.InitFlags(nil)
 	fs.AddGoFlagSet(flag.CommandLine)
+
+	// Map deprecated flag names to their new names
+	fs.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		switch name {
+		case "control-plane-size":
+			klog.Warningf("deprecated --control-plane-size specified; please use --control-plane-count instead")
+			name = "control-plane-count"
+		}
+		return pflag.NormalizedName(name)
+	})
+
 	return d, fs
 }
 

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -134,7 +134,7 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		args = append(args, createArgs...)
 	}
 	args = appendIfUnset(args, "--admin-access", adminAccess)
-	args = appendIfUnset(args, "--master-count", fmt.Sprintf("%d", d.ControlPlaneSize))
+	args = appendIfUnset(args, "--control-plane-count", fmt.Sprintf("%d", d.ControlPlaneCount))
 	args = appendIfUnset(args, "--master-volume-size", "48")
 	args = appendIfUnset(args, "--node-count", "4")
 	args = appendIfUnset(args, "--node-volume-size", "48")
@@ -284,7 +284,7 @@ func (d *deployer) verifyUpFlags() error {
 func (d *deployer) zones() ([]string, error) {
 	switch d.CloudProvider {
 	case "aws":
-		return aws.RandomZones(d.ControlPlaneSize)
+		return aws.RandomZones(d.ControlPlaneCount)
 	case "gce":
 		return gce.RandomZones(1)
 	case "digitalocean":

--- a/tests/e2e/scenarios/lib/common.sh
+++ b/tests/e2e/scenarios/lib/common.sh
@@ -143,11 +143,17 @@ function kops-up() {
         create_args="${create_args} --discovery-store=${DISCOVERY_STORE}/${CLUSTER_NAME}/discovery"
     fi
 
+    # TODO: Switch scripts to use KOPS_CONTROL_PLANE_COUNT
+    if [[ -n "${KOPS_CONTROL_PLANE_SIZE:-}" ]]; then
+      echo "Recognized (deprecated) KOPS_CONTROL_PLANE_SIZE=${KOPS_CONTROL_PLANE_SIZE}, please set KOPS_CONTROL_PLANE_COUNT instead"
+      KOPS_CONTROL_PLANE_COUNT=${KOPS_CONTROL_PLANE_SIZE}
+    fi
+
     ${KUBETEST2} \
         --up \
         --kops-binary-path="${KOPS}" \
         --kubernetes-version="${K8S_VERSION}" \
         --create-args="${create_args}" \
-        --control-plane-size="${KOPS_CONTROL_PLANE_SIZE:-1}" \
+        --control-plane-count="${KOPS_CONTROL_PLANE_COUNT:-1}" \
         --template-path="${KOPS_TEMPLATE-}"
 }

--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -84,7 +84,7 @@ ${KUBETEST2} \
     --up \
     --kops-binary-path="${KOPS_A}" \
     --kubernetes-version="${K8S_VERSION_A}" \
-    --control-plane-size="${KOPS_CONTROL_PLANE_SIZE:-1}" \
+    --control-plane-count="${KOPS_CONTROL_PLANE_SIZE:-1}" \
     --template-path="${KOPS_TEMPLATE:-}" \
     --create-args="--networking calico"
 

--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -80,11 +80,17 @@ fi
 
 
 
+# TODO: Switch scripts to use KOPS_CONTROL_PLANE_COUNT
+if [[ -n "${KOPS_CONTROL_PLANE_SIZE:-}" ]]; then
+  echo "Recognized (deprecated) KOPS_CONTROL_PLANE_SIZE=${KOPS_CONTROL_PLANE_SIZE}, please set KOPS_CONTROL_PLANE_COUNT instead"
+  KOPS_CONTROL_PLANE_COUNT=${KOPS_CONTROL_PLANE_SIZE}
+fi
+
 ${KUBETEST2} \
     --up \
     --kops-binary-path="${KOPS_A}" \
     --kubernetes-version="${K8S_VERSION_A}" \
-    --control-plane-count="${KOPS_CONTROL_PLANE_SIZE:-1}" \
+    --control-plane-count="${KOPS_CONTROL_PLANE_COUNT:-1}" \
     --template-path="${KOPS_TEMPLATE:-}" \
     --create-args="--networking calico"
 


### PR DESCRIPTION
Cherry pick of #15674 on release-1.26.

#15674: kubetest2-kops: rename control-plane-size flag to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```