### PR TITLE
Automated cherry pick of #15910: Add Cognito permissions for AWS LBC.

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -921,6 +921,8 @@ func AddCCMPermissions(p *Policy, cloudRoutes bool) {
 // AddAWSLoadbalancerControllerPermissions adds the permissions needed for the AWS Load Balancer Controller to the givnen policy
 func AddAWSLoadbalancerControllerPermissions(p *Policy, enableWAF, enableWAFv2, enableShield bool) {
 	p.unconditionalAction.Insert(
+		"cognito-idp:DescribeUserPoolClient",
+
 		"acm:DescribeCertificate",
 		"acm:ListCertificates",
 

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -37,6 +37,7 @@
       "Action": [
         "acm:DescribeCertificate",
         "acm:ListCertificates",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -214,6 +214,7 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:AssignPrivateIpAddresses",
         "ec2:AttachNetworkInterface",
         "ec2:CreateNetworkInterface",

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -214,6 +214,7 @@
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeScalingActivities",
         "autoscaling:DescribeTags",
+        "cognito-idp:DescribeUserPoolClient",
         "ec2:AssignPrivateIpAddresses",
         "ec2:AttachNetworkInterface",
         "ec2:CreateNetworkInterface",


### PR DESCRIPTION
Cherry pick of #15910 on release-1.28.

#15910: Add Cognito permissions for AWS LBC.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```