### PR TITLE
Automated cherry pick of #15762: fix: fixed an edge case with setting NodePort access in

### DIFF
--- a/pkg/model/hetznermodel/firewall.go
+++ b/pkg/model/hetznermodel/firewall.go
@@ -127,7 +127,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.CloudupModelBuilderContext) err
 		nodesFirewall.Rules = append(nodesFirewall.Rules, &hetznertasks.FirewallRule{
 			Direction: string(hcloud.FirewallRuleDirectionIn),
 			SourceIPs: nodePortAccess,
-			Protocol:  string(hcloud.FirewallRuleProtocolTCP),
+			Protocol:  string(hcloud.FirewallRuleProtocolUDP),
 			Port:      fi.PtrTo(fmt.Sprintf("%d-%d", nodePortRange.Base, nodePortRange.Base+nodePortRange.Size-1)),
 		})
 	}


### PR DESCRIPTION
Cherry pick of #15762 on release-1.27.

#15762: fix: fixed an edge case with setting NodePort access in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```