### PR TITLE
Use localhost for k8s api address in cert-manager pods

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 1d9ddc6d025438aa22182e434f9534e983ddefa857913ef0a456d9cf9cea360b
+    manifestHash: 96b5ac2aa61e0c2275db5996d7e04c24775216163718f45e9809292633772ee0
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9788,6 +9788,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-cainjector:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
@@ -9870,6 +9872,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-controller:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
@@ -9956,6 +9960,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-webhook:v1.12.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 1d9ddc6d025438aa22182e434f9534e983ddefa857913ef0a456d9cf9cea360b
+    manifestHash: 96b5ac2aa61e0c2275db5996d7e04c24775216163718f45e9809292633772ee0
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9788,6 +9788,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-cainjector:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
@@ -9870,6 +9872,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-controller:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
@@ -9956,6 +9960,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-webhook:v1.12.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 1d9ddc6d025438aa22182e434f9534e983ddefa857913ef0a456d9cf9cea360b
+    manifestHash: 96b5ac2aa61e0c2275db5996d7e04c24775216163718f45e9809292633772ee0
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9788,6 +9788,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-cainjector:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
@@ -9870,6 +9872,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-controller:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
@@ -9956,6 +9960,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-webhook:v1.12.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -63,7 +63,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 1d9ddc6d025438aa22182e434f9534e983ddefa857913ef0a456d9cf9cea360b
+    manifestHash: 96b5ac2aa61e0c2275db5996d7e04c24775216163718f45e9809292633772ee0
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9788,6 +9788,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-cainjector:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
@@ -9870,6 +9872,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-controller:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
@@ -9956,6 +9960,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-webhook:v1.12.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -63,7 +63,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 1d9ddc6d025438aa22182e434f9534e983ddefa857913ef0a456d9cf9cea360b
+    manifestHash: 96b5ac2aa61e0c2275db5996d7e04c24775216163718f45e9809292633772ee0
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9788,6 +9788,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-cainjector:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
@@ -9870,6 +9872,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-controller:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
@@ -9956,6 +9960,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-webhook:v1.12.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -63,7 +63,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 1d9ddc6d025438aa22182e434f9534e983ddefa857913ef0a456d9cf9cea360b
+    manifestHash: 96b5ac2aa61e0c2275db5996d7e04c24775216163718f45e9809292633772ee0
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9788,6 +9788,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-cainjector:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
@@ -9870,6 +9872,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-controller:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
@@ -9956,6 +9960,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-webhook:v1.12.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -64,7 +64,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 1d9ddc6d025438aa22182e434f9534e983ddefa857913ef0a456d9cf9cea360b
+    manifestHash: 96b5ac2aa61e0c2275db5996d7e04c24775216163718f45e9809292633772ee0
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9788,6 +9788,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-cainjector:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
@@ -9870,6 +9872,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-controller:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
@@ -9956,6 +9960,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-webhook:v1.12.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 1d9ddc6d025438aa22182e434f9534e983ddefa857913ef0a456d9cf9cea360b
+    manifestHash: 96b5ac2aa61e0c2275db5996d7e04c24775216163718f45e9809292633772ee0
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9788,6 +9788,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-cainjector:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
@@ -9870,6 +9872,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-controller:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
@@ -9956,6 +9960,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-webhook:v1.12.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 1d9ddc6d025438aa22182e434f9534e983ddefa857913ef0a456d9cf9cea360b
+    manifestHash: 96b5ac2aa61e0c2275db5996d7e04c24775216163718f45e9809292633772ee0
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9788,6 +9788,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-cainjector:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
@@ -9870,6 +9872,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-controller:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
@@ -9956,6 +9960,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-webhook:v1.12.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 1d9ddc6d025438aa22182e434f9534e983ddefa857913ef0a456d9cf9cea360b
+    manifestHash: 96b5ac2aa61e0c2275db5996d7e04c24775216163718f45e9809292633772ee0
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9788,6 +9788,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-cainjector:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
@@ -9870,6 +9872,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-controller:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
@@ -9956,6 +9960,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-webhook:v1.12.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 1d9ddc6d025438aa22182e434f9534e983ddefa857913ef0a456d9cf9cea360b
+    manifestHash: 96b5ac2aa61e0c2275db5996d7e04c24775216163718f45e9809292633772ee0
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9788,6 +9788,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-cainjector:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
@@ -9870,6 +9872,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-controller:v1.12.2
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
@@ -9956,6 +9960,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: quay.io/jetstack/cert-manager-webhook:v1.12.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -5356,6 +5356,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: KUBERNETES_SERVICE_HOST
+            value: "127.0.0.1"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -5457,6 +5459,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: KUBERNETES_SERVICE_HOST
+            value: "127.0.0.1"
 ---
 # Source: cert-manager/templates/webhook-deployment.yaml
 apiVersion: apps/v1
@@ -5558,6 +5562,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: KUBERNETES_SERVICE_HOST
+            value: "127.0.0.1"
 ---
 # Source: cert-manager/templates/webhook-mutating-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
The aws-load-balancer-controller [tests are failing](https://testgrid.k8s.io/kops-misc#kops-aws-aws-load-balancer-controller) because the cert-manager pods are [timing out trying to reach the k8s api](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-aws-load-balancer-controller/1687699439508000768/artifacts/cluster-info/kube-system/cert-manager-cainjector-7fbb85f9c6-b6jkn/logs.txt) via the service IP.

Since all cert-manager pods have hard affinity towards control plane nodes it makes sense to use localhost, similar to [what we did for AWS CCM](https://github.com/kubernetes/kops/pull/11939/commits/af0aefd2e7b1ec07730a843e43e93f4527b6094c)