### PR TITLE
Make `--cloudonly` sound less innocuous

### DIFF
--- a/cmd/kops/rolling-update_cluster.go
+++ b/cmd/kops/rolling-update_cluster.go
@@ -58,6 +58,9 @@ var (
 	updated with the --force flag.  Rolling update drains and validates the cluster by default.  A cluster is
 	deemed validated when all required nodes are running and all pods with a critical priority are operational.
 
+	If the cluster is in a broken state and cannot be validated, rolling-update will get stuck and eventually 
+	fail; you can force the update to proceed with the --cloudonly flag, which will skip validation.
+
 	Note: terraform users will need to run all of the following commands from the same directory
 	` + pretty.Bash("kops update cluster --target=terraform") + ` then ` + pretty.Bash("terraform plan") + ` then
 	` + pretty.Bash("terraform apply") + ` prior to running ` + pretty.Bash("kops rolling-update cluster") + `.`))
@@ -189,7 +192,7 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd.Flags().BoolVarP(&options.Yes, "yes", "y", options.Yes, "Perform rolling update immediately; without --yes rolling-update executes a dry-run")
 	cmd.Flags().BoolVar(&options.Force, "force", options.Force, "Force rolling update, even if no changes")
-	cmd.Flags().BoolVar(&options.CloudOnly, "cloudonly", options.CloudOnly, "Perform rolling update without confirming progress with Kubernetes")
+	cmd.Flags().BoolVar(&options.CloudOnly, "cloudonly", options.CloudOnly, "Perform rolling update without validating cluster status (will cause downtime)")
 
 	cmd.Flags().DurationVar(&options.ValidationTimeout, "validation-timeout", options.ValidationTimeout, "Maximum time to wait for a cluster to validate")
 	cmd.Flags().DurationVar(&options.DrainTimeout, "drain-timeout", options.DrainTimeout, "Maximum time to wait for a node to drain")

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -17,6 +17,9 @@ If rolling-update does not report that the cluster needs to be updated, you can 
 updated with the --force flag.  Rolling update drains and validates the cluster by default.  A cluster is
 deemed validated when all required nodes are running and all pods with a critical priority are operational.
 
+If the cluster is in a broken state and cannot be validated, rolling-update will get stuck and eventually 
+fail; you can force the update to proceed with the --cloudonly flag, which will skip validation.
+
 Note: terraform users will need to run all of the following commands from the same directory
 `kops update cluster --target=terraform` then `terraform plan` then
 `terraform apply` prior to running `kops rolling-update cluster`.
@@ -57,7 +60,7 @@ kops rolling-update cluster [CLUSTER] [flags]
 
 ```
       --bastion-interval duration         Time to wait between restarting bastions (default 15s)
-      --cloudonly                         Perform rolling update without confirming progress with Kubernetes
+      --cloudonly                         Perform rolling update without validating cluster status (will cause downtime)
       --control-plane-interval duration   Time to wait between restarting control plane nodes (default 15s)
       --drain-timeout duration            Maximum time to wait for a node to drain (default 15m0s)
       --fail-on-drain-error               Fail if draining a node fails (default true)


### PR DESCRIPTION
How's this wording @hakman?