### PR TITLE
aws: Fix minor typos for Karpenter setup

### DIFF
--- a/pkg/model/components/addonmanifests/karpenter/iam.go
+++ b/pkg/model/components/addonmanifests/karpenter/iam.go
@@ -51,9 +51,11 @@ func addKarpenterPermissions(p *iam.Policy) {
 		// Not included because we require Karpenter
 		// use existing kOps instance group launch templates
 		// "ec2:CreateLaunchTemplate",
+		// "ec2:DeleteLaunchTemplate",
 		"ec2:CreateFleet",
 		"ec2:CreateTags",
 		"ec2:DescribeAvailabilityZones",
+		"ec2:DescribeImages",
 		"ec2:DescribeInstanceTypeOfferings",
 		"ec2:DescribeInstanceTypes",
 		"ec2:DescribeInstances",
@@ -61,9 +63,9 @@ func addKarpenterPermissions(p *iam.Policy) {
 		"ec2:DescribeSecurityGroups",
 		"ec2:DescribeSpotPriceHistory",
 		"ec2:DescribeSubnets",
-		"iam:PassRole",
 		"ec2:RunInstances",
 		"ec2:TerminateInstances",
+		"iam:PassRole",
 		"pricing:GetProducts",
 		"ssm:GetParameter",
 	)

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_karpenter.kube-system.sa.minimal.example.com_policy
@@ -5,6 +5,7 @@
         "ec2:CreateFleet",
         "ec2:CreateTags",
         "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeImages",
         "ec2:DescribeInstanceTypeOfferings",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -120,7 +120,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: aab89cad4f4a52b8620f581548694a6fc096bdbd1a297310beda01b57d3550ae
+    manifestHash: ff8aea6ec871d9b7d8482dab9831d002de4466243c9df7c10b363e47ccc58601
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -1998,7 +1998,7 @@ spec:
     operator: In
     values:
     - spot
-    - ondemand
+    - on-demand
   - key: kubernetes.io/arch
     operator: In
     values:
@@ -2049,7 +2049,7 @@ spec:
     operator: In
     values:
     - spot
-    - ondemand
+    - on-demand
   - key: kubernetes.io/arch
     operator: In
     values:

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -1771,7 +1771,7 @@ spec:
   requirements:
     - key: karpenter.sh/capacity-type
       operator: In
-      values: ["spot", "ondemand"]
+      values: ["spot", "on-demand"]
     - key: kubernetes.io/arch
       operator: In
       values: ["{{ ArchitectureOfAMI $spec.Image }}"]


### PR DESCRIPTION
`on-demand` is the right string to indicate OnDemand in Karpenter. See: https://github.com/aws/karpenter-core/blob/main/pkg/apis/v1alpha5/labels.go#L30 As the result it does not fall back to ondemand instances.

Also add `ec2:DescribeImages` to karpenter IAM policies -- it's noted in https://karpenter.sh/docs/getting-started/migrating-from-cas/#create-iam-roles (the list also has DeleteLaunchTemplates but I don't think this is necessary for kOps).