### PR TITLE
Rename eventbridge rule in toolbox dump output

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -44,6 +44,7 @@ const (
 	TypeAutoscalingLaunchConfig = "autoscaling-config"
 	TypeNatGateway              = "nat-gateway"
 	TypeElasticIp               = "elastic-ip"
+	TypeEventBridgeRule         = "eventbridge-rule"
 	TypeLoadBalancer            = "load-balancer"
 	TypeTargetGroup             = "target-group"
 )

--- a/pkg/resources/aws/eventbridge.go
+++ b/pkg/resources/aws/eventbridge.go
@@ -105,7 +105,7 @@ func ListEventBridgeRules(cloud fi.Cloud, clusterName string) ([]*resources.Reso
 		resourceTracker := &resources.Resource{
 			Name:    *rule.Name,
 			ID:      *rule.Name,
-			Type:    "eventbridge",
+			Type:    TypeEventBridgeRule,
 			Deleter: EventBridgeRuleDeleter,
 			Dumper:  DumpEventBridgeRule,
 			Obj:     rule,


### PR DESCRIPTION
`eventbridge` itself is too generic given there are many resource types within the eventbridge service