### PR TITLE
Automated cherry pick of #14991: Allow custom service account issuer without public bucket

### DIFF
--- a/pkg/model/issuerdiscovery.go
+++ b/pkg/model/issuerdiscovery.go
@@ -87,13 +87,22 @@ func (b *IssuerDiscoveryModelBuilder) Build(c *fi.CloudupModelBuilderContext) er
 
 	switch discoveryStore := discoveryStore.(type) {
 	case *vfs.S3Path:
-		isPublic, err := discoveryStore.IsBucketPublic(ctx)
+		discoveryStoreURL, err := discoveryStore.GetHTTPsUrl(b.Cluster.Spec.IsIPv6Only())
 		if err != nil {
-			return fmt.Errorf("checking if bucket was public: %w", err)
+			return err
 		}
-		if !isPublic {
-			klog.Infof("serviceAccountIssuers bucket %q is not public; will use object ACL", discoveryStore.Bucket())
-			publicFileACL = fi.PtrTo(true)
+		if discoveryStoreURL == fi.ValueOf(b.Cluster.Spec.KubeAPIServer.ServiceAccountIssuer) {
+			// Using Amazon S3 static website hosting requires public access
+			isPublic, err := discoveryStore.IsBucketPublic(ctx)
+			if err != nil {
+				return fmt.Errorf("checking if bucket was public: %w", err)
+			}
+			if !isPublic {
+				klog.Infof("serviceAccountIssuers bucket %q is not public; will use object ACL", discoveryStore.Bucket())
+				publicFileACL = fi.PtrTo(true)
+			}
+		} else {
+			klog.Infof("using user managed serviceAccountIssuers")
 		}
 
 	case *vfs.MemFSPath:


### PR DESCRIPTION
Cherry pick of #14991 on release-1.27.

#14991: Allow custom service account issuer without public bucket

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```