### PR TITLE
Add a new field for using a custom registry for Cilium

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5117,6 +5117,10 @@ spec:
                       reconfigureKubelet:
                         description: ReconfigureKubelet is unused.
                         type: boolean
+                      registry:
+                        description: Registry overrides the default Cilium container
+                          registry (quay.io)
+                        type: string
                       removeCbrBridge:
                         description: RemoveCbrBridge is unused.
                         type: boolean

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -331,6 +331,9 @@ const (
 
 // CiliumNetworkingSpec declares that we want Cilium networking
 type CiliumNetworkingSpec struct {
+	// Registry overrides the default Cilium container registry (quay.io)
+	Registry string `json:"registry,omitempty"`
+
 	// Version is the version of the Cilium agent and the Cilium Operator.
 	Version string `json:"version,omitempty"`
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -296,6 +296,9 @@ const (
 
 // CiliumNetworkingSpec declares that we want Cilium networking
 type CiliumNetworkingSpec struct {
+	// Registry overrides the default Cilium container registry (quay.io)
+	Registry string `json:"registry,omitempty"`
+
 	// Version is the version of the Cilium agent and the Cilium Operator.
 	Version string `json:"version,omitempty"`
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1908,6 +1908,7 @@ func Convert_kops_CertManagerConfig_To_v1alpha2_CertManagerConfig(in *kops.CertM
 }
 
 func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *CiliumNetworkingSpec, out *kops.CiliumNetworkingSpec, s conversion.Scope) error {
+	out.Registry = in.Registry
 	out.Version = in.Version
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
@@ -2020,6 +2021,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 }
 
 func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *kops.CiliumNetworkingSpec, out *CiliumNetworkingSpec, s conversion.Scope) error {
+	out.Registry = in.Registry
 	out.Version = in.Version
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -294,6 +294,9 @@ type CiliumEncryptionType string
 
 // CiliumNetworkingSpec declares that we want Cilium networking
 type CiliumNetworkingSpec struct {
+	// Registry overrides the default Cilium container registry (quay.io)
+	Registry string `json:"registry,omitempty"`
+
 	// Version is the version of the Cilium agent and the Cilium Operator.
 	Version string `json:"version,omitempty"`
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2090,6 +2090,7 @@ func Convert_kops_CertManagerConfig_To_v1alpha3_CertManagerConfig(in *kops.CertM
 }
 
 func autoConvert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *CiliumNetworkingSpec, out *kops.CiliumNetworkingSpec, s conversion.Scope) error {
+	out.Registry = in.Registry
 	out.Version = in.Version
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
@@ -2155,6 +2156,7 @@ func Convert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *Cili
 }
 
 func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha3_CiliumNetworkingSpec(in *kops.CiliumNetworkingSpec, out *CiliumNetworkingSpec, s conversion.Scope) error {
+	out.Registry = in.Registry
 	out.Version = in.Version
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.13.yaml.template
@@ -750,7 +750,7 @@ spec:
         - name: CILIUM_ENABLE_POLICY
           value: {{ . }}
         {{ end }}
-        image: "quay.io/cilium/cilium:{{ .Version }}"
+        image: "{{ or .Registry "quay.io" }}/cilium/cilium:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -828,7 +828,7 @@ spec:
       {{- if semverCompare "~1.11.15 || ~1.12.8 || >=1.13.1" $semver }}
       - command:
         - /install-plugin.sh
-        image: "quay.io/cilium/cilium:{{ .Version }}"
+        image: "{{ or .Registry "quay.io" }}/cilium/cilium:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -868,7 +868,7 @@ spec:
               name: cilium-config
               optional: true
         {{- end }}
-        image: "quay.io/cilium/cilium:{{ .Version }}"
+        image: "{{ or .Registry "quay.io" }}/cilium/cilium:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         terminationMessagePolicy: FallbackToLogsOnError
@@ -1045,7 +1045,7 @@ spec:
           value: "{{ APIInternalName }}"
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: "quay.io/cilium/operator:{{ .Version }}"
+        image: "{{ or .Registry "quay.io" }}/cilium/operator:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         {{ if .EnablePrometheusMetrics }}
@@ -1155,7 +1155,7 @@ spec:
     spec:
       containers:
         - name: hubble-relay
-          image: "quay.io/cilium/hubble-relay:{{ .Version }}"
+          image: "{{ or .Registry "quay.io" }}/cilium/hubble-relay:{{ .Version }}"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay


### PR DESCRIPTION
Fixes #15786.

There is a bit more context in the issue, but this adds a `Registry` field to the `CiliumNetworkingSpec` so that users can override the image registry used to pull Cilium images.

This copies the method used for similar Networking add ons when specifying a `Registry` argument in their NetworkingSpec; defaulting to `quay.io` when the `Registry` field is empty.