### PR TITLE
Automated cherry pick of #15824: Add support for --experimental-allocatable-ignore-eviction

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3717,6 +3717,10 @@ spec:
                     description: Comma-delimited list of grace periods for each soft
                       eviction signal.  For example, 'memory.available=30s'.
                     type: string
+                  experimentalAllocatableIgnoreEviction:
+                    description: ExperimentalAllocatableIgnoreEviction enables ignoring
+                      Hard Eviction Thresholds while calculating Node Allocatable
+                    type: boolean
                   experimentalAllowedUnsafeSysctls:
                     description: ExperimentalAllowedUnsafeSysctls are passed to the
                       kubelet config to whitelist allowable sysctls Was promoted to
@@ -4150,6 +4154,10 @@ spec:
                     description: Comma-delimited list of grace periods for each soft
                       eviction signal.  For example, 'memory.available=30s'.
                     type: string
+                  experimentalAllocatableIgnoreEviction:
+                    description: ExperimentalAllocatableIgnoreEviction enables ignoring
+                      Hard Eviction Thresholds while calculating Node Allocatable
+                    type: boolean
                   experimentalAllowedUnsafeSysctls:
                     description: ExperimentalAllowedUnsafeSysctls are passed to the
                       kubelet config to whitelist allowable sysctls Was promoted to

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -531,6 +531,10 @@ spec:
                     description: Comma-delimited list of grace periods for each soft
                       eviction signal.  For example, 'memory.available=30s'.
                     type: string
+                  experimentalAllocatableIgnoreEviction:
+                    description: ExperimentalAllocatableIgnoreEviction enables ignoring
+                      Hard Eviction Thresholds while calculating Node Allocatable
+                    type: boolean
                   experimentalAllowedUnsafeSysctls:
                     description: ExperimentalAllowedUnsafeSysctls are passed to the
                       kubelet config to whitelist allowable sysctls Was promoted to

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -225,6 +225,8 @@ type KubeletConfigSpec struct {
 	EnableCadvisorJsonEndpoints *bool `json:"enableCadvisorJsonEndpoints,omitempty" flag:"enable-cadvisor-json-endpoints"`
 	// PodPidsLimit is the maximum number of pids in any pod.
 	PodPidsLimit *int64 `json:"podPidsLimit,omitempty" flag:"pod-max-pids"`
+	// ExperimentalAllocatableIgnoreEviction enables ignoring Hard Eviction Thresholds while calculating Node Allocatable
+	ExperimentalAllocatableIgnoreEviction *bool `json:"experimentalAllocatableIgnoreEviction,omitempty" flag:"experimental-allocatable-ignore-eviction"`
 
 	// ShutdownGracePeriod specifies the total duration that the node should delay the shutdown by.
 	// Default: 30s

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -225,6 +225,8 @@ type KubeletConfigSpec struct {
 	EnableCadvisorJsonEndpoints *bool `json:"enableCadvisorJsonEndpoints,omitempty" flag:"enable-cadvisor-json-endpoints"`
 	// PodPidsLimit is the maximum number of pids in any pod.
 	PodPidsLimit *int64 `json:"podPidsLimit,omitempty" flag:"pod-max-pids"`
+	// ExperimentalAllocatableIgnoreEviction enables ignoring Hard Eviction Thresholds while calculating Node Allocatable
+	ExperimentalAllocatableIgnoreEviction *bool `json:"experimentalAllocatableIgnoreEviction,omitempty" flag:"experimental-allocatable-ignore-eviction"`
 
 	// ShutdownGracePeriod specifies the total duration that the node should delay the shutdown by.
 	// Default: 30s

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5389,6 +5389,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.ContainerLogMaxFiles = in.ContainerLogMaxFiles
 	out.EnableCadvisorJsonEndpoints = in.EnableCadvisorJsonEndpoints
 	out.PodPidsLimit = in.PodPidsLimit
+	out.ExperimentalAllocatableIgnoreEviction = in.ExperimentalAllocatableIgnoreEviction
 	out.ShutdownGracePeriod = in.ShutdownGracePeriod
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior
@@ -5489,6 +5490,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.ContainerLogMaxFiles = in.ContainerLogMaxFiles
 	out.EnableCadvisorJsonEndpoints = in.EnableCadvisorJsonEndpoints
 	out.PodPidsLimit = in.PodPidsLimit
+	out.ExperimentalAllocatableIgnoreEviction = in.ExperimentalAllocatableIgnoreEviction
 	out.ShutdownGracePeriod = in.ShutdownGracePeriod
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3929,6 +3929,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ExperimentalAllocatableIgnoreEviction != nil {
+		in, out := &in.ExperimentalAllocatableIgnoreEviction, &out.ExperimentalAllocatableIgnoreEviction
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ShutdownGracePeriod != nil {
 		in, out := &in.ShutdownGracePeriod, &out.ShutdownGracePeriod
 		*out = new(v1.Duration)

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -223,6 +223,8 @@ type KubeletConfigSpec struct {
 	EnableCadvisorJsonEndpoints *bool `json:"enableCadvisorJsonEndpoints,omitempty" flag:"enable-cadvisor-json-endpoints"`
 	// PodPidsLimit is the maximum number of pids in any pod.
 	PodPidsLimit *int64 `json:"podPidsLimit,omitempty" flag:"pod-max-pids"`
+	// ExperimentalAllocatableIgnoreEviction enables ignoring Hard Eviction Thresholds while calculating Node Allocatable
+	ExperimentalAllocatableIgnoreEviction *bool `json:"experimentalAllocatableIgnoreEviction,omitempty" flag:"experimental-allocatable-ignore-eviction"`
 
 	// ShutdownGracePeriod specifies the total duration that the node should delay the shutdown by.
 	// Default: 30s

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5746,6 +5746,7 @@ func autoConvert_v1alpha3_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.ContainerLogMaxFiles = in.ContainerLogMaxFiles
 	out.EnableCadvisorJsonEndpoints = in.EnableCadvisorJsonEndpoints
 	out.PodPidsLimit = in.PodPidsLimit
+	out.ExperimentalAllocatableIgnoreEviction = in.ExperimentalAllocatableIgnoreEviction
 	out.ShutdownGracePeriod = in.ShutdownGracePeriod
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior
@@ -5846,6 +5847,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha3_KubeletConfigSpec(in *kops.K
 	out.ContainerLogMaxFiles = in.ContainerLogMaxFiles
 	out.EnableCadvisorJsonEndpoints = in.EnableCadvisorJsonEndpoints
 	out.PodPidsLimit = in.PodPidsLimit
+	out.ExperimentalAllocatableIgnoreEviction = in.ExperimentalAllocatableIgnoreEviction
 	out.ShutdownGracePeriod = in.ShutdownGracePeriod
 	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
 	out.MemorySwapBehavior = in.MemorySwapBehavior

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3882,6 +3882,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ExperimentalAllocatableIgnoreEviction != nil {
+		in, out := &in.ExperimentalAllocatableIgnoreEviction, &out.ExperimentalAllocatableIgnoreEviction
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ShutdownGracePeriod != nil {
 		in, out := &in.ShutdownGracePeriod, &out.ShutdownGracePeriod
 		*out = new(v1.Duration)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -4061,6 +4061,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ExperimentalAllocatableIgnoreEviction != nil {
+		in, out := &in.ExperimentalAllocatableIgnoreEviction, &out.ExperimentalAllocatableIgnoreEviction
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ShutdownGracePeriod != nil {
 		in, out := &in.ShutdownGracePeriod, &out.ShutdownGracePeriod
 		*out = new(v1.Duration)


### PR DESCRIPTION
Cherry pick of #15824 on release-1.27.

#15824: Add support for --experimental-allocatable-ignore-eviction

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```