### PR TITLE
shorten cluster names

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -256,6 +256,13 @@ func defaultClusterName(cloudProvider string) (string, error) {
 		suffix = "k8s.local"
 	}
 
+	if cloudProvider == "gce" {
+		// jobname must be less than 63 chars, we are prepending 4/6 chars and appending 9 chars
+		// some GCP resources cant be longer than 61/63 characters
+		if len(jobName) > 50 {
+			jobName = jobName[:49]
+		}
+	}
 	if jobType == "presubmit" {
 		return fmt.Sprintf("e2e-pr%s.%s.%s", pullNumber, jobName, suffix), nil
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to kubernetes/kops!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines:

 https://git.k8s.io/kops/CONTRIBUTING.md

2. Also, you'll probably want to checkout our development documentation:

https://git.k8s.io/kops/docs/development

3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

4. Finally, make sure all verifications and tests pass by running:
```
 make pr
```
-->

**What this PR does / why we need it**:

Some jobs have a very long name and are unable to run on GCE.

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-ci-kubernetes-e2e-cos-gce-conformance-concurrrency-canary/1706744659054694400

```
I0926 18:59:22.999032    5221 new_cluster.go:1404] Cloud Provider ID: "gce"
Error: error populating configuration: error fetching network "e2e-e2e-ci-kubernetes-e2e-cos-gce-conformance-concurrrency-canary-k8s-local": googleapi: Error 400: Invalid value for field 'network': 'e2e-e2e-ci-kubernetes-e2e-cos-gce-conformance-concurrrency-canary-k8s-local'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}', invalid
I0926 18:59:23.188927    4895 dumplogs.go:45] /home/prow/go/src/k8s.io/kops/_rundir/d0459643-8d65-47b4-aea3-8e18732a05d0/kops toolbox dump --name e2e-e2e-ci-kubernetes-e2e-cos-gce-conformance-concurrrency-canary.k8s.local --dir /logs/artifacts --private-key /tmp/kops-ssh416189211/key --ssh-user prow
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
