### PR TITLE
Refactor: Replace ForAPIServer with WellKnownServices

### DIFF
--- a/pkg/model/bootstrapscript_test.go
+++ b/pkg/model/bootstrapscript_test.go
@@ -72,7 +72,7 @@ type nodeupConfigBuilder struct {
 	cluster *kops.Cluster
 }
 
-func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, keysets map[string]*fi.Keyset) (*nodeup.Config, *nodeup.BootConfig, error) {
+func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddresses WellKnownAddresses, keysets map[string]*fi.Keyset) (*nodeup.Config, *nodeup.BootConfig, error) {
 	config, bootConfig := nodeup.NewConfig(n.cluster, ig)
 	return config, bootConfig, nil
 }

--- a/pkg/model/hetznermodel/loadbalancer.go
+++ b/pkg/model/hetznermodel/loadbalancer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/wellknownports"
+	"k8s.io/kops/pkg/wellknownservices"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetznertasks"
@@ -63,6 +64,8 @@ func (b *LoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) error
 		Labels: map[string]string{
 			hetzner.TagKubernetesClusterName: b.ClusterName(),
 		},
+
+		WellKnownServices: []wellknownservices.WellKnownService{wellknownservices.KubeAPIServer, wellknownservices.KopsController},
 	}
 
 	c.AddTask(&loadbalancer)

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -1548,7 +1548,7 @@ func createBuilderForCluster(cluster *kops.Cluster, instanceGroups []*kops.Insta
 
 type nodeupConfigBuilder struct{}
 
-func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, keysets map[string]*fi.Keyset) (*nodeup.Config, *nodeup.BootConfig, error) {
+func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddresses model.WellKnownAddresses, keysets map[string]*fi.Keyset) (*nodeup.Config, *nodeup.BootConfig, error) {
 	return &nodeup.Config{}, &nodeup.BootConfig{}, nil
 }
 

--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -5,7 +5,6 @@ AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.2-4
 FloatingIP: null
-ForAPIServer: false
 GroupName: node
 ID: null
 Image: image-node
@@ -76,6 +75,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -5,7 +5,6 @@ AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.2-4
 FloatingIP: null
-ForAPIServer: false
 GroupName: node
 ID: null
 Image: image-node
@@ -75,6 +74,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -5,7 +5,6 @@ AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.2-4
 FloatingIP: null
-ForAPIServer: false
 GroupName: node
 ID: null
 Image: image-node
@@ -75,6 +74,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/configures-allowed-address-pairs-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-allowed-address-pairs-with-annotations.yaml
@@ -5,7 +5,6 @@ AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.2-4
 FloatingIP: null
-ForAPIServer: false
 GroupName: node
 ID: null
 Image: image-node
@@ -77,6 +76,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
@@ -5,7 +5,6 @@ AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.2-4
 FloatingIP: null
-ForAPIServer: false
 GroupName: node
 ID: null
 Image: image-node
@@ -74,6 +73,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -4,59 +4,66 @@ Name: master
 Lifecycle: ""
 Name: node
 ---
-ForAPIServer: true
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-master-1-cluster
+WellKnownServices:
+- kube-apiserver
+- kops-controller
 ---
-ForAPIServer: true
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-master-2-cluster
+WellKnownServices:
+- kube-apiserver
+- kops-controller
 ---
-ForAPIServer: true
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-master-3-cluster
+WellKnownServices:
+- kube-apiserver
+- kops-controller
 ---
-ForAPIServer: false
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-node-1-cluster
+WellKnownServices: null
 ---
-ForAPIServer: false
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-node-2-cluster
+WellKnownServices: null
 ---
-ForAPIServer: false
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-node-3-cluster
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: true
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-master-1-cluster
-ForAPIServer: false
+  WellKnownServices:
+  - kube-apiserver
+  - kops-controller
 GroupName: master
 ID: null
 Image: image
@@ -134,18 +141,20 @@ UserData:
   task:
     Lifecycle: ""
     Name: master
+WellKnownServices: null
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: true
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-master-2-cluster
-ForAPIServer: false
+  WellKnownServices:
+  - kube-apiserver
+  - kops-controller
 GroupName: master
 ID: null
 Image: image
@@ -223,18 +232,20 @@ UserData:
   task:
     Lifecycle: ""
     Name: master
+WellKnownServices: null
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: true
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-master-3-cluster
-ForAPIServer: false
+  WellKnownServices:
+  - kube-apiserver
+  - kops-controller
 GroupName: master
 ID: null
 Image: image
@@ -312,18 +323,18 @@ UserData:
   task:
     Lifecycle: ""
     Name: master
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: false
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-node-1-cluster
-ForAPIServer: false
+  WellKnownServices: null
 GroupName: node
 ID: null
 Image: image
@@ -392,18 +403,18 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: false
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-node-2-cluster
-ForAPIServer: false
+  WellKnownServices: null
 GroupName: node
 ID: null
 Image: image
@@ -472,18 +483,18 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: false
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-node-3-cluster
-ForAPIServer: false
+  WellKnownServices: null
 GroupName: node
 ID: null
 Image: image
@@ -552,6 +563,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -16,7 +16,6 @@ Name: node-b
 Lifecycle: ""
 Name: node-c
 ---
-ForAPIServer: true
 ID: null
 IP: null
 LB:
@@ -37,12 +36,13 @@ LB:
   VipSubnet: null
 Lifecycle: Sync
 Name: fip-api.cluster
+WellKnownServices:
+- kube-apiserver
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-a
 ID: null
 Image: image
@@ -114,12 +114,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-a
+WellKnownServices: null
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-b
 ID: null
 Image: image
@@ -191,12 +191,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-b
+WellKnownServices: null
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-c
 ID: null
 Image: image
@@ -268,12 +268,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-c
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node-a
 ID: null
 Image: image
@@ -342,12 +342,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-a
+WellKnownServices: null
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node-b
 ID: null
 Image: image
@@ -416,12 +416,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-b
+WellKnownServices: null
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node-c
 ID: null
 Image: image
@@ -490,6 +490,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-c
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -16,7 +16,6 @@ Name: node-b
 Lifecycle: ""
 Name: node-c
 ---
-ForAPIServer: false
 ID: null
 IP: null
 LB:
@@ -37,12 +36,13 @@ LB:
   VipSubnet: null
 Lifecycle: Sync
 Name: fip-master-public-name
+WellKnownServices:
+- kube-apiserver
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-a
 ID: null
 Image: image
@@ -114,12 +114,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-a
+WellKnownServices: null
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-b
 ID: null
 Image: image
@@ -191,12 +191,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-b
+WellKnownServices: null
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-c
 ID: null
 Image: image
@@ -268,12 +268,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-c
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node-a
 ID: null
 Image: image
@@ -342,12 +342,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-a
+WellKnownServices: null
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node-b
 ID: null
 Image: image
@@ -416,12 +416,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-b
+WellKnownServices: null
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node-c
 ID: null
 Image: image
@@ -490,6 +490,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-c
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -16,59 +16,66 @@ Name: node-b
 Lifecycle: ""
 Name: node-c
 ---
-ForAPIServer: true
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-master-a-1-cluster
+WellKnownServices:
+- kube-apiserver
+- kops-controller
 ---
-ForAPIServer: true
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-master-b-1-cluster
+WellKnownServices:
+- kube-apiserver
+- kops-controller
 ---
-ForAPIServer: true
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-master-c-1-cluster
+WellKnownServices:
+- kube-apiserver
+- kops-controller
 ---
-ForAPIServer: false
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-node-a-1-cluster
+WellKnownServices: null
 ---
-ForAPIServer: false
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-node-b-1-cluster
+WellKnownServices: null
 ---
-ForAPIServer: false
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-node-c-1-cluster
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: true
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-master-a-1-cluster
-ForAPIServer: false
+  WellKnownServices:
+  - kube-apiserver
+  - kops-controller
 GroupName: master-a
 ID: null
 Image: image
@@ -146,18 +153,20 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-a
+WellKnownServices: null
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: true
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-master-b-1-cluster
-ForAPIServer: false
+  WellKnownServices:
+  - kube-apiserver
+  - kops-controller
 GroupName: master-b
 ID: null
 Image: image
@@ -235,18 +244,20 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-b
+WellKnownServices: null
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: true
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-master-c-1-cluster
-ForAPIServer: false
+  WellKnownServices:
+  - kube-apiserver
+  - kops-controller
 GroupName: master-c
 ID: null
 Image: image
@@ -324,18 +335,18 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-c
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: false
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-node-a-1-cluster
-ForAPIServer: false
+  WellKnownServices: null
 GroupName: node-a
 ID: null
 Image: image
@@ -404,18 +415,18 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-a
+WellKnownServices: null
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: false
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-node-b-1-cluster
-ForAPIServer: false
+  WellKnownServices: null
 GroupName: node-b
 ID: null
 Image: image
@@ -484,18 +495,18 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-b
+WellKnownServices: null
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: false
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-node-c-1-cluster
-ForAPIServer: false
+  WellKnownServices: null
 GroupName: node-c
 ID: null
 Image: image
@@ -564,6 +575,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-c
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -20,7 +20,6 @@ AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-a
 ID: null
 Image: image
@@ -98,12 +97,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-a
+WellKnownServices: null
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-b
 ID: null
 Image: image
@@ -181,12 +180,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-b
+WellKnownServices: null
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-c
 ID: null
 Image: image
@@ -264,12 +263,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-c
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node-a
 ID: null
 Image: image
@@ -338,12 +337,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-a
+WellKnownServices: null
 ---
 AvailabilityZone: zone-2
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node-b
 ID: null
 Image: image
@@ -412,12 +411,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-b
+WellKnownServices: null
 ---
 AvailabilityZone: zone-3
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node-c
 ID: null
 Image: image
@@ -486,6 +485,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-c
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -11,7 +11,6 @@ AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: bastion
 ID: null
 Image: image
@@ -78,12 +77,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: bastion
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master
 ID: null
 Image: image
@@ -161,12 +160,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node
 ID: null
 Image: image
@@ -235,6 +234,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -7,24 +7,23 @@ Name: master
 Lifecycle: ""
 Name: node
 ---
-ForAPIServer: false
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-bastion-1-cluster
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: false
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-bastion-1-cluster
-ForAPIServer: false
+  WellKnownServices: null
 GroupName: bastion
 ID: null
 Image: image
@@ -91,12 +90,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: bastion
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master
 ID: null
 Image: image
@@ -174,12 +173,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node
 ID: null
 Image: image
@@ -248,6 +247,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -8,7 +8,6 @@ AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master
 ID: null
 Image: image-master
@@ -86,12 +85,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.2-4
 FloatingIP: null
-ForAPIServer: false
 GroupName: node
 ID: null
 Image: image-node
@@ -160,6 +159,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -4,31 +4,34 @@ Name: master
 Lifecycle: ""
 Name: node
 ---
-ForAPIServer: true
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-master-1-cluster
+WellKnownServices:
+- kube-apiserver
+- kops-controller
 ---
-ForAPIServer: false
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-node-1-cluster
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: true
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-master-1-cluster
-ForAPIServer: false
+  WellKnownServices:
+  - kube-apiserver
+  - kops-controller
 GroupName: master
 ID: null
 Image: image-master
@@ -106,18 +109,18 @@ UserData:
   task:
     Lifecycle: ""
     Name: master
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.2-4
 FloatingIP:
-  ForAPIServer: false
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-node-1-cluster
-ForAPIServer: false
+  WellKnownServices: null
 GroupName: node
 ID: null
 Image: image-node
@@ -186,6 +189,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/single-zone-setup-3-masters-1-node-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/single-zone-setup-3-masters-1-node-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -10,7 +10,6 @@ Name: master-c
 Lifecycle: ""
 Name: node-a
 ---
-ForAPIServer: true
 ID: null
 IP: null
 LB:
@@ -31,12 +30,13 @@ LB:
   VipSubnet: null
 Lifecycle: Sync
 Name: fip-api.cluster
+WellKnownServices:
+- kube-apiserver
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-a
 ID: null
 Image: image
@@ -110,12 +110,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-a
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-b
 ID: null
 Image: image
@@ -189,12 +189,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-b
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: master-c
 ID: null
 Image: image
@@ -268,12 +268,12 @@ UserData:
   task:
     Lifecycle: ""
     Name: master-c
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP: null
-ForAPIServer: false
 GroupName: node-a
 ID: null
 Image: image
@@ -342,6 +342,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node-a
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
@@ -4,31 +4,34 @@ Name: master
 Lifecycle: ""
 Name: node
 ---
-ForAPIServer: true
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-master-1-tom-software-dev-playground-real33-k8s-local
+WellKnownServices:
+- kube-apiserver
+- kops-controller
 ---
-ForAPIServer: false
 ID: null
 IP: null
 LB: null
 Lifecycle: Sync
 Name: fip-node-1-tom-software-dev-playground-real33-k8s-local
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.1-2
 FloatingIP:
-  ForAPIServer: true
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-master-1-tom-software-dev-playground-real33-k8s-local
-ForAPIServer: false
+  WellKnownServices:
+  - kube-apiserver
+  - kops-controller
 GroupName: master
 ID: null
 Image: image-master
@@ -106,18 +109,18 @@ UserData:
   task:
     Lifecycle: ""
     Name: master
+WellKnownServices: null
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
 Flavor: blc.2-4
 FloatingIP:
-  ForAPIServer: false
   ID: null
   IP: null
   LB: null
   Lifecycle: Sync
   Name: fip-node-1-tom-software-dev-playground-real33-k8s-local
-ForAPIServer: false
+  WellKnownServices: null
 GroupName: node
 ID: null
 Image: image-node
@@ -186,6 +189,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -5,7 +5,6 @@ AvailabilityZone: subnet
 ConfigDrive: false
 Flavor: blc.2-4
 FloatingIP: null
-ForAPIServer: false
 GroupName: node
 ID: null
 Image: image-node
@@ -76,6 +75,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -5,7 +5,6 @@ AvailabilityZone: zone-a
 ConfigDrive: false
 Flavor: blc.2-4
 FloatingIP: null
-ForAPIServer: false
 GroupName: node
 ID: null
 Image: image-node
@@ -76,6 +75,7 @@ UserData:
   task:
     Lifecycle: ""
     Name: node
+WellKnownServices: null
 ---
 Lifecycle: ""
 Name: apiserver-aggregator-ca

--- a/pkg/wellknownservices/wellknownservices.go
+++ b/pkg/wellknownservices/wellknownservices.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wellknownservices
+
+type WellKnownService string
+
+const (
+	// KubeAPIServer is the service where kube-apiserver listens.
+	KubeAPIServer WellKnownService = "kube-apiserver"
+
+	// KopsController is the service where kops-controller listens.
+	KopsController WellKnownService = "kops-controller"
+)

--- a/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
@@ -55,8 +55,9 @@ func (lb *LoadBalancer) CompareWithID() *string {
 	return lb.Name
 }
 
-// IsForAPIServer for api server.
-func (lb *LoadBalancer) IsForAPIServer() bool {
+// GetWellKnownServices implements fi.HasAddress::GetWellKnownServices.
+// It indicates which services we support with this load balancer.
+func (lb *LoadBalancer) GetWellKnownServices() bool {
 	return lb.ForAPIServer
 }
 

--- a/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/wellknownservices"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/hetzner"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
@@ -46,6 +47,10 @@ type LoadBalancer struct {
 	Target   string
 
 	Labels map[string]string
+
+	// WellKnownServices indicates which services are supported by this resource.
+	// This field is internal and is not rendered to the cloud.
+	WellKnownServices []wellknownservices.WellKnownService
 }
 
 var _ fi.CompareWithID = &LoadBalancer{}
@@ -56,8 +61,10 @@ func (v *LoadBalancer) CompareWithID() *string {
 
 var _ fi.HasAddress = &LoadBalancer{}
 
-func (e *LoadBalancer) IsForAPIServer() bool {
-	return true
+// GetWellKnownServices implements fi.HasAddress::GetWellKnownServices.
+// It indicates which services we support with this load balancer.
+func (e *LoadBalancer) GetWellKnownServices() []wellknownservices.WellKnownService {
+	return e.WellKnownServices
 }
 
 func (v *LoadBalancer) FindAddresses(c *fi.CloudupContext) ([]string, error) {

--- a/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
@@ -26,6 +26,7 @@ import (
 	l3floatingip "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/wellknownservices"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/util/pkg/vfs"
@@ -33,12 +34,15 @@ import (
 
 // +kops:fitask
 type FloatingIP struct {
-	Name         *string
-	ID           *string
-	LB           *LB
-	IP           *string
-	Lifecycle    fi.Lifecycle
-	ForAPIServer bool
+	Name      *string
+	ID        *string
+	LB        *LB
+	IP        *string
+	Lifecycle fi.Lifecycle
+
+	// WellKnownServices indicates which services are supported by this resource.
+	// This field is internal and is not rendered to the cloud.
+	WellKnownServices []wellknownservices.WellKnownService
 }
 
 var _ fi.HasAddress = &FloatingIP{}
@@ -73,8 +77,10 @@ func findL3Floating(cloud openstack.OpenstackCloud, opts l3floatingip.ListOpts) 
 	return result, nil
 }
 
-func (e *FloatingIP) IsForAPIServer() bool {
-	return e.ForAPIServer
+// GetWellKnownServices implements fi.HasAddress::GetWellKnownServices.
+// It indicates which services we support with this address.
+func (e *FloatingIP) GetWellKnownServices() []wellknownservices.WellKnownService {
+	return e.WellKnownServices
 }
 
 func (e *FloatingIP) FindAddresses(context *fi.CloudupContext) ([]string, error) {

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -82,7 +82,9 @@ func (s *Port) FindAddresses(context *fi.CloudupContext) ([]string, error) {
 	return addrs, nil
 }
 
-func (s *Port) IsForAPIServer() bool {
+// GetWellKnownServices implements fi.HasAddress::GetWellKnownServices.
+// It indicates which services we support with this load balancer.
+func (s *Port) GetWellKnownServices() bool {
 	return s.ForAPIServer
 }
 

--- a/upup/pkg/fi/cloudup/scalewaytasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/loadbalancer.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/wellknownservices"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/scaleway"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
@@ -45,7 +46,10 @@ type LoadBalancer struct {
 	Tags                  []string
 	Description           string
 	SslCompatibilityLevel string
-	ForAPIServer          bool
+
+	// WellKnownServices indicates which services are supported by this resource.
+	// This field is internal and is not rendered to the cloud.
+	WellKnownServices []wellknownservices.WellKnownService
 }
 
 var _ fi.CompareWithID = &LoadBalancer{}
@@ -55,8 +59,10 @@ func (l *LoadBalancer) CompareWithID() *string {
 	return l.LBID
 }
 
-func (l *LoadBalancer) IsForAPIServer() bool {
-	return l.ForAPIServer
+// GetWellKnownServices implements fi.HasAddress::GetWellKnownServices.
+// It indicates which services we support with this load balancer.
+func (l *LoadBalancer) GetWellKnownServices() []wellknownservices.WellKnownService {
+	return l.WellKnownServices
 }
 
 func (l *LoadBalancer) Find(context *fi.CloudupContext) (*LoadBalancer, error) {
@@ -81,13 +87,13 @@ func (l *LoadBalancer) Find(context *fi.CloudupContext) (*LoadBalancer, error) {
 	}
 
 	return &LoadBalancer{
-		Name:         fi.PtrTo(loadBalancer.Name),
-		LBID:         fi.PtrTo(loadBalancer.ID),
-		Zone:         fi.PtrTo(string(loadBalancer.Zone)),
-		LBAddresses:  lbIPs,
-		Tags:         loadBalancer.Tags,
-		Lifecycle:    l.Lifecycle,
-		ForAPIServer: l.ForAPIServer,
+		Name:              fi.PtrTo(loadBalancer.Name),
+		LBID:              fi.PtrTo(loadBalancer.ID),
+		Zone:              fi.PtrTo(string(loadBalancer.Zone)),
+		LBAddresses:       lbIPs,
+		Tags:              loadBalancer.Tags,
+		Lifecycle:         l.Lifecycle,
+		WellKnownServices: l.WellKnownServices,
 	}, nil
 }
 

--- a/upup/pkg/fi/has_address.go
+++ b/upup/pkg/fi/has_address.go
@@ -16,12 +16,16 @@ limitations under the License.
 
 package fi
 
+import "k8s.io/kops/pkg/wellknownservices"
+
 // HasAddress is implemented by elastic/floating IP addresses in order to include
 // relevant dynamically allocated addresses in the api-server's server TLS certificate.
 type HasAddress interface {
 	Task[CloudupSubContext]
-	// IsForAPIServer indicates whether the implementation provides an address that needs to be added to the api-server server certificate.
-	IsForAPIServer() bool
+
+	// GetWellKnownServices returns the services that are behind this address.
+	GetWellKnownServices() []wellknownservices.WellKnownService
+
 	// FindIPAddress returns the address associated with the implementor.  If there is no address, returns (nil, nil).
 	FindAddresses(context *CloudupContext) ([]string, error)
 }


### PR DESCRIPTION
We instead return a list of the services we are supporting.

We can in future split out internal and external apiserver services.
