### PR TITLE
Allow more than one instance type for workers when creating a cluster

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -278,7 +278,9 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.BastionImage, "bastion-image", options.BastionImage, "Machine image for bastions. Takes precedence over --image")
 	cmd.RegisterFlagCompletionFunc("bastion-image", completeInstanceImage)
 
+	cmd.Flags().StringSliceVar(&options.NodeSizes, "node-sizes", options.NodeSizes, "Machine type(s) for worker nodes")
 	cmd.Flags().StringVar(&options.NodeSize, "node-size", options.NodeSize, "Machine type for worker nodes")
+	cmd.Flags().MarkDeprecated("node-size", "use --node-sizes instead")
 	cmd.RegisterFlagCompletionFunc("node-size", completeMachineType)
 	cmd.Flags().StringVar(&options.ControlPlaneSize, "master-size", options.ControlPlaneSize, "Machine type for control-plane nodes")
 	cmd.Flags().MarkDeprecated("master-size", "use --control-plane-size instead")

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -105,7 +105,7 @@ kops create cluster [CLUSTER] [flags]
       --node-count int32                        Total number of worker nodes. Defaults to one node per zone
       --node-image string                       Machine image for worker nodes. Takes precedence over --image
       --node-security-groups strings            Additional pre-created security groups to add to worker nodes.
-      --node-size string                        Machine type for worker nodes
+      --node-sizes strings                      Machine type(s) for worker nodes
       --node-tenancy string                     Tenancy of the node group (AWS only): default or dedicated
       --node-volume-size int32                  Instance volume size (in GB) for worker nodes
       --os-dns-servers string                   comma separated list of DNS Servers which is used in network

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -164,6 +164,7 @@ type NewClusterOptions struct {
 	BastionImage      string
 	ControlPlaneSize  string
 	NodeSize          string
+	NodeSizes         []string
 }
 
 func (o *NewClusterOptions) InitDefaults() {
@@ -1014,6 +1015,8 @@ func setupNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetsMap m
 
 	countPerIG := nodeCount / int32(numZones)
 	remainder := int(nodeCount) % numZones
+	instanceTypes := make([]string, len(opt.NodeSizes))
+	instanceTypes = append([]string{opt.NodeSize}, instanceTypes...)
 
 	for i, zone := range opt.Zones {
 		count := countPerIG
@@ -1055,7 +1058,7 @@ func setupNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetsMap m
 			g.Spec.NodeLabels["cloud.google.com/metadata-proxy-ready"] = "true"
 		}
 
-		g.Spec.MachineType = opt.NodeSize
+		g.Spec.MachineType = instanceTypes[i%len(instanceTypes)]
 		g.Spec.Image = opt.NodeImage
 
 		nodes = append(nodes, g)


### PR DESCRIPTION
Keep the old `node-size` so we don't break anyone. Add a new one which is plural `node-sizes`. Ensure we have room in the data structure during initialization and simply cycle through the instance types when creating nodes.