### PR TITLE
WIP: Find kops-controller using a SAN IP in the apiserver cert

### DIFF
--- a/nodeup/pkg/model/bootstrap_client.go
+++ b/nodeup/pkg/model/bootstrap_client.go
@@ -26,12 +26,12 @@ import (
 	"k8s.io/kops/pkg/bootstrap"
 	"k8s.io/kops/pkg/kopscontrollerclient"
 	"k8s.io/kops/pkg/resolver"
+	"k8s.io/kops/pkg/resolver/certresolver"
 	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 	"k8s.io/kops/upup/pkg/fi/cloudup/do"
-	"k8s.io/kops/upup/pkg/fi/cloudup/gce/gcediscovery"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm/gcetpmsigner"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
@@ -65,11 +65,13 @@ func (b BootstrapClientBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 			return err
 		}
 		authenticator = a
-		r, err := gcediscovery.New()
+
+		r, err := certresolver.New(b.BootConfig.ConfigServer.CACertificates)
 		if err != nil {
 			return err
 		}
 		resolver = r
+
 	case kops.CloudProviderHetzner:
 		a, err := hetzner.NewHetznerAuthenticator()
 		if err != nil {

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -573,6 +573,13 @@ func (c *NodeupModelContext) GetMetadataLocalIP() (string, error) {
 		}
 		internalIP = localIPv4
 
+	case kops.CloudProviderGCE:
+		b, err := vfs.Context.ReadFile("metadata://gce/instance/network-interfaces/0/ip")
+		if err != nil {
+			return "", fmt.Errorf("error reading internal ip from GCE metadata: %w", err)
+		}
+		internalIP = string(b)
+
 	case kops.CloudProviderHetzner:
 		client := hcloudmetadata.NewClient()
 		privateNetworksYaml, err := client.PrivateNetworks()

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -429,7 +429,14 @@ func (b *KubeAPIServerBuilder) writeServerCertificate(c *fi.NodeupModelBuilderCo
 			}
 		}
 		if b.CloudProvider() == kops.CloudProviderOpenstack {
-			instanceAddress, err := getInstanceAddress()
+			instanceAddress, err := getOpenstackInstanceAddress()
+			if err != nil {
+				return err
+			}
+			alternateNames = append(alternateNames, instanceAddress)
+		}
+		if b.CloudProvider() == kops.CloudProviderGCE {
+			instanceAddress, err := b.GetMetadataLocalIP()
 			if err != nil {
 				return err
 			}

--- a/nodeup/pkg/model/secrets.go
+++ b/nodeup/pkg/model/secrets.go
@@ -64,7 +64,7 @@ func (b *SecretBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	return nil
 }
 
-func getInstanceAddress() (string, error) {
+func getOpenstackInstanceAddress() (string, error) {
 	addrBytes, err := vfs.Context.ReadFile("metadata://openstack/local-ipv4")
 	if err != nil {
 		return "", nil

--- a/pkg/kopscontrollerclient/client.go
+++ b/pkg/kopscontrollerclient/client.go
@@ -66,7 +66,7 @@ func (b *Client) dial(ctx context.Context, network, addr string) (net.Conn, erro
 	// TODO: cache?
 	addresses, err := b.Resolver.Resolve(ctx, host)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolving with custom resolver %T: %w", b.Resolver, err)
 	}
 
 	klog.Infof("resolved %q to %v", host, addresses)

--- a/pkg/resolver/certresolver/certificateresolver.go
+++ b/pkg/resolver/certresolver/certificateresolver.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certresolver
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+
+	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/resolver"
+)
+
+type CertResolver struct {
+	// RootCAs are used to validate the server certificates.
+	RootCAs *x509.CertPool
+}
+
+func New(caCertificates string) (resolver.Resolver, error) {
+	rootCAs := x509.NewCertPool()
+	if !rootCAs.AppendCertsFromPEM([]byte(caCertificates)) {
+		klog.Warningf("no CA certs found in boot config")
+	}
+
+	return &CertResolver{
+		RootCAs: rootCAs,
+	}, nil
+}
+
+var _ resolver.Resolver = &CertResolver{}
+
+// Resolve resolves the host to IP addresses or alternative hostnames.
+func (r *CertResolver) Resolve(ctx context.Context, host string) ([]string, error) {
+	tlsConfig := &tls.Config{
+		RootCAs: r.RootCAs,
+		// This is sort of a hack.  We do want to verify that this is the apiserver.
+		ServerName: "kubernetes.default",
+	}
+	httpTransport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	httpClient := &http.Client{Transport: httpTransport}
+
+	url := "https://" + host + "/.well-known/cert-discovery"
+	response, err := httpClient.Get(url)
+	if err != nil {
+		klog.Infof("CertResolver unable to resolve %q: %v", err)
+		return nil, fmt.Errorf("error doing HTTP get on %q: %w", url, err)
+	}
+
+	// We don't really care about the response per-se (we expect a 401), just the certificates
+
+	var records []string
+	if response.TLS != nil {
+		for _, cert := range response.TLS.PeerCertificates {
+			// TODO: Check this cert is signed by our CA?
+			for _, ip := range cert.IPAddresses {
+				ip := ip.String()
+				switch ip {
+				case "127.0.0.1":
+					// ignore
+
+					// TODO: Ignore others?
+					// DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster.local, DNS:api.internal.foo.k8s.local, IP Address:34.86.xx.xx, IP Address:100.64.0.1, IP Address:127.0.0.1, IP Address:10.0.16.3
+
+				default:
+					records = append(records, ip)
+				}
+			}
+		}
+	}
+
+	klog.Infof("CertResolver resolved %q to %v", host, records)
+	return records, nil
+}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1459,7 +1459,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 	} else {
 		// If we do have a fixed IP, we use it (on some clouds, initially)
 		switch cluster.Spec.GetCloudProvider() {
-		case kops.CloudProviderHetzner, kops.CloudProviderScaleway:
+		case kops.CloudProviderHetzner, kops.CloudProviderScaleway, kops.CloudProviderGCE:
 			bootConfig.APIServerIPs = controlPlaneIPs
 		}
 	}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -49,12 +49,12 @@ import (
 	"k8s.io/kops/pkg/configserver"
 	"k8s.io/kops/pkg/kopscontrollerclient"
 	"k8s.io/kops/pkg/resolver"
+	"k8s.io/kops/pkg/resolver/certresolver"
 	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 	"k8s.io/kops/upup/pkg/fi/cloudup/do"
-	"k8s.io/kops/upup/pkg/fi/cloudup/gce/gcediscovery"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm/gcetpmsigner"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
@@ -714,7 +714,7 @@ func getNodeConfigFromServers(ctx context.Context, bootConfig *nodeup.BootConfig
 		}
 		authenticator = a
 
-		discovery, err := gcediscovery.New()
+		discovery, err := certresolver.New(bootConfig.ConfigServer.CACertificates)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We connect to kube-apiserver, issue a dummy GET request, but inspect
the TLS certificate to discovery the internal IP.

This does expose a small bit of information, but we are exposing it on
other clouds anyway.
