### PR TITLE
Continue skipping SCTP HostPort tests in older k8s versions

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -84,10 +84,16 @@ func (t *Tester) setSkipRegexFlag() error {
 		if isPre28 {
 			// These may be fixed in Cilium 1.13 but skipping for now
 			skipRegex += "|Service.with.multiple.ports.specified.in.multiple.EndpointSlices"
-			skipRegex += "|should.create.a.Pod.with.SCTP.HostPort"
 			// https://github.com/cilium/cilium/issues/18241
 			skipRegex += "|Services.should.create.endpoints.for.unready.pods"
 			skipRegex += "|Services.should.be.able.to.connect.to.terminating.and.unready.endpoints.if.PublishNotReadyAddresses.is.true"
+		}
+		if k8sVersion.Minor < 27 {
+			// Partially implemented in Cilium 1.13 but kops doesn't enable it
+			// Ref: https://github.com/cilium/cilium/pull/20033
+			// K8s 1.27+ added [Serial] to the test case, which is skipped by default
+			// Ref: https://github.com/kubernetes/kubernetes/pull/113335
+			skipRegex += "|should.create.a.Pod.with.SCTP.HostPort"
 		}
 	} else if networking.KubeRouter != nil {
 		skipRegex += "|load-balancer|hairpin|affinity\\stimeout|service\\.kubernetes\\.io|CLOSE_WAIT"


### PR DESCRIPTION
After no longer skipping these in kops 1.28, the e2e tests began failing again (examples [1](https://testgrid.k8s.io/kops-grid#kops-grid-cilium-amzn2-k23) and [2](https://testgrid.k8s.io/kops-grid#kops-grid-cilium-deb10-k25))

It turns out cilium doesn't enable SCTP support by default, it is guarded by a `enable-sctp` [config boolean](https://github.com/cilium/cilium/pull/20033/files#diff-83e9b8b2ccacddb2fbdb28fbcfa148473d05056c0b4c955fc971709b469d7331).

In k8s 1.27 the test [was also renamed](https://github.com/kubernetes/kubernetes/pull/113335/files#diff-e9b5b9ac3748355ab1c53360290889c0a4e1d6f4bba01395e425088882619d13) and added `[Serial]`, so it is still being skipped on k8s 1.27+ test jobs

/cc @hakman