### PR TITLE
aws: Ignore volumes set to delete on instance termination

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -561,6 +561,17 @@ func ListVolumes(cloud fi.Cloud, clusterName string) ([]*resources.Resource, err
 	for _, volume := range volumes {
 		id := aws.StringValue(volume.VolumeId)
 
+		deleteOnTermination := false
+		for _, attachment := range volume.Attachments {
+			if aws.BoolValue(attachment.DeleteOnTermination) {
+				deleteOnTermination = true
+				break
+			}
+		}
+		if deleteOnTermination {
+			continue
+		}
+
 		resourceTracker := &resources.Resource{
 			Name:    FindName(volume.Tags),
 			ID:      id,


### PR DESCRIPTION
There's no point to try and delete volumes that are already set to delete on instance termination.
During scale tests, with 100+ instances, the following can be seen a lot during cluster deletion:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/15778/presubmit-kops-aws-scale-amazonvpc-using-cl2/1691068965809295360/build-log.txt
```
W0814 13:38:55.239051    7068 retry_handler.go:55] Inserting delay before AWS request
(ec2::DeleteVolume) to avoid RequestLimitExceeded: 9s
```