### PR TITLE
Fix warmpool to expose dependencies for dependency analysis

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -93,9 +93,10 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 
 			enabled := fi.PtrTo(warmPool.IsEnabled())
 			warmPoolTask := &awstasks.WarmPool{
-				Name:      &name,
-				Lifecycle: b.Lifecycle,
-				Enabled:   enabled,
+				Name:             &name,
+				Lifecycle:        b.Lifecycle,
+				Enabled:          enabled,
+				AutoscalingGroup: b.LinkToAutoscalingGroup(ig),
 			}
 			if warmPool.IsEnabled() {
 				warmPoolTask.MinSize = warmPool.MinSize


### PR DESCRIPTION
We should populate the AutoscalingGroup field, so that it can be used
by dependency analysis.
