### PR TITLE
E2E - Dont set --master-count if --control-plane-count is provided

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -134,7 +134,21 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		args = append(args, createArgs...)
 	}
 	args = appendIfUnset(args, "--admin-access", adminAccess)
-	args = appendIfUnset(args, "--master-count", fmt.Sprintf("%d", d.ControlPlaneCount))
+
+	// Dont set --master-count if either --control-plane-count or --master-count
+	// has been provided in --create-args
+	foundCPCount := false
+	for _, existingArg := range args {
+		existingKey := strings.Split(existingArg, "=")
+		if existingKey[0] == "--control-plane-count" || existingKey[0] == "--master-count" {
+			foundCPCount = true
+			break
+		}
+	}
+	if !foundCPCount {
+		args = appendIfUnset(args, "--master-count", fmt.Sprintf("%d", d.ControlPlaneCount))
+	}
+
 	args = appendIfUnset(args, "--master-volume-size", "48")
 	args = appendIfUnset(args, "--node-count", "4")
 	args = appendIfUnset(args, "--node-volume-size", "48")


### PR DESCRIPTION
Previously we were only not setting --master-count if --master-count was in --create-args. Now we recognize either flag. This fixes E2E jobs that specify --control-plane-count and kops create cluster ends up having both flags

followup to https://github.com/kubernetes/kops/pull/15742

Fixes https://testgrid.k8s.io/kops-upgrades#kops-leader-migration