### PR TITLE
fix some comments

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -156,8 +156,8 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 		}
 	}
 
-	if strings.HasPrefix(image, "registry.k8s.io/kops/kops-controller:") {
-		// To use user-defined DNS Controller:
+	if strings.HasPrefix(image, "k8s.gcr.io/kops/kops-controller:") || strings.HasPrefix(image, "registry.k8s.io/kops/kops-controller:") {
+		// To use user-defined kops Controller:
 		// 1. DOCKER_REGISTRY=[your docker hub repo] make kops-controller-push
 		// 2. export KOPSCONTROLLER_IMAGE=[your docker hub repo]
 		// 3. make kops and create/apply cluster

--- a/pkg/truncate/truncate.go
+++ b/pkg/truncate/truncate.go
@@ -37,7 +37,7 @@ type TruncateStringOptions struct {
 	HashLength int
 }
 
-// TruncateString will attempt to truncate a string to a max, adding a prefix to avoid collisions.
+// TruncateString will attempt to truncate a string to a max length, adding a suffix to avoid collisions.
 // Will never return a string longer than maxLength chars
 func TruncateString(s string, opt TruncateStringOptions) string {
 	if opt.MaxLength == 0 {


### PR DESCRIPTION
We had hard-coded k8s.gcr.io, but this is also available in registry.k8s.io

Also cleanup a few comments