### PR TITLE
Cilium: Implement node encryption

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5167,6 +5167,10 @@ spec:
                       nat46Range:
                         description: Nat46Range is unused.
                         type: string
+                      nodeEncryption:
+                        description: 'NodeEncryption enables encryption for pure node
+                          to node traffic. Default: false'
+                        type: boolean
                       nodeInitBootstrapFile:
                         description: NodeInitBootstrapFile is unused.
                         type: string

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -382,6 +382,9 @@ type CiliumNetworkingSpec struct {
 	// EncryptionType specifies Cilium Encryption method ("ipsec", "wireguard").
 	// Default: ipsec
 	EncryptionType CiliumEncryptionType `json:"encryptionType,omitempty"`
+	// NodeEncryption enables encryption for pure node to node traffic.
+	// Default: false
+	NodeEncryption bool `json:"nodeEncryption,omitempty"`
 	// IdentityAllocationMode specifies in which backend identities are stored ("crd", "kvstore").
 	// Default: crd
 	IdentityAllocationMode string `json:"identityAllocationMode,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -387,6 +387,9 @@ type CiliumNetworkingSpec struct {
 	// EncryptionType specifies Cilium Encryption method ("ipsec", "wireguard").
 	// Default: ipsec
 	EncryptionType CiliumEncryptionType `json:"encryptionType,omitempty"`
+	// NodeEncryption enables encryption for pure node to node traffic.
+	// Default: false
+	NodeEncryption bool `json:"nodeEncryption,omitempty"`
 	// EnvoyLog is unused.
 	// +k8s:conversion-gen=false
 	EnvoyLog string `json:"envoyLog,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1977,6 +1977,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableEncryption = in.EnableEncryption
 	out.EncryptionType = kops.CiliumEncryptionType(in.EncryptionType)
+	out.NodeEncryption = in.NodeEncryption
 	// INFO: in.EnvoyLog opted out of conversion generation
 	out.IdentityAllocationMode = in.IdentityAllocationMode
 	out.IdentityChangeGracePeriod = in.IdentityChangeGracePeriod
@@ -2086,6 +2087,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableEncryption = in.EnableEncryption
 	out.EncryptionType = CiliumEncryptionType(in.EncryptionType)
+	out.NodeEncryption = in.NodeEncryption
 	out.IdentityAllocationMode = in.IdentityAllocationMode
 	out.IdentityChangeGracePeriod = in.IdentityChangeGracePeriod
 	out.Masquerade = in.Masquerade

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -345,6 +345,9 @@ type CiliumNetworkingSpec struct {
 	// EncryptionType specifies Cilium Encryption method ("ipsec", "wireguard").
 	// Default: ipsec
 	EncryptionType CiliumEncryptionType `json:"encryptionType,omitempty"`
+	// NodeEncryption enables encryption for pure node to node traffic.
+	// Default: false
+	NodeEncryption bool `json:"nodeEncryption,omitempty"`
 	// IdentityAllocationMode specifies in which backend identities are stored ("crd", "kvstore").
 	// Default: crd
 	IdentityAllocationMode string `json:"identityAllocationMode,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2146,6 +2146,7 @@ func autoConvert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableEncryption = in.EnableEncryption
 	out.EncryptionType = kops.CiliumEncryptionType(in.EncryptionType)
+	out.NodeEncryption = in.NodeEncryption
 	out.IdentityAllocationMode = in.IdentityAllocationMode
 	out.IdentityChangeGracePeriod = in.IdentityChangeGracePeriod
 	out.Masquerade = in.Masquerade
@@ -2221,6 +2222,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha3_CiliumNetworkingSpec(in *
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableEncryption = in.EnableEncryption
 	out.EncryptionType = CiliumEncryptionType(in.EncryptionType)
+	out.NodeEncryption = in.NodeEncryption
 	out.IdentityAllocationMode = in.IdentityAllocationMode
 	out.IdentityChangeGracePeriod = in.IdentityChangeGracePeriod
 	out.Masquerade = in.Masquerade

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.13.yaml.template
@@ -103,6 +103,7 @@ data:
   {{ else if eq .EncryptionType "wireguard"  }}
   enable-wireguard: "true"
   {{ end }}
+  encrypt-node: "{{ .NodeEncryption }}"
   {{ end }}
 
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kops/issues/15853

In 1.13 and below, the node encryption only works with IPsec and from 1.14 and above it only works with wireguard.

There is no extra validation added, because the setting will be ignored if you have `wiredguard` + `nodeEncryption` + cilum 1.13 or `ipsec` + `nodeEncryption` + cilium 1.14.

