### PR TITLE
Automated cherry pick of #14893: Don't expose v1alpha3 API

### DIFF
--- a/pkg/apis/kops/install/install.go
+++ b/pkg/apis/kops/install/install.go
@@ -23,12 +23,10 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/v1alpha2"
-	"k8s.io/kops/pkg/apis/kops/v1alpha3"
 )
 
 func Install(scheme *runtime.Scheme) {
 	utilruntime.Must(kops.AddToScheme(scheme))
 	utilruntime.Must(v1alpha2.AddToScheme(scheme))
-	utilruntime.Must(v1alpha3.AddToScheme(scheme))
-	utilruntime.Must(scheme.SetVersionPriority(v1alpha2.SchemeGroupVersion, v1alpha3.SchemeGroupVersion))
+	utilruntime.Must(scheme.SetVersionPriority(v1alpha2.SchemeGroupVersion))
 }

--- a/tests/codecs/componentconfig_test.go
+++ b/tests/codecs/componentconfig_test.go
@@ -19,32 +19,28 @@ package codecs
 import (
 	"testing"
 
-	"k8s.io/kops/pkg/apis/kops/v1alpha3"
+	"k8s.io/kops/pkg/apis/kops/v1alpha2"
 	"k8s.io/kops/pkg/diff"
 	"k8s.io/kops/pkg/kopscodecs"
 )
 
 func TestSerializeEmptyCluster(t *testing.T) {
-	cluster := &v1alpha3.Cluster{}
-	cluster.Spec.Kubelet = &v1alpha3.KubeletConfigSpec{}
-	cluster.Spec.KubeControllerManager = &v1alpha3.KubeControllerManagerConfig{}
-	yaml, err := kopscodecs.ToVersionedYamlWithVersion(cluster, v1alpha3.SchemeGroupVersion)
+	cluster := &v1alpha2.Cluster{}
+	cluster.Spec.Kubelet = &v1alpha2.KubeletConfigSpec{}
+	cluster.Spec.KubeControllerManager = &v1alpha2.KubeControllerManagerConfig{}
+	yaml, err := kopscodecs.ToVersionedYamlWithVersion(cluster, v1alpha2.SchemeGroupVersion)
 	if err != nil {
 		t.Errorf("unexpected error marshaling Cluster: %v", err)
 	}
 
 	yamlString := string(yaml)
-	expected := `apiVersion: kops.k8s.io/v1alpha3
+	expected := `apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: null
 spec:
-  api: {}
-  cloudProvider: {}
-  configStore: {}
   kubeControllerManager: {}
   kubelet: {}
-  networking: {}
 `
 	if yamlString != expected {
 		diffString := diff.FormatDiff(expected, yamlString)

--- a/tests/integration/conversion/integration_test.go
+++ b/tests/integration/conversion/integration_test.go
@@ -34,45 +34,7 @@ import (
 // TestConversionMinimal runs the test on a minimum configuration, similar to kops create cluster minimal.example.com --zones us-west-1a
 func TestConversionMinimal(t *testing.T) {
 	runTest(t, "minimal", "legacy-v1alpha2", "v1alpha2")
-	runTest(t, "minimal", "v1alpha2", "v1alpha3")
-	runTest(t, "minimal", "v1alpha3", "v1alpha2")
 }
-
-func TestConversionAWS(t *testing.T) {
-	runTest(t, "aws", "v1alpha2", "v1alpha3")
-	runTest(t, "aws", "v1alpha3", "v1alpha2")
-}
-
-func TestConversionAzure(t *testing.T) {
-	runTest(t, "azure", "v1alpha2", "v1alpha3")
-	runTest(t, "azure", "v1alpha3", "v1alpha2")
-}
-
-func TestConversionCanal(t *testing.T) {
-	runTest(t, "canal", "v1alpha2", "v1alpha3")
-	runTest(t, "canal", "v1alpha3", "v1alpha2")
-}
-
-func TestConversionCilium(t *testing.T) {
-	runTest(t, "cilium", "v1alpha2", "v1alpha3")
-	runTest(t, "cilium", "v1alpha3", "v1alpha2")
-}
-
-func TestConversionDO(t *testing.T) {
-	runTest(t, "do", "v1alpha2", "v1alpha3")
-	runTest(t, "do", "v1alpha3", "v1alpha2")
-}
-
-func TestConversionGCE(t *testing.T) {
-	runTest(t, "gce", "v1alpha2", "v1alpha3")
-	runTest(t, "gce", "v1alpha3", "v1alpha2")
-}
-
-func TestConversionOpenstack(t *testing.T) {
-	runTest(t, "openstack", "v1alpha2", "v1alpha3")
-	runTest(t, "openstack", "v1alpha3", "v1alpha2")
-}
-
 func runTest(t *testing.T, srcDir string, fromVersion string, toVersion string) {
 	t.Run(fromVersion+"-"+toVersion, func(t *testing.T) {
 		sourcePath := path.Join(srcDir, fromVersion+".yaml")


### PR DESCRIPTION
Cherry pick of #14893 on release-1.28.

#14893: Don't expose v1alpha3 API

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.