### PR TITLE
Use arm64 AMI for LBC scenario

### DIFF
--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -26,7 +26,7 @@ NETWORKING="amazonvpc"
 OVERRIDES="${OVERRIDES-} --set=cluster.spec.cloudProvider.aws.loadBalancerController.enabled=true"
 OVERRIDES="${OVERRIDES} --set=cluster.spec.certManager.enabled=true"
 OVERRIDES="${OVERRIDES} --master-size=t4g.medium --node-size=t4g.medium"
-OVERRIDES="${OVERRIDES} --image=${INSTANCE_IMAGE:-ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id}"
+OVERRIDES="${OVERRIDES} --image=${INSTANCE_IMAGE:-ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/arm64/hvm/ebs-gp2/ami-id}"
 
 # shellcheck disable=SC2034
 ZONES="eu-west-1a,eu-west-1b,eu-west-1c"


### PR DESCRIPTION
Fixes https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-aws-load-balancer-controller/1688303425676120064

`Error: control-plane-eu-west-1a.spec.machineType: Invalid value: "t4g.medium": machine type architecture "arm64" does not match image architecture "x86_64"`