### PR TITLE
Allow setting env vars from the command line

### DIFF
--- a/util/pkg/reflectutils/access.go
+++ b/util/pkg/reflectutils/access.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/kops/pkg/apis/kops"
 )
 
 func SetString(target interface{}, targetPath string, newValue string) error {
@@ -187,6 +188,16 @@ func setType(v reflect.Value, newValue string) error {
 		}
 	case "intstr.IntOrString":
 		newV = reflect.ValueOf(intstr.Parse(newValue))
+
+	case "kops.EnvVar":
+		name, value, found := strings.Cut(newValue, "=")
+		envVar := kops.EnvVar{
+			Name: name,
+		}
+		if found {
+			envVar.Value = value
+		}
+		newV = reflect.ValueOf(envVar)
 
 	default:
 		// This handles enums and other simple conversions

--- a/util/pkg/reflectutils/access_test.go
+++ b/util/pkg/reflectutils/access_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"k8s.io/kops/pkg/apis/kops"
 )
 
 type fakeEnum string
@@ -55,6 +57,8 @@ type fakeObjectContainers struct {
 	Int   *int32 `json:"int"`
 	Int32 *int32 `json:"int32"`
 	Int64 *int64 `json:"int64"`
+
+	Env []kops.EnvVar `json:"env"`
 
 	Enum      fakeEnum   `json:"enum"`
 	EnumSlice []fakeEnum `json:"enumSlice"`
@@ -168,6 +172,20 @@ func TestSet(t *testing.T) {
 			Expected: "{ 'spec': { 'containers': [ { 'enumSlice': [ 'ABC', 'DEF', 'GHI', 'JKL' ] } ] } }",
 			Path:     "spec.containers[0].enumSlice",
 			Value:    "GHI,JKL",
+		},
+		{
+			Name:     "set env var",
+			Input:    "{ 'spec': { 'containers': [ {} ] } }",
+			Expected: "{ 'spec': { 'containers': [ { 'env': [ { 'name': 'ABC' } ] } ] } }",
+			Path:     "spec.containers[0].env",
+			Value:    "ABC",
+		},
+		{
+			Name:     "set env var with val",
+			Input:    "{ 'spec': { 'containers': [ {} ] } }",
+			Expected: "{ 'spec': { 'containers': [ { 'env': [ { 'name': 'ABC', 'value': 'DEF' } ] } ] } }",
+			Path:     "spec.containers[0].env",
+			Value:    "ABC=DEF",
 		},
 		// Not sure if we should do this...
 		// {


### PR DESCRIPTION
Usage:
```
kops edit cluster --set cluster.spec.networking.amazonvpc.env=ENABLE_PREFIX_DELEGATION=true
```

Closes #15759 