### PR TITLE
Create clusters with bigger default subnets

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -611,7 +611,7 @@ func validateSubnet(subnetSpec *kops.ClusterSubnetSpec, c *kops.ClusterSpec, fie
 				allErrs = append(allErrs, field.Forbidden(fieldPath.Child("cidr"), fmt.Sprintf("subnet %q cidr %q is not a subnet of the networkCIDR %q%s", subnetSpec.Name, subnetSpec.CIDR, c.Networking.NetworkCIDR, extraMsg)))
 			}
 		}
-		if subnet.Overlap(subnetCIDR, podCIDR) {
+		if subnet.Overlap(subnetCIDR, podCIDR) && c.Networking.AmazonVPC == nil {
 			allErrs = append(allErrs, field.Forbidden(fieldPath.Child("cidr"), fmt.Sprintf("subnet %q cidr %q must not overlap podCIDR %q", subnetSpec.Name, subnetSpec.CIDR, podCIDR)))
 		}
 		if subnet.Overlap(subnetCIDR, serviceClusterIPRange) {

--- a/pkg/util/subnet/subnet.go
+++ b/pkg/util/subnet/subnet.go
@@ -45,13 +45,32 @@ func BelongsTo(parent *net.IPNet, child *net.IPNet) bool {
 	return childMasked.Equal(parentMasked)
 }
 
+// SplitInto2 splits the parent IPNet into 2 subnets
+func SplitInto2(parent *net.IPNet) ([]*net.IPNet, error) {
+	return SplitInto(1, parent)
+}
+
+// SplitInto4 splits the parent IPNet into 4 subnets
+func SplitInto4(parent *net.IPNet) ([]*net.IPNet, error) {
+	return SplitInto(2, parent)
+}
+
 // SplitInto8 splits the parent IPNet into 8 subnets
 func SplitInto8(parent *net.IPNet) ([]*net.IPNet, error) {
+	return SplitInto(3, parent)
+}
+
+// SplitInto splits the parent IPNet into 8 subnets
+func SplitInto(additionalBits int, parent *net.IPNet) ([]*net.IPNet, error) {
+	if additionalBits < 1 || additionalBits > 3 {
+		return nil, fmt.Errorf("additionalBits value must be between 1 and 3, not %d", additionalBits)
+	}
+
 	networkLength, _ := parent.Mask.Size()
-	networkLength += 3
+	networkLength += additionalBits
 
 	var subnets []*net.IPNet
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 2<<(additionalBits-1); i++ {
 		ip4 := parent.IP.To4()
 		if ip4 != nil {
 			n := binary.BigEndian.Uint32(ip4)

--- a/pkg/util/subnet/subnet.go
+++ b/pkg/util/subnet/subnet.go
@@ -60,7 +60,7 @@ func SplitInto8(parent *net.IPNet) ([]*net.IPNet, error) {
 	return SplitInto(3, parent)
 }
 
-// SplitInto splits the parent IPNet into 8 subnets
+// SplitInto splits the parent IPNet into subnets with the specified number of additional bits in the prefix.
 func SplitInto(additionalBits int, parent *net.IPNet) ([]*net.IPNet, error) {
 	if additionalBits < 1 || additionalBits > 3 {
 		return nil, fmt.Errorf("additionalBits value must be between 1 and 3, not %d", additionalBits)
@@ -70,7 +70,7 @@ func SplitInto(additionalBits int, parent *net.IPNet) ([]*net.IPNet, error) {
 	networkLength += additionalBits
 
 	var subnets []*net.IPNet
-	for i := 0; i < 2<<(additionalBits-1); i++ {
+	for i := 0; i < 1<<additionalBits; i++ {
 		ip4 := parent.IP.To4()
 		if ip4 != nil {
 			n := binary.BigEndian.Uint32(ip4)

--- a/tests/integration/create_cluster/cilium-eni/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/cilium-eni/expected-v1alpha2.yaml
@@ -52,7 +52,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -47,7 +47,7 @@ spec:
   sshAccess:
   - 1.2.3.4/32
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/different-amis/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/different-amis/expected-v1alpha2.yaml
@@ -50,11 +50,11 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Private
     zone: us-test-1a
-  - cidr: 172.20.0.0/22
+  - cidr: 172.20.0.0/20
     name: utility-us-test-1a
     type: Utility
     zone: us-test-1a

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -60,15 +60,15 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.64.0/18
     name: us-test-1a
     type: Public
     zone: us-test-1a
-  - cidr: 172.20.64.0/19
+  - cidr: 172.20.128.0/18
     name: us-test-1b
     type: Public
     zone: us-test-1b
-  - cidr: 172.20.96.0/19
+  - cidr: 172.20.192.0/18
     name: us-test-1c
     type: Public
     zone: us-test-1c

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -60,15 +60,15 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.64.0/18
     name: us-test-1a
     type: Public
     zone: us-test-1a
-  - cidr: 172.20.64.0/19
+  - cidr: 172.20.128.0/18
     name: us-test-1b
     type: Public
     zone: us-test-1b
-  - cidr: 172.20.96.0/19
+  - cidr: 172.20.192.0/18
     name: us-test-1c
     type: Public
     zone: us-test-1c

--- a/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
@@ -68,7 +68,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 10.0.32.0/19
+  - cidr: 10.0.128.0/17
     name: us-test1
     type: Public
     zone: us-test1

--- a/tests/integration/create_cluster/ha_openstack_nodns/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_nodns/expected-v1alpha2.yaml
@@ -76,11 +76,11 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 10.0.32.0/19
+  - cidr: 10.0.128.0/17
     name: us-test1
     type: Private
     zone: us-test1
-  - cidr: 10.0.0.0/22
+  - cidr: 10.0.0.0/20
     name: utility-us-test1
     type: Utility
     zone: us-test1

--- a/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
@@ -74,11 +74,11 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 10.0.32.0/19
+  - cidr: 10.0.128.0/17
     name: us-test1
     type: Private
     zone: us-test1
-  - cidr: 10.0.0.0/22
+  - cidr: 10.0.0.0/20
     name: utility-us-test1
     type: Utility
     zone: us-test1

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -60,7 +60,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -72,11 +72,11 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.64.0/18
     name: us-test-1a
     type: Public
     zone: us-test-1a
-  - cidr: 172.20.64.0/19
+  - cidr: 172.20.128.0/18
     name: us-test-1b
     type: Public
     zone: us-test-1b

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -50,12 +50,12 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     egress: i-09123456
     name: us-test-1a
     type: Private
     zone: us-test-1a
-  - cidr: 172.20.0.0/22
+  - cidr: 172.20.0.0/20
     name: utility-us-test-1a
     type: Utility
     zone: us-test-1a

--- a/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
@@ -55,12 +55,12 @@ spec:
     name: us-test-1a
     type: Private
     zone: us-test-1a
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.64.0/18
     ipv6CIDR: /64#1
     name: dualstack-us-test-1a
     type: DualStack
     zone: us-test-1a
-  - cidr: 172.20.0.0/22
+  - cidr: 172.20.0.0/21
     ipv6CIDR: /64#2
     name: utility-us-test-1a
     type: Utility

--- a/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
@@ -54,15 +54,15 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.64.0/18
     name: us-test-1a
     type: Public
     zone: us-test-1a
-  - cidr: 172.20.64.0/19
+  - cidr: 172.20.128.0/18
     name: us-test-1b
     type: Public
     zone: us-test-1b
-  - cidr: 172.20.96.0/19
+  - cidr: 172.20.192.0/18
     name: us-test-1c
     type: Public
     zone: us-test-1c

--- a/tests/integration/create_cluster/minimal-1.23/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.23/expected-v1alpha2.yaml
@@ -48,7 +48,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
@@ -48,7 +48,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/minimal-1.25/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.25/expected-v1alpha2.yaml
@@ -48,7 +48,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/minimal-1.26-arm64/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-arm64/expected-v1alpha2.yaml
@@ -48,7 +48,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/minimal-1.26-irsa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-irsa/expected-v1alpha2.yaml
@@ -52,7 +52,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/minimal-1.26/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26/expected-v1alpha2.yaml
@@ -48,7 +48,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/minimal-1.27/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.27/expected-v1alpha2.yaml
@@ -48,7 +48,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/minimal_feature-gates/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal_feature-gates/expected-v1alpha2.yaml
@@ -72,7 +72,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -50,12 +50,12 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     egress: nat-09123456
     name: us-test-1a
     type: Private
     zone: us-test-1a
-  - cidr: 172.20.0.0/22
+  - cidr: 172.20.0.0/20
     name: utility-us-test-1a
     type: Utility
     zone: us-test-1a

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -51,7 +51,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Public
     zone: us-test-1a

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -54,11 +54,11 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
+  - cidr: 172.20.128.0/17
     name: us-test-1a
     type: Private
     zone: us-test-1a
-  - cidr: 172.20.0.0/22
+  - cidr: 172.20.0.0/20
     name: utility-us-test-1a
     type: Utility
     zone: us-test-1a

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -49,7 +49,7 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 10.2.0.0/15
+  - cidr: 10.8.0.0/13
     name: us-test-1a
     type: Public
     zone: us-test-1a


### PR DESCRIPTION
When creating a cluster, the network CIRD is split into 8 subnets.
For AWS, the network CIDR is at max a /16, which results in /19 subnets (8192 IPs). This is quite small for AWS VPC CNI.

When doing scalability tests, even 500 nodes are too many for such small subnets, considering 16 IPs / node.
Even using multi-AZ, we still get a max of 48 IPs / node, again, not so great.

This PR proposes to split the network CIDR into bigger subnets, when the number of subnets allows it.

This only affects AWS and OpenStack:
https://github.com/kubernetes/kops/blob/73159cd6f50f72e004d972ce2ade21dcf40b7860/upup/pkg/fi/cloudup/defaults.go#L122-L128

/cc @johngmyers @justinsb @zetaab