### PR TITLE
Use Ubuntu 20.04 in load-balancer-controller E2E scenario

### DIFF
--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -26,6 +26,7 @@ NETWORKING="amazonvpc"
 OVERRIDES="${OVERRIDES-} --set=cluster.spec.cloudProvider.aws.loadBalancerController.enabled=true"
 OVERRIDES="${OVERRIDES} --set=cluster.spec.certManager.enabled=true"
 OVERRIDES="${OVERRIDES} --master-size=t4g.medium --node-size=t4g.medium"
+OVERRIDES="${OVERRIDES} --image=${INSTANCE_IMAGE:-ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id}"
 
 # shellcheck disable=SC2034
 ZONES="eu-west-1a,eu-west-1b,eu-west-1c"

--- a/tests/e2e/scenarios/podidentitywebhook/cluster.yaml.tmpl
+++ b/tests/e2e/scenarios/podidentitywebhook/cluster.yaml.tmpl
@@ -71,7 +71,7 @@ metadata:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
   associatePublicIp: true
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20221018
+  image: ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id
   machineType: t4g.medium
   maxSize: 4
   minSize: 4
@@ -89,7 +89,7 @@ metadata:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
   associatePublicIp: true
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20221018
+  image: ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id
   machineType: c6g.large
   maxSize: 1
   minSize: 1


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kops/pull/15745#issuecomment-1666752940


Also updating the podidentitywebhook E2E scenario to use the latest 20.04 AMI from SSM rather than a hard-coded AMI that doesn't get updated automatically.