### PR TITLE
aws: Create subnets for additional network CIDRs

### DIFF
--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -97,6 +97,11 @@ func TestCreateClusterComplex(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/complex", "v1alpha2")
 }
 
+// TestCreateClusterComplexPrivate runs kops create cluster, with a grab-bag of edge cases
+func TestCreateClusterComplexPrivate(t *testing.T) {
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/complex-private", "v1alpha2")
+}
+
 // TestCreateClusterHA runs kops create cluster ha.example.com --zones us-test-1a,us-test-1b,us-test-1c --master-zones us-test-1a,us-test-1b,us-test-1c
 func TestCreateClusterHA(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/ha", "v1alpha2")

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -99,7 +99,7 @@ kops create cluster [CLUSTER] [flags]
       --ipv6                                    Use IPv6 for the pod network (AWS only)
       --kubernetes-feature-gates strings        List of Kubernetes feature gates to enable/disable
       --kubernetes-version string               Version of Kubernetes to run (defaults to version in channel)
-      --network-cidr string                     Network CIDR to use
+      --network-cidr strings                    Network CIDR(s) to use
       --network-id string                       Shared Network or VPC to use
       --networking string                       Networking mode.  kubenet, external, flannel-vxlan (or flannel), flannel-udp, calico, canal, kube-router, amazonvpc, cilium, cilium-etcd, cni. (default "cilium")
       --node-count int32                        Total number of worker nodes. Defaults to one node per zone

--- a/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
@@ -10,7 +10,9 @@ spec:
   - 10.3.0.0/16
   - 10.4.0.0/16
   api:
-    dns: {}
+    loadBalancer:
+      class: Network
+      type: Public
   authorization:
     rbac: {}
   channel: stable
@@ -64,37 +66,94 @@ spec:
   sshAccess:
   - 1.2.3.4/32
   subnets:
-  - cidr: 10.0.0.0/18
-    name: us-test-1a
-    type: Public
-    zone: us-test-1a
   - cidr: 10.0.64.0/18
-    name: us-test-1b
-    type: Public
-    zone: us-test-1b
+    name: us-test-1a
+    type: Private
+    zone: us-test-1a
   - cidr: 10.0.128.0/18
+    name: us-test-1b
+    type: Private
+    zone: us-test-1b
+  - cidr: 10.0.192.0/18
     name: us-test-1c
-    type: Public
+    type: Private
     zone: us-test-1c
   - cidr: 10.1.0.0/16
     name: us-test-1a-1
-    type: Public
+    type: Private
     zone: us-test-1a
   - cidr: 10.2.0.0/16
     name: us-test-1b-2
-    type: Public
+    type: Private
     zone: us-test-1b
   - cidr: 10.3.0.0/16
     name: us-test-1c-3
-    type: Public
+    type: Private
     zone: us-test-1c
   - cidr: 10.4.0.0/16
     name: us-test-1a-4
-    type: Public
+    type: Private
+    zone: us-test-1a
+  - cidr: 10.0.0.0/21
+    name: utility-us-test-1a
+    type: Utility
+    zone: us-test-1a
+  - cidr: 10.0.24.0/21
+    name: utility-us-test-1b
+    type: Utility
+    zone: us-test-1b
+  - cidr: 10.0.40.0/21
+    name: utility-us-test-1c
+    type: Utility
+    zone: us-test-1c
+  - cidr: 10.0.8.0/21
+    name: utility-us-test-1a-1
+    type: Utility
+    zone: us-test-1a
+  - cidr: 10.0.32.0/21
+    name: utility-us-test-1b-2
+    type: Utility
+    zone: us-test-1b
+  - cidr: 10.0.48.0/21
+    name: utility-us-test-1c-3
+    type: Utility
+    zone: us-test-1c
+  - cidr: 10.0.16.0/21
+    name: utility-us-test-1a-4
+    type: Utility
     zone: us-test-1a
   topology:
+    bastion:
+      bastionPublicName: bastion.complex.example.com
     dns:
       type: Public
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: complex.example.com
+  name: bastions
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230814
+  instanceMetadata:
+    httpPutResponseHopLimit: 1
+    httpTokens: required
+  machineType: t2.micro
+  maxSize: 1
+  minSize: 1
+  role: Bastion
+  subnets:
+  - us-test-1a
+  - us-test-1b
+  - us-test-1c
+  - us-test-1a-1
+  - us-test-1b-2
+  - us-test-1c-3
+  - us-test-1a-4
 
 ---
 

--- a/tests/integration/create_cluster/complex-private/options.yaml
+++ b/tests/integration/create_cluster/complex-private/options.yaml
@@ -11,6 +11,8 @@ NetworkCIDRs:
 - 10.3.0.0/16
 - 10.4.0.0/16
 Networking: cni
+Topology: private
+Bastion: true
 ControlPlaneCount: 3
 NodeCount: 10
 KubernetesVersion: v1.26.0

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -4,6 +4,10 @@ metadata:
   creationTimestamp: "2017-01-01T00:00:00Z"
   name: complex.example.com
 spec:
+  additionalNetworkCIDRs:
+  - 10.1.0.0/16
+  - 10.2.0.0/16
+  - 10.3.0.0/16
   api:
     dns: {}
   authorization:
@@ -40,15 +44,27 @@ spec:
   - ::/0
   kubernetesVersion: v1.26.0
   masterPublicName: api.complex.example.com
-  networkCIDR: 172.20.0.0/16
+  networkCIDR: 10.0.0.0/16
   networking:
     cni: {}
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
   - 1.2.3.4/32
   subnets:
-  - cidr: 172.20.0.0/16
+  - cidr: 10.0.0.0/16
     name: us-test-1a
+    type: Public
+    zone: us-test-1a
+  - cidr: 10.1.0.0/16
+    name: us-test-1a-1
+    type: Public
+    zone: us-test-1a
+  - cidr: 10.2.0.0/16
+    name: us-test-1a-2
+    type: Public
+    zone: us-test-1a
+  - cidr: 10.3.0.0/16
+    name: us-test-1a-3
     type: Public
     zone: us-test-1a
   topology:
@@ -74,6 +90,9 @@ spec:
   role: Master
   subnets:
   - us-test-1a
+  - us-test-1a-1
+  - us-test-1a-2
+  - us-test-1a-3
 
 ---
 
@@ -95,3 +114,6 @@ spec:
   role: Node
   subnets:
   - us-test-1a
+  - us-test-1a-1
+  - us-test-1a-2
+  - us-test-1a-3

--- a/tests/integration/create_cluster/complex/options.yaml
+++ b/tests/integration/create_cluster/complex/options.yaml
@@ -2,6 +2,11 @@ ClusterName: complex.example.com
 Zones:
 - us-test-1a
 CloudProvider: aws
+NetworkCIDRs:
+- 10.0.0.0/16
+- 10.1.0.0/16
+- 10.2.0.0/16
+- 10.3.0.0/16
 Networking: cni
 KubernetesVersion: v1.26.0
 # We specify SSHAccess but _not_ AdminAccess

--- a/tests/integration/create_cluster/ha_hetzner/options.yaml
+++ b/tests/integration/create_cluster/ha_hetzner/options.yaml
@@ -2,7 +2,8 @@ CloudProvider: hetzner
 ClusterName: ha.example.com
 KubernetesVersion: v1.25.0
 ControlPlaneCount: 3
-NetworkCIDR: 10.0.0.0/16
+NetworkCIDRs:
+  - 10.0.0.0/16
 Networking: cni
 Zones:
   - fsn1

--- a/tests/integration/create_cluster/ha_openstack/options.yaml
+++ b/tests/integration/create_cluster/ha_openstack/options.yaml
@@ -3,7 +3,8 @@ ClusterName: minimal.k8s.local
 Image: ubuntu-20.04
 KubernetesVersion: v1.25.0
 ControlPlaneCount: 3
-NetworkCIDR: 10.0.0.0/16
+NetworkCIDRs:
+  - 10.0.0.0/16
 Networking: cni
 Zones:
   - us-test1

--- a/tests/integration/create_cluster/ha_openstack_nodns/options.yaml
+++ b/tests/integration/create_cluster/ha_openstack_nodns/options.yaml
@@ -3,7 +3,8 @@ ClusterName: ha.example.com
 Image: ubuntu-20.04
 KubernetesVersion: v1.25.0
 ControlPlaneCount: 3
-NetworkCIDR: 10.0.0.0/16
+NetworkCIDRs:
+  - 10.0.0.0/16
 Networking: calico
 Zones:
   - us-test1

--- a/tests/integration/create_cluster/ha_openstack_octavia/options.yaml
+++ b/tests/integration/create_cluster/ha_openstack_octavia/options.yaml
@@ -3,7 +3,8 @@ ClusterName: minimal.k8s.local
 Image: ubuntu-20.04
 KubernetesVersion: v1.25.0
 ControlPlaneCount: 3
-NetworkCIDR: 10.0.0.0/16
+NetworkCIDRs:
+  - 10.0.0.0/16
 Networking: cni
 Zones:
   - us-test1

--- a/tests/integration/create_cluster/minimal_hetzner/options.yaml
+++ b/tests/integration/create_cluster/minimal_hetzner/options.yaml
@@ -1,7 +1,8 @@
 CloudProvider: hetzner
 ClusterName: minimal.k8s.local
 KubernetesVersion: v1.25.0
-NetworkCIDR: 10.0.0.0/16
+NetworkCIDRs:
+  - 10.0.0.0/16
 Networking: cni
 Zones:
   - fsn1

--- a/upup/pkg/fi/cloudup/subnets.go
+++ b/upup/pkg/fi/cloudup/subnets.go
@@ -110,6 +110,16 @@ func assignCIDRsToSubnets(c *kops.Cluster, cloud fi.Cloud) error {
 	var reserved []*net.IPNet
 	for i := range c.Spec.Networking.Subnets {
 		subnet := &c.Spec.Networking.Subnets[i]
+		if subnet.CIDR != "" {
+			_, cidrSubnet, err := net.ParseCIDR(subnet.CIDR)
+			if err != nil {
+				return fmt.Errorf("invalid subnet %q CIDR: %q", subnet.Name, subnet.CIDR)
+			}
+			// Skip additional subnets
+			if !cidr.Contains(cidrSubnet.IP) {
+				continue
+			}
+		}
 		switch subnet.Type {
 		case kops.SubnetTypeDualStack, kops.SubnetTypePublic, kops.SubnetTypePrivate:
 			bigSubnets = append(bigSubnets, subnet)


### PR DESCRIPTION
This will be needed for scale tests, to be able to use clusters with more than 500 nodes.