### PR TITLE
update alpha channel with k8s emergency release and ubuntu ami versions

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -58,19 +58,19 @@ spec:
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230714
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230814
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.18.0 <1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20230714
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20230814
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0 <1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230711
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230728
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20230711
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20230728
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.27.0"
@@ -104,16 +104,16 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.27.0"
-    recommendedVersion: 1.27.4
+    recommendedVersion: 1.27.5
     requiredVersion: 1.27.0
   - range: ">=1.26.0"
-    recommendedVersion: 1.26.7
+    recommendedVersion: 1.26.8
     requiredVersion: 1.26.0
   - range: ">=1.25.0"
-    recommendedVersion: 1.25.12
+    recommendedVersion: 1.25.13
     requiredVersion: 1.25.0
   - range: ">=1.24.0"
-    recommendedVersion: 1.24.16
+    recommendedVersion: 1.24.17
     requiredVersion: 1.24.0
   - range: ">=1.23.0"
     recommendedVersion: 1.23.17
@@ -161,19 +161,19 @@ spec:
   - range: ">=1.27.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.27.0
-    kubernetesVersion: 1.27.4
+    kubernetesVersion: 1.27.5
   - range: ">=1.26.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.26.0
-    kubernetesVersion: 1.26.7
+    kubernetesVersion: 1.26.8
   - range: ">=1.25.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.25.0
-    kubernetesVersion: 1.25.12
+    kubernetesVersion: 1.25.13
   - range: ">=1.24.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.24.0
-    kubernetesVersion: 1.24.16
+    kubernetesVersion: 1.24.17
   - range: ">=1.23.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.23.0


### PR DESCRIPTION
**What this PR does / why we need it**:
following k8s releases yesterday with high CVE fixes, bumping alpha channel.

I'll submit a separate PR to promote to stable soon as well.


**Special notes for your reviewer**:
- https://github.com/kubernetes/kubernetes/releases/tag/v1.24.17
- https://github.com/kubernetes/kubernetes/releases/tag/v1.25.13
- https://github.com/kubernetes/kubernetes/releases/tag/v1.26.8
- https://github.com/kubernetes/kubernetes/releases/tag/v1.27.5