### PR TITLE
Automated cherry pick of #15565: etcd-manager: support symlinking versions

### DIFF
--- a/cmd/kops-utils-cp/main.go
+++ b/cmd/kops-utils-cp/main.go
@@ -17,17 +17,18 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/klog/v2"
 )
 
-func copyFile(source, target string) error {
-	klog.Infof("Copying source file %q to target directory %q", source, target)
+func copyFile(source, targetDir string, force bool) error {
+	klog.Infof("Copying source file %q to target directory %q", source, targetDir)
 
 	sf, err := os.Open(source)
 	if err != nil {
@@ -40,42 +41,107 @@ func copyFile(source, target string) error {
 		return fmt.Errorf("unable to stat source file %q: %w", source, err)
 	}
 
-	fn := filepath.Join(target, filepath.Base(source))
-	df, err := os.Create(fn)
+	destPath := filepath.Join(targetDir, filepath.Base(source))
+
+	if force {
+		if err := os.Remove(destPath); err != nil {
+			if os.IsNotExist(err) {
+				// ignore
+			} else {
+				return fmt.Errorf("error removing file %q (for force): %w", destPath, err)
+			}
+		} else {
+			klog.Infof("removed existing file %q (for force)", destPath)
+		}
+	}
+
+	df, err := os.Create(destPath)
 	if err != nil {
-		return fmt.Errorf("unable to create target file %q: %w", fn, err)
+		return fmt.Errorf("unable to create target file %q: %w", destPath, err)
 	}
 	defer df.Close()
 
 	_, err = io.Copy(df, sf)
 	if err != nil {
-		return fmt.Errorf("unable to copy source file %q contents to target file %q: %w", source, fn, err)
+		return fmt.Errorf("unable to copy source file %q contents to target file %q: %w", source, destPath, err)
 	}
 
 	if err := df.Close(); err != nil {
-		return fmt.Errorf("unable to close target file %q: %w", fn, err)
+		return fmt.Errorf("unable to close target file %q: %w", destPath, err)
 	}
-	if err := os.Chmod(fn, fi.Mode()); err != nil {
-		return fmt.Errorf("unable to change mode of target file %q: %w", fn, err)
+	if err := os.Chmod(destPath, fi.Mode()); err != nil {
+		return fmt.Errorf("unable to change mode of target file %q: %w", destPath, err)
 	}
 
 	return nil
 }
 
+func symlinkFile(oldPath, targetDir string, force bool) error {
+	klog.Infof("symlinking source file %q to target directory %q", oldPath, targetDir)
+
+	newPath := filepath.Join(targetDir, filepath.Base(oldPath))
+	if force {
+		if err := os.Remove(newPath); err != nil {
+			if os.IsNotExist(err) {
+				// ignore
+			} else {
+				return fmt.Errorf("error removing file %q (for force): %w", newPath, err)
+			}
+		} else {
+			klog.Infof("removed existing file %q (for force)", newPath)
+		}
+	}
+	if err := os.Symlink(oldPath, newPath); err != nil {
+		return fmt.Errorf("unable to create symlink from %q -> %q: %w", newPath, oldPath, err)
+	}
+
+	return nil
+}
+
+type stringSliceFlags []string
+
+func (f *stringSliceFlags) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *stringSliceFlags) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
 func main() {
-	if len(os.Args) < 3 {
-		log.Fatal("Usage: kops-utils-cp SOURCE ... TARGET")
+	// We force (overwrite existing files), so we can be idempotent in case of restart
+	force := true
+
+	var symlink bool
+	flag.BoolVar(&symlink, "symlink", symlink, "make symbolic link")
+	var targetDirs stringSliceFlags
+	flag.Var(&targetDirs, "target-dir", "copy to directory")
+	var sources stringSliceFlags
+	flag.Var(&sources, "src", "source files to copy")
+
+	flag.Parse()
+
+	if len(sources) == 0 || len(targetDirs) == 0 || len(flag.Args()) != 0 {
+		flag.Usage()
+		os.Exit(1)
 	}
 
-	target := os.Args[len(os.Args)-1]
+	for _, targetDir := range targetDirs {
+		if err := os.MkdirAll(targetDir, 0755); err != nil {
+			klog.Exitf("unable to create target directory %q: %v", targetDir, err)
+		}
 
-	if err := os.MkdirAll(target, 0755); err != nil {
-		klog.Exitf("unable to create target directory %q: %v", target, err)
-	}
-
-	for _, src := range os.Args[1 : len(os.Args)-1] {
-		if err := copyFile(src, target); err != nil {
-			klog.Exitf("unable to copy source file %q to target directory %q: %v", src, target, err)
+		for _, src := range sources {
+			if symlink {
+				if err := symlinkFile(src, targetDir, force); err != nil {
+					klog.Exitf("unable to copy source file %q to target directory %q: %v", src, targetDir, err)
+				}
+			} else {
+				if err := copyFile(src, targetDir, force); err != nil {
+					klog.Exitf("unable to copy source file %q to target directory %q: %v", src, targetDir, err)
+				}
+			}
 		}
 	}
 }

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -218,7 +218,7 @@ spec:
     emptyDir: {}
 `
 
-const kopsUtilsImage = "registry.k8s.io/kops/kops-utils-cp:1.28.0-alpha.1"
+const kopsUtilsImage = "registry.k8s.io/kops/kops-utils-cp:1.27.0"
 
 // buildPod creates the pod spec, based on the EtcdClusterSpec
 func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instanceGroupName string) (*v1.Pod, error) {

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/assets"
@@ -200,18 +201,6 @@ spec:
       name: opt
   hostNetwork: true
   hostPID: true # helps with mounting volumes from inside a container
-  initContainers:
-  - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
-    command:
-    - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.27.0
-    name: kops-utils-cp
-    resources: {}
-    volumeMounts:
-    - mountPath: /opt
-      name: opt
   volumes:
   - hostPath:
       path: /
@@ -228,6 +217,8 @@ spec:
   - name: opt
     emptyDir: {}
 `
+
+const kopsUtilsImage = "registry.k8s.io/kops/kops-utils-cp:1.28.0-alpha.1"
 
 // buildPod creates the pod spec, based on the EtcdClusterSpec
 func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instanceGroupName string) (*v1.Pod, error) {
@@ -256,33 +247,88 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 	}
 
 	{
-		for _, etcdVersion := range etcdSupportedVersions() {
+		utilMounts := []v1.VolumeMount{
+			{
+				MountPath: "/opt",
+				Name:      "opt",
+			},
+		}
+		{
 			initContainer := v1.Container{
-				Name:    "init-etcd-" + strings.ReplaceAll(etcdVersion, ".", "-"),
-				Image:   etcdSupportedImages[etcdVersion],
-				Command: []string{"/opt/bin/kops-utils-cp"},
+				Name:    "kops-utils-cp",
+				Image:   kopsUtilsImage,
+				Command: []string{"/ko-app/kops-utils-cp"},
 				Args: []string{
-					"/usr/local/bin/etcd",
-					"/usr/local/bin/etcdctl",
-					"/opt/etcd-v" + etcdVersion,
+					"--target-dir=/opt/kops-utils/",
+					"--src=/ko-app/kops-utils-cp",
 				},
-				VolumeMounts: []v1.VolumeMount{
-					{
-						MountPath: "/opt",
-						Name:      "opt",
-					},
-				},
+				VolumeMounts: utilMounts,
 			}
 			pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
 		}
 
-		// Remap all init container images via AssetBuilder
-		for i, container := range pod.Spec.InitContainers {
-			remapped, err := b.AssetBuilder.RemapImage(container.Image)
+		symlinkToVersions := sets.NewString()
+		for _, etcdVersion := range etcdSupportedVersions() {
+			if etcdVersion.SymlinkToVersion != "" {
+				symlinkToVersions.Insert(etcdVersion.SymlinkToVersion)
+				continue
+			}
+
+			initContainer := v1.Container{
+				Name:         "init-etcd-" + strings.ReplaceAll(etcdVersion.Version, ".", "-"),
+				Image:        etcdVersion.Image,
+				Command:      []string{"/opt/kops-utils/kops-utils-cp"},
+				VolumeMounts: utilMounts,
+			}
+
+			initContainer.Args = []string{
+				"--target-dir=/opt/etcd-v" + etcdVersion.Version,
+				"--src=/usr/local/bin/etcd",
+				"--src=/usr/local/bin/etcdctl",
+			}
+
+			pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
+		}
+
+		for _, symlinkToVersion := range symlinkToVersions.List() {
+			targetVersions := sets.NewString()
+
+			for _, etcdVersion := range etcdSupportedVersions() {
+				if etcdVersion.SymlinkToVersion == symlinkToVersion {
+					targetVersions.Insert(etcdVersion.Version)
+				}
+			}
+
+			initContainer := v1.Container{
+				Name:         "init-etcd-symlinks-" + strings.ReplaceAll(symlinkToVersion, ".", "-"),
+				Image:        kopsUtilsImage,
+				Command:      []string{"/opt/kops-utils/kops-utils-cp"},
+				VolumeMounts: utilMounts,
+			}
+
+			initContainer.Args = []string{
+				"--symlink",
+			}
+			for _, targetVersion := range targetVersions.List() {
+				initContainer.Args = append(initContainer.Args, "--target-dir=/opt/etcd-v"+targetVersion)
+			}
+			// NOTE: Flags must come before positional arguments
+			initContainer.Args = append(initContainer.Args,
+				"--src=/opt/etcd-v"+symlinkToVersion+"/etcd",
+				"--src=/opt/etcd-v"+symlinkToVersion+"/etcdctl",
+			)
+
+			pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
+		}
+
+		// Remap image via AssetBuilder
+		for i := range pod.Spec.InitContainers {
+			initContainer := &pod.Spec.InitContainers[i]
+			remapped, err := b.AssetBuilder.RemapImage(initContainer.Image)
 			if err != nil {
 				return nil, fmt.Errorf("unable to remap init container image %q: %w", container.Image, err)
 			}
-			pod.Spec.InitContainers[i].Image = remapped
+			initContainer.Image = remapped
 		}
 	}
 

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -109,8 +109,8 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
-      - /ko-app/kops-utils-cp
-      - /opt/bin
+      - --target-dir=/opt/kops-utils/
+      - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -120,11 +120,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
+      - --target-dir=/opt/etcd-v3.2.24
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -132,11 +132,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.10
+      - --target-dir=/opt/etcd-v3.3.10
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.10-0
       name: init-etcd-3-3-10
       resources: {}
@@ -144,11 +144,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
+      - --target-dir=/opt/etcd-v3.3.17
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -156,11 +156,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.4.13
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -168,11 +168,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.3
+      - --target-dir=/opt/etcd-v3.4.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.3-0
       name: init-etcd-3-4-3
       resources: {}
@@ -180,11 +180,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.0
+      - --target-dir=/opt/etcd-v3.5.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.0-0
       name: init-etcd-3-5-0
       resources: {}
@@ -192,11 +192,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.1
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.1-0
       name: init-etcd-3-5-1
       resources: {}
@@ -204,11 +204,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.3
+      - --target-dir=/opt/etcd-v3.5.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.3-0
       name: init-etcd-3-5-3
       resources: {}
@@ -216,11 +216,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.4
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.4-0
       name: init-etcd-3-5-4
       resources: {}
@@ -228,11 +228,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.6
+      - --target-dir=/opt/etcd-v3.5.6
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.6-0
       name: init-etcd-3-5-6
       resources: {}
@@ -240,11 +240,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.7
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.7-0
       name: init-etcd-3-5-7
       resources: {}
@@ -252,11 +252,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
+      - --target-dir=/opt/etcd-v3.5.9
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}
@@ -338,8 +338,8 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
-      - /ko-app/kops-utils-cp
-      - /opt/bin
+      - --target-dir=/opt/kops-utils/
+      - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -349,11 +349,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
+      - --target-dir=/opt/etcd-v3.2.24
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -361,11 +361,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.10
+      - --target-dir=/opt/etcd-v3.3.10
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.10-0
       name: init-etcd-3-3-10
       resources: {}
@@ -373,11 +373,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
+      - --target-dir=/opt/etcd-v3.3.17
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -385,11 +385,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.4.13
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -397,11 +397,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.3
+      - --target-dir=/opt/etcd-v3.4.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.3-0
       name: init-etcd-3-4-3
       resources: {}
@@ -409,11 +409,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.0
+      - --target-dir=/opt/etcd-v3.5.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.0-0
       name: init-etcd-3-5-0
       resources: {}
@@ -421,11 +421,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.1
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.1-0
       name: init-etcd-3-5-1
       resources: {}
@@ -433,11 +433,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.3
+      - --target-dir=/opt/etcd-v3.5.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.3-0
       name: init-etcd-3-5-3
       resources: {}
@@ -445,11 +445,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.4
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.4-0
       name: init-etcd-3-5-4
       resources: {}
@@ -457,11 +457,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.6
+      - --target-dir=/opt/etcd-v3.5.6
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.6-0
       name: init-etcd-3-5-6
       resources: {}
@@ -469,11 +469,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.7
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.7-0
       name: init-etcd-3-5-7
       resources: {}
@@ -481,11 +481,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
+      - --target-dir=/opt/etcd-v3.5.9
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -108,8 +108,8 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
-      - /ko-app/kops-utils-cp
-      - /opt/bin
+      - --target-dir=/opt/kops-utils/
+      - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -119,11 +119,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
+      - --target-dir=/opt/etcd-v3.2.24
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -131,11 +131,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.10
+      - --target-dir=/opt/etcd-v3.3.10
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.10-0
       name: init-etcd-3-3-10
       resources: {}
@@ -143,11 +143,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
+      - --target-dir=/opt/etcd-v3.3.17
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -155,11 +155,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.4.13
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -167,11 +167,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.3
+      - --target-dir=/opt/etcd-v3.4.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.3-0
       name: init-etcd-3-4-3
       resources: {}
@@ -179,11 +179,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.0
+      - --target-dir=/opt/etcd-v3.5.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.0-0
       name: init-etcd-3-5-0
       resources: {}
@@ -191,11 +191,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.1
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.1-0
       name: init-etcd-3-5-1
       resources: {}
@@ -203,11 +203,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.3
+      - --target-dir=/opt/etcd-v3.5.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.3-0
       name: init-etcd-3-5-3
       resources: {}
@@ -215,11 +215,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.4
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.4-0
       name: init-etcd-3-5-4
       resources: {}
@@ -227,11 +227,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.6
+      - --target-dir=/opt/etcd-v3.5.6
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.6-0
       name: init-etcd-3-5-6
       resources: {}
@@ -239,11 +239,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.7
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.7-0
       name: init-etcd-3-5-7
       resources: {}
@@ -251,11 +251,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
+      - --target-dir=/opt/etcd-v3.5.9
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}
@@ -336,8 +336,8 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
-      - /ko-app/kops-utils-cp
-      - /opt/bin
+      - --target-dir=/opt/kops-utils/
+      - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -347,11 +347,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
+      - --target-dir=/opt/etcd-v3.2.24
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -359,11 +359,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.10
+      - --target-dir=/opt/etcd-v3.3.10
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.10-0
       name: init-etcd-3-3-10
       resources: {}
@@ -371,11 +371,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
+      - --target-dir=/opt/etcd-v3.3.17
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -383,11 +383,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.4.13
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -395,11 +395,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.3
+      - --target-dir=/opt/etcd-v3.4.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.3-0
       name: init-etcd-3-4-3
       resources: {}
@@ -407,11 +407,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.0
+      - --target-dir=/opt/etcd-v3.5.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.0-0
       name: init-etcd-3-5-0
       resources: {}
@@ -419,11 +419,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.1
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.1-0
       name: init-etcd-3-5-1
       resources: {}
@@ -431,11 +431,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.3
+      - --target-dir=/opt/etcd-v3.5.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.3-0
       name: init-etcd-3-5-3
       resources: {}
@@ -443,11 +443,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.4
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.4-0
       name: init-etcd-3-5-4
       resources: {}
@@ -455,11 +455,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.6
+      - --target-dir=/opt/etcd-v3.5.6
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.6-0
       name: init-etcd-3-5-6
       resources: {}
@@ -467,11 +467,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.7
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.7-0
       name: init-etcd-3-5-7
       resources: {}
@@ -479,11 +479,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
+      - --target-dir=/opt/etcd-v3.5.9
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -111,8 +111,8 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
-      - /ko-app/kops-utils-cp
-      - /opt/bin
+      - --target-dir=/opt/kops-utils/
+      - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -122,11 +122,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
+      - --target-dir=/opt/etcd-v3.2.24
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -134,11 +134,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.10
+      - --target-dir=/opt/etcd-v3.3.10
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.10-0
       name: init-etcd-3-3-10
       resources: {}
@@ -146,11 +146,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
+      - --target-dir=/opt/etcd-v3.3.17
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -158,11 +158,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.4.13
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -170,11 +170,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.3
+      - --target-dir=/opt/etcd-v3.4.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.3-0
       name: init-etcd-3-4-3
       resources: {}
@@ -182,11 +182,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.0
+      - --target-dir=/opt/etcd-v3.5.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.0-0
       name: init-etcd-3-5-0
       resources: {}
@@ -194,11 +194,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.1
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.1-0
       name: init-etcd-3-5-1
       resources: {}
@@ -206,11 +206,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.3
+      - --target-dir=/opt/etcd-v3.5.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.3-0
       name: init-etcd-3-5-3
       resources: {}
@@ -218,11 +218,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.4
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.4-0
       name: init-etcd-3-5-4
       resources: {}
@@ -230,11 +230,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.6
+      - --target-dir=/opt/etcd-v3.5.6
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.6-0
       name: init-etcd-3-5-6
       resources: {}
@@ -242,11 +242,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.7
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.7-0
       name: init-etcd-3-5-7
       resources: {}
@@ -254,11 +254,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
+      - --target-dir=/opt/etcd-v3.5.9
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}
@@ -342,8 +342,8 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
-      - /ko-app/kops-utils-cp
-      - /opt/bin
+      - --target-dir=/opt/kops-utils/
+      - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -353,11 +353,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
+      - --target-dir=/opt/etcd-v3.2.24
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -365,11 +365,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.10
+      - --target-dir=/opt/etcd-v3.3.10
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.10-0
       name: init-etcd-3-3-10
       resources: {}
@@ -377,11 +377,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
+      - --target-dir=/opt/etcd-v3.3.17
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -389,11 +389,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.4.13
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -401,11 +401,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.3
+      - --target-dir=/opt/etcd-v3.4.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.3-0
       name: init-etcd-3-4-3
       resources: {}
@@ -413,11 +413,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.0
+      - --target-dir=/opt/etcd-v3.5.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.0-0
       name: init-etcd-3-5-0
       resources: {}
@@ -425,11 +425,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.1
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.1-0
       name: init-etcd-3-5-1
       resources: {}
@@ -437,11 +437,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.3
+      - --target-dir=/opt/etcd-v3.5.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.3-0
       name: init-etcd-3-5-3
       resources: {}
@@ -449,11 +449,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.4
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.4-0
       name: init-etcd-3-5-4
       resources: {}
@@ -461,11 +461,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.6
+      - --target-dir=/opt/etcd-v3.5.6
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.6-0
       name: init-etcd-3-5-6
       resources: {}
@@ -473,11 +473,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.7
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.7-0
       name: init-etcd-3-5-7
       resources: {}
@@ -485,11 +485,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
+      - --target-dir=/opt/etcd-v3.5.9
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -117,8 +117,8 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
-      - /ko-app/kops-utils-cp
-      - /opt/bin
+      - --target-dir=/opt/kops-utils/
+      - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -128,11 +128,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
+      - --target-dir=/opt/etcd-v3.2.24
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -140,11 +140,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.10
+      - --target-dir=/opt/etcd-v3.3.10
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.10-0
       name: init-etcd-3-3-10
       resources: {}
@@ -152,11 +152,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
+      - --target-dir=/opt/etcd-v3.3.17
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -164,11 +164,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.4.13
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -176,11 +176,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.3
+      - --target-dir=/opt/etcd-v3.4.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.3-0
       name: init-etcd-3-4-3
       resources: {}
@@ -188,11 +188,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.0
+      - --target-dir=/opt/etcd-v3.5.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.0-0
       name: init-etcd-3-5-0
       resources: {}
@@ -200,11 +200,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.1
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.1-0
       name: init-etcd-3-5-1
       resources: {}
@@ -212,11 +212,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.3
+      - --target-dir=/opt/etcd-v3.5.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.3-0
       name: init-etcd-3-5-3
       resources: {}
@@ -224,11 +224,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.4
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.4-0
       name: init-etcd-3-5-4
       resources: {}
@@ -236,11 +236,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.6
+      - --target-dir=/opt/etcd-v3.5.6
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.6-0
       name: init-etcd-3-5-6
       resources: {}
@@ -248,11 +248,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.7
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.7-0
       name: init-etcd-3-5-7
       resources: {}
@@ -260,11 +260,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
+      - --target-dir=/opt/etcd-v3.5.9
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}
@@ -354,8 +354,8 @@ Contents: |
     hostPID: true
     initContainers:
     - args:
-      - /ko-app/kops-utils-cp
-      - /opt/bin
+      - --target-dir=/opt/kops-utils/
+      - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
       image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -365,11 +365,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.2.24
+      - --target-dir=/opt/etcd-v3.2.24
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.2.24-1
       name: init-etcd-3-2-24
       resources: {}
@@ -377,11 +377,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.10
+      - --target-dir=/opt/etcd-v3.3.10
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.10-0
       name: init-etcd-3-3-10
       resources: {}
@@ -389,11 +389,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.3.17
+      - --target-dir=/opt/etcd-v3.3.17
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.3.17-0
       name: init-etcd-3-3-17
       resources: {}
@@ -401,11 +401,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.13
+      - --target-dir=/opt/etcd-v3.4.13
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.13-0
       name: init-etcd-3-4-13
       resources: {}
@@ -413,11 +413,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.4.3
+      - --target-dir=/opt/etcd-v3.4.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.4.3-0
       name: init-etcd-3-4-3
       resources: {}
@@ -425,11 +425,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.0
+      - --target-dir=/opt/etcd-v3.5.0
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.0-0
       name: init-etcd-3-5-0
       resources: {}
@@ -437,11 +437,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.1
+      - --target-dir=/opt/etcd-v3.5.1
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.1-0
       name: init-etcd-3-5-1
       resources: {}
@@ -449,11 +449,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.3
+      - --target-dir=/opt/etcd-v3.5.3
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.3-0
       name: init-etcd-3-5-3
       resources: {}
@@ -461,11 +461,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.4
+      - --target-dir=/opt/etcd-v3.5.4
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.4-0
       name: init-etcd-3-5-4
       resources: {}
@@ -473,11 +473,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.6
+      - --target-dir=/opt/etcd-v3.5.6
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.6-0
       name: init-etcd-3-5-6
       resources: {}
@@ -485,11 +485,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.7
+      - --target-dir=/opt/etcd-v3.5.7
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.7-0
       name: init-etcd-3-5-7
       resources: {}
@@ -497,11 +497,11 @@ Contents: |
       - mountPath: /opt
         name: opt
     - args:
-      - /usr/local/bin/etcd
-      - /usr/local/bin/etcdctl
-      - /opt/etcd-v3.5.9
+      - --target-dir=/opt/etcd-v3.5.9
+      - --src=/usr/local/bin/etcd
+      - --src=/usr/local/bin/etcdctl
       command:
-      - /opt/bin/kops-utils-cp
+      - /opt/kops-utils/kops-utils-cp
       image: registry.k8s.io/etcd:3.5.9-0
       name: init-etcd-3-5-9
       resources: {}

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -47,8 +47,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -58,11 +58,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +70,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -82,11 +82,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -94,11 +94,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -106,11 +106,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -118,11 +118,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -130,11 +130,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -142,11 +142,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -154,11 +154,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -166,11 +166,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -178,11 +178,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -190,11 +190,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -47,8 +47,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -58,11 +58,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +70,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -82,11 +82,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -94,11 +94,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -106,11 +106,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -118,11 +118,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -130,11 +130,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -142,11 +142,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -154,11 +154,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -166,11 +166,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -178,11 +178,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -190,11 +190,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -47,8 +47,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -58,11 +58,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -70,11 +70,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -82,11 +82,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -94,11 +94,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -106,11 +106,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -118,11 +118,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -130,11 +130,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -142,11 +142,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -154,11 +154,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -166,11 +166,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -178,11 +178,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -190,11 +190,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -46,8 +46,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -57,11 +57,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -69,11 +69,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -81,11 +81,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -93,11 +93,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -105,11 +105,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -117,11 +117,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -129,11 +129,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -141,11 +141,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -153,11 +153,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -165,11 +165,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -177,11 +177,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -189,11 +189,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -46,8 +46,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -57,11 +57,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -69,11 +69,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -81,11 +81,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -93,11 +93,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -105,11 +105,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -117,11 +117,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -129,11 +129,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -141,11 +141,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -153,11 +153,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -165,11 +165,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -177,11 +177,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -189,11 +189,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -48,8 +48,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -59,11 +59,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -71,11 +71,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -83,11 +83,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -95,11 +95,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -107,11 +107,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -119,11 +119,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -131,11 +131,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -143,11 +143,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -155,11 +155,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -167,11 +167,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -179,11 +179,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -191,11 +191,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -48,8 +48,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -59,11 +59,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -71,11 +71,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -83,11 +83,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -95,11 +95,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -107,11 +107,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -119,11 +119,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -131,11 +131,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -143,11 +143,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -155,11 +155,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -167,11 +167,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -179,11 +179,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -191,11 +191,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -45,8 +45,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -56,11 +56,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -68,11 +68,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -80,11 +80,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -92,11 +92,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -104,11 +104,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -116,11 +116,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -128,11 +128,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -140,11 +140,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -152,11 +152,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -164,11 +164,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -176,11 +176,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -188,11 +188,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -44,8 +44,8 @@ spec:
   hostPID: true
   initContainers:
   - args:
-    - /ko-app/kops-utils-cp
-    - /opt/bin
+    - --target-dir=/opt/kops-utils/
+    - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
     image: registry.k8s.io/kops/kops-utils-cp:1.27.0
@@ -55,11 +55,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.2.24
+    - --target-dir=/opt/etcd-v3.2.24
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.2.24-1
     name: init-etcd-3-2-24
     resources: {}
@@ -67,11 +67,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.10
+    - --target-dir=/opt/etcd-v3.3.10
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.10-0
     name: init-etcd-3-3-10
     resources: {}
@@ -79,11 +79,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.3.17
+    - --target-dir=/opt/etcd-v3.3.17
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.3.17-0
     name: init-etcd-3-3-17
     resources: {}
@@ -91,11 +91,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.13
+    - --target-dir=/opt/etcd-v3.4.13
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.13-0
     name: init-etcd-3-4-13
     resources: {}
@@ -103,11 +103,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.4.3
+    - --target-dir=/opt/etcd-v3.4.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.4.3-0
     name: init-etcd-3-4-3
     resources: {}
@@ -115,11 +115,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.0
+    - --target-dir=/opt/etcd-v3.5.0
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.0-0
     name: init-etcd-3-5-0
     resources: {}
@@ -127,11 +127,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.1
+    - --target-dir=/opt/etcd-v3.5.1
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.1-0
     name: init-etcd-3-5-1
     resources: {}
@@ -139,11 +139,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.3
+    - --target-dir=/opt/etcd-v3.5.3
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.3-0
     name: init-etcd-3-5-3
     resources: {}
@@ -151,11 +151,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.4
+    - --target-dir=/opt/etcd-v3.5.4
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.4-0
     name: init-etcd-3-5-4
     resources: {}
@@ -163,11 +163,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.6
+    - --target-dir=/opt/etcd-v3.5.6
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.6-0
     name: init-etcd-3-5-6
     resources: {}
@@ -175,11 +175,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.7
+    - --target-dir=/opt/etcd-v3.5.7
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.7-0
     name: init-etcd-3-5-7
     resources: {}
@@ -187,11 +187,11 @@ spec:
     - mountPath: /opt
       name: opt
   - args:
-    - /usr/local/bin/etcd
-    - /usr/local/bin/etcdctl
-    - /opt/etcd-v3.5.9
+    - --target-dir=/opt/etcd-v3.5.9
+    - --src=/usr/local/bin/etcd
+    - --src=/usr/local/bin/etcdctl
     command:
-    - /opt/bin/kops-utils-cp
+    - /opt/kops-utils/kops-utils-cp
     image: registry.k8s.io/etcd:3.5.9-0
     name: init-etcd-3-5-9
     resources: {}


### PR DESCRIPTION
Cherry pick of #15565 on release-1.27.

#15565: etcd-manager: support symlinking versions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```