### PR TITLE
kops-controller: Increase client-side throttling limits

### DIFF
--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -106,6 +106,8 @@ func main() {
 	}
 
 	kubeConfig := ctrl.GetConfigOrDie()
+	kubeConfig.Burst = 200
+	kubeConfig.QPS = 100
 	mgr, err := ctrl.NewManager(kubeConfig, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/kops/pull/15593.

kOps controller is at the core of the cluster. It should be able to check nodes registration on large clusters, without blocking:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/15836/presubmit-kops-aws-scale-amazonvpc-using-cl2/1701807832023699456/artifacts/cluster-info/kube-system/kops-controller-2qgsh/logs.txt
```
I0913 05:49:15.260083       1 server.go:190] bootstrap 10.0.71.103:37030 error querying for node "i-0f5820f600c12a0e9": client rate limiter Wait returned an error: context canceled
I0913 05:49:15.275159       1 server.go:190] bootstrap 10.0.83.79:56446 error querying for node "i-0da05fd199796fe79": client rate limiter Wait returned an error: context canceled
I0913 05:49:15.342441       1 request.go:697] Waited for 14.940373885s due to client-side throttling, not priority and fairness, request: GET:https://127.0.0.1:443/api/v1/nodes/i-0447fe9e05141350a
I0913 05:49:15.342466       1 server.go:190] bootstrap 10.0.45.176:54702 error querying for node "i-0447fe9e05141350a": client rate limiter Wait returned an error: context canceled
I0913 05:49:15.479936       1 server.go:190] bootstrap 10.1.215.14:58962 error querying for node "i-06f811f3dc4e054da": client rate limiter Wait returned an error: context canceled
I0913 05:49:15.572171       1 server.go:190] bootstrap 10.9.162.10:59182 error querying for node "i-06f4198b4c4b553be": client rate limiter Wait returned an error: context canceled
```