### PR TITLE
Fix e2e testing logic

### DIFF
--- a/tests/e2e/e2e.mk
+++ b/tests/e2e/e2e.mk
@@ -18,7 +18,6 @@ GOARCH ?= $(shell go env GOARCH)
 .PHONY: test-e2e-install
 test-e2e-install:
 	cd $(KOPS_ROOT)/tests/e2e && \
-		go install sigs.k8s.io/kubetest2 && \
 		go install ./kubetest2-tester-kops && \
 		go install ./kubetest2-kops
 

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/klog/v2 v2.100.1
 	k8s.io/kops v1.24.1
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/boskos v0.0.0-20220704141725-37bd9bb41b86
 	sigs.k8s.io/kubetest2 v0.0.0-20220801170629-1284e5ada592
 	sigs.k8s.io/yaml v1.3.0
@@ -139,7 +140,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
 	k8s.io/release v0.7.1-0.20210204090829-09fb5e3883b8 // indirect
 	k8s.io/test-infra v0.0.0-20210730160938-8ad9b8c53bd8 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect
 )

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -48,13 +48,14 @@ type deployer struct {
 	KopsBaseURL          string `flag:"-"`
 	PublishVersionMarker string `flag:"publish-version-marker" desc:"The GCS path to which the --kops-version-marker is uploaded if the tests pass"`
 
-	ClusterName    string   `flag:"cluster-name" desc:"The FQDN to use for the cluster name"`
-	CloudProvider  string   `flag:"cloud-provider" desc:"Which cloud provider to use"`
-	GCPProject     string   `flag:"gcp-project" desc:"Which GCP Project to use when --cloud-provider=gce"`
-	Env            []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`
-	CreateArgs     string   `flag:"create-args" desc:"Extra space-separated arguments passed to 'kops create cluster'"`
-	KopsBinaryPath string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
-	createBucket   bool     `flag:"-"`
+	ClusterName            string   `flag:"cluster-name" desc:"The FQDN to use for the cluster name"`
+	CloudProvider          string   `flag:"cloud-provider" desc:"Which cloud provider to use"`
+	GCPProject             string   `flag:"gcp-project" desc:"Which GCP Project to use when --cloud-provider=gce"`
+	Env                    []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`
+	CreateArgs             string   `flag:"create-args" desc:"Extra space-separated arguments passed to 'kops create cluster'"`
+	KopsBinaryPath         string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
+	KubernetesFeatureGates string   `flag:"kubernetes-feature-gates" desc:"Feature Gates to enable on Kubernetes components"`
+	createBucket           bool     `flag:"-"`
 
 	// ControlPlaneCount specifies the number of VMs in the control-plane.
 	ControlPlaneCount int `flag:"control-plane-count" desc:"Number of control-plane instances"`

--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -281,8 +281,3 @@ func findControlPlaneIPUser(dump resources.Dump) (string, string, bool) {
 	klog.Warning("ControlPlane instance not found from kops toolbox dump")
 	return "", "", false
 }
-
-func runWithOutput(cmd exec.Cmd) error {
-	exec.InheritOutput(cmd)
-	return cmd.Run()
-}

--- a/tests/e2e/kubetest2-kops/gce/gcs.go
+++ b/tests/e2e/kubetest2-kops/gce/gcs.go
@@ -17,8 +17,8 @@ limitations under the License.
 package gce
 
 import (
+	"crypto/rand"
 	"encoding/hex"
-	"math/rand"
 	"os"
 	"strings"
 


### PR DESCRIPTION
I cleaned up some logic in the kubetest2-kops deployer. Some flags are automatically enabled when testing on GCE.

