### PR TITLE
Pass error when failing to get SSM parameter

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -2079,7 +2079,7 @@ func resolveSSMParameter(ssmClient ssmiface.SSMAPI, name string) (string, error)
 
 	response, err := ssmClient.GetParameter(request)
 	if err != nil {
-		return "", fmt.Errorf("failed to get value for SSM Parameter %q", name)
+		return "", fmt.Errorf("failed to get value for SSM parameter: %w", err)
 	}
 
 	return aws.StringValue(response.Parameter.Value), nil


### PR DESCRIPTION
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/15599/presubmit-kops-aws-scale-amazonvpc-using-cl2/1690212199458410496/build-log.txt
```
Error: control-plane-ap-northeast-2a-1.spec.image: Invalid value: "ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/arm64/hvm/ebs-gp2/ami-id":
specified image "ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/arm64/hvm/ebs-gp2/ami-id" is invalid:
failed to get value for SSM Parameter "/aws/service/canonical/ubuntu/server/20.04/stable/current/arm64/hvm/ebs-gp2/ami-id"
```

/cc @johngmyers @rifelpet @dims
@prateekgogia