### PR TITLE
Use the same LBC version for e2e tests as what is deployed

### DIFF
--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -45,7 +45,13 @@ REPORT_DIR="${ARTIFACTS:-$(pwd)/_artifacts}/aws-lb-controller"
 cd "$(mktemp -dt kops.XXXXXXXXX)"
 go install github.com/onsi/ginkgo/ginkgo@latest
 
-git clone https://github.com/kubernetes-sigs/aws-load-balancer-controller .
+LBC_VERSION=$(kubectl get deployment -n kube-system aws-load-balancer-controller -o jsonpath='{.spec.template.spec.containers[?(@.name=="controller")].image}' | cut -d':' -f2-)
+CLONE_ARGS=
+if [ -n "$LBC_VERSION" ]; then
+    CLONE_ARGS="-b ${LBC_VERSION}"
+fi
+# shellcheck disable=SC2086
+git clone ${CLONE_ARGS} https://github.com/kubernetes-sigs/aws-load-balancer-controller .
 
 mkdir -p "${REPORT_DIR}"
 

--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -26,7 +26,7 @@ NETWORKING="amazonvpc"
 OVERRIDES="${OVERRIDES-} --set=cluster.spec.cloudProvider.aws.loadBalancerController.enabled=true"
 OVERRIDES="${OVERRIDES} --set=cluster.spec.certManager.enabled=true"
 OVERRIDES="${OVERRIDES} --master-size=t4g.medium --node-size=t4g.medium"
-OVERRIDES="${OVERRIDES} --image=${INSTANCE_IMAGE:-ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/arm64/hvm/ebs-gp2/ami-id}"
+OVERRIDES="${OVERRIDES} --image=${INSTANCE_IMAGE:-099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20230811}"
 
 # shellcheck disable=SC2034
 ZONES="eu-west-1a,eu-west-1b,eu-west-1c"


### PR DESCRIPTION
Previously we were running tests from the head of the LBC repo. Now we clone the same version as what is deployed to ensure e2e tests match.

Also using a static AMI ID until kops permissions are fixed in the e2e accounts: https://github.com/kubernetes/kops/pull/15599#issuecomment-1675808982