### PR TITLE
Automated cherry pick of #15866: Default to 100.64.0.0/13 as IPv4 service cluster IP range

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -128,7 +128,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: Elzo/rIOjAxly0oM7DRFIJMLY2Tjr7Hmq2Cz9JUTy94=
+NodeupConfigHash: KcnbZLY7LCbjnvOe0vHk1c3BObT1OU0HsZlfebU6dzw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -151,7 +151,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 6zBnYt9ifwaf9tP3HRh2eAUUIHkTj82HfCkWcj7QOmo=
+NodeupConfigHash: Q/5lnobS7oex8BMOQc8DYbYmvZeeSSt7NgnB7WgKBYQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -123,7 +123,7 @@ spec:
     securePort: 443
     serviceAccountIssuer: https://discovery.example.com/minimal.example.com
     serviceAccountJWKSURI: https://discovery.example.com/minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
@@ -153,7 +153,7 @@ spec:
       image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
       memoryRequest: 5Mi
     provider: CoreDNS
-    serverIP: 172.20.0.10
+    serverIP: 100.64.0.10
   kubeProxy:
     cpuRequest: 100m
     image: registry.k8s.io/kube-proxy:v1.26.0
@@ -171,7 +171,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -194,7 +194,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -233,7 +233,7 @@ spec:
   serviceAccountIssuerDiscovery:
     discoveryStore: memfs://discovery.example.com/minimal.example.com
     enableAWSOIDCProvider: true
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
   snapshotController:
     enabled: true
   sshAccess:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 264a628e688f29334cbc9f3d125da5bd0f6f07ee71ac80fb16fd6b66290ff092
+    manifestHash: d2bbb7cbee5835c3891fe80fbacf8963508359ef9159f8480325ce9a7174f14a
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -226,7 +226,7 @@ metadata:
   namespace: kube-system
   resourceVersion: "0"
 spec:
-  clusterIP: 172.20.0.10
+  clusterIP: 100.64.0.10
   ports:
   - name: dns
     port: 53

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -47,7 +47,7 @@ APIServerConfig:
     securePort: 443
     serviceAccountIssuer: https://discovery.example.com/minimal.example.com
     serviceAccountJWKSURI: https://discovery.example.com/minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   ServiceAccountPublicKeys: |
     -----BEGIN RSA PUBLIC KEY-----
@@ -286,7 +286,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -311,7 +311,7 @@ KubernetesVersion: 1.26.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-nodes_content
@@ -29,7 +29,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -50,7 +50,7 @@ KubernetesVersion: 1.26.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 containerdConfig:
   logLevel: info

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -128,7 +128,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: XbCJqHyJ7SRbUfztqh5+TQKQgMiGI7NOmCqlUsKqEfA=
+NodeupConfigHash: ArbHCUg1eDddnkTJCRlQREsPoFTWhgA9I6eq1TePOMs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -151,7 +151,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: FBvQ2jGSdx5Z4Yc++O63eYHPbQ41JJJt3lx+zdAI4wU=
+NodeupConfigHash: v2XodnplzENJXadmxd+2pvpL1XivAOEzSsji/WH1kDQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
@@ -123,7 +123,7 @@ spec:
     securePort: 443
     serviceAccountIssuer: https://discovery.example.com/minimal.example.com
     serviceAccountJWKSURI: https://discovery.example.com/minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
@@ -153,7 +153,7 @@ spec:
       image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
       memoryRequest: 5Mi
     provider: CoreDNS
-    serverIP: 172.20.0.10
+    serverIP: 100.64.0.10
   kubeProxy:
     cpuRequest: 100m
     image: registry.k8s.io/kube-proxy:v1.23.0
@@ -171,7 +171,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -195,7 +195,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -235,7 +235,7 @@ spec:
   serviceAccountIssuerDiscovery:
     discoveryStore: memfs://discovery.example.com/minimal.example.com
     enableAWSOIDCProvider: true
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
   snapshotController:
     enabled: true
   sshAccess:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 264a628e688f29334cbc9f3d125da5bd0f6f07ee71ac80fb16fd6b66290ff092
+    manifestHash: d2bbb7cbee5835c3891fe80fbacf8963508359ef9159f8480325ce9a7174f14a
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -226,7 +226,7 @@ metadata:
   namespace: kube-system
   resourceVersion: "0"
 spec:
-  clusterIP: 172.20.0.10
+  clusterIP: 100.64.0.10
   ports:
   - name: dns
     port: 53

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -47,7 +47,7 @@ APIServerConfig:
     securePort: 443
     serviceAccountIssuer: https://discovery.example.com/minimal.example.com
     serviceAccountJWKSURI: https://discovery.example.com/minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   ServiceAccountPublicKeys: |
     -----BEGIN RSA PUBLIC KEY-----
@@ -286,7 +286,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -314,7 +314,7 @@ KubernetesVersion: 1.23.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_nodeupconfig-nodes_content
@@ -29,7 +29,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -52,7 +52,7 @@ KubernetesVersion: 1.23.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 containerdConfig:
   logLevel: info

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -128,7 +128,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: XPWMy2SQ8swDsHPFiJFqahsEJSJZMic9Be5P49ROAjw=
+NodeupConfigHash: +AXqoT7WKiDYd7aEDQVLH4k104I/W1JqNBLhRqzYEH4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -151,7 +151,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: L5BjPzVcKn6ItKtnRRN8FQKGP6JLVg0jao+1d+9sBbc=
+NodeupConfigHash: 9Kv5lCFI4fbwDje6L26P7XwurDEzYV+ZjurjhKs284U=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
@@ -124,7 +124,7 @@ spec:
     securePort: 443
     serviceAccountIssuer: https://discovery.example.com/minimal.example.com
     serviceAccountJWKSURI: https://discovery.example.com/minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
@@ -154,7 +154,7 @@ spec:
       image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
       memoryRequest: 5Mi
     provider: CoreDNS
-    serverIP: 172.20.0.10
+    serverIP: 100.64.0.10
   kubeProxy:
     cpuRequest: 100m
     image: registry.k8s.io/kube-proxy:v1.24.0
@@ -172,7 +172,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -195,7 +195,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -234,7 +234,7 @@ spec:
   serviceAccountIssuerDiscovery:
     discoveryStore: memfs://discovery.example.com/minimal.example.com
     enableAWSOIDCProvider: true
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
   snapshotController:
     enabled: true
   sshAccess:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 264a628e688f29334cbc9f3d125da5bd0f6f07ee71ac80fb16fd6b66290ff092
+    manifestHash: d2bbb7cbee5835c3891fe80fbacf8963508359ef9159f8480325ce9a7174f14a
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -226,7 +226,7 @@ metadata:
   namespace: kube-system
   resourceVersion: "0"
 spec:
-  clusterIP: 172.20.0.10
+  clusterIP: 100.64.0.10
   ports:
   - name: dns
     port: 53

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -47,7 +47,7 @@ APIServerConfig:
     securePort: 443
     serviceAccountIssuer: https://discovery.example.com/minimal.example.com
     serviceAccountJWKSURI: https://discovery.example.com/minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   ServiceAccountPublicKeys: |
     -----BEGIN RSA PUBLIC KEY-----
@@ -286,7 +286,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -311,7 +311,7 @@ KubernetesVersion: 1.24.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_nodeupconfig-nodes_content
@@ -29,7 +29,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -50,7 +50,7 @@ KubernetesVersion: 1.24.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 containerdConfig:
   logLevel: info

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -128,7 +128,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: mBbsPgGwaaxPpchci/m95cG5nVoPKqAXQl/wABqcKSc=
+NodeupConfigHash: aR7fW9UWRlw320nnyGWrFYfvkiP6fji970Xkdr5g93o=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -151,7 +151,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 8L8jRnJMKNmWDZnBWu1MJN9cVptFH1ULcavClQS/BVI=
+NodeupConfigHash: oxnAjwadN2x3LXnvGxx4yNXzkm2Fpqa8RJR2GItY850=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_cluster-completed.spec_content
@@ -123,7 +123,7 @@ spec:
     securePort: 443
     serviceAccountIssuer: https://discovery.example.com/minimal.example.com
     serviceAccountJWKSURI: https://discovery.example.com/minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
@@ -153,7 +153,7 @@ spec:
       image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
       memoryRequest: 5Mi
     provider: CoreDNS
-    serverIP: 172.20.0.10
+    serverIP: 100.64.0.10
   kubeProxy:
     cpuRequest: 100m
     image: registry.k8s.io/kube-proxy:v1.25.0-rc.1
@@ -171,7 +171,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -194,7 +194,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -233,7 +233,7 @@ spec:
   serviceAccountIssuerDiscovery:
     discoveryStore: memfs://discovery.example.com/minimal.example.com
     enableAWSOIDCProvider: true
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
   snapshotController:
     enabled: true
   sshAccess:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 264a628e688f29334cbc9f3d125da5bd0f6f07ee71ac80fb16fd6b66290ff092
+    manifestHash: d2bbb7cbee5835c3891fe80fbacf8963508359ef9159f8480325ce9a7174f14a
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -226,7 +226,7 @@ metadata:
   namespace: kube-system
   resourceVersion: "0"
 spec:
-  clusterIP: 172.20.0.10
+  clusterIP: 100.64.0.10
   ports:
   - name: dns
     port: 53

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -47,7 +47,7 @@ APIServerConfig:
     securePort: 443
     serviceAccountIssuer: https://discovery.example.com/minimal.example.com
     serviceAccountJWKSURI: https://discovery.example.com/minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   ServiceAccountPublicKeys: |
     -----BEGIN RSA PUBLIC KEY-----
@@ -286,7 +286,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -311,7 +311,7 @@ KubernetesVersion: 1.25.0-rc.1
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_nodeupconfig-nodes_content
@@ -29,7 +29,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -50,7 +50,7 @@ KubernetesVersion: 1.25.0-rc.1
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 containerdConfig:
   logLevel: info

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -128,7 +128,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: wq0CCrj8vsagiWzFCdzM2C4wEILLw3QZG/S9ebj3Cl0=
+NodeupConfigHash: 6DqpUUQ0BUCaERVVx1qWTcV9eJxQ1cJXAkgh0T4f/Do=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -151,7 +151,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 0OeT5XSzPFfU1u5b4oE0g2FBQ34WWczblFS8supuZhY=
+NodeupConfigHash: IrDEdaCv/md7bGB9UX5CrEgd42bBam9udBR2iUEwlIQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_cluster-completed.spec_content
@@ -123,7 +123,7 @@ spec:
     securePort: 443
     serviceAccountIssuer: https://discovery.example.com/minimal.example.com
     serviceAccountJWKSURI: https://discovery.example.com/minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
@@ -160,7 +160,7 @@ spec:
       localIP: 169.254.20.10
       memoryRequest: 5Mi
     provider: CoreDNS
-    serverIP: 172.20.0.10
+    serverIP: 100.64.0.10
   kubeProxy:
     cpuRequest: 100m
     image: registry.k8s.io/kube-proxy:v1.26.0-alpha.0
@@ -240,7 +240,7 @@ spec:
   serviceAccountIssuerDiscovery:
     discoveryStore: memfs://discovery.example.com/minimal.example.com
     enableAWSOIDCProvider: true
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
   snapshotController:
     enabled: true
   sshAccess:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 264a628e688f29334cbc9f3d125da5bd0f6f07ee71ac80fb16fd6b66290ff092
+    manifestHash: d2bbb7cbee5835c3891fe80fbacf8963508359ef9159f8480325ce9a7174f14a
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -226,7 +226,7 @@ metadata:
   namespace: kube-system
   resourceVersion: "0"
 spec:
-  clusterIP: 172.20.0.10
+  clusterIP: 100.64.0.10
   ports:
   - name: dns
     port: 53

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -47,7 +47,7 @@ APIServerConfig:
     securePort: 443
     serviceAccountIssuer: https://discovery.example.com/minimal.example.com
     serviceAccountJWKSURI: https://discovery.example.com/minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   ServiceAccountPublicKeys: |
     -----BEGIN RSA PUBLIC KEY-----
@@ -311,7 +311,7 @@ KubernetesVersion: 1.26.0-alpha.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_nodeupconfig-nodes_content
@@ -50,7 +50,7 @@ KubernetesVersion: 1.26.0-alpha.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 containerdConfig:
   logLevel: info

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -128,7 +128,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: sLzi++zH+DdlGaBG+eXxqYJG3df0raToM2m8BvS66no=
+NodeupConfigHash: wdZGrlGt44zutqlcirdfJWHWQH+3auZZeFvWU8Ee6NA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -151,7 +151,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 6zBnYt9ifwaf9tP3HRh2eAUUIHkTj82HfCkWcj7QOmo=
+NodeupConfigHash: Q/5lnobS7oex8BMOQc8DYbYmvZeeSSt7NgnB7WgKBYQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -122,7 +122,7 @@ spec:
     securePort: 443
     serviceAccountIssuer: https://api.internal.minimal.example.com
     serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
@@ -152,7 +152,7 @@ spec:
       image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
       memoryRequest: 5Mi
     provider: CoreDNS
-    serverIP: 172.20.0.10
+    serverIP: 100.64.0.10
   kubeProxy:
     cpuRequest: 100m
     image: registry.k8s.io/kube-proxy:v1.26.0
@@ -170,7 +170,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -193,7 +193,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -229,7 +229,7 @@ spec:
   nonMasqueradeCIDR: 172.20.0.0/16
   podCIDR: 172.20.128.0/17
   secretStore: memfs://clusters.example.com/minimal.example.com/secrets
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
   snapshotController:
     enabled: true
   sshAccess:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 264a628e688f29334cbc9f3d125da5bd0f6f07ee71ac80fb16fd6b66290ff092
+    manifestHash: d2bbb7cbee5835c3891fe80fbacf8963508359ef9159f8480325ce9a7174f14a
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -226,7 +226,7 @@ metadata:
   namespace: kube-system
   resourceVersion: "0"
 spec:
-  clusterIP: 172.20.0.10
+  clusterIP: 100.64.0.10
   ports:
   - name: dns
     port: 53

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -47,7 +47,7 @@ APIServerConfig:
     securePort: 443
     serviceAccountIssuer: https://api.internal.minimal.example.com
     serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   ServiceAccountPublicKeys: |
     -----BEGIN RSA PUBLIC KEY-----
@@ -286,7 +286,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -311,7 +311,7 @@ KubernetesVersion: 1.26.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-nodes_content
@@ -29,7 +29,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -50,7 +50,7 @@ KubernetesVersion: 1.26.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 containerdConfig:
   logLevel: info

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -128,7 +128,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: sLzi++zH+DdlGaBG+eXxqYJG3df0raToM2m8BvS66no=
+NodeupConfigHash: wdZGrlGt44zutqlcirdfJWHWQH+3auZZeFvWU8Ee6NA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -151,7 +151,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 6zBnYt9ifwaf9tP3HRh2eAUUIHkTj82HfCkWcj7QOmo=
+NodeupConfigHash: Q/5lnobS7oex8BMOQc8DYbYmvZeeSSt7NgnB7WgKBYQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -123,7 +123,7 @@ spec:
     securePort: 443
     serviceAccountIssuer: https://api.internal.minimal.example.com
     serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   kubeControllerManager:
     allocateNodeCIDRs: true
@@ -153,7 +153,7 @@ spec:
       image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
       memoryRequest: 5Mi
     provider: CoreDNS
-    serverIP: 172.20.0.10
+    serverIP: 100.64.0.10
   kubeProxy:
     cpuRequest: 100m
     image: registry.k8s.io/kube-proxy:v1.26.0
@@ -171,7 +171,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -194,7 +194,7 @@ spec:
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: external
-    clusterDNS: 172.20.0.10
+    clusterDNS: 100.64.0.10
     clusterDomain: cluster.local
     enableDebuggingHandlers: true
     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -230,7 +230,7 @@ spec:
   nonMasqueradeCIDR: 172.20.0.0/16
   podCIDR: 172.20.128.0/17
   secretStore: memfs://clusters.example.com/minimal.example.com/secrets
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
   snapshotController:
     enabled: true
   sshAccess:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 264a628e688f29334cbc9f3d125da5bd0f6f07ee71ac80fb16fd6b66290ff092
+    manifestHash: d2bbb7cbee5835c3891fe80fbacf8963508359ef9159f8480325ce9a7174f14a
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -226,7 +226,7 @@ metadata:
   namespace: kube-system
   resourceVersion: "0"
 spec:
-  clusterIP: 172.20.0.10
+  clusterIP: 100.64.0.10
   ports:
   - name: dns
     port: 53

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -47,7 +47,7 @@ APIServerConfig:
     securePort: 443
     serviceAccountIssuer: https://api.internal.minimal.example.com
     serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 172.20.0.0/19
+    serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   ServiceAccountPublicKeys: |
     -----BEGIN RSA PUBLIC KEY-----
@@ -286,7 +286,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -311,7 +311,7 @@ KubernetesVersion: 1.26.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-nodes_content
@@ -29,7 +29,7 @@ KubeletConfig:
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: external
-  clusterDNS: 172.20.0.10
+  clusterDNS: 100.64.0.10
   clusterDomain: cluster.local
   enableDebuggingHandlers: true
   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
@@ -50,7 +50,7 @@ KubernetesVersion: 1.26.0
 Networking:
   amazonVPC: {}
   nonMasqueradeCIDR: 172.20.0.0/16
-  serviceClusterIPRange: 172.20.0.0/19
+  serviceClusterIPRange: 100.64.0.0/13
 UpdatePolicy: automatic
 containerdConfig:
   logLevel: info

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -394,14 +394,7 @@ func (c *populateClusterSpec) assignSubnets(cluster *kopsapi.Cluster) error {
 		if nmBits > 32 {
 			cluster.Spec.Networking.ServiceClusterIPRange = "fd00:5e4f:ce::/108"
 		} else {
-			// Allocate from the '0' subnet; but only carve off 1/4 of that (i.e. add 1 + 2 bits to the netmask)
-			serviceOnes := nmOnes + 3
-			// Max size of network is 20 bits
-			if nmBits-serviceOnes > 20 {
-				serviceOnes = nmBits - 20
-			}
-			cidr := net.IPNet{IP: nonMasqueradeCIDR.IP.Mask(nonMasqueradeCIDR.Mask), Mask: net.CIDRMask(serviceOnes, nmBits)}
-			cluster.Spec.Networking.ServiceClusterIPRange = cidr.String()
+			cluster.Spec.Networking.ServiceClusterIPRange = "100.64.0.0/13"
 		}
 		klog.V(2).Infof("Defaulted ServiceClusterIPRange to %v", cluster.Spec.Networking.ServiceClusterIPRange)
 	}

--- a/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
@@ -71,12 +71,12 @@ func TestPopulateCluster_Subnets(t *testing.T) {
 		{
 			NonMasqueradeCIDR:             "10.0.0.0/9",
 			ExpectedClusterCIDR:           "10.64.0.0/10",
-			ExpectedServiceClusterIPRange: "10.0.0.0/12",
+			ExpectedServiceClusterIPRange: "100.64.0.0/13",
 		},
 		{
 			NonMasqueradeCIDR:             "10.0.0.0/8",
 			ExpectedClusterCIDR:           "10.128.0.0/9",
-			ExpectedServiceClusterIPRange: "10.0.0.0/12",
+			ExpectedServiceClusterIPRange: "100.64.0.0/13",
 		},
 		{
 			NonMasqueradeCIDR:             "::/0",


### PR DESCRIPTION
Cherry pick of #15866 on release-1.28.

#15866: Default to 100.64.0.0/13 as IPv4 service cluster IP range

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```