### PR TITLE
Fixing a typo in Hetzner Firewall Model management

### DIFF
--- a/pkg/model/hetznermodel/firewall.go
+++ b/pkg/model/hetznermodel/firewall.go
@@ -127,7 +127,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.CloudupModelBuilderContext) err
 		nodesFirewall.Rules = append(nodesFirewall.Rules, &hetznertasks.FirewallRule{
 			Direction: string(hcloud.FirewallRuleDirectionIn),
 			SourceIPs: nodePortAccess,
-			Protocol:  string(hcloud.FirewallRuleProtocolTCP),
+			Protocol:  string(hcloud.FirewallRuleProtocolUDP),
 			Port:      fi.PtrTo(fmt.Sprintf("%d-%d", nodePortRange.Base, nodePortRange.Base+nodePortRange.Size-1)),
 		})
 	}


### PR DESCRIPTION
Hello there kOps Mantainers :)

While we were using kOps for managing our Hetzner Cloud Production Clusters, we found that the cluster spec attribute `spec.nodePortAccess` (of `kind: Cluster`) was misbehaving with following error:
```
W0810 11:17:19.121986      56 executor.go:139] error running task "Firewall/nodes.<my-cluster-name>.k8s.local" (56s remaining to succeed): rules contain duplicates (invalid_input)
``` 

Going deeper by analyzing the commits, it seems that a typo error was creating twice same firewall rules that triggered an hcloud package error (constraint: two rules can't be identical).

Since the fact that file was and remained untouched for several months (and the support for Hetzner clusters is still in beta), it seems to me a typo to double create **TCP** rules for firewall, if we should align to other deployment models for the rest of cloud providers, kOps should create two firewall rules: one for TCP traffic and one for UDP.

This simple fix attached was tested in production with success.

Refers to issue: #15763 