### PR TITLE
Skip UDP LoadBalancer test on k8s 1.26

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -51,14 +51,15 @@ func (t *Tester) setSkipRegexFlag() error {
 
 	skipRegex := skipRegexBase
 
-	if isPre28 {
-		// All the loadbalancer tests in the suite fail on IPv6, however,
-		// they were skipped because they were tagged as [Slow]
-		// skip these tests temporary since they fail always on IPv6
-		// TODO: aojea
-		// https://github.com/kubernetes/kubernetes/issues/113964
+	if k8sVersion.Minor == 26 && cluster.Spec.LegacyCloudProvider == "aws" {
+		// This test was introduced in k8s 1.26
+		// and skipped automatically for AWS clusters as of k8s 1.27
+		// because Classic Load Balancers dont support UDP
+		// https://github.com/kubernetes/kubernetes/pull/113650
+		// https://github.com/kubernetes/kubernetes/pull/115977
 		skipRegex += "|LoadBalancers.should.be.able.to.preserve.UDP.traffic"
-	} else {
+	}
+	if !isPre28 {
 		// K8s 1.28 promoted ProxyTerminatingEndpoints to GA, but it has limited CNI support
 		// https://github.com/kubernetes/kubernetes/pull/117718
 		// https://github.com/cilium/cilium/issues/27358


### PR DESCRIPTION
fixes these e2e jobs:

https://testgrid.k8s.io/kops-distro-amzn2#kops-grid-cilium-amzn2-k26
https://testgrid.k8s.io/kops-distro-amzn2#kops-grid-calico-amzn2-k26
https://testgrid.k8s.io/kops-distro-u2204#kops-grid-cilium-eni-u2204-k26

etc.