### PR TITLE
aws: Add option to provide multiple instance types on cluster creation

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -278,11 +278,11 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.BastionImage, "bastion-image", options.BastionImage, "Machine image for bastions. Takes precedence over --image")
 	cmd.RegisterFlagCompletionFunc("bastion-image", completeInstanceImage)
 
-	cmd.Flags().StringVar(&options.NodeSize, "node-size", options.NodeSize, "Machine type for worker nodes")
+	cmd.Flags().StringSliceVar(&options.NodeSizes, "node-size", options.NodeSizes, "Machine type(s) for worker nodes")
 	cmd.RegisterFlagCompletionFunc("node-size", completeMachineType)
-	cmd.Flags().StringVar(&options.ControlPlaneSize, "master-size", options.ControlPlaneSize, "Machine type for control-plane nodes")
+	cmd.Flags().StringSliceVar(&options.ControlPlaneSizes, "master-size", options.ControlPlaneSizes, "Machine type(s) for control-plane nodes")
 	cmd.Flags().MarkDeprecated("master-size", "use --control-plane-size instead")
-	cmd.Flags().StringVar(&options.ControlPlaneSize, "control-plane-size", options.ControlPlaneSize, "Machine type for control-plane nodes")
+	cmd.Flags().StringSliceVar(&options.ControlPlaneSizes, "control-plane-size", options.ControlPlaneSizes, "Machine type(s) for control-plane nodes")
 	cmd.RegisterFlagCompletionFunc("control-plane-size", completeMachineType)
 
 	cmd.Flags().Int32Var(&options.ControlPlaneVolumeSize, "master-volume-size", options.ControlPlaneVolumeSize, "Instance volume size (in GB) for control-plane nodes")

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -80,7 +80,7 @@ kops create cluster [CLUSTER] [flags]
       --control-plane-count int32               Number of control-plane nodes. Defaults to one control-plane node per control-plane-zone
       --control-plane-image string              Machine image for control-plane nodes. Takes precedence over --image
       --control-plane-security-groups strings   Additional pre-created security groups to add to control-plane nodes.
-      --control-plane-size string               Machine type for control-plane nodes
+      --control-plane-size strings              Machine type(s) for control-plane nodes
       --control-plane-tenancy string            Tenancy of the control-plane group (AWS only): default or dedicated
       --control-plane-volume-size int32         Instance volume size (in GB) for control-plane nodes
       --control-plane-zones strings             Zones in which to run control-plane nodes. (must be an odd number)
@@ -105,7 +105,7 @@ kops create cluster [CLUSTER] [flags]
       --node-count int32                        Total number of worker nodes. Defaults to one node per zone
       --node-image string                       Machine image for worker nodes. Takes precedence over --image
       --node-security-groups strings            Additional pre-created security groups to add to worker nodes.
-      --node-size string                        Machine type for worker nodes
+      --node-size strings                       Machine type(s) for worker nodes
       --node-tenancy string                     Tenancy of the node group (AWS only): default or dedicated
       --node-volume-size int32                  Instance volume size (in GB) for worker nodes
       --os-dns-servers string                   comma separated list of DNS Servers which is used in network

--- a/tests/integration/create_cluster/ha_openstack_nodns/options.yaml
+++ b/tests/integration/create_cluster/ha_openstack_nodns/options.yaml
@@ -13,8 +13,10 @@ OpenstackExternalNet: vlan1
 OpenstackExternalSubnet: vlan1subnet
 OpenstackLBSubnet: vlan1lbsubnet
 OpenstackDNSServers: 1.1.1.1
-ControlPlaneSize: m1.medium
-NodeSize: m1.large
+ControlPlaneSizes:
+- m1.medium
+NodeSizes:
+- m1.large
 APILoadBalancerType: public
 Topology: private
 DNSType: none

--- a/tests/integration/create_cluster/minimal-1.26-arm64/options.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-arm64/options.yaml
@@ -4,5 +4,7 @@ Zones:
 CloudProvider: aws
 Networking: cni
 KubernetesVersion: v1.26.0
-NodeSize: m6g.xlarge
-ControlPlaneSize: m6g.xlarge
+NodeSizes:
+- m6g.xlarge
+ControlPlaneSizes:
+- m6g.xlarge

--- a/tests/integration/create_cluster/private_gce/options.yaml
+++ b/tests/integration/create_cluster/private_gce/options.yaml
@@ -15,4 +15,5 @@ KubernetesVersion: v1.26.0
 cloudLabels: "Owner=John Doe,dn=\"cn=John Doe: dc=example dc=com\", foo/bar=fib+baz"
 Project: testproject
 GCEServiceAccount: test-account@testproject.iam.gserviceaccount.com
-ControlPlaneSize: e2-standard-2
+ControlPlaneSizes:
+- e2-standard-2


### PR DESCRIPTION
Alternative to #15849, for use in scalability tests.

/cc @justinsb @johngmyers @dims 