### PR TITLE
ENI Cleanup Improvements

### DIFF
--- a/cloudmock/aws/mockec2/eni.go
+++ b/cloudmock/aws/mockec2/eni.go
@@ -22,3 +22,7 @@ func (m *MockEC2) DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfaces
 	output := &ec2.DescribeNetworkInterfacesOutput{}
 	return output, nil
 }
+
+func (m *MockEC2) DescribeNetworkInterfacesPages(*ec2.DescribeNetworkInterfacesInput, func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error {
+	return nil
+}

--- a/pkg/resources/aws/eni.go
+++ b/pkg/resources/aws/eni.go
@@ -66,18 +66,21 @@ func DumpENI(op *resources.DumpOperation, r *resources.Resource) error {
 func DescribeENIs(cloud fi.Cloud, clusterName string) (map[string]*ec2.NetworkInterface, error) {
 	c := cloud.(awsup.AWSCloud)
 
+	statusFilter := &ec2.Filter{
+		Name: aws.String("status"),
+		Values: []*string{
+			aws.String(ec2.NetworkInterfaceStatusDetaching),
+			aws.String(ec2.NetworkInterfaceStatusAvailable),
+		},
+	}
 	enis := make(map[string]*ec2.NetworkInterface)
 	klog.V(2).Info("Listing ENIs")
 	for _, filters := range buildEC2FiltersForCluster(clusterName) {
 		request := &ec2.DescribeNetworkInterfacesInput{
-			Filters: filters,
+			Filters: append(filters, statusFilter),
 		}
 		err := c.EC2().DescribeNetworkInterfacesPages(request, func(dnio *ec2.DescribeNetworkInterfacesOutput, b bool) bool {
 			for _, eni := range dnio.NetworkInterfaces {
-				// Skip ENIs that are attached
-				if eni.Attachment != nil {
-					continue
-				}
 				enis[aws.StringValue(eni.NetworkInterfaceId)] = eni
 			}
 			return true


### PR DESCRIPTION
Attempting to fix the scalability tests: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-scale-amazonvpc-using-cl2/1699576183240265728

* Paginate DescribeNetworkInterfaces which should help with large VPCs containing many ENIs. A similar change was made to the AWS VPC CNI: https://github.com/aws/amazon-vpc-cni-k8s/pull/1333
* Filter for unattached ENIs in the API rather than after the fact, reducing the number of response pages.