### PR TITLE
Fix gossip on DigitalOcean

### DIFF
--- a/pkg/apis/kops/model/features.go
+++ b/pkg/apis/kops/model/features.go
@@ -44,8 +44,8 @@ func UseKopsControllerForNodeConfig(cluster *kops.Cluster) bool {
 		switch cluster.Spec.GetCloudProvider() {
 		case kops.CloudProviderGCE:
 			// We can use cloud-discovery here.
-		case kops.CloudProviderHetzner, kops.CloudProviderScaleway:
-			// We don't have a cloud-discovery mechanism implemented in nodeup for hetzner,
+		case kops.CloudProviderHetzner, kops.CloudProviderScaleway, kops.CloudProviderDO:
+			// We don't have a cloud-discovery mechanism implemented in nodeup for many clouds,
 			// but we assume that we're using a load balancer with a fixed IP address
 		default:
 			return false

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1458,8 +1458,10 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 		bootConfig.APIServerIPs = controlPlaneIPs
 	} else {
 		// If we do have a fixed IP, we use it (on some clouds, initially)
+		// This covers the clouds in UseKopsControllerForNodeConfig which use kops-controller for node config,
+		// but don't have a specialized discovery mechanism for finding kops-controller etc.
 		switch cluster.Spec.GetCloudProvider() {
-		case kops.CloudProviderHetzner, kops.CloudProviderScaleway:
+		case kops.CloudProviderHetzner, kops.CloudProviderScaleway, kops.CloudProviderDO:
 			bootConfig.APIServerIPs = controlPlaneIPs
 		}
 	}


### PR DESCRIPTION
We don't have a seeding mechanism for DigitalOcean (this relies on
cloud credentials, which we don't want to put on the nodes).

Instead, use the (stable) load balancer IP to connect.
