### PR TITLE
Use us-east-2 region for scale tests

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -76,6 +76,10 @@ func (t *Tester) setSkipRegexFlag() error {
 		// https://github.com/cilium/cilium/issues/9207
 		skipRegex += "|serve.endpoints.on.same.port.and.different.protocols"
 
+		if cluster.Spec.LegacyCloudProvider == "gce" {
+			skipRegex += "|fallback.to.local.terminating.endpoints.when.there.are.no.ready.endpoints.with.externalTrafficPolicy.Local"
+		}
+
 		if isPre28 {
 			// These may be fixed in Cilium 1.13 but skipping for now
 			skipRegex += "|Service.with.multiple.ports.specified.in.multiple.EndpointSlices"

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -102,9 +102,7 @@ create_args+=("--dns none")
 create_args+=("--node-size=c6g.medium")
 create_args+=("--control-plane-count=${CONTROL_PLANE_COUNT:-1}")
 create_args+=("--master-size=${CONTROL_PLANE_SIZE:-c6g.2xlarge}")
-if [[ -n "${ZONES:-}" ]]; then
-    create_args+=("--zones=${ZONES}")
-fi
+create_args+=("--zones=us-east-2a,us-east-2b,us-east-2c")
 
 
 # Enable cluster addons, this enables us to replace the built-in manifest

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -86,6 +86,7 @@ echo "ADMIN_ACCESS=${ADMIN_ACCESS}"
 # cilium does not yet pass conformance tests (shared hostport test)
 #create_args="--networking cilium"
 create_args=()
+create_args=("--network-cidr=10.0.0.0/16")
 create_args+=("--networking=${CNI_PLUGIN:-calico}")
 if [[ "${CNI_PLUGIN}" == "amazonvpc" ]]; then
 create_args+=("--set spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true")


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/15778/presubmit-kops-aws-scale-amazonvpc-using-cl2/1691438764041179136

/cc @rifelpet @dims @justinsb 