### PR TITLE
Add Cognito permissions for AWS LBC

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -891,6 +891,8 @@ func AddCCMPermissions(p *Policy, cloudRoutes bool) {
 // AddAWSLoadbalancerControllerPermissions adds the permissions needed for the AWS Load Balancer Controller to the givnen policy
 func AddAWSLoadbalancerControllerPermissions(p *Policy, enableWAF, enableWAFv2, enableShield bool) {
 	p.unconditionalAction.Insert(
+		"cognito-idp:DescribeUserPoolClient",
+
 		"acm:DescribeCertificate",
 		"acm:ListCertificates",
 

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -214,6 +214,7 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:AssignPrivateIpAddresses",
         "ec2:AttachNetworkInterface",
         "ec2:CreateNetworkInterface",

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -214,6 +214,7 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:AssignPrivateIpAddresses",
         "ec2:AttachNetworkInterface",
         "ec2:CreateNetworkInterface",


### PR DESCRIPTION
This is needed for configuring [Cognito authentication](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.6/guide/tasks/cognito_authentication/). The `cognito-idp:DescribeUserPoolClient` permission has been present in the [upstream install docs](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/e619a48553981e153860044f8c14bc6cb27e891c/docs/install/iam_policy.json#L48) for a long time. I haven't looked into the integration test infrastructure so I have no idea if I should have updated all of the stuff in `tests/integration/update_cluster`.