### PR TITLE
Bump cilium to v1.13.5

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1237,8 +1237,8 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Could not parse as semantic version"))
 		}
 
-		if version.Minor != 12 {
-			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Only version 1.12 is supported"))
+		if version.Minor != 13 {
+			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Only version 1.13 is supported"))
 		}
 
 		if v.Hubble != nil && fi.ValueOf(v.Hubble.Enabled) {

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -979,7 +979,7 @@ func Test_Validate_Cilium(t *testing.T) {
 		},
 		{
 			Cilium: kops.CiliumNetworkingSpec{
-				Version: "v1.12.4",
+				Version: "v1.13.5",
 				Hubble: &kops.HubbleSpec{
 					Enabled: fi.PtrTo(true),
 				},

--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.12.10"
+		c.Version = "v1.13.5"
 	}
 
 	if c.EnableEndpointHealthChecking == nil {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -229,7 +229,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.12.10
+      version: v1.13.5
   nodeTerminationHandler:
     cpuRequest: 50m
     enableRebalanceDraining: false

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -105,8 +105,8 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
-    manifest: networking.cilium.io/k8s-1.16-v1.12.yaml
-    manifestHash: dea487bf6b1b7fe738189959345233264860eb0476be3aa9bf2adea26c8d62e2
+    manifest: networking.cilium.io/k8s-1.16-v1.13.yaml
+    manifestHash: 33440a8acbacd86a9b5cd6c44eabf93e591e6cdfd0245feae791b75ddc579a3c
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -26,6 +26,7 @@ metadata:
 
 apiVersion: v1
 data:
+  agent-health-port: "9879"
   auto-direct-node-routes: "false"
   bpf-ct-global-any-max: "262144"
   bpf-ct-global-tcp-max: "524288"
@@ -454,7 +455,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -536,7 +537,7 @@ spec:
       initContainers:
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -567,7 +568,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -704,7 +705,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.12.10
+        image: quay.io/cilium/operator:v1.13.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
@@ -943,7 +943,7 @@ resource "aws_s3_object" "minimal-ipv6-example-com-addons-limit-range-addons-k8s
 resource "aws_s3_object" "minimal-ipv6-example-com-addons-networking-cilium-io-k8s-1-16" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content")
-  key                    = "clusters.example.com/minimal-ipv6.example.com/addons/networking.cilium.io/k8s-1.16-v1.12.yaml"
+  key                    = "clusters.example.com/minimal-ipv6.example.com/addons/networking.cilium.io/k8s-1.16-v1.13.yaml"
   provider               = aws.files
   server_side_encryption = "AES256"
 }

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -177,7 +177,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal-warmpool.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 2l3il4V5FfecVLbgcQeTB/WaqelFq9DL1jchiiDg4G4=
+NodeupConfigHash: OT4O13L3ayRFN/UshzCqMHfXhpYbpfPmRQK71S70QXM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -220,7 +220,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.12.10
+      version: v1.13.5
   nodeTerminationHandler:
     cpuRequest: 50m
     enableRebalanceDraining: false

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -98,8 +98,8 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
-    manifest: networking.cilium.io/k8s-1.16-v1.12.yaml
-    manifestHash: e47a9b297b7164c269de1f5218bbf5112ce68771648075156819f04c151d0814
+    manifest: networking.cilium.io/k8s-1.16-v1.13.yaml
+    manifestHash: 3ce725cc07a4344fb82f4666145c6dd4070d10217a9bf43939bada12094cce95
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -26,6 +26,7 @@ metadata:
 
 apiVersion: v1
 data:
+  agent-health-port: "9879"
   auto-direct-node-routes: "false"
   bpf-ct-global-any-max: "262144"
   bpf-ct-global-tcp-max: "524288"
@@ -454,7 +455,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -536,7 +537,7 @@ spec:
       initContainers:
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -567,7 +568,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -704,7 +705,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.12.10
+        image: quay.io/cilium/operator:v1.13.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
@@ -64,8 +64,8 @@ useInstanceIDForNodeName: true
 usesLegacyGossip: false
 usesNoneDNS: false
 warmPoolImages:
-- quay.io/cilium/cilium:v1.12.10
-- quay.io/cilium/operator:v1.12.10
+- quay.io/cilium/cilium:v1.13.5
+- quay.io/cilium/operator:v1.13.5
 - registry.k8s.io/kube-proxy:v1.26.0
 - registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.14.1
 - registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.6

--- a/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
@@ -712,7 +712,7 @@ resource "aws_s3_object" "minimal-warmpool-example-com-addons-limit-range-addons
 resource "aws_s3_object" "minimal-warmpool-example-com-addons-networking-cilium-io-k8s-1-16" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content")
-  key                    = "clusters.example.com/minimal-warmpool.example.com/addons/networking.cilium.io/k8s-1.16-v1.12.yaml"
+  key                    = "clusters.example.com/minimal-warmpool.example.com/addons/networking.cilium.io/k8s-1.16-v1.13.yaml"
   provider               = aws.files
   server_side_encryption = "AES256"
 }

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
@@ -200,7 +200,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.12.10
+      version: v1.13.5
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://tests/scw-minimal.k8s.local/secrets

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -54,8 +54,8 @@ spec:
       k8s-addon: scaleway-csi-driver.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
-    manifest: networking.cilium.io/k8s-1.16-v1.12.yaml
-    manifestHash: 6fae0d9dfb1e3c9adeaa10ec433a5cd5b738149e5e50bd9c1522618911a8a8f1
+    manifest: networking.cilium.io/k8s-1.16-v1.13.yaml
+    manifestHash: 0965eae063f29669172d217374bc812d27eab79b5e2daeeda759de9ba7fdfeb6
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
@@ -26,6 +26,7 @@ metadata:
 
 apiVersion: v1
 data:
+  agent-health-port: "9879"
   auto-direct-node-routes: "false"
   bpf-ct-global-any-max: "262144"
   bpf-ct-global-tcp-max: "524288"
@@ -454,7 +455,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -536,7 +537,7 @@ spec:
       initContainers:
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -567,7 +568,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -704,7 +705,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.12.10
+        image: quay.io/cilium/operator:v1.13.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal_scaleway/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_scaleway/kubernetes.tf
@@ -143,7 +143,7 @@ resource "aws_s3_object" "scw-minimal-k8s-local-addons-limit-range-addons-k8s-io
 resource "aws_s3_object" "scw-minimal-k8s-local-addons-networking-cilium-io-k8s-1-16" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content")
-  key                    = "tests/scw-minimal.k8s.local/addons/networking.cilium.io/k8s-1.16-v1.12.yaml"
+  key                    = "tests/scw-minimal.k8s.local/addons/networking.cilium.io/k8s-1.16-v1.13.yaml"
   provider               = aws.files
   server_side_encryption = "AES256"
 }

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -222,7 +222,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.12.10
+      version: v1.13.5
   nodeTerminationHandler:
     cpuRequest: 50m
     enableRebalanceDraining: false

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,8 +98,8 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
-    manifest: networking.cilium.io/k8s-1.16-v1.12.yaml
-    manifestHash: 6c62e2232c454c915ee5eaba78b28b4e2b26df64dd006a736a2cb2d7235b40d5
+    manifest: networking.cilium.io/k8s-1.16-v1.13.yaml
+    manifestHash: f477be8a0899c266e8a71d80fc70ddd61b6564455ce75560b877d92c6f12a762
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -26,6 +26,7 @@ metadata:
 
 apiVersion: v1
 data:
+  agent-health-port: "9879"
   auto-create-cilium-node-resource: "true"
   auto-direct-node-routes: "false"
   blacklist-conflicting-routes: "false"
@@ -457,7 +458,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -539,7 +540,7 @@ spec:
       initContainers:
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -570,7 +571,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -707,7 +708,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.12.10
+        image: quay.io/cilium/operator:v1.13.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
@@ -1031,7 +1031,7 @@ resource "aws_s3_object" "privatecilium-example-com-addons-limit-range-addons-k8
 resource "aws_s3_object" "privatecilium-example-com-addons-networking-cilium-io-k8s-1-16" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content")
-  key                    = "clusters.example.com/privatecilium.example.com/addons/networking.cilium.io/k8s-1.16-v1.12.yaml"
+  key                    = "clusters.example.com/privatecilium.example.com/addons/networking.cilium.io/k8s-1.16-v1.13.yaml"
   provider               = aws.files
   server_side_encryption = "AES256"
 }

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -230,7 +230,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.12.10
+      version: v1.13.5
   nodeTerminationHandler:
     cpuRequest: 50m
     enableRebalanceDraining: false

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -98,8 +98,8 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
-    manifest: networking.cilium.io/k8s-1.16-v1.12.yaml
-    manifestHash: b1fd164b9daad8e508ed4586271d5646be9696e1f23a15b9a79d12f771eb9ed9
+    manifest: networking.cilium.io/k8s-1.16-v1.13.yaml
+    manifestHash: 1bcf01aca5730c31ac7b86d72831968485235c479566cf6a26da17ede4f0c351
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -26,6 +26,7 @@ metadata:
 
 apiVersion: v1
 data:
+  agent-health-port: "9879"
   auto-direct-node-routes: "false"
   bpf-ct-global-any-max: "262144"
   bpf-ct-global-tcp-max: "524288"
@@ -458,7 +459,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -540,7 +541,7 @@ spec:
       initContainers:
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -571,7 +572,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -712,7 +713,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.12.10
+        image: quay.io/cilium/operator:v1.13.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -1031,7 +1031,7 @@ resource "aws_s3_object" "privatecilium-example-com-addons-limit-range-addons-k8
 resource "aws_s3_object" "privatecilium-example-com-addons-networking-cilium-io-k8s-1-16" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content")
-  key                    = "clusters.example.com/privatecilium.example.com/addons/networking.cilium.io/k8s-1.16-v1.12.yaml"
+  key                    = "clusters.example.com/privatecilium.example.com/addons/networking.cilium.io/k8s-1.16-v1.13.yaml"
   provider               = aws.files
   server_side_encryption = "AES256"
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -225,7 +225,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.12.10
+      version: v1.13.5
   nodeTerminationHandler:
     cpuRequest: 50m
     enableRebalanceDraining: false

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -161,8 +161,8 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
-    manifest: networking.cilium.io/k8s-1.16-v1.12.yaml
-    manifestHash: fa6d1a824457511482c155258094dff8b7f290afa61efd821a3d6577f3698a7a
+    manifest: networking.cilium.io/k8s-1.16-v1.13.yaml
+    manifestHash: 94282761f698163d4f9aa873a28fc28992db00d8f335c9c9a27d2a91cb8802fd
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -39,6 +39,7 @@ metadata:
 
 apiVersion: v1
 data:
+  agent-health-port: "9879"
   auto-direct-node-routes: "false"
   bpf-ct-global-any-max: "262144"
   bpf-ct-global-tcp-max: "524288"
@@ -519,7 +520,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -604,7 +605,7 @@ spec:
       initContainers:
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -635,7 +636,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -776,7 +777,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.12.10
+        image: quay.io/cilium/operator:v1.13.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -864,7 +865,7 @@ spec:
         env:
         - name: GODEBUG
           value: x509ignoreCN=0
-        image: quay.io/cilium/hubble-relay:v1.12.10
+        image: quay.io/cilium/hubble-relay:v1.13.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           tcpSocket:

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -1047,7 +1047,7 @@ resource "aws_s3_object" "privatecilium-example-com-addons-limit-range-addons-k8
 resource "aws_s3_object" "privatecilium-example-com-addons-networking-cilium-io-k8s-1-16" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content")
-  key                    = "clusters.example.com/privatecilium.example.com/addons/networking.cilium.io/k8s-1.16-v1.12.yaml"
+  key                    = "clusters.example.com/privatecilium.example.com/addons/networking.cilium.io/k8s-1.16-v1.13.yaml"
   provider               = aws.files
   server_side_encryption = "AES256"
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -234,7 +234,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.12.10
+      version: v1.13.5
   nodeTerminationHandler:
     cpuRequest: 50m
     enableRebalanceDraining: false

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -98,8 +98,8 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
-    manifest: networking.cilium.io/k8s-1.16-v1.12.yaml
-    manifestHash: 2ca8c035cbd862c4b795b02f19bf61e400064f8018fcc53ab6744505bf1a3c61
+    manifest: networking.cilium.io/k8s-1.16-v1.13.yaml
+    manifestHash: c6b553b26348b9bda91297615c885dfeb20ec41a56cdeedcf433255bd62d4d58
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -26,6 +26,7 @@ metadata:
 
 apiVersion: v1
 data:
+  agent-health-port: "9879"
   auto-create-cilium-node-resource: "true"
   auto-direct-node-routes: "false"
   blacklist-conflicting-routes: "false"
@@ -468,7 +469,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -556,7 +557,7 @@ spec:
       initContainers:
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -587,7 +588,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.12.10
+        image: quay.io/cilium/cilium:v1.13.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -735,7 +736,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.12.10
+        image: quay.io/cilium/operator:v1.13.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -1064,7 +1064,7 @@ resource "aws_s3_object" "privateciliumadvanced-example-com-addons-limit-range-a
 resource "aws_s3_object" "privateciliumadvanced-example-com-addons-networking-cilium-io-k8s-1-16" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content")
-  key                    = "clusters.example.com/privateciliumadvanced.example.com/addons/networking.cilium.io/k8s-1.16-v1.12.yaml"
+  key                    = "clusters.example.com/privateciliumadvanced.example.com/addons/networking.cilium.io/k8s-1.16-v1.13.yaml"
   provider               = aws.files
   server_side_encryption = "AES256"
 }

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.13.yaml.template
@@ -38,6 +38,7 @@ metadata:
   name: cilium-config
   namespace: kube-system
 data:
+  agent-health-port: "{{ $healthPort }}"
 
 {{- if .EtcdManaged }}
   kvstore: etcd

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/cilium.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/cilium.go
@@ -35,7 +35,7 @@ func addCiliumAddon(b *BootstrapChannelBuilder, addons *AddonList) error {
 		klog.Infof("found cilium (%q) in addons; won't use builtin", key)
 	} else {
 		id := "k8s-1.16"
-		location := key + "/" + id + "-v1.12.yaml"
+		location := key + "/" + id + "-v1.13.yaml"
 
 		addon := &api.AddonSpec{
 			Name:               fi.PtrTo(key),

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -98,8 +98,8 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
-    manifest: networking.cilium.io/k8s-1.16-v1.12.yaml
-    manifestHash: 4e82169ed7f2247b5347427539cba5ea4140120b716e4c28cbe59dc28fd20d16
+    manifest: networking.cilium.io/k8s-1.16-v1.13.yaml
+    manifestHash: 166325a914768c7916145fb5569a8673c50e90e74661391e63854fcf6a28daab
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -112,8 +112,8 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
-    manifest: networking.cilium.io/k8s-1.16-v1.12.yaml
-    manifestHash: 2045965a451579b2a01239022b29fe8e47c01659a11e2e1ebb951e6c0fd7ccbc
+    manifest: networking.cilium.io/k8s-1.16-v1.13.yaml
+    manifestHash: ea67f30269a53430de0accac2f9cb9d0488783621fba9aebb469bae736ee15f9
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -169,8 +169,8 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
-    manifest: networking.cilium.io/k8s-1.16-v1.12.yaml
-    manifestHash: 2045965a451579b2a01239022b29fe8e47c01659a11e2e1ebb951e6c0fd7ccbc
+    manifest: networking.cilium.io/k8s-1.16-v1.13.yaml
+    manifestHash: ea67f30269a53430de0accac2f9cb9d0488783621fba9aebb469bae736ee15f9
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Unfortunately, Cilium 1.14 is not ready yet (https://github.com/kubernetes/kops/pull/15705)

So here is a bump to 1.13.5

Tested this on a K8s Deployment in Openstack with Cilium ETCD.

![image](https://github.com/kubernetes/kops/assets/121857296/6cc3d3ee-3ae2-471e-a309-fb461c8115d3)

![image](https://github.com/kubernetes/kops/assets/121857296/01f07594-7728-4e7b-8297-891b3044a4ad)
