### PR TITLE
Allow setting metav1.Duration from the command line

### DIFF
--- a/util/pkg/reflectutils/access.go
+++ b/util/pkg/reflectutils/access.go
@@ -21,7 +21,9 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kops/pkg/apis/kops"
 )
@@ -198,6 +200,13 @@ func setType(v reflect.Value, newValue string) error {
 			envVar.Value = value
 		}
 		newV = reflect.ValueOf(envVar)
+
+	case "v1.Duration":
+		duration, err := time.ParseDuration(newValue)
+		if err != nil {
+			return fmt.Errorf("cannot interpret %q value as v1.Duration", newValue)
+		}
+		newV = reflect.ValueOf(metav1.Duration{Duration: duration})
 
 	default:
 		// This handles enums and other simple conversions

--- a/util/pkg/reflectutils/access_test.go
+++ b/util/pkg/reflectutils/access_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kops/pkg/apis/kops"
 )
 
@@ -59,6 +60,8 @@ type fakeObjectContainers struct {
 	Int64 *int64 `json:"int64"`
 
 	Env []kops.EnvVar `json:"env"`
+
+	Duration *metav1.Duration `json:"duration"`
 
 	Enum      fakeEnum   `json:"enum"`
 	EnumSlice []fakeEnum `json:"enumSlice"`
@@ -186,6 +189,13 @@ func TestSet(t *testing.T) {
 			Expected: "{ 'spec': { 'containers': [ { 'env': [ { 'name': 'ABC', 'value': 'DEF' } ] } ] } }",
 			Path:     "spec.containers[0].env",
 			Value:    "ABC=DEF",
+		},
+		{
+			Name:     "set duration",
+			Input:    "{ 'spec': { 'containers': [ {} ] } }",
+			Expected: "{ 'spec': { 'containers': [ { 'duration': '500ms' } ] } }",
+			Path:     "spec.containers[0].duration",
+			Value:    "500ms",
 		},
 		// Not sure if we should do this...
 		// {


### PR DESCRIPTION
```shell
$ kops create cluster --set spec.kubeControllerManager.endpointSliceUpdatesBatchPeriod=500ms

Error: cannot set field "spec.kubeControllerManager.endpointSliceUpdatesBatchPeriod": unhandled type "v1.Duration"
```

/cc @dims @rifelpet @justinsb 
@prateekgogia 