### PR TITLE
Optimize subnets asignment to IGs for clusters with multiple CIDRs

### DIFF
--- a/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
@@ -174,8 +174,6 @@ spec:
   role: Master
   subnets:
   - us-test-1a
-  - us-test-1a-1
-  - us-test-1a-4
 
 ---
 
@@ -196,7 +194,6 @@ spec:
   role: Master
   subnets:
   - us-test-1b
-  - us-test-1b-2
 
 ---
 
@@ -217,7 +214,6 @@ spec:
   role: Master
   subnets:
   - us-test-1c
-  - us-test-1c-3
 
 ---
 
@@ -238,7 +234,6 @@ spec:
   minSize: 4
   role: Node
   subnets:
-  - us-test-1a
   - us-test-1a-1
   - us-test-1a-4
 
@@ -261,7 +256,6 @@ spec:
   minSize: 3
   role: Node
   subnets:
-  - us-test-1b
   - us-test-1b-2
 
 ---
@@ -283,5 +277,4 @@ spec:
   minSize: 3
   role: Node
   subnets:
-  - us-test-1c
   - us-test-1c-3

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -115,8 +115,6 @@ spec:
   role: Master
   subnets:
   - us-test-1a
-  - us-test-1a-1
-  - us-test-1a-4
 
 ---
 
@@ -137,7 +135,6 @@ spec:
   role: Master
   subnets:
   - us-test-1b
-  - us-test-1b-2
 
 ---
 
@@ -158,7 +155,6 @@ spec:
   role: Master
   subnets:
   - us-test-1c
-  - us-test-1c-3
 
 ---
 
@@ -179,7 +175,6 @@ spec:
   minSize: 4
   role: Node
   subnets:
-  - us-test-1a
   - us-test-1a-1
   - us-test-1a-4
 
@@ -202,7 +197,6 @@ spec:
   minSize: 3
   role: Node
   subnets:
-  - us-test-1b
   - us-test-1b-2
 
 ---
@@ -224,5 +218,4 @@ spec:
   minSize: 3
   role: Node
   subnets:
-  - us-test-1c
   - us-test-1c-3


### PR DESCRIPTION
The main CIDR is considered special. It will be split into smaller CIDRs to allow it to hold all the control-plane instance groups. This makes these smaller CIDRs less suitable for worker nodes as they will run out of IPs faster, especially when ENIs are used.
/cc @dims @justinsb 
@hakuna-matatah 