### PR TITLE
scaleway: rolling-update feature

### DIFF
--- a/docs/getting_started/scaleway.md
+++ b/docs/getting_started/scaleway.md
@@ -5,7 +5,10 @@
 ## Features
 
 * Create, update and delete clusters
-* Create, edit and delete instance groups 
+  * [Rolling-update](../operations/rolling-update.md)
+* Create, edit and delete instance groups --> Editable fields include but are not limited to:
+  * Instance image
+  * Instance size (also called commercial type)
 * Migrating from single to multi-master
 
 ### Coming soon
@@ -15,7 +18,6 @@
 
 ### Next features to implement
 
-* `kops rolling-update`
 * [Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/scaleway) support
 * BareMetal servers
 

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/sftp v1.13.6
 	github.com/prometheus/client_golang v1.16.0
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.20
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.20.0.20230829075301-d16b548612e4
 	github.com/sergi/go-diff v1.3.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -619,8 +619,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sahilm/fuzzy v0.1.0 h1:FzWGaw2Opqyu+794ZQ9SYifWv2EIXpwP4q8dY1kDAwI=
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.20 h1:a9hSJdJcd16e0HoMsnFvaHvxB3pxSD+SC7+CISp7xY0=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.20/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.20.0.20230829075301-d16b548612e4 h1:yaIT6F5d7vs4MRg+aCaWIO9FAN2kYRy61y0Did8RuSU=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.20.0.20230829075301-d16b548612e4/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -442,7 +442,9 @@ func (c *RollingUpdateCluster) drainTerminateAndWait(u *cloudinstances.CloudInst
 	}
 
 	// GCE often re-uses names, so we delete the node object to prevent the new instance from using the cordoned Node object
-	if c.Cluster.Spec.GetCloudProvider() == api.CloudProviderGCE && !isBastion && !c.CloudOnly {
+	// Scaleway has the same behavior
+	if (c.Cluster.Spec.GetCloudProvider() == api.CloudProviderGCE || c.Cluster.Spec.GetCloudProvider() == api.CloudProviderScaleway) &&
+		!isBastion && !c.CloudOnly {
 		if u.Node == nil {
 			klog.Warningf("no kubernetes Node associated with %s, skipping node deletion", instanceID)
 		} else {
@@ -473,6 +475,7 @@ func (c *RollingUpdateCluster) drainTerminateAndWait(u *cloudinstances.CloudInst
 func (c *RollingUpdateCluster) reconcileInstanceGroup() error {
 	if c.Cluster.Spec.GetCloudProvider() != api.CloudProviderOpenstack &&
 		c.Cluster.Spec.GetCloudProvider() != api.CloudProviderHetzner &&
+		c.Cluster.Spec.GetCloudProvider() != api.CloudProviderScaleway &&
 		c.Cluster.Spec.GetCloudProvider() != api.CloudProviderDO {
 		return nil
 	}

--- a/upup/pkg/fi/cloudup/scalewaytasks/instance.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/instance.go
@@ -450,16 +450,16 @@ func checkUserDataDifferences(c *fi.CloudupContext, cloud scaleway.ScwCloud, act
 		Key:      "cloud-init",
 	}, scw.WithContext(c.Context()))
 	if err != nil {
-		return false, fmt.Errorf("error getting actual user-data: %w", err)
+		return false, fmt.Errorf("getting actual user-data: %w", err)
 	}
 
 	actualUserDataBytes, err := io.ReadAll(actualUserData)
 	if err != nil {
-		return false, fmt.Errorf("error reading actual user-data: %w", err)
+		return false, fmt.Errorf("reading actual user-data: %w", err)
 	}
 	expectedUserDataBytes, err := fi.ResourceAsBytes(*expectedUserData)
 	if err != nil {
-		return false, fmt.Errorf("error reading expected user-data: %w", err)
+		return false, fmt.Errorf("reading expected user-data: %w", err)
 	}
 
 	if sha256.Sum256(actualUserDataBytes) != sha256.Sum256(expectedUserDataBytes) {

--- a/vendor/github.com/scaleway/scaleway-sdk-go/api/domain/v2beta1/domain_sdk.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/api/domain/v2beta1/domain_sdk.go
@@ -581,6 +581,41 @@ func (enum *LanguageCode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+type ListContactsRequestRole string
+
+const (
+	ListContactsRequestRoleUnknownRole = ListContactsRequestRole("unknown_role")
+	// The contact is a domain's owner.
+	ListContactsRequestRoleOwner = ListContactsRequestRole("owner")
+	// The contact is a domain's administrative contact.
+	ListContactsRequestRoleAdministrative = ListContactsRequestRole("administrative")
+	// The contact is a domain's technical contact.
+	ListContactsRequestRoleTechnical = ListContactsRequestRole("technical")
+)
+
+func (enum ListContactsRequestRole) String() string {
+	if enum == "" {
+		// return default value if empty
+		return "unknown_role"
+	}
+	return string(enum)
+}
+
+func (enum ListContactsRequestRole) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, enum)), nil
+}
+
+func (enum *ListContactsRequestRole) UnmarshalJSON(data []byte) error {
+	tmp := ""
+
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	*enum = ListContactsRequestRole(ListContactsRequestRole(tmp).String())
+	return nil
+}
+
 type ListDNSZoneRecordsRequestOrderBy string
 
 const (
@@ -1052,6 +1087,8 @@ const (
 	TaskTypeUpdateHost = TaskType("update_host")
 	// Delete domain's hostname.
 	TaskTypeDeleteHost = TaskType("delete_host")
+	// Move a domain to another project.
+	TaskTypeMoveProject = TaskType("move_project")
 )
 
 func (enum TaskType) String() string {
@@ -3145,6 +3182,10 @@ type RegistrarAPIListContactsRequest struct {
 	ProjectID *string `json:"-"`
 
 	OrganizationID *string `json:"-"`
+	// Role: default value: unknown_role
+	Role ListContactsRequestRole `json:"-"`
+	// EmailStatus: default value: email_status_unknown
+	EmailStatus ContactEmailStatus `json:"-"`
 }
 
 // ListContacts: list contacts.
@@ -3164,6 +3205,8 @@ func (s *RegistrarAPI) ListContacts(req *RegistrarAPIListContactsRequest, opts .
 	parameter.AddToQuery(query, "domain", req.Domain)
 	parameter.AddToQuery(query, "project_id", req.ProjectID)
 	parameter.AddToQuery(query, "organization_id", req.OrganizationID)
+	parameter.AddToQuery(query, "role", req.Role)
+	parameter.AddToQuery(query, "email_status", req.EmailStatus)
 
 	scwReq := &scw.ScalewayRequest{
 		Method:  "GET",

--- a/vendor/github.com/scaleway/scaleway-sdk-go/api/instance/v1/instance_sdk.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/api/instance/v1/instance_sdk.go
@@ -56,6 +56,7 @@ type Arch string
 const (
 	ArchX86_64 = Arch("x86_64")
 	ArchArm    = Arch("arm")
+	ArchArm64  = Arch("arm64")
 )
 
 func (enum Arch) String() string {
@@ -1493,6 +1494,8 @@ type ServerType struct {
 	Network *ServerTypeNetwork `json:"network"`
 	// Capabilities: capabilities.
 	Capabilities *ServerTypeCapabilities `json:"capabilities"`
+	// ScratchStorageMaxSize: maximum available scratch storage.
+	ScratchStorageMaxSize *uint64 `json:"scratch_storage_max_size"`
 }
 
 // ServerTypeCapabilities: server type. capabilities.
@@ -1821,7 +1824,7 @@ type setSnapshotResponse struct {
 
 // Zones list localities the api is available in
 func (s *API) Zones() []scw.Zone {
-	return []scw.Zone{scw.ZoneFrPar1, scw.ZoneFrPar2, scw.ZoneFrPar3, scw.ZoneNlAms1, scw.ZoneNlAms2, scw.ZoneNlAms3, scw.ZonePlWaw1, scw.ZonePlWaw2}
+	return []scw.Zone{scw.ZoneFrPar1, scw.ZoneFrPar2, scw.ZoneFrPar3, scw.ZoneNlAms1, scw.ZoneNlAms2, scw.ZoneNlAms3, scw.ZonePlWaw1, scw.ZonePlWaw2, scw.ZonePlWaw3}
 }
 
 type GetServerTypesAvailabilityRequest struct {
@@ -2077,7 +2080,7 @@ type CreateServerRequest struct {
 	// PublicIP: ID of the reserved IP to attach to the Instance.
 	PublicIP *string `json:"public_ip,omitempty"`
 	// PublicIPs: a list of reserved IP IDs to attach to the Instance.
-	PublicIPs []*string `json:"public_ips,omitempty"`
+	PublicIPs *[]string `json:"public_ips,omitempty"`
 	// BootType: boot type to use.
 	// Default value: local
 	BootType *BootType `json:"boot_type,omitempty"`
@@ -2974,7 +2977,7 @@ type CreateSnapshotRequest struct {
 	// VolumeID: UUID of the volume.
 	VolumeID *string `json:"volume_id,omitempty"`
 	// Tags: tags of the snapshot.
-	Tags []string `json:"tags,omitempty"`
+	Tags *[]string `json:"tags,omitempty"`
 	// Deprecated: Organization: organization ID of the snapshot.
 	// Precisely one of Organization, Project must be set.
 	Organization *string `json:"organization,omitempty"`

--- a/vendor/github.com/scaleway/scaleway-sdk-go/api/lb/v1/lb_sdk.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/api/lb/v1/lb_sdk.go
@@ -1490,13 +1490,13 @@ type ListSubscriberResponse struct {
 type PrivateNetwork struct {
 	// LB: load Balancer object which is attached to the Private Network.
 	LB *LB `json:"lb"`
-	// StaticConfig: object containing an array of a local IP address for the Load Balancer on this Private Network.
+	// Deprecated: StaticConfig: object containing an array of a local IP address for the Load Balancer on this Private Network.
 	// Precisely one of DHCPConfig, IpamConfig, StaticConfig must be set.
 	StaticConfig *PrivateNetworkStaticConfig `json:"static_config,omitempty"`
-	// DHCPConfig: defines whether to let DHCP assign IP addresses.
+	// DHCPConfig: object containing DHCP-assigned IP addresses.
 	// Precisely one of DHCPConfig, IpamConfig, StaticConfig must be set.
 	DHCPConfig *PrivateNetworkDHCPConfig `json:"dhcp_config,omitempty"`
-	// IpamConfig: for internal use only.
+	// Deprecated: IpamConfig: for internal use only.
 	// Precisely one of DHCPConfig, IpamConfig, StaticConfig must be set.
 	IpamConfig *PrivateNetworkIpamConfig `json:"ipam_config,omitempty"`
 	// PrivateNetworkID: private Network ID.
@@ -1511,6 +1511,7 @@ type PrivateNetwork struct {
 }
 
 type PrivateNetworkDHCPConfig struct {
+	IPID *string `json:"ip_id"`
 }
 
 type PrivateNetworkIpamConfig struct {
@@ -1518,8 +1519,8 @@ type PrivateNetworkIpamConfig struct {
 
 // PrivateNetworkStaticConfig: private network. static config.
 type PrivateNetworkStaticConfig struct {
-	// IPAddress: array of a local IP address for the Load Balancer on this Private Network.
-	IPAddress []string `json:"ip_address"`
+	// Deprecated: IPAddress: array of a local IP address for the Load Balancer on this Private Network.
+	IPAddress *[]string `json:"ip_address,omitempty"`
 }
 
 // Route: route.
@@ -4470,13 +4471,13 @@ type ZonedAPIAttachPrivateNetworkRequest struct {
 	LBID string `json:"-"`
 	// PrivateNetworkID: private Network ID.
 	PrivateNetworkID string `json:"-"`
-	// StaticConfig: object containing an array of a local IP address for the Load Balancer on this Private Network.
+	// Deprecated: StaticConfig: object containing an array of a local IP address for the Load Balancer on this Private Network.
 	// Precisely one of DHCPConfig, IpamConfig, StaticConfig must be set.
 	StaticConfig *PrivateNetworkStaticConfig `json:"static_config,omitempty"`
 	// DHCPConfig: defines whether to let DHCP assign IP addresses.
 	// Precisely one of DHCPConfig, IpamConfig, StaticConfig must be set.
 	DHCPConfig *PrivateNetworkDHCPConfig `json:"dhcp_config,omitempty"`
-	// IpamConfig: for internal use only.
+	// Deprecated: IpamConfig: for internal use only.
 	// Precisely one of DHCPConfig, IpamConfig, StaticConfig must be set.
 	IpamConfig *PrivateNetworkIpamConfig `json:"ipam_config,omitempty"`
 }
@@ -7361,13 +7362,13 @@ type AttachPrivateNetworkRequest struct {
 	LBID string `json:"-"`
 	// PrivateNetworkID: private Network ID.
 	PrivateNetworkID string `json:"-"`
-	// StaticConfig: object containing an array of a local IP address for the Load Balancer on this Private Network.
+	// Deprecated: StaticConfig: object containing an array of a local IP address for the Load Balancer on this Private Network.
 	// Precisely one of DHCPConfig, IpamConfig, StaticConfig must be set.
 	StaticConfig *PrivateNetworkStaticConfig `json:"static_config,omitempty"`
 	// DHCPConfig: defines whether to let DHCP assign IP addresses.
 	// Precisely one of DHCPConfig, IpamConfig, StaticConfig must be set.
 	DHCPConfig *PrivateNetworkDHCPConfig `json:"dhcp_config,omitempty"`
-	// IpamConfig: for internal use only.
+	// Deprecated: IpamConfig: for internal use only.
 	// Precisely one of DHCPConfig, IpamConfig, StaticConfig must be set.
 	IpamConfig *PrivateNetworkIpamConfig `json:"ipam_config,omitempty"`
 }

--- a/vendor/github.com/scaleway/scaleway-sdk-go/api/marketplace/v2/marketplace_sdk.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/api/marketplace/v2/marketplace_sdk.go
@@ -1,0 +1,645 @@
+// This file was automatically generated. DO NOT EDIT.
+// If you have any remark or suggestion do not hesitate to open an issue.
+
+// Package marketplace provides methods and message types of the marketplace v2 API.
+package marketplace
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/scaleway/scaleway-sdk-go/internal/errors"
+	"github.com/scaleway/scaleway-sdk-go/internal/marshaler"
+	"github.com/scaleway/scaleway-sdk-go/internal/parameter"
+	"github.com/scaleway/scaleway-sdk-go/namegenerator"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+// always import dependencies
+var (
+	_ fmt.Stringer
+	_ json.Unmarshaler
+	_ url.URL
+	_ net.IP
+	_ http.Header
+	_ bytes.Reader
+	_ time.Time
+	_ = strings.Join
+
+	_ scw.ScalewayRequest
+	_ marshaler.Duration
+	_ scw.File
+	_ = parameter.AddToQuery
+	_ = namegenerator.GetRandomName
+)
+
+// API: marketplace API.
+type API struct {
+	client *scw.Client
+}
+
+// NewAPI returns a API object from a Scaleway client.
+func NewAPI(client *scw.Client) *API {
+	return &API{
+		client: client,
+	}
+}
+
+type ListImagesRequestOrderBy string
+
+const (
+	ListImagesRequestOrderByNameAsc       = ListImagesRequestOrderBy("name_asc")
+	ListImagesRequestOrderByNameDesc      = ListImagesRequestOrderBy("name_desc")
+	ListImagesRequestOrderByCreatedAtAsc  = ListImagesRequestOrderBy("created_at_asc")
+	ListImagesRequestOrderByCreatedAtDesc = ListImagesRequestOrderBy("created_at_desc")
+	ListImagesRequestOrderByUpdatedAtAsc  = ListImagesRequestOrderBy("updated_at_asc")
+	ListImagesRequestOrderByUpdatedAtDesc = ListImagesRequestOrderBy("updated_at_desc")
+)
+
+func (enum ListImagesRequestOrderBy) String() string {
+	if enum == "" {
+		// return default value if empty
+		return "name_asc"
+	}
+	return string(enum)
+}
+
+func (enum ListImagesRequestOrderBy) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, enum)), nil
+}
+
+func (enum *ListImagesRequestOrderBy) UnmarshalJSON(data []byte) error {
+	tmp := ""
+
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	*enum = ListImagesRequestOrderBy(ListImagesRequestOrderBy(tmp).String())
+	return nil
+}
+
+type ListLocalImagesRequestOrderBy string
+
+const (
+	ListLocalImagesRequestOrderByCreatedAtAsc  = ListLocalImagesRequestOrderBy("created_at_asc")
+	ListLocalImagesRequestOrderByCreatedAtDesc = ListLocalImagesRequestOrderBy("created_at_desc")
+)
+
+func (enum ListLocalImagesRequestOrderBy) String() string {
+	if enum == "" {
+		// return default value if empty
+		return "created_at_asc"
+	}
+	return string(enum)
+}
+
+func (enum ListLocalImagesRequestOrderBy) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, enum)), nil
+}
+
+func (enum *ListLocalImagesRequestOrderBy) UnmarshalJSON(data []byte) error {
+	tmp := ""
+
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	*enum = ListLocalImagesRequestOrderBy(ListLocalImagesRequestOrderBy(tmp).String())
+	return nil
+}
+
+type ListVersionsRequestOrderBy string
+
+const (
+	ListVersionsRequestOrderByCreatedAtAsc  = ListVersionsRequestOrderBy("created_at_asc")
+	ListVersionsRequestOrderByCreatedAtDesc = ListVersionsRequestOrderBy("created_at_desc")
+)
+
+func (enum ListVersionsRequestOrderBy) String() string {
+	if enum == "" {
+		// return default value if empty
+		return "created_at_asc"
+	}
+	return string(enum)
+}
+
+func (enum ListVersionsRequestOrderBy) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, enum)), nil
+}
+
+func (enum *ListVersionsRequestOrderBy) UnmarshalJSON(data []byte) error {
+	tmp := ""
+
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	*enum = ListVersionsRequestOrderBy(ListVersionsRequestOrderBy(tmp).String())
+	return nil
+}
+
+type LocalImageType string
+
+const (
+	// Unspecified image type
+	LocalImageTypeUnknownType = LocalImageType("unknown_type")
+	// An image type that can be used to create volumes which are managed via the Instance API.
+	LocalImageTypeInstanceLocal = LocalImageType("instance_local")
+	// An image type that can be used to create volumes which are managed via the Scaleway Block Storage (SBS) API.
+	LocalImageTypeInstanceSbs = LocalImageType("instance_sbs")
+)
+
+func (enum LocalImageType) String() string {
+	if enum == "" {
+		// return default value if empty
+		return "unknown_type"
+	}
+	return string(enum)
+}
+
+func (enum LocalImageType) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, enum)), nil
+}
+
+func (enum *LocalImageType) UnmarshalJSON(data []byte) error {
+	tmp := ""
+
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	*enum = LocalImageType(LocalImageType(tmp).String())
+	return nil
+}
+
+type Category struct {
+	ID string `json:"id"`
+
+	Name string `json:"name"`
+
+	Description string `json:"description"`
+}
+
+// Image: image.
+type Image struct {
+	// ID: UUID of this image.
+	ID string `json:"id"`
+	// Name: name of the image.
+	Name string `json:"name"`
+	// Description: text description of this image.
+	Description string `json:"description"`
+	// Logo: URL of this image's logo.
+	Logo string `json:"logo"`
+	// Categories: list of categories this image belongs to.
+	Categories []string `json:"categories"`
+	// CreatedAt: creation date of this image.
+	CreatedAt *time.Time `json:"created_at"`
+	// UpdatedAt: date of the last modification of this image.
+	UpdatedAt *time.Time `json:"updated_at"`
+	// ValidUntil: expiration date of this image.
+	ValidUntil *time.Time `json:"valid_until"`
+	// Label: label of this image.
+	// Typically an identifier for a distribution (ex. "ubuntu_focal").
+	Label string `json:"label"`
+}
+
+type ListCategoriesResponse struct {
+	Categories []*Category `json:"categories"`
+
+	TotalCount uint32 `json:"total_count"`
+}
+
+type ListImagesResponse struct {
+	Images []*Image `json:"images"`
+
+	TotalCount uint32 `json:"total_count"`
+}
+
+type ListLocalImagesResponse struct {
+	LocalImages []*LocalImage `json:"local_images"`
+
+	TotalCount uint32 `json:"total_count"`
+}
+
+type ListVersionsResponse struct {
+	Versions []*Version `json:"versions"`
+
+	TotalCount uint32 `json:"total_count"`
+}
+
+// LocalImage: local image.
+type LocalImage struct {
+	// ID: UUID of this local image.
+	// Version you will typically use to define an image in an API call.
+	ID string `json:"id"`
+	// CompatibleCommercialTypes: list of all commercial types that are compatible with this local image.
+	CompatibleCommercialTypes []string `json:"compatible_commercial_types"`
+	// Arch: supported architecture for this local image.
+	Arch string `json:"arch"`
+	// Zone: availability Zone where this local image is available.
+	Zone scw.Zone `json:"zone"`
+	// Label: image label this image belongs to.
+	Label string `json:"label"`
+	// Type: type of this local image.
+	// Default value: unknown_type
+	Type LocalImageType `json:"type"`
+}
+
+// Version: version.
+type Version struct {
+	// ID: UUID of this version.
+	ID string `json:"id"`
+	// Name: name of this version.
+	Name string `json:"name"`
+	// CreatedAt: creation date of this image version.
+	CreatedAt *time.Time `json:"created_at"`
+	// UpdatedAt: date of the last modification of this version.
+	UpdatedAt *time.Time `json:"updated_at"`
+	// PublishedAt: date this version was officially published.
+	PublishedAt *time.Time `json:"published_at"`
+}
+
+// Service API
+
+type ListImagesRequest struct {
+	// PageSize: a positive integer lower or equal to 100 to select the number of items to display.
+	PageSize *uint32 `json:"-"`
+	// Page: a positive integer to choose the page to display.
+	Page *int32 `json:"-"`
+	// OrderBy: ordering to use.
+	// Default value: name_asc
+	OrderBy ListImagesRequestOrderBy `json:"-"`
+	// Arch: choose for which machine architecture to return images.
+	Arch *string `json:"-"`
+	// Category: choose the category of images to get.
+	Category *string `json:"-"`
+	// IncludeEol: choose to include end-of-life images.
+	IncludeEol bool `json:"-"`
+}
+
+// ListImages: list marketplace images.
+// List all available images on the marketplace, their UUID, CPU architecture and description.
+func (s *API) ListImages(req *ListImagesRequest, opts ...scw.RequestOption) (*ListImagesResponse, error) {
+	var err error
+
+	defaultPageSize, exist := s.client.GetDefaultPageSize()
+	if (req.PageSize == nil || *req.PageSize == 0) && exist {
+		req.PageSize = &defaultPageSize
+	}
+
+	query := url.Values{}
+	parameter.AddToQuery(query, "page_size", req.PageSize)
+	parameter.AddToQuery(query, "page", req.Page)
+	parameter.AddToQuery(query, "order_by", req.OrderBy)
+	parameter.AddToQuery(query, "arch", req.Arch)
+	parameter.AddToQuery(query, "category", req.Category)
+	parameter.AddToQuery(query, "include_eol", req.IncludeEol)
+
+	scwReq := &scw.ScalewayRequest{
+		Method:  "GET",
+		Path:    "/marketplace/v2/images",
+		Query:   query,
+		Headers: http.Header{},
+	}
+
+	var resp ListImagesResponse
+
+	err = s.client.Do(scwReq, &resp, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+type GetImageRequest struct {
+	// ImageID: display the image name.
+	ImageID string `json:"-"`
+}
+
+// GetImage: get a specific marketplace image.
+// Get detailed information about a marketplace image, specified by its `image_id` (UUID format).
+func (s *API) GetImage(req *GetImageRequest, opts ...scw.RequestOption) (*Image, error) {
+	var err error
+
+	if fmt.Sprint(req.ImageID) == "" {
+		return nil, errors.New("field ImageID cannot be empty in request")
+	}
+
+	scwReq := &scw.ScalewayRequest{
+		Method:  "GET",
+		Path:    "/marketplace/v2/images/" + fmt.Sprint(req.ImageID) + "",
+		Headers: http.Header{},
+	}
+
+	var resp Image
+
+	err = s.client.Do(scwReq, &resp, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+type ListVersionsRequest struct {
+	ImageID string `json:"-"`
+
+	PageSize *uint32 `json:"-"`
+
+	Page *int32 `json:"-"`
+	// OrderBy: default value: created_at_asc
+	OrderBy ListVersionsRequestOrderBy `json:"-"`
+}
+
+// ListVersions: list versions of an Image.
+// Get a list of all available version of an image, specified by its `image_id` (UUID format).
+func (s *API) ListVersions(req *ListVersionsRequest, opts ...scw.RequestOption) (*ListVersionsResponse, error) {
+	var err error
+
+	defaultPageSize, exist := s.client.GetDefaultPageSize()
+	if (req.PageSize == nil || *req.PageSize == 0) && exist {
+		req.PageSize = &defaultPageSize
+	}
+
+	query := url.Values{}
+	parameter.AddToQuery(query, "image_id", req.ImageID)
+	parameter.AddToQuery(query, "page_size", req.PageSize)
+	parameter.AddToQuery(query, "page", req.Page)
+	parameter.AddToQuery(query, "order_by", req.OrderBy)
+
+	scwReq := &scw.ScalewayRequest{
+		Method:  "GET",
+		Path:    "/marketplace/v2/versions",
+		Query:   query,
+		Headers: http.Header{},
+	}
+
+	var resp ListVersionsResponse
+
+	err = s.client.Do(scwReq, &resp, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+type GetVersionRequest struct {
+	VersionID string `json:"-"`
+}
+
+// GetVersion: get a specific image version.
+// Get information such as the name, creation date, last update and published date for an image version specified by its `version_id` (UUID format).
+func (s *API) GetVersion(req *GetVersionRequest, opts ...scw.RequestOption) (*Version, error) {
+	var err error
+
+	if fmt.Sprint(req.VersionID) == "" {
+		return nil, errors.New("field VersionID cannot be empty in request")
+	}
+
+	scwReq := &scw.ScalewayRequest{
+		Method:  "GET",
+		Path:    "/marketplace/v2/versions/" + fmt.Sprint(req.VersionID) + "",
+		Headers: http.Header{},
+	}
+
+	var resp Version
+
+	err = s.client.Do(scwReq, &resp, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+type ListLocalImagesRequest struct {
+	ImageID *string `json:"-"`
+
+	VersionID *string `json:"-"`
+
+	PageSize *uint32 `json:"-"`
+
+	Page *int32 `json:"-"`
+	// OrderBy: default value: created_at_asc
+	OrderBy ListLocalImagesRequestOrderBy `json:"-"`
+
+	ImageLabel *string `json:"-"`
+
+	Zone *scw.Zone `json:"-"`
+	// Type: default value: unknown_type
+	Type LocalImageType `json:"-"`
+}
+
+// ListLocalImages: list local images from a specific image or version.
+// List information about local images in a specific Availability Zone, specified by its `image_id` (UUID format), `version_id` (UUID format) or `image_label`. Only one of these three parameters may be set.
+func (s *API) ListLocalImages(req *ListLocalImagesRequest, opts ...scw.RequestOption) (*ListLocalImagesResponse, error) {
+	var err error
+
+	defaultZone, exist := s.client.GetDefaultZone()
+	if (req.Zone == nil || *req.Zone == "") && exist {
+		req.Zone = &defaultZone
+	}
+
+	defaultPageSize, exist := s.client.GetDefaultPageSize()
+	if (req.PageSize == nil || *req.PageSize == 0) && exist {
+		req.PageSize = &defaultPageSize
+	}
+
+	query := url.Values{}
+	parameter.AddToQuery(query, "image_id", req.ImageID)
+	parameter.AddToQuery(query, "version_id", req.VersionID)
+	parameter.AddToQuery(query, "page_size", req.PageSize)
+	parameter.AddToQuery(query, "page", req.Page)
+	parameter.AddToQuery(query, "order_by", req.OrderBy)
+	parameter.AddToQuery(query, "image_label", req.ImageLabel)
+	parameter.AddToQuery(query, "zone", req.Zone)
+	parameter.AddToQuery(query, "type", req.Type)
+
+	scwReq := &scw.ScalewayRequest{
+		Method:  "GET",
+		Path:    "/marketplace/v2/local-images",
+		Query:   query,
+		Headers: http.Header{},
+	}
+
+	var resp ListLocalImagesResponse
+
+	err = s.client.Do(scwReq, &resp, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+type GetLocalImageRequest struct {
+	LocalImageID string `json:"-"`
+}
+
+// GetLocalImage: get a specific local image by ID.
+// Get detailed information about a local image, including compatible commercial types, supported architecture, labels and the Availability Zone of the image, specified by its `local_image_id` (UUID format).
+func (s *API) GetLocalImage(req *GetLocalImageRequest, opts ...scw.RequestOption) (*LocalImage, error) {
+	var err error
+
+	if fmt.Sprint(req.LocalImageID) == "" {
+		return nil, errors.New("field LocalImageID cannot be empty in request")
+	}
+
+	scwReq := &scw.ScalewayRequest{
+		Method:  "GET",
+		Path:    "/marketplace/v2/local-images/" + fmt.Sprint(req.LocalImageID) + "",
+		Headers: http.Header{},
+	}
+
+	var resp LocalImage
+
+	err = s.client.Do(scwReq, &resp, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+type ListCategoriesRequest struct {
+	PageSize *uint32 `json:"-"`
+
+	Page *int32 `json:"-"`
+}
+
+// ListCategories: list existing image categories.
+// Get a list of all existing categories. The output can be paginated.
+func (s *API) ListCategories(req *ListCategoriesRequest, opts ...scw.RequestOption) (*ListCategoriesResponse, error) {
+	var err error
+
+	defaultPageSize, exist := s.client.GetDefaultPageSize()
+	if (req.PageSize == nil || *req.PageSize == 0) && exist {
+		req.PageSize = &defaultPageSize
+	}
+
+	query := url.Values{}
+	parameter.AddToQuery(query, "page_size", req.PageSize)
+	parameter.AddToQuery(query, "page", req.Page)
+
+	scwReq := &scw.ScalewayRequest{
+		Method:  "GET",
+		Path:    "/marketplace/v2/categories",
+		Query:   query,
+		Headers: http.Header{},
+	}
+
+	var resp ListCategoriesResponse
+
+	err = s.client.Do(scwReq, &resp, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+type GetCategoryRequest struct {
+	CategoryID string `json:"-"`
+}
+
+// GetCategory: get a specific category.
+// Get information about a specific category of the marketplace catalog, specified by its `category_id` (UUID format).
+func (s *API) GetCategory(req *GetCategoryRequest, opts ...scw.RequestOption) (*Category, error) {
+	var err error
+
+	if fmt.Sprint(req.CategoryID) == "" {
+		return nil, errors.New("field CategoryID cannot be empty in request")
+	}
+
+	scwReq := &scw.ScalewayRequest{
+		Method:  "GET",
+		Path:    "/marketplace/v2/categories/" + fmt.Sprint(req.CategoryID) + "",
+		Headers: http.Header{},
+	}
+
+	var resp Category
+
+	err = s.client.Do(scwReq, &resp, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UnsafeGetTotalCount should not be used
+// Internal usage only
+func (r *ListImagesResponse) UnsafeGetTotalCount() uint32 {
+	return r.TotalCount
+}
+
+// UnsafeAppend should not be used
+// Internal usage only
+func (r *ListImagesResponse) UnsafeAppend(res interface{}) (uint32, error) {
+	results, ok := res.(*ListImagesResponse)
+	if !ok {
+		return 0, errors.New("%T type cannot be appended to type %T", res, r)
+	}
+
+	r.Images = append(r.Images, results.Images...)
+	r.TotalCount += uint32(len(results.Images))
+	return uint32(len(results.Images)), nil
+}
+
+// UnsafeGetTotalCount should not be used
+// Internal usage only
+func (r *ListVersionsResponse) UnsafeGetTotalCount() uint32 {
+	return r.TotalCount
+}
+
+// UnsafeAppend should not be used
+// Internal usage only
+func (r *ListVersionsResponse) UnsafeAppend(res interface{}) (uint32, error) {
+	results, ok := res.(*ListVersionsResponse)
+	if !ok {
+		return 0, errors.New("%T type cannot be appended to type %T", res, r)
+	}
+
+	r.Versions = append(r.Versions, results.Versions...)
+	r.TotalCount += uint32(len(results.Versions))
+	return uint32(len(results.Versions)), nil
+}
+
+// UnsafeGetTotalCount should not be used
+// Internal usage only
+func (r *ListLocalImagesResponse) UnsafeGetTotalCount() uint32 {
+	return r.TotalCount
+}
+
+// UnsafeAppend should not be used
+// Internal usage only
+func (r *ListLocalImagesResponse) UnsafeAppend(res interface{}) (uint32, error) {
+	results, ok := res.(*ListLocalImagesResponse)
+	if !ok {
+		return 0, errors.New("%T type cannot be appended to type %T", res, r)
+	}
+
+	r.LocalImages = append(r.LocalImages, results.LocalImages...)
+	r.TotalCount += uint32(len(results.LocalImages))
+	return uint32(len(results.LocalImages)), nil
+}
+
+// UnsafeGetTotalCount should not be used
+// Internal usage only
+func (r *ListCategoriesResponse) UnsafeGetTotalCount() uint32 {
+	return r.TotalCount
+}
+
+// UnsafeAppend should not be used
+// Internal usage only
+func (r *ListCategoriesResponse) UnsafeAppend(res interface{}) (uint32, error) {
+	results, ok := res.(*ListCategoriesResponse)
+	if !ok {
+		return 0, errors.New("%T type cannot be appended to type %T", res, r)
+	}
+
+	r.Categories = append(r.Categories, results.Categories...)
+	r.TotalCount += uint32(len(results.Categories))
+	return uint32(len(results.Categories)), nil
+}

--- a/vendor/github.com/scaleway/scaleway-sdk-go/api/marketplace/v2/marketplace_utils.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/api/marketplace/v2/marketplace_utils.go
@@ -1,0 +1,85 @@
+package marketplace
+
+import (
+	"strings"
+
+	"github.com/scaleway/scaleway-sdk-go/internal/errors"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+// FindByLabel returns the first image with the given label in the image list
+// Cannot find an image if it is not in the ListImagesResponse struct
+// Use scw.WithAllPages when listing image to get all images
+func (r *ListImagesResponse) FindByLabel(label string) *Image {
+	for _, image := range r.Images {
+		if image.Label == label {
+			return image
+		}
+	}
+	return nil
+}
+
+type GetImageByLabelRequest struct {
+	Label string
+}
+
+// GetImageByLabel returns the image with the given label
+func (s *API) GetImageByLabel(req *GetImageByLabelRequest, opts ...scw.RequestOption) (*Image, error) {
+	listImagesRequest := &ListImagesRequest{}
+	opts = append(opts, scw.WithAllPages())
+
+	listImagesResponse, err := s.ListImages(listImagesRequest, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	image := listImagesResponse.FindByLabel(req.Label)
+	if image == nil {
+		return nil, errors.New("couldn't find a matching image for the given label (%s)", req.Label)
+	}
+
+	return image, nil
+}
+
+type GetLocalImageByLabelRequest struct {
+	ImageLabel     string
+	Zone           scw.Zone
+	CommercialType string
+	Type           LocalImageType
+}
+
+// GetLocalImageByLabel returns the local image for the given image label in the given zone and compatible with given commercial type
+func (s *API) GetLocalImageByLabel(req *GetLocalImageByLabelRequest, opts ...scw.RequestOption) (*LocalImage, error) {
+	if req.Zone == "" {
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
+	}
+	req.CommercialType = strings.ToUpper(req.CommercialType)
+
+	resp, err := s.ListLocalImages(&ListLocalImagesRequest{
+		ImageLabel: scw.StringPtr(req.ImageLabel),
+		Zone:       &req.Zone,
+		Type:       req.Type,
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+	for _, localImage := range resp.LocalImages {
+		if localImage.IsCompatible(req.CommercialType) {
+			return localImage, nil
+		}
+	}
+
+	return nil, errors.New("couldn't find a local image for the given zone (%s) and commercial type (%s)", req.Zone, req.CommercialType)
+}
+
+// IsCompatible returns true if a local image is compatible with the given instance type
+// commercialType should be an uppercase string ex: DEV1-S
+func (li *LocalImage) IsCompatible(commercialType string) bool {
+	for _, compatibleCommercialType := range li.CompatibleCommercialTypes {
+		if compatibleCommercialType == commercialType {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/scaleway/scaleway-sdk-go/scw/locality.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/scw/locality.go
@@ -33,6 +33,8 @@ const (
 	ZonePlWaw1 = Zone("pl-waw-1")
 	// ZonePlWaw2 represents the pl-waw-2 zone
 	ZonePlWaw2 = Zone("pl-waw-2")
+	// ZonePlWaw3 represents the pl-waw-3 zone
+	ZonePlWaw3 = Zone("pl-waw-3")
 )
 
 var (
@@ -46,6 +48,7 @@ var (
 		ZoneNlAms3,
 		ZonePlWaw1,
 		ZonePlWaw2,
+		ZonePlWaw3,
 	}
 )
 
@@ -114,7 +117,7 @@ func (region Region) GetZones() []Zone {
 	case RegionNlAms:
 		return []Zone{ZoneNlAms1, ZoneNlAms2, ZoneNlAms3}
 	case RegionPlWaw:
-		return []Zone{ZonePlWaw1, ZonePlWaw2}
+		return []Zone{ZonePlWaw1, ZonePlWaw2, ZonePlWaw3}
 	default:
 		return []Zone{}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -774,13 +774,14 @@ github.com/russross/blackfriday/v2
 # github.com/sahilm/fuzzy v0.1.0
 ## explicit
 github.com/sahilm/fuzzy
-# github.com/scaleway/scaleway-sdk-go v1.0.0-beta.20
+# github.com/scaleway/scaleway-sdk-go v1.0.0-beta.20.0.20230829075301-d16b548612e4
 ## explicit; go 1.17
 github.com/scaleway/scaleway-sdk-go/api/domain/v2beta1
 github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1
 github.com/scaleway/scaleway-sdk-go/api/instance/v1
 github.com/scaleway/scaleway-sdk-go/api/lb/v1
 github.com/scaleway/scaleway-sdk-go/api/marketplace/v1
+github.com/scaleway/scaleway-sdk-go/api/marketplace/v2
 github.com/scaleway/scaleway-sdk-go/internal/async
 github.com/scaleway/scaleway-sdk-go/internal/auth
 github.com/scaleway/scaleway-sdk-go/internal/errors


### PR DESCRIPTION
This PR adds the possibility to edit the image and the size of the instances on a live cluster by performing a rolling-update.

This feature will also be useful for the Terraform support that's coming up next.