### PR TITLE
Fix COS image mounter URL

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -495,7 +495,7 @@ func (b *KubeletBuilder) addContainerizedMounter(c *fi.NodeupModelBuilderContext
 	// TODO: leverage assets for this tar file (but we want to avoid expansion of the archive)
 	c.AddTask(&nodetasks.Archive{
 		Name:      "containerized_mounter",
-		Source:    "https://dl.k8s.io/gci-mounter/mounter.tar",
+		Source:    "https://storage.googleapis.com/kubernetes-release/gci-mounter/mounter.tar",
 		Hash:      "6a9f5f52e0b066183e6b90a3820b8c2c660d30f6ac7aeafb5064355bf0a5b6dd",
 		TargetDir: path.Join(containerizedMounterHome, "rootfs"),
 	})


### PR DESCRIPTION
There is a bug caused by the CDN switch recently that is causing COS e2e clusters to not provision properly.

https://github.com/kubernetes/k8s.io/issues/5659