### PR TITLE
OpenStack: add server group name override annotation

### DIFF
--- a/docs/getting_started/openstack.md
+++ b/docs/getting_started/openstack.md
@@ -123,29 +123,6 @@ kops update cluster my-cluster.k8s.local --state ${KOPS_STATE_STORE} --yes
 
 kOps should create instances to all three zones, but provision volumes from the same zone.
 
-## Using external cloud controller manager
-
-If you want to use [External CCM](https://github.com/kubernetes/cloud-provider-openstack) in your installation, this section contains instructions what you should do to get it up and running.
-
-Create cluster without `--yes` flag (or modify existing cluster):
-
-```bash
-kops edit cluster <cluster>
-```
-
-Add the following to clusterspec:
-
-```yaml
-spec:
-  cloudControllerManager: {}
-```
-
-Finally, update the cluster:
-
-```bash
-kops update cluster --name <cluster> --yes
-```
-
 ## Using CCM created Loadbalancers
 
 With the default configuration, the loadbalancers created using the [cloud-provider-openstack](https://github.com/kubernetes/cloud-provider-openstack) cloud controller provider do not have access to the exposed NodePorts.
@@ -301,6 +278,20 @@ metadata:
 ```
 
 Please refer to the [OpenStack Compute API documentation](https://docs.openstack.org/api-ref/compute/?expanded=create-server-group-detail#create-server-group) for supported policies.
+
+### Using a custom server group name
+
+By default kOps provisions the server groups in OpenStack with `anti-affinity`.
+However, if you have only one AZ and you want to run multiple control-planes you might want to have anti-affinity between control planes.
+
+To override this add the following annotation to all control-plane Instance Groups configuration where kOps should provision a server group with another policy:
+
+```yaml
+kind: InstanceGroup
+metadata:
+  annotations:
+    openstack.kops.io/serverGroupName: control-plane
+```
 
 ## Next steps
 

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -388,6 +388,7 @@ func (b *ServerGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) error 
 				associateTask := &openstacktasks.PoolAssociation{
 					Name:          fi.PtrTo(fmt.Sprintf("%s-%s", clusterName, ig.Name)),
 					ServerPrefix:  fi.PtrTo(ig.Name),
+					ClusterName:   s(clusterName),
 					Pool:          poolTask,
 					InterfaceName: fi.PtrTo(ifName),
 					ProtocolPort:  fi.PtrTo(wellknownports.KubeAPIServer),

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -678,6 +678,135 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 			},
 		},
 		{
+			desc: "single-zone setup 3 masters 1 node without bastion with API loadbalancer dns none",
+			cluster: &kops.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: kops.ClusterSpec{
+					API: kops.APISpec{
+						LoadBalancer: &kops.LoadBalancerAccessSpec{
+							Type: kops.LoadBalancerTypePublic,
+						},
+					},
+					CloudProvider: kops.CloudProviderSpec{
+						Openstack: &kops.OpenstackSpec{
+							BlockStorage: &kops.OpenstackBlockStorageConfig{
+								Version:            fi.PtrTo("v3"),
+								IgnoreAZ:           fi.PtrTo(false),
+								CreateStorageClass: fi.PtrTo(false),
+								CSITopologySupport: fi.PtrTo(true),
+							},
+							Loadbalancer: &kops.OpenstackLoadbalancerConfig{
+								FloatingNetwork: fi.PtrTo("test"),
+								FloatingSubnet:  fi.PtrTo("test-lb-subnet"),
+								Method:          fi.PtrTo("ROUND_ROBIN"),
+								Provider:        fi.PtrTo("amphora"),
+								UseOctavia:      fi.PtrTo(true),
+							},
+							Monitor: &kops.OpenstackMonitor{
+								Delay:      fi.PtrTo("1m"),
+								MaxRetries: fi.PtrTo(3),
+								Timeout:    fi.PtrTo("30s"),
+							},
+							Network: &kops.OpenstackNetwork{
+								AvailabilityZoneHints: []*string{fi.PtrTo("zone-1")},
+							},
+							Router: &kops.OpenstackRouter{
+								DNSServers:            fi.PtrTo("8.8.8.8,8.8.4.4"),
+								ExternalSubnet:        fi.PtrTo("test-router-subnet"),
+								ExternalNetwork:       fi.PtrTo("test"),
+								AvailabilityZoneHints: []*string{fi.PtrTo("zone-1")},
+							},
+							Metadata: &kops.OpenstackMetadata{
+								ConfigDrive: fi.PtrTo(false),
+							},
+						},
+					},
+					KubernetesVersion: "1.25.0",
+					Networking: kops.NetworkingSpec{
+						Subnets: []kops.ClusterSubnetSpec{
+							{
+								Name: "subnet-1",
+								Zone: "zone-1",
+								Type: kops.SubnetTypePrivate,
+							},
+						},
+						Topology: &kops.TopologySpec{
+							DNS: kops.DNSTypeNone,
+						},
+					},
+				},
+			},
+			instanceGroups: []*kops.InstanceGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "master-a",
+						Annotations: map[string]string{
+							"openstack.kops.io/serverGroupName": "control-plane",
+						},
+					},
+					Spec: kops.InstanceGroupSpec{
+						Role:        kops.InstanceGroupRoleControlPlane,
+						Image:       "image",
+						MinSize:     i32(1),
+						MaxSize:     i32(1),
+						MachineType: "blc.1-2",
+						Subnets:     []string{"subnet-1"},
+						Zones:       []string{"zone-1"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-a",
+					},
+					Spec: kops.InstanceGroupSpec{
+						Role:        kops.InstanceGroupRoleNode,
+						Image:       "image",
+						MinSize:     i32(1),
+						MaxSize:     i32(1),
+						MachineType: "blc.1-2",
+						Subnets:     []string{"subnet-1"},
+						Zones:       []string{"zone-1"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "master-b",
+						Annotations: map[string]string{
+							"openstack.kops.io/serverGroupName": "control-plane",
+						},
+					},
+					Spec: kops.InstanceGroupSpec{
+						Role:        kops.InstanceGroupRoleControlPlane,
+						Image:       "image",
+						MinSize:     i32(1),
+						MaxSize:     i32(1),
+						MachineType: "blc.1-2",
+						Subnets:     []string{"subnet-1"},
+						Zones:       []string{"zone-1"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "master-c",
+						Annotations: map[string]string{
+							"openstack.kops.io/serverGroupName": "control-plane",
+						},
+					},
+					Spec: kops.InstanceGroupSpec{
+						Role:        kops.InstanceGroupRoleControlPlane,
+						Image:       "image",
+						MinSize:     i32(1),
+						MaxSize:     i32(1),
+						MachineType: "blc.1-2",
+						Subnets:     []string{"subnet-1"},
+						Zones:       []string{"zone-1"},
+					},
+				},
+			},
+		},
+		{
 			desc: "multizone setup 3 masters 3 nodes without external router",
 			cluster: &kops.Cluster{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -65,9 +65,9 @@ SecurityGroups:
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -229,9 +229,9 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -64,9 +64,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -227,9 +227,9 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -64,9 +64,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -227,9 +227,9 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/configures-allowed-address-pairs-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-allowed-address-pairs-with-annotations.yaml
@@ -66,9 +66,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -232,9 +232,9 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
@@ -63,9 +63,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node
   Policies:
   - soft-anti-affinity
@@ -226,9 +226,9 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node
 Policies:
 - soft-anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -123,9 +123,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master
+  IGMap:
+    master: 3
   Lifecycle: Sync
-  MaxSize: 3
   Name: cluster-master
   Policies:
   - anti-affinity
@@ -212,9 +212,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master
+  IGMap:
+    master: 3
   Lifecycle: Sync
-  MaxSize: 3
   Name: cluster-master
   Policies:
   - anti-affinity
@@ -301,9 +301,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master
+  IGMap:
+    master: 3
   Lifecycle: Sync
-  MaxSize: 3
   Name: cluster-master
   Policies:
   - anti-affinity
@@ -381,9 +381,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 3
   Lifecycle: Sync
-  MaxSize: 3
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -461,9 +461,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 3
   Lifecycle: Sync
-  MaxSize: 3
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -541,9 +541,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 3
   Lifecycle: Sync
-  MaxSize: 3
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -897,18 +897,18 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: master
+IGMap:
+  master: 3
 Lifecycle: Sync
-MaxSize: 3
 Name: cluster-master
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 3
 Lifecycle: Sync
-MaxSize: 3
 Name: cluster-node
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -103,9 +103,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-a
+  IGMap:
+    master-a: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-a
   Policies:
   - anti-affinity
@@ -180,9 +180,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-b
+  IGMap:
+    master-b: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-b
   Policies:
   - anti-affinity
@@ -257,9 +257,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-c
+  IGMap:
+    master-c: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-c
   Policies:
   - anti-affinity
@@ -331,9 +331,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-a
+  IGMap:
+    node-a: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-a
   Policies:
   - anti-affinity
@@ -405,9 +405,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-b
+  IGMap:
+    node-b: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-b
   Policies:
   - anti-affinity
@@ -479,9 +479,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-c
+  IGMap:
+    node-c: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-c
   Policies:
   - anti-affinity
@@ -719,6 +719,7 @@ Location: igconfig/node/node-c/nodeupconfig.yaml
 Name: nodeupconfig-node-c
 PublicACL: null
 ---
+ClusterName: cluster
 ID: null
 InterfaceName: cluster
 Lifecycle: Sync
@@ -744,17 +745,10 @@ Pool:
     VipSubnet: null
   Name: api.cluster-https
 ProtocolPort: 443
-ServerGroup:
-  ClusterName: cluster
-  ID: null
-  IGName: master-a
-  Lifecycle: Sync
-  MaxSize: 1
-  Name: cluster-master-a
-  Policies:
-  - anti-affinity
+ServerPrefix: master-a
 Weight: 1
 ---
+ClusterName: cluster
 ID: null
 InterfaceName: cluster
 Lifecycle: Sync
@@ -780,17 +774,10 @@ Pool:
     VipSubnet: null
   Name: api.cluster-https
 ProtocolPort: 443
-ServerGroup:
-  ClusterName: cluster
-  ID: null
-  IGName: master-b
-  Lifecycle: Sync
-  MaxSize: 1
-  Name: cluster-master-b
-  Policies:
-  - anti-affinity
+ServerPrefix: master-b
 Weight: 1
 ---
+ClusterName: cluster
 ID: null
 InterfaceName: cluster
 Lifecycle: Sync
@@ -816,15 +803,7 @@ Pool:
     VipSubnet: null
   Name: api.cluster-https
 ProtocolPort: 443
-ServerGroup:
-  ClusterName: cluster
-  ID: null
-  IGName: master-c
-  Lifecycle: Sync
-  MaxSize: 1
-  Name: cluster-master-c
-  Policies:
-  - anti-affinity
+ServerPrefix: master-c
 Weight: 1
 ---
 ID: null
@@ -1051,54 +1030,54 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: master-a
+IGMap:
+  master-a: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-a
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: master-b
+IGMap:
+  master-b: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-b
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: master-c
+IGMap:
+  master-c: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-c
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-a
+IGMap:
+  node-a: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-a
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-b
+IGMap:
+  node-b: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-b
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-c
+IGMap:
+  node-c: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-c
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -103,9 +103,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-a
+  IGMap:
+    master-a: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-a
   Policies:
   - anti-affinity
@@ -180,9 +180,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-b
+  IGMap:
+    master-b: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-b
   Policies:
   - anti-affinity
@@ -257,9 +257,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-c
+  IGMap:
+    master-c: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-c
   Policies:
   - anti-affinity
@@ -331,9 +331,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-a
+  IGMap:
+    node-a: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-a
   Policies:
   - anti-affinity
@@ -405,9 +405,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-b
+  IGMap:
+    node-b: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-b
   Policies:
   - anti-affinity
@@ -479,9 +479,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-c
+  IGMap:
+    node-c: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-c
   Policies:
   - anti-affinity
@@ -719,6 +719,7 @@ Location: igconfig/node/node-c/nodeupconfig.yaml
 Name: nodeupconfig-node-c
 PublicACL: null
 ---
+ClusterName: cluster
 ID: null
 InterfaceName: cluster
 Lifecycle: Sync
@@ -744,17 +745,10 @@ Pool:
     VipSubnet: null
   Name: master-public-name-https
 ProtocolPort: 443
-ServerGroup:
-  ClusterName: cluster
-  ID: null
-  IGName: master-a
-  Lifecycle: Sync
-  MaxSize: 1
-  Name: cluster-master-a
-  Policies:
-  - anti-affinity
+ServerPrefix: master-a
 Weight: 1
 ---
+ClusterName: cluster
 ID: null
 InterfaceName: cluster
 Lifecycle: Sync
@@ -780,17 +774,10 @@ Pool:
     VipSubnet: null
   Name: master-public-name-https
 ProtocolPort: 443
-ServerGroup:
-  ClusterName: cluster
-  ID: null
-  IGName: master-b
-  Lifecycle: Sync
-  MaxSize: 1
-  Name: cluster-master-b
-  Policies:
-  - anti-affinity
+ServerPrefix: master-b
 Weight: 1
 ---
+ClusterName: cluster
 ID: null
 InterfaceName: cluster
 Lifecycle: Sync
@@ -816,15 +803,7 @@ Pool:
     VipSubnet: null
   Name: master-public-name-https
 ProtocolPort: 443
-ServerGroup:
-  ClusterName: cluster
-  ID: null
-  IGName: master-c
-  Lifecycle: Sync
-  MaxSize: 1
-  Name: cluster-master-c
-  Policies:
-  - anti-affinity
+ServerPrefix: master-c
 Weight: 1
 ---
 ID: null
@@ -1051,54 +1030,54 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: master-a
+IGMap:
+  master-a: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-a
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: master-b
+IGMap:
+  master-b: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-b
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: master-c
+IGMap:
+  master-c: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-c
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-a
+IGMap:
+  node-a: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-a
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-b
+IGMap:
+  node-b: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-b
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-c
+IGMap:
+  node-c: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-c
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -135,9 +135,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-a
+  IGMap:
+    master-a: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-a
   Policies:
   - anti-affinity
@@ -224,9 +224,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-b
+  IGMap:
+    master-b: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-b
   Policies:
   - anti-affinity
@@ -313,9 +313,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-c
+  IGMap:
+    master-c: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-c
   Policies:
   - anti-affinity
@@ -393,9 +393,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-a
+  IGMap:
+    node-a: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-a
   Policies:
   - anti-affinity
@@ -473,9 +473,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-b
+  IGMap:
+    node-b: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-b
   Policies:
   - anti-affinity
@@ -553,9 +553,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-c
+  IGMap:
+    node-c: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-c
   Policies:
   - anti-affinity
@@ -949,54 +949,54 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: master-a
+IGMap:
+  master-a: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-a
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: master-b
+IGMap:
+  master-b: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-b
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: master-c
+IGMap:
+  master-c: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-c
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-a
+IGMap:
+  node-a: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-a
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-b
+IGMap:
+  node-b: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-b
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-c
+IGMap:
+  node-c: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-c
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -87,9 +87,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-a
+  IGMap:
+    master-a: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-a
   Policies:
   - anti-affinity
@@ -170,9 +170,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-b
+  IGMap:
+    master-b: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-b
   Policies:
   - anti-affinity
@@ -253,9 +253,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master-c
+  IGMap:
+    master-c: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master-c
   Policies:
   - anti-affinity
@@ -327,9 +327,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-a
+  IGMap:
+    node-a: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-a
   Policies:
   - anti-affinity
@@ -401,9 +401,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-b
+  IGMap:
+    node-b: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-b
   Policies:
   - anti-affinity
@@ -475,9 +475,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node-c
+  IGMap:
+    node-c: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node-c
   Policies:
   - anti-affinity
@@ -871,54 +871,54 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: master-a
+IGMap:
+  master-a: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-a
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: master-b
+IGMap:
+  master-b: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-b
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: master-c
+IGMap:
+  master-c: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master-c
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-a
+IGMap:
+  node-a: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-a
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-b
+IGMap:
+  node-b: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-b
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node-c
+IGMap:
+  node-c: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node-c
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -67,9 +67,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: bastion
+  IGMap:
+    bastion: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-bastion
   Policies:
   - anti-affinity
@@ -150,9 +150,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master
+  IGMap:
+    master: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master
   Policies:
   - anti-affinity
@@ -224,9 +224,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -479,27 +479,27 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: bastion
+IGMap:
+  bastion: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-bastion
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: master
+IGMap:
+  master: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -80,9 +80,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: bastion
+  IGMap:
+    bastion: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-bastion
   Policies:
   - anti-affinity
@@ -163,9 +163,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master
+  IGMap:
+    master: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master
   Policies:
   - anti-affinity
@@ -237,9 +237,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -492,27 +492,27 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: bastion
+IGMap:
+  bastion: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-bastion
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: master
+IGMap:
+  master: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -75,9 +75,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master
+  IGMap:
+    master: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master
   Policies:
   - anti-affinity
@@ -149,9 +149,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -361,18 +361,18 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: master
+IGMap:
+  master: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -95,9 +95,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: master
+  IGMap:
+    master: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-master
   Policies:
   - anti-affinity
@@ -175,9 +175,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -387,18 +387,18 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: master
+IGMap:
+  master: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-master
 Policies:
 - anti-affinity
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/single-zone-setup-3-masters-1-node-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/single-zone-setup-3-masters-1-node-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -1,0 +1,815 @@
+Lifecycle: ""
+Name: master-a
+---
+Lifecycle: ""
+Name: master-b
+---
+Lifecycle: ""
+Name: master-c
+---
+Lifecycle: ""
+Name: node-a
+---
+ForAPIServer: true
+ID: null
+IP: null
+LB:
+  FlavorID: null
+  ID: null
+  Lifecycle: Sync
+  Name: api.cluster
+  PortID: null
+  Provider: null
+  SecurityGroup:
+    Description: null
+    ID: null
+    Lifecycle: ""
+    Name: api.cluster
+    RemoveExtraRules: null
+    RemoveGroup: false
+  Subnet: subnet-1.cluster
+  VipSubnet: null
+Lifecycle: Sync
+Name: fip-api.cluster
+---
+AvailabilityZone: zone-1
+ConfigDrive: false
+Flavor: blc.1-2
+FloatingIP: null
+ForAPIServer: false
+GroupName: master-a
+ID: null
+Image: image
+Lifecycle: Sync
+Metadata:
+  KopsInstanceGroup: master-a
+  KopsName: master-a-1-cluster
+  KopsNetwork: cluster
+  KopsRole: ControlPlane
+  KubernetesCluster: cluster
+  cluster_generation: "0"
+  ig_generation: "0"
+  k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
+  k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
+  k8s.io_role_control-plane: "1"
+  k8s.io_role_master: "1"
+  kops.k8s.io_instancegroup: master-a
+Name: master-a-1-cluster
+Port:
+  AdditionalSecurityGroups: null
+  AllowedAddressPairs: null
+  ForAPIServer: true
+  ID: null
+  InstanceGroupName: master-a
+  Lifecycle: Sync
+  Name: port-master-a-1-cluster
+  Network:
+    AvailabilityZoneHints: null
+    ID: null
+    Lifecycle: ""
+    Name: cluster
+    Tag: null
+  SecurityGroups:
+  - Description: null
+    ID: null
+    Lifecycle: ""
+    Name: masters.cluster
+    RemoveExtraRules: null
+    RemoveGroup: false
+  Subnets:
+  - CIDR: null
+    DNSServers: null
+    ID: null
+    Lifecycle: ""
+    Name: subnet-1.cluster
+    Network: null
+    Tag: null
+  Tags:
+  - KopsInstanceGroup=master-a
+  - KopsName=port-master-a-1
+  - KubernetesCluster=cluster
+Region: ""
+Role: ControlPlane
+SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
+SecurityGroups: null
+ServerGroup:
+  ClusterName: cluster
+  ID: null
+  IGMap:
+    master-a: 1
+    master-b: 1
+    master-c: 1
+  Lifecycle: Sync
+  Name: cluster-control-plane
+  Policies:
+  - anti-affinity
+Status: null
+UserData:
+  task:
+    Lifecycle: ""
+    Name: master-a
+---
+AvailabilityZone: zone-1
+ConfigDrive: false
+Flavor: blc.1-2
+FloatingIP: null
+ForAPIServer: false
+GroupName: master-b
+ID: null
+Image: image
+Lifecycle: Sync
+Metadata:
+  KopsInstanceGroup: master-b
+  KopsName: master-b-1-cluster
+  KopsNetwork: cluster
+  KopsRole: ControlPlane
+  KubernetesCluster: cluster
+  cluster_generation: "0"
+  ig_generation: "0"
+  k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
+  k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
+  k8s.io_role_control-plane: "1"
+  k8s.io_role_master: "1"
+  kops.k8s.io_instancegroup: master-b
+Name: master-b-1-cluster
+Port:
+  AdditionalSecurityGroups: null
+  AllowedAddressPairs: null
+  ForAPIServer: true
+  ID: null
+  InstanceGroupName: master-b
+  Lifecycle: Sync
+  Name: port-master-b-1-cluster
+  Network:
+    AvailabilityZoneHints: null
+    ID: null
+    Lifecycle: ""
+    Name: cluster
+    Tag: null
+  SecurityGroups:
+  - Description: null
+    ID: null
+    Lifecycle: ""
+    Name: masters.cluster
+    RemoveExtraRules: null
+    RemoveGroup: false
+  Subnets:
+  - CIDR: null
+    DNSServers: null
+    ID: null
+    Lifecycle: ""
+    Name: subnet-1.cluster
+    Network: null
+    Tag: null
+  Tags:
+  - KopsInstanceGroup=master-b
+  - KopsName=port-master-b-1
+  - KubernetesCluster=cluster
+Region: ""
+Role: ControlPlane
+SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
+SecurityGroups: null
+ServerGroup:
+  ClusterName: cluster
+  ID: null
+  IGMap:
+    master-a: 1
+    master-b: 1
+    master-c: 1
+  Lifecycle: Sync
+  Name: cluster-control-plane
+  Policies:
+  - anti-affinity
+Status: null
+UserData:
+  task:
+    Lifecycle: ""
+    Name: master-b
+---
+AvailabilityZone: zone-1
+ConfigDrive: false
+Flavor: blc.1-2
+FloatingIP: null
+ForAPIServer: false
+GroupName: master-c
+ID: null
+Image: image
+Lifecycle: Sync
+Metadata:
+  KopsInstanceGroup: master-c
+  KopsName: master-c-1-cluster
+  KopsNetwork: cluster
+  KopsRole: ControlPlane
+  KubernetesCluster: cluster
+  cluster_generation: "0"
+  ig_generation: "0"
+  k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
+  k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
+  k8s.io_role_control-plane: "1"
+  k8s.io_role_master: "1"
+  kops.k8s.io_instancegroup: master-c
+Name: master-c-1-cluster
+Port:
+  AdditionalSecurityGroups: null
+  AllowedAddressPairs: null
+  ForAPIServer: true
+  ID: null
+  InstanceGroupName: master-c
+  Lifecycle: Sync
+  Name: port-master-c-1-cluster
+  Network:
+    AvailabilityZoneHints: null
+    ID: null
+    Lifecycle: ""
+    Name: cluster
+    Tag: null
+  SecurityGroups:
+  - Description: null
+    ID: null
+    Lifecycle: ""
+    Name: masters.cluster
+    RemoveExtraRules: null
+    RemoveGroup: false
+  Subnets:
+  - CIDR: null
+    DNSServers: null
+    ID: null
+    Lifecycle: ""
+    Name: subnet-1.cluster
+    Network: null
+    Tag: null
+  Tags:
+  - KopsInstanceGroup=master-c
+  - KopsName=port-master-c-1
+  - KubernetesCluster=cluster
+Region: ""
+Role: ControlPlane
+SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
+SecurityGroups: null
+ServerGroup:
+  ClusterName: cluster
+  ID: null
+  IGMap:
+    master-a: 1
+    master-b: 1
+    master-c: 1
+  Lifecycle: Sync
+  Name: cluster-control-plane
+  Policies:
+  - anti-affinity
+Status: null
+UserData:
+  task:
+    Lifecycle: ""
+    Name: master-c
+---
+AvailabilityZone: zone-1
+ConfigDrive: false
+Flavor: blc.1-2
+FloatingIP: null
+ForAPIServer: false
+GroupName: node-a
+ID: null
+Image: image
+Lifecycle: Sync
+Metadata:
+  KopsInstanceGroup: node-a
+  KopsName: node-a-1-cluster
+  KopsNetwork: cluster
+  KopsRole: Node
+  KubernetesCluster: cluster
+  cluster_generation: "0"
+  ig_generation: "0"
+  k8s: cluster
+  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
+  k8s.io_role_node: "1"
+  kops.k8s.io_instancegroup: node-a
+Name: node-a-1-cluster
+Port:
+  AdditionalSecurityGroups: null
+  AllowedAddressPairs: null
+  ForAPIServer: false
+  ID: null
+  InstanceGroupName: node-a
+  Lifecycle: Sync
+  Name: port-node-a-1-cluster
+  Network:
+    AvailabilityZoneHints: null
+    ID: null
+    Lifecycle: ""
+    Name: cluster
+    Tag: null
+  SecurityGroups:
+  - Description: null
+    ID: null
+    Lifecycle: ""
+    Name: nodes.cluster
+    RemoveExtraRules: null
+    RemoveGroup: false
+  Subnets:
+  - CIDR: null
+    DNSServers: null
+    ID: null
+    Lifecycle: ""
+    Name: subnet-1.cluster
+    Network: null
+    Tag: null
+  Tags:
+  - KopsInstanceGroup=node-a
+  - KopsName=port-node-a-1
+  - KubernetesCluster=cluster
+Region: ""
+Role: Node
+SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
+SecurityGroups: null
+ServerGroup:
+  ClusterName: cluster
+  ID: null
+  IGMap:
+    node-a: 1
+  Lifecycle: Sync
+  Name: cluster-node-a
+  Policies:
+  - anti-affinity
+Status: null
+UserData:
+  task:
+    Lifecycle: ""
+    Name: node-a
+---
+Lifecycle: ""
+Name: apiserver-aggregator-ca
+Signer: null
+alternateNames: null
+issuer: ""
+oldFormat: false
+subject: cn=apiserver-aggregator-ca
+type: ca
+---
+Lifecycle: ""
+Name: etcd-clients-ca
+Signer: null
+alternateNames: null
+issuer: ""
+oldFormat: false
+subject: cn=etcd-clients-ca
+type: ca
+---
+Lifecycle: ""
+Name: etcd-manager-ca-events
+Signer: null
+alternateNames: null
+issuer: ""
+oldFormat: false
+subject: cn=etcd-manager-ca-events
+type: ca
+---
+Lifecycle: ""
+Name: etcd-manager-ca-main
+Signer: null
+alternateNames: null
+issuer: ""
+oldFormat: false
+subject: cn=etcd-manager-ca-main
+type: ca
+---
+Lifecycle: ""
+Name: etcd-peers-ca-events
+Signer: null
+alternateNames: null
+issuer: ""
+oldFormat: false
+subject: cn=etcd-peers-ca-events
+type: ca
+---
+Lifecycle: ""
+Name: etcd-peers-ca-main
+Signer: null
+alternateNames: null
+issuer: ""
+oldFormat: false
+subject: cn=etcd-peers-ca-main
+type: ca
+---
+Lifecycle: ""
+Name: kube-proxy
+Signer:
+  Lifecycle: ""
+  Name: kubernetes-ca
+  Signer: null
+  alternateNames: null
+  issuer: ""
+  oldFormat: false
+  subject: cn=kubernetes
+  type: ca
+alternateNames: null
+issuer: ""
+oldFormat: false
+subject: cn=kube-proxy
+type: client
+---
+Lifecycle: ""
+Name: kubelet
+Signer:
+  Lifecycle: ""
+  Name: kubernetes-ca
+  Signer: null
+  alternateNames: null
+  issuer: ""
+  oldFormat: false
+  subject: cn=kubernetes
+  type: ca
+alternateNames: null
+issuer: ""
+oldFormat: false
+subject: cn=kubelet
+type: client
+---
+Lifecycle: ""
+Name: kubernetes-ca
+Signer: null
+alternateNames: null
+issuer: ""
+oldFormat: false
+subject: cn=kubernetes
+type: ca
+---
+Lifecycle: ""
+Name: service-account
+Signer: null
+alternateNames: null
+issuer: ""
+oldFormat: false
+subject: cn=service-account
+type: ca
+---
+FlavorID: null
+ID: null
+Lifecycle: Sync
+Name: api.cluster
+PortID: null
+Provider: null
+SecurityGroup:
+  Description: null
+  ID: null
+  Lifecycle: ""
+  Name: api.cluster
+  RemoveExtraRules: null
+  RemoveGroup: false
+Subnet: subnet-1.cluster
+VipSubnet: null
+---
+AllowedCIDRs: null
+ID: null
+Lifecycle: Sync
+Name: api.cluster
+Pool:
+  ID: null
+  Lifecycle: Sync
+  Loadbalancer:
+    FlavorID: null
+    ID: null
+    Lifecycle: Sync
+    Name: api.cluster
+    PortID: null
+    Provider: null
+    SecurityGroup:
+      Description: null
+      ID: null
+      Lifecycle: ""
+      Name: api.cluster
+      RemoveExtraRules: null
+      RemoveGroup: false
+    Subnet: subnet-1.cluster
+    VipSubnet: null
+  Name: api.cluster-https
+Port: 443
+---
+ID: null
+Lifecycle: Sync
+Loadbalancer:
+  FlavorID: null
+  ID: null
+  Lifecycle: Sync
+  Name: api.cluster
+  PortID: null
+  Provider: null
+  SecurityGroup:
+    Description: null
+    ID: null
+    Lifecycle: ""
+    Name: api.cluster
+    RemoveExtraRules: null
+    RemoveGroup: false
+  Subnet: subnet-1.cluster
+  VipSubnet: null
+Name: api.cluster-https
+---
+Base: null
+Contents:
+  task:
+    Lifecycle: ""
+    Name: master-a
+Lifecycle: ""
+Location: igconfig/control-plane/master-a/nodeupconfig.yaml
+Name: nodeupconfig-master-a
+PublicACL: null
+---
+Base: null
+Contents:
+  task:
+    Lifecycle: ""
+    Name: master-b
+Lifecycle: ""
+Location: igconfig/control-plane/master-b/nodeupconfig.yaml
+Name: nodeupconfig-master-b
+PublicACL: null
+---
+Base: null
+Contents:
+  task:
+    Lifecycle: ""
+    Name: master-c
+Lifecycle: ""
+Location: igconfig/control-plane/master-c/nodeupconfig.yaml
+Name: nodeupconfig-master-c
+PublicACL: null
+---
+Base: null
+Contents:
+  task:
+    Lifecycle: ""
+    Name: node-a
+Lifecycle: ""
+Location: igconfig/node/node-a/nodeupconfig.yaml
+Name: nodeupconfig-node-a
+PublicACL: null
+---
+ClusterName: cluster
+ID: null
+InterfaceName: cluster
+Lifecycle: Sync
+Name: cluster-master-a
+Pool:
+  ID: null
+  Lifecycle: Sync
+  Loadbalancer:
+    FlavorID: null
+    ID: null
+    Lifecycle: Sync
+    Name: api.cluster
+    PortID: null
+    Provider: null
+    SecurityGroup:
+      Description: null
+      ID: null
+      Lifecycle: ""
+      Name: api.cluster
+      RemoveExtraRules: null
+      RemoveGroup: false
+    Subnet: subnet-1.cluster
+    VipSubnet: null
+  Name: api.cluster-https
+ProtocolPort: 443
+ServerPrefix: master-a
+Weight: 1
+---
+ClusterName: cluster
+ID: null
+InterfaceName: cluster
+Lifecycle: Sync
+Name: cluster-master-b
+Pool:
+  ID: null
+  Lifecycle: Sync
+  Loadbalancer:
+    FlavorID: null
+    ID: null
+    Lifecycle: Sync
+    Name: api.cluster
+    PortID: null
+    Provider: null
+    SecurityGroup:
+      Description: null
+      ID: null
+      Lifecycle: ""
+      Name: api.cluster
+      RemoveExtraRules: null
+      RemoveGroup: false
+    Subnet: subnet-1.cluster
+    VipSubnet: null
+  Name: api.cluster-https
+ProtocolPort: 443
+ServerPrefix: master-b
+Weight: 1
+---
+ClusterName: cluster
+ID: null
+InterfaceName: cluster
+Lifecycle: Sync
+Name: cluster-master-c
+Pool:
+  ID: null
+  Lifecycle: Sync
+  Loadbalancer:
+    FlavorID: null
+    ID: null
+    Lifecycle: Sync
+    Name: api.cluster
+    PortID: null
+    Provider: null
+    SecurityGroup:
+      Description: null
+      ID: null
+      Lifecycle: ""
+      Name: api.cluster
+      RemoveExtraRules: null
+      RemoveGroup: false
+    Subnet: subnet-1.cluster
+    VipSubnet: null
+  Name: api.cluster-https
+ProtocolPort: 443
+ServerPrefix: master-c
+Weight: 1
+---
+ID: null
+Lifecycle: Sync
+Name: api.cluster
+Pool:
+  ID: null
+  Lifecycle: Sync
+  Loadbalancer:
+    FlavorID: null
+    ID: null
+    Lifecycle: Sync
+    Name: api.cluster
+    PortID: null
+    Provider: null
+    SecurityGroup:
+      Description: null
+      ID: null
+      Lifecycle: ""
+      Name: api.cluster
+      RemoveExtraRules: null
+      RemoveGroup: false
+    Subnet: subnet-1.cluster
+    VipSubnet: null
+  Name: api.cluster-https
+---
+AdditionalSecurityGroups: null
+AllowedAddressPairs: null
+ForAPIServer: true
+ID: null
+InstanceGroupName: master-a
+Lifecycle: Sync
+Name: port-master-a-1-cluster
+Network:
+  AvailabilityZoneHints: null
+  ID: null
+  Lifecycle: ""
+  Name: cluster
+  Tag: null
+SecurityGroups:
+- Description: null
+  ID: null
+  Lifecycle: ""
+  Name: masters.cluster
+  RemoveExtraRules: null
+  RemoveGroup: false
+Subnets:
+- CIDR: null
+  DNSServers: null
+  ID: null
+  Lifecycle: ""
+  Name: subnet-1.cluster
+  Network: null
+  Tag: null
+Tags:
+- KopsInstanceGroup=master-a
+- KopsName=port-master-a-1
+- KubernetesCluster=cluster
+---
+AdditionalSecurityGroups: null
+AllowedAddressPairs: null
+ForAPIServer: true
+ID: null
+InstanceGroupName: master-b
+Lifecycle: Sync
+Name: port-master-b-1-cluster
+Network:
+  AvailabilityZoneHints: null
+  ID: null
+  Lifecycle: ""
+  Name: cluster
+  Tag: null
+SecurityGroups:
+- Description: null
+  ID: null
+  Lifecycle: ""
+  Name: masters.cluster
+  RemoveExtraRules: null
+  RemoveGroup: false
+Subnets:
+- CIDR: null
+  DNSServers: null
+  ID: null
+  Lifecycle: ""
+  Name: subnet-1.cluster
+  Network: null
+  Tag: null
+Tags:
+- KopsInstanceGroup=master-b
+- KopsName=port-master-b-1
+- KubernetesCluster=cluster
+---
+AdditionalSecurityGroups: null
+AllowedAddressPairs: null
+ForAPIServer: true
+ID: null
+InstanceGroupName: master-c
+Lifecycle: Sync
+Name: port-master-c-1-cluster
+Network:
+  AvailabilityZoneHints: null
+  ID: null
+  Lifecycle: ""
+  Name: cluster
+  Tag: null
+SecurityGroups:
+- Description: null
+  ID: null
+  Lifecycle: ""
+  Name: masters.cluster
+  RemoveExtraRules: null
+  RemoveGroup: false
+Subnets:
+- CIDR: null
+  DNSServers: null
+  ID: null
+  Lifecycle: ""
+  Name: subnet-1.cluster
+  Network: null
+  Tag: null
+Tags:
+- KopsInstanceGroup=master-c
+- KopsName=port-master-c-1
+- KubernetesCluster=cluster
+---
+AdditionalSecurityGroups: null
+AllowedAddressPairs: null
+ForAPIServer: false
+ID: null
+InstanceGroupName: node-a
+Lifecycle: Sync
+Name: port-node-a-1-cluster
+Network:
+  AvailabilityZoneHints: null
+  ID: null
+  Lifecycle: ""
+  Name: cluster
+  Tag: null
+SecurityGroups:
+- Description: null
+  ID: null
+  Lifecycle: ""
+  Name: nodes.cluster
+  RemoveExtraRules: null
+  RemoveGroup: false
+Subnets:
+- CIDR: null
+  DNSServers: null
+  ID: null
+  Lifecycle: ""
+  Name: subnet-1.cluster
+  Network: null
+  Tag: null
+Tags:
+- KopsInstanceGroup=node-a
+- KopsName=port-node-a-1
+- KubernetesCluster=cluster
+---
+ClusterName: cluster
+ID: null
+IGMap:
+  master-a: 1
+  master-b: 1
+  master-c: 1
+Lifecycle: Sync
+Name: cluster-control-plane
+Policies:
+- anti-affinity
+---
+ClusterName: cluster
+ID: null
+IGMap:
+  node-a: 1
+Lifecycle: Sync
+Name: cluster-node-a
+Policies:
+- anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
@@ -95,9 +95,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: tom-software-dev-playground-real33-k8s-local
   ID: null
-  IGName: master
+  IGMap:
+    master: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: tom-software-dev-playground-real33-k8s-local-master
   Policies:
   - anti-affinity
@@ -175,9 +175,9 @@ SecurityGroups: null
 ServerGroup:
   ClusterName: tom-software-dev-playground-real33-k8s-local
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: tom-software-dev-playground-real33-k8s-local-node
   Policies:
   - anti-affinity
@@ -387,18 +387,18 @@ Tags:
 ---
 ClusterName: tom-software-dev-playground-real33-k8s-local
 ID: null
-IGName: master
+IGMap:
+  master: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: tom-software-dev-playground-real33-k8s-local-master
 Policies:
 - anti-affinity
 ---
 ClusterName: tom-software-dev-playground-real33-k8s-local
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: tom-software-dev-playground-real33-k8s-local-node
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -65,9 +65,9 @@ SecurityGroups:
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -229,9 +229,9 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node
 Policies:
 - anti-affinity

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -65,9 +65,9 @@ SecurityGroups:
 ServerGroup:
   ClusterName: cluster
   ID: null
-  IGName: node
+  IGMap:
+    node: 1
   Lifecycle: Sync
-  MaxSize: 1
   Name: cluster-node
   Policies:
   - anti-affinity
@@ -229,9 +229,9 @@ Tags:
 ---
 ClusterName: cluster
 ID: null
-IGName: node
+IGMap:
+  node: 1
 Lifecycle: Sync
-MaxSize: 1
 Name: cluster-node
 Policies:
 - anti-affinity

--- a/upup/pkg/fi/cloudup/openstack/instance.go
+++ b/upup/pkg/fi/cloudup/openstack/instance.go
@@ -45,6 +45,7 @@ const (
 	BOOT_VOLUME_SIZE          = "osVolumeSize"
 	SERVER_GROUP_AFFINITY     = "serverGroupAffinity"
 	ALLOWED_ADDRESS_PAIR      = "allowedAddressPair"
+	SERVER_GROUP_NAME         = "serverGroupName"
 
 	defaultActiveTimeout = time.Second * 120
 	activeStatus         = "ACTIVE"

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -152,16 +152,12 @@ func (e *Instance) Find(c *fi.CloudupContext) (*Instance, error) {
 		return nil, nil
 	}
 	cloud := c.T.Cloud.(openstack.OpenstackCloud)
-	computeClient := cloud.ComputeClient()
-	serverPage, err := servers.List(computeClient, servers.ListOpts{
+
+	serverList, err := cloud.ListInstances(servers.ListOpts{
 		Name: fmt.Sprintf("^%s", fi.ValueOf(e.GroupName)),
-	}).AllPages()
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error listing servers: %v", err)
-	}
-	serverList, err := servers.ExtractServers(serverPage)
-	if err != nil {
-		return nil, fmt.Errorf("error extracting server page: %v", err)
 	}
 
 	var filteredList []servers.Server

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -386,7 +386,6 @@ func (_ *Instance) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, change
 			return fmt.Errorf("Error creating instance: %v", err)
 		}
 		e.ID = fi.PtrTo(v.ID)
-		e.ServerGroup.AddNewMember(fi.ValueOf(e.ID))
 
 		if e.FloatingIP != nil {
 			err = associateFloatingIP(t, e)

--- a/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
@@ -32,6 +32,7 @@ import (
 type PoolAssociation struct {
 	ID            *string
 	Name          *string
+	ClusterName   *string
 	ServerPrefix  *string
 	Lifecycle     fi.Lifecycle
 	Pool          *LBPool
@@ -109,6 +110,7 @@ func (p *PoolAssociation) Find(context *fi.CloudupContext) (*PoolAssociation, er
 		Name:          fi.PtrTo(found.Name),
 		Pool:          pool,
 		ServerPrefix:  p.ServerPrefix,
+		ClusterName:   p.ClusterName,
 		InterfaceName: p.InterfaceName,
 		ProtocolPort:  p.ProtocolPort,
 		Lifecycle:     p.Lifecycle,
@@ -163,6 +165,11 @@ func (_ *PoolAssociation) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e,
 		}
 
 		for _, server := range serverList {
+			val, ok := server.Metadata["k8s"]
+			if !ok || val != fi.ValueOf(e.ClusterName) {
+				continue
+			}
+
 			memberAddress, err := GetServerFixedIP(t.Cloud.ComputeClient(), &server, fi.ValueOf(e.InterfaceName))
 			if err != nil {
 				return err

--- a/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
@@ -32,9 +32,9 @@ import (
 type PoolAssociation struct {
 	ID            *string
 	Name          *string
+	ServerPrefix  *string
 	Lifecycle     fi.Lifecycle
 	Pool          *LBPool
-	ServerGroup   *ServerGroup
 	InterfaceName *string
 	ProtocolPort  *int
 	Weight        *int
@@ -108,7 +108,7 @@ func (p *PoolAssociation) Find(context *fi.CloudupContext) (*PoolAssociation, er
 		ID:            fi.PtrTo(found.ID),
 		Name:          fi.PtrTo(found.Name),
 		Pool:          pool,
-		ServerGroup:   p.ServerGroup,
+		ServerPrefix:  p.ServerPrefix,
 		InterfaceName: p.InterfaceName,
 		ProtocolPort:  p.ProtocolPort,
 		Lifecycle:     p.Lifecycle,
@@ -138,13 +138,8 @@ func (_ *PoolAssociation) CheckChanges(a, e, changes *PoolAssociation) error {
 	return nil
 }
 
-func GetServerFixedIP(client *gophercloud.ServiceClient, serverID string, interfaceName string) (server *servers.Server, memberAddress string, err error) {
+func GetServerFixedIP(client *gophercloud.ServiceClient, server *servers.Server, interfaceName string) (memberAddress string, err error) {
 	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
-		server, err = servers.Get(client, serverID).Extract()
-		if err != nil {
-			return true, fmt.Errorf("Failed to find server with id `%s`: %v", serverID, err)
-		}
-
 		memberAddress, err = openstack.GetServerFixedIP(server, interfaceName)
 		if err != nil {
 			// sometimes provisioning interfaces is slow, that is why we need retry the interface from the server
@@ -153,21 +148,31 @@ func GetServerFixedIP(client *gophercloud.ServiceClient, serverID string, interf
 		return true, nil
 	})
 	if done {
-		return server, memberAddress, nil
+		return memberAddress, nil
 	}
-	return server, memberAddress, err
+	return memberAddress, err
 }
 
 func (_ *PoolAssociation) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *PoolAssociation) error {
 	if a == nil {
+		serverPage, err := servers.List(t.Cloud.ComputeClient(), servers.ListOpts{
+			Name: fmt.Sprintf("^%s", fi.ValueOf(e.ServerPrefix)),
+		}).AllPages()
+		if err != nil {
+			return fmt.Errorf("error listing servers: %v", err)
+		}
+		serverList, err := servers.ExtractServers(serverPage)
+		if err != nil {
+			return fmt.Errorf("error extracting server page: %v", err)
+		}
 
-		for _, serverID := range e.ServerGroup.GetMembers() {
-			server, memberAddress, err := GetServerFixedIP(t.Cloud.ComputeClient(), serverID, fi.ValueOf(e.InterfaceName))
+		for _, server := range serverList {
+			memberAddress, err := GetServerFixedIP(t.Cloud.ComputeClient(), &server, fi.ValueOf(e.InterfaceName))
 			if err != nil {
 				return err
 			}
 
-			member, err := t.Cloud.AssociateToPool(server, fi.ValueOf(e.Pool.ID), v2pools.CreateMemberOpts{
+			member, err := t.Cloud.AssociateToPool(&server, fi.ValueOf(e.Pool.ID), v2pools.CreateMemberOpts{
 				Name:         fi.ValueOf(e.Name),
 				ProtocolPort: fi.ValueOf(e.ProtocolPort),
 				SubnetID:     fi.ValueOf(e.Pool.Loadbalancer.VipSubnet),

--- a/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
@@ -155,15 +155,11 @@ func GetServerFixedIP(client *gophercloud.ServiceClient, server *servers.Server,
 
 func (_ *PoolAssociation) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *PoolAssociation) error {
 	if a == nil {
-		serverPage, err := servers.List(t.Cloud.ComputeClient(), servers.ListOpts{
+		serverList, err := t.Cloud.ListInstances(servers.ListOpts{
 			Name: fmt.Sprintf("^%s", fi.ValueOf(e.ServerPrefix)),
-		}).AllPages()
+		})
 		if err != nil {
 			return fmt.Errorf("error listing servers: %v", err)
-		}
-		serverList, err := servers.ExtractServers(serverPage)
-		if err != nil {
-			return fmt.Errorf("error extracting server page: %v", err)
 		}
 
 		for _, server := range serverList {


### PR DESCRIPTION
fixes #15734

makes it possible to override server group name used in instance group.

Example:

```yaml
kind: InstanceGroup
metadata:
  annotations:
    openstack.kops.io/serverGroupName: control-plane
```