### PR TITLE
Automated cherry pick of #15848: Fix warmpool to expose dependencies for dependency analysis

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -93,9 +93,10 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 
 			enabled := fi.PtrTo(warmPool.IsEnabled())
 			warmPoolTask := &awstasks.WarmPool{
-				Name:      &name,
-				Lifecycle: b.Lifecycle,
-				Enabled:   enabled,
+				Name:             &name,
+				Lifecycle:        b.Lifecycle,
+				Enabled:          enabled,
+				AutoscalingGroup: b.LinkToAutoscalingGroup(ig),
 			}
 			if warmPool.IsEnabled() {
 				warmPoolTask.MinSize = warmPool.MinSize


### PR DESCRIPTION
Cherry pick of #15848 on release-1.28.

#15848: Fix warmpool to expose dependencies for dependency analysis

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.