### PR TITLE
cleanup: Fix comment on GetExternalNetwork

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -168,7 +168,7 @@ type OpenstackCloud interface {
 	// ListNetworks will return the Neutron networks which match the options
 	ListNetworks(opt networks.ListOptsBuilder) ([]networks.Network, error)
 
-	// ListExternalNetworks will return the Neutron networks with the router:external property
+	// GetExternalNetwork will return the Neutron networks with the router:external property
 	GetExternalNetwork() (*networks.Network, error)
 
 	// GetExternalSubnet will return the subnet for floatingip which is used in external router


### PR DESCRIPTION
Small typo-level fix to match the function name.
