### PR TITLE
Fix AMI SSM parameter for podidentitywebhook scenarioo

### DIFF
--- a/tests/e2e/scenarios/podidentitywebhook/cluster.yaml.tmpl
+++ b/tests/e2e/scenarios/podidentitywebhook/cluster.yaml.tmpl
@@ -71,7 +71,7 @@ metadata:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
   associatePublicIp: true
-  image: ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id
+  image: ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/arm64/hvm/ebs-gp2/ami-id
   machineType: t4g.medium
   maxSize: 4
   minSize: 4
@@ -89,7 +89,7 @@ metadata:
     kops.k8s.io/cluster: {{.clusterName}}
 spec:
   associatePublicIp: true
-  image: ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id
+  image: ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/arm64/hvm/ebs-gp2/ami-id
   machineType: c6g.large
   maxSize: 1
   minSize: 1


### PR DESCRIPTION
followup to https://github.com/kubernetes/kops/pull/15747/files#diff-9200dd891c42dc71f164e8f0b4d8bb9785fc003b7482b9d95124ddc9d82cc268

fixes https://testgrid.k8s.io/kops-misc#kops-aws-pod-identity-webhook