### PR TITLE
scale-test: Measure APIServer SLOs

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -115,12 +115,14 @@ create_args+=("--set spec.kubeAPIServer.enableProfiling=true")
 create_args+=("--set spec.kubeAPIServer.enableContentionProfiling=true")
 # this is required for Prometheus server to scrape metrics endpoint on APIServer
 create_args+=("--set spec.kubeAPIServer.anonymousAuth=true")
+# this is required for prometheus to scrape kube-proxy metrics endpoint
+create_args+=("--set spec.kubeProxy.metricsBindAddress=0.0.0.0:10249")
 create_args+=("--node-count=${KUBE_NODE_COUNT:-101}")
 # TODO: track failures of tests (HostPort & OIDC) when using `--dns=none`
 create_args+=("--dns none")
 create_args+=("--node-size=t3a.large,c7a.large,m7a.large,m6a.large,r7a.large,r6a.large")
 create_args+=("--control-plane-count=${CONTROL_PLANE_COUNT:-1}")
-create_args+=("--master-size=c5.4xlarge")
+create_args+=("--master-size=${CONTROL_PLANE_SIZE:-c5.2xlarge}")
 create_args+=("--zones=us-east-2a,us-east-2b,us-east-2c")
 
 
@@ -158,8 +160,10 @@ kops get instances
 
 # CL2 uses KUBE_SSH_KEY_PATH path to ssh to instances for scraping metrics
 export KUBE_SSH_KEY_PATH="/tmp/kops/${CLUSTER_NAME}/id_ed25519"
+# this is used as a label to select kube-proxy pods on kops for kube-proxy service 
+# used by CL2 Prometheus here https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/pkg/prometheus/manifests/default/kube-proxy-service.yaml#L2
 export PROMETHEUS_KUBE_PROXY_SELECTOR_KEY="k8s-app"
-printenv
+
 kubetest2 kops "${KUBETEST2_ARGS[@]}" \
   --test=clusterloader2 \
   --kubernetes-version="${K8S_VERSION}" \

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -115,7 +115,7 @@ create_args+=("--set spec.kubeAPIServer.enableProfiling=true")
 create_args+=("--set spec.kubeAPIServer.enableContentionProfiling=true")
 # this is required for Prometheus server to scrape metrics endpoint on APIServer
 create_args+=("--set spec.kubeAPIServer.anonymousAuth=true")
-create_args+=("--node-count=500")
+create_args+=("--node-count=${KUBE_NODE_COUNT:-101}")
 # TODO: track failures of tests (HostPort & OIDC) when using `--dns=none`
 create_args+=("--dns none")
 create_args+=("--node-size=t3a.large,c7a.large,m7a.large,m6a.large,r7a.large,r6a.large")
@@ -158,10 +158,9 @@ kops get instances
 
 # CL2 uses KUBE_SSH_KEY_PATH path to ssh to instances for scraping metrics
 export KUBE_SSH_KEY_PATH="/tmp/kops/${CLUSTER_NAME}/id_ed25519"
-export PROMETHEUS_SCRAPE_KUBE_PROXY=false
-export CL2_ENABLE_DNS_PROGRAMMING=false
+export PROMETHEUS_KUBE_PROXY_SELECTOR_KEY="k8s-app"
 printenv
-export PROMETHEUS_SCRAPE_KUBE_PROXY=false kubetest2 kops "${KUBETEST2_ARGS[@]}" \
+kubetest2 kops "${KUBETEST2_ARGS[@]}" \
   --test=clusterloader2 \
   --kubernetes-version="${K8S_VERSION}" \
   -- \
@@ -169,9 +168,6 @@ export PROMETHEUS_SCRAPE_KUBE_PROXY=false kubetest2 kops "${KUBETEST2_ARGS[@]}" 
   --repo-root="${GOPATH}"/src/k8s.io/perf-tests \
   --test-configs="${GOPATH}"/src/k8s.io/perf-tests/clusterloader2/testing/load/config.yaml \
   --kube-config="${KUBECONFIG}"
-
-
-printenv
 
 if [[ "${DELETE_CLUSTER:-}" == "true" ]]; then
   kubetest2 kops "${KUBETEST2_ARGS[@]}" --down

--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -91,8 +91,7 @@ create_args+=("--networking=${CNI_PLUGIN:-calico}")
 if [[ "${CNI_PLUGIN}" == "amazonvpc" ]]; then
 create_args+=("--set spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true")
 fi
-# INSTANCE_IMAGE configures the image used for control plane and kube nodes
-create_args+=("--image=${INSTANCE_IMAGE:-ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/arm64/hvm/ebs-gp2/ami-id}")
+create_args+=("--image=${INSTANCE_IMAGE:-ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id}")
 create_args+=("--set spec.etcdClusters[0].manager.listenMetricsURLs=http://localhost:2382")
 create_args+=("--set spec.etcdClusters[0].manager.env=ETCD_QUOTA_BACKEND_BYTES=8589934592")
 create_args+=("--set spec.etcdClusters[1].manager.env=ETCD_QUOTA_BACKEND_BYTES=8589934592")
@@ -117,9 +116,9 @@ create_args+=("--set spec.kubeAPIServer.enableContentionProfiling=true")
 create_args+=("--node-count=${KUBE_NODE_COUNT:-101}")
 # TODO: track failures of tests (HostPort & OIDC) when using `--dns=none`
 create_args+=("--dns none")
-create_args+=("--node-size=t4g.large,c7g.large,c6g.large,m7g.large,m6g.large,r7g.large,r6g.large")
+create_args+=("--node-size=t3a.large,c7a.large,m7a.large,m6a.large,r7a.large,r6a.large")
 create_args+=("--control-plane-count=${CONTROL_PLANE_COUNT:-1}")
-create_args+=("--master-size=${CONTROL_PLANE_SIZE:-c6g.2xlarge}")
+create_args+=("--master-size=c5.4xlarge")
 create_args+=("--zones=us-east-2a,us-east-2b,us-east-2c")
 
 
@@ -155,28 +154,19 @@ kops export kubecfg --admin --kubeconfig="${KUBECONFIG}"
 
 kops get instances
 
-if [[ "${RUN_CL2_TEST:-}" == "true" ]]; then
-  # CL2 uses KUBE_SSH_KEY_PATH path to ssh to instances for scraping metrics
-  export KUBE_SSH_KEY_PATH="/tmp/kops/${CLUSTER_NAME}/id_ed25519"
+# CL2 uses KUBE_SSH_KEY_PATH path to ssh to instances for scraping metrics
+export KUBE_SSH_KEY_PATH="/tmp/kops/${CLUSTER_NAME}/id_ed25519"
 
-  kubetest2 kops "${KUBETEST2_ARGS[@]}" \
+kubetest2 kops "${KUBETEST2_ARGS[@]}" \
   --test=clusterloader2 \
   --kubernetes-version="${K8S_VERSION}" \
   -- \
   --provider="${CLOUD_PROVIDER}" \
   --repo-root="${GOPATH}"/src/k8s.io/perf-tests \
   --test-configs="${GOPATH}"/src/k8s.io/perf-tests/clusterloader2/testing/load/config.yaml \
+  --test-configs="${GOPATH}"/src/k8s.io/perf-tests/clusterloader2/testing/huge-service/config.yaml \
+  --test-configs="${GOPATH}"/src/k8s.io/perf-tests/clusterloader2/testing/access-tokens/config.yaml \
   --kube-config="${KUBECONFIG}"
-else
-  kubetest2 kops "${KUBETEST2_ARGS[@]}" \
-  --test=kops \
-  --kubernetes-version="${K8S_VERSION}" \
-  -- \
-  --test-package-version="${K8S_VERSION}" \
-  --parallel=1 \
-  --skip-regex="\[Serial\]" \
-  --focus-regex="\[Conformance\]"
-fi
 
 if [[ "${DELETE_CLUSTER:-}" == "true" ]]; then
   kubetest2 kops "${KUBETEST2_ARGS[@]}" --down


### PR DESCRIPTION
~- This PR makes CL2 to install prometheus stack locally before kicking off the load test~
~- Update go deps from https://github.com/kubernetes-sigs/kubetest2/pull/244~
- Also update the worker node architecture to `amd64` for prometheus and grafana nodes to come up successfully.
- Also this [https://github.com/kubernetes/kops/pull/15963#issuecomment-1760718194](url)
- Also this [https://github.com/kubernetes/kops/pull/15963#issuecomment-1766864001](url)
- Also this [https://github.com/kubernetes/kops/pull/15963#issuecomment-1767112397](url)
- Clean up to make the script to only run CL2 and not conformance