### PR TITLE
gce: when using only ipv6, we don't need a CNI to set up the network.

### DIFF
--- a/cmd/kops-controller/controllers/gceipam.go
+++ b/cmd/kops-controller/controllers/gceipam.go
@@ -18,7 +18,9 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 
@@ -26,6 +28,8 @@ import (
 	"google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,8 +41,9 @@ import (
 func NewGCEIPAMReconciler(mgr manager.Manager) (*GCEIPAMReconciler, error) {
 	klog.Info("starting gce ipam controller")
 	r := &GCEIPAMReconciler{
-		client: mgr.GetClient(),
-		log:    ctrl.Log.WithName("controllers").WithName("gce-ipam"),
+		client:     mgr.GetClient(),
+		fieldOwner: "kops-controller",
+		log:        ctrl.Log.WithName("controllers").WithName("gce-ipam"),
 	}
 
 	coreClient, err := corev1client.NewForConfig(mgr.GetConfig())
@@ -60,6 +65,9 @@ func NewGCEIPAMReconciler(mgr manager.Manager) (*GCEIPAMReconciler, error) {
 type GCEIPAMReconciler struct {
 	// client is the controller-runtime client
 	client client.Client
+
+	// fieldOwner is the field-manager owner for fields that we apply
+	fieldOwner string
 
 	// log is a logr
 	log logr.Logger
@@ -139,6 +147,46 @@ func (r *GCEIPAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
+	if len(node.Spec.PodCIDRs) != 0 {
+		allIPv6 := true
+
+		for _, podCIDR := range node.Spec.PodCIDRs {
+			_, cidr, err := net.ParseCIDR(podCIDR)
+			if err != nil {
+				klog.Warning("failed to parse podCIDR %q", podCIDR)
+				allIPv6 = false
+				continue
+			}
+
+			// Split into ipv4s and ipv6s, but treat IPv4-mapped IPv6 addresses as IPv6
+			if cidr.IP.To4() != nil && !strings.Contains(podCIDR, ":") {
+				// ipv4
+				allIPv6 = false
+			} else {
+				// ipv6
+			}
+		}
+
+		if allIPv6 {
+			// IPv6 does not require a route to be set up, so mark the node as NetworkReady
+			for _, condition := range node.Status.Conditions {
+				if condition.Type == "NetworkUnavailable" {
+					if condition.Status == corev1.ConditionTrue {
+						newCondition := metav1.Condition{
+							Message: "Node has IPv6",
+							Status:  metav1.ConditionFalse,
+							Reason:  "RouteCreated",
+							Type:    "NetworkUnavailable",
+						}
+						if err := patchStatusCondition(ctx, r.client, node, r.fieldOwner, newCondition); err != nil {
+							return ctrl.Result{}, fmt.Errorf("updating NetworkUnavailable condition: %w", err)
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return ctrl.Result{}, nil
 }
 
@@ -146,4 +194,46 @@ func (r *GCEIPAMReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Node{}).
 		Complete(r)
+}
+
+type statusConditions struct {
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+type objectStatusPatch struct {
+	APIVersion string            `json:"apiVersion"`
+	Kind       string            `json:"kind"`
+	Metadata   metav1.ObjectMeta `json:"metadata"`
+	Status     statusConditions  `json:"status,omitempty"`
+}
+
+// patchStatusCondition server-side-applies the node status to set the specified status condition.
+func patchStatusCondition(ctx context.Context, kube client.Client, obj client.Object, fieldOwner string, condition metav1.Condition) error {
+	apiVersion, kind := obj.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+
+	klog.Infof("setting condition %v on %v %q", condition, kind, obj.GetName())
+	patch := &objectStatusPatch{
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Metadata: metav1.ObjectMeta{
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+		},
+		Status: statusConditions{
+			Conditions: []metav1.Condition{condition},
+		},
+	}
+
+	patchJSON, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("error building patch: %w", err)
+	}
+
+	klog.V(2).Infof("sending patch for %v %q: %q", kind, obj.GetName(), string(patchJSON))
+
+	if err := kube.Status().Patch(ctx, obj, client.RawPatch(types.ApplyPatchType, patchJSON), client.ForceOwnership, client.FieldOwner(fieldOwner)); err != nil {
+		return fmt.Errorf("applying patch to %v %v: %w", kind, obj.GetName(), err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
IPv6 addresses are "real" addresses, and don't need any further
configuration on GCE.
