### PR TITLE
Update references to control-plane-count

### DIFF
--- a/tests/e2e/scenarios/digital-ocean/run-test
+++ b/tests/e2e/scenarios/digital-ocean/run-test
@@ -40,7 +40,7 @@ kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 		--up --down \
 		--env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
 		--env JOB_NAME=pull-kops-e2e-kubernetes-do-kubetest2 \
-		--create-args "--networking=cilium --api-loadbalancer-type=public --node-count=2 --master-count=3" \
+		--create-args "--networking=cilium --api-loadbalancer-type=public --node-count=2 --control-plane-count=3" \
 		--kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
 		--kubernetes-version=https://dl.k8s.io/release/stable-1.27.txt \
 		--test=kops \

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -98,7 +98,7 @@ create_args+=("--node-count=${KUBE_NODE_COUNT:-101}")
 # However, it currently fails two tests (HostPort & OIDC) so need to track that down
 #create_args="--dns none"
 create_args+=("--node-size=c6g.medium")
-create_args+=("--master-count=${CONTROL_PLANE_COUNT:-1}")
+create_args+=("--control-plane-count=${CONTROL_PLANE_COUNT:-1}")
 create_args+=("--master-size=${CONTROL_PLANE_SIZE:-c6g.2xlarge}")
 if [[ -n "${ZONES:-}" ]]; then
     create_args+=("--zones=${ZONES}")

--- a/tests/e2e/scenarios/upgrade-ha-leader-migration/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ha-leader-migration/run-test.sh
@@ -35,7 +35,7 @@ else
 	KUBETEST2="${KUBETEST2} --build"
 fi
 
-OVERRIDES=("--channel=alpha" "--node-count=1" "--master-count=3")
+OVERRIDES=("--channel=alpha" "--node-count=1" "--control-plane-count=3")
 
 case "${CLOUD_PROVIDER}" in
 gce)


### PR DESCRIPTION
kubetest2-kops searches for create-args values of --control-plane-count. While kops recognizes both --control-plane-count and --master-count, kubetest2-kops will add --control-plane-count if it isn't already set in --create-args. This means any references to --master-count need to be updated to --control-plane-count.


This should fix at least this job: https://testgrid.k8s.io/kops-gce#kops-leader-migration

`I0801 22:50:40.366862    5814 local.go:42] ⚙️ /home/prow/go/src/k8s.io/kops/_rundir/121db271-a4e7-46bc-842f-abf92494756d/kops create cluster --name ha-migration.k8s.local --cloud gce --kubernetes-version v1.23.17 --ssh-public-key /tmp/kops-ssh2613636737/key.pub --set cluster.spec.nodePortAccess=0.0.0.0/0 --channel=alpha --node-count=1 --master-count=3 --zones=us-central1-a,us-central1-b,us-central1-c --master-zones=us-central1-a,us-central1-b,us-central1-c --gce-service-account=default --admin-access 35.224.130.54/32 --control-plane-count 1 --master-volume-size 48 --node-volume-size 48 --master-size e2-standard-2 --project k8s-kubeadm-1-6-on-1-7
I0801 22:50:40.455002    6136 create_cluster.go:885] Using SSH public key: /tmp/kops-ssh2613636737/key.pub
I0801 22:50:40.760691    6136 new_cluster.go:579] VMs will be configured to use specified Service Account: default
Error: specified 3 control-plane zones, but also requested 1 control-plane nodes.  If specifying both, the count should match.`