### PR TITLE
Add missing rbac roles and don't run gkenetparams controller

### DIFF
--- a/pkg/model/components/gcpcloudcontrollermanager.go
+++ b/pkg/model/components/gcpcloudcontrollermanager.go
@@ -61,21 +61,14 @@ func (b *GCPCloudControllerManagerOptionsBuilder) BuildOptions(options interface
 	}
 
 	if ccmConfig.Controllers == nil {
-		var changes []string
-
-		// Don't run gkenetworkparamset controller, looks for some CRDs (GKENetworkParamSet and Network) which are only installed on GKE
-		// However, the version we're current running doesn't support this controller anyway, so we need to introduce this later,
-		// possibly based on the image version.
-		// changes = append(ccmConfig.Controllers, "-gkenetworkparams")
+		changes := []string{"*,-gkenetworkparamset"}
 
 		// Turn off some controllers if kops-controller is running them
 		if clusterSpec.IsKopsControllerIPAM() {
-			changes = append(ccmConfig.Controllers, "-nodeipam", "-route")
+			changes = append(changes, "-nodeipam", "-route")
 		}
 
-		if len(changes) != 0 {
-			ccmConfig.Controllers = append([]string{"*"}, changes...)
-		}
+		ccmConfig.Controllers = changes
 	}
 
 	if ccmConfig.Image == "" {

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -20,6 +20,8 @@ spec:
     cidrAllocatorType: CloudAllocator
     clusterCIDR: 100.96.0.0/11
     clusterName: ha-gce-example-com
+    controllers:
+    - '*,-gkenetworkparamset'
     image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v26.2.4
     leaderElection:
       leaderElect: true

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: b9fd0b9dde71d34a4c73ebbff89ecfefd6286232846afcdd1a2d09491900d886
+    manifestHash: dacbfa4c544a4b20b9354355f260c0513352d99830e549dcf78962e089d3bcd8
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -37,6 +37,7 @@ spec:
         - --cidr-allocator-type=CloudAllocator
         - --cluster-cidr=100.96.0.0/11
         - --cluster-name=ha-gce-example-com
+        - --controllers=*,-gkenetworkparamset
         - --leader-elect=true
         - --v=2
         - --cloud-provider=gce
@@ -148,6 +149,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -252,6 +260,8 @@ rules:
   resources:
   - configmaps
   verbs:
+  - create
+  - patch
   - get
   - update
 
@@ -350,8 +360,7 @@ roleRef:
   kind: ClusterRole
   name: system:cloud-controller-manager
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: cloud-controller-manager
   namespace: kube-system
 

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -22,6 +22,8 @@ spec:
     cidrAllocatorType: CloudAllocator
     clusterCIDR: 100.96.0.0/11
     clusterName: minimal-example-com
+    controllers:
+    - '*,-gkenetworkparamset'
     image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v26.2.4
     leaderElection:
       leaderElect: true

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -133,7 +133,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: e40e89303c4872972482abd7a438cec5b374ea8afb3e69d2230c7835b59c2d33
+    manifestHash: 9e80ca766c56a45af5a93a49a067740cf9d35716b95d300ac6f4aa08384f3544
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -37,6 +37,7 @@ spec:
         - --cidr-allocator-type=CloudAllocator
         - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal-example-com
+        - --controllers=*,-gkenetworkparamset
         - --leader-elect=true
         - --v=2
         - --cloud-provider=gce
@@ -148,6 +149,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -252,6 +260,8 @@ rules:
   resources:
   - configmaps
   verbs:
+  - create
+  - patch
   - get
   - update
 
@@ -350,8 +360,7 @@ roleRef:
   kind: ClusterRole
   name: system:cloud-controller-manager
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: cloud-controller-manager
   namespace: kube-system
 

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -20,6 +20,8 @@ spec:
     cidrAllocatorType: CloudAllocator
     clusterCIDR: 100.96.0.0/11
     clusterName: minimal-gce-example-com
+    controllers:
+    - '*,-gkenetworkparamset'
     image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v26.2.4
     leaderElection:
       leaderElect: true

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 447139a03ae68fa785c155f0ec4bb0bc38cdb657fda9687039013d3e2353ab6d
+    manifestHash: f6318f9f355302147958c18f744391cb59d0642d3002451b7ca84d1e1210f49a
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -37,6 +37,7 @@ spec:
         - --cidr-allocator-type=CloudAllocator
         - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal-gce-example-com
+        - --controllers=*,-gkenetworkparamset
         - --leader-elect=true
         - --v=2
         - --cloud-provider=gce
@@ -148,6 +149,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -252,6 +260,8 @@ rules:
   resources:
   - configmaps
   verbs:
+  - create
+  - patch
   - get
   - update
 
@@ -350,8 +360,7 @@ roleRef:
   kind: ClusterRole
   name: system:cloud-controller-manager
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: cloud-controller-manager
   namespace: kube-system
 

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -24,6 +24,8 @@ spec:
     cidrAllocatorType: CloudAllocator
     clusterCIDR: 100.96.0.0/11
     clusterName: minimal-gce-example-com
+    controllers:
+    - '*,-gkenetworkparamset'
     image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v26.2.4
     leaderElection:
       leaderElect: true

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 447139a03ae68fa785c155f0ec4bb0bc38cdb657fda9687039013d3e2353ab6d
+    manifestHash: f6318f9f355302147958c18f744391cb59d0642d3002451b7ca84d1e1210f49a
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -37,6 +37,7 @@ spec:
         - --cidr-allocator-type=CloudAllocator
         - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal-gce-example-com
+        - --controllers=*,-gkenetworkparamset
         - --leader-elect=true
         - --v=2
         - --cloud-provider=gce
@@ -148,6 +149,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -252,6 +260,8 @@ rules:
   resources:
   - configmaps
   verbs:
+  - create
+  - patch
   - get
   - update
 
@@ -350,8 +360,7 @@ roleRef:
   kind: ClusterRole
   name: system:cloud-controller-manager
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: cloud-controller-manager
   namespace: kube-system
 

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
@@ -24,6 +24,8 @@ spec:
     cidrAllocatorType: CloudAllocator
     clusterCIDR: 100.96.0.0/11
     clusterName: minimal-gce-ilb-example-com
+    controllers:
+    - '*,-gkenetworkparamset'
     image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v26.2.4
     leaderElection:
       leaderElect: true

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: f3c98b2b2ad3b91f4b82a97af7d8d58411166ac29e8a04cb04905a81ffb16ad9
+    manifestHash: e28ca21950fe4c0bdd94348e91a89594c68be7e95059dbdfb0a043e33abeb0fc
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -37,6 +37,7 @@ spec:
         - --cidr-allocator-type=CloudAllocator
         - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal-gce-ilb-example-com
+        - --controllers=*,-gkenetworkparamset
         - --leader-elect=true
         - --v=2
         - --cloud-provider=gce
@@ -148,6 +149,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -252,6 +260,8 @@ rules:
   resources:
   - configmaps
   verbs:
+  - create
+  - patch
   - get
   - update
 
@@ -350,8 +360,7 @@ roleRef:
   kind: ClusterRole
   name: system:cloud-controller-manager
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: cloud-controller-manager
   namespace: kube-system
 

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -24,6 +24,8 @@ spec:
     cidrAllocatorType: CloudAllocator
     clusterCIDR: 100.96.0.0/11
     clusterName: minimal-gce-with-a-very-very-very-very-very-long-name-example-com
+    controllers:
+    - '*,-gkenetworkparamset'
     image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v26.2.4
     leaderElection:
       leaderElect: true

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 04674610fafbf0bf7a284d39cd3bb8c5fc5e3ff1707c218cb235d60debaf536b
+    manifestHash: 854e64edebc744f2d8e7ee5dff7342e3a7f5ba3dd385a2446a4c6e10fe9c23f3
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -37,6 +37,7 @@ spec:
         - --cidr-allocator-type=CloudAllocator
         - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
+        - --controllers=*,-gkenetworkparamset
         - --leader-elect=true
         - --v=2
         - --cloud-provider=gce
@@ -148,6 +149,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -252,6 +260,8 @@ rules:
   resources:
   - configmaps
   verbs:
+  - create
+  - patch
   - get
   - update
 
@@ -350,8 +360,7 @@ roleRef:
   kind: ClusterRole
   name: system:cloud-controller-manager
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: cloud-controller-manager
   namespace: kube-system
 

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -20,6 +20,8 @@ spec:
     cidrAllocatorType: CloudAllocator
     clusterCIDR: 100.96.0.0/11
     clusterName: minimal-gce-with-a-very-very-very-very-very-long-name-example-com
+    controllers:
+    - '*,-gkenetworkparamset'
     image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v26.2.4
     leaderElection:
       leaderElect: true

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 04674610fafbf0bf7a284d39cd3bb8c5fc5e3ff1707c218cb235d60debaf536b
+    manifestHash: 854e64edebc744f2d8e7ee5dff7342e3a7f5ba3dd385a2446a4c6e10fe9c23f3
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -37,6 +37,7 @@ spec:
         - --cidr-allocator-type=CloudAllocator
         - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal-gce-with-a-very-very-very-very-very-long-name-example-com
+        - --controllers=*,-gkenetworkparamset
         - --leader-elect=true
         - --v=2
         - --cloud-provider=gce
@@ -148,6 +149,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -252,6 +260,8 @@ rules:
   resources:
   - configmaps
   verbs:
+  - create
+  - patch
   - get
   - update
 
@@ -350,8 +360,7 @@ roleRef:
   kind: ClusterRole
   name: system:cloud-controller-manager
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: cloud-controller-manager
   namespace: kube-system
 

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
@@ -24,6 +24,8 @@ spec:
     cidrAllocatorType: CloudAllocator
     clusterCIDR: 100.96.0.0/11
     clusterName: minimal-gce-plb-example-com
+    controllers:
+    - '*,-gkenetworkparamset'
     image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v26.2.4
     leaderElection:
       leaderElect: true

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 25977d1f21dea7d3b29bdd65ae4f1a454e2539e9e53f94ea193e5e0c543dbb41
+    manifestHash: fd710d47ea12ec2f0662ec4ca628c1050d28310ea8631c811dba6baef89f14df
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -37,6 +37,7 @@ spec:
         - --cidr-allocator-type=CloudAllocator
         - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal-gce-plb-example-com
+        - --controllers=*,-gkenetworkparamset
         - --leader-elect=true
         - --v=2
         - --cloud-provider=gce
@@ -148,6 +149,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -252,6 +260,8 @@ rules:
   resources:
   - configmaps
   verbs:
+  - create
+  - patch
   - get
   - update
 
@@ -350,8 +360,7 @@ roleRef:
   kind: ClusterRole
   name: system:cloud-controller-manager
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: cloud-controller-manager
   namespace: kube-system
 

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
@@ -20,6 +20,8 @@ spec:
     cidrAllocatorType: CloudAllocator
     clusterCIDR: 100.96.0.0/11
     clusterName: minimal-gce-private-example-com
+    controllers:
+    - '*,-gkenetworkparamset'
     image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v26.2.4
     leaderElection:
       leaderElect: true

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 553ec14dae35de48048472c7463f696dad7cc05aa5233202ae19d4b4c53b39bf
+    manifestHash: 2643e77f40cb84dc4d7b873a80f88a5f682cc19d5cd9c1fd9b546bb149a8f000
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -37,6 +37,7 @@ spec:
         - --cidr-allocator-type=CloudAllocator
         - --cluster-cidr=100.96.0.0/11
         - --cluster-name=minimal-gce-private-example-com
+        - --controllers=*,-gkenetworkparamset
         - --leader-elect=true
         - --v=2
         - --cloud-provider=gce
@@ -148,6 +149,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -252,6 +260,8 @@ rules:
   resources:
   - configmaps
   verbs:
+  - create
+  - patch
   - get
   - update
 
@@ -350,8 +360,7 @@ roleRef:
   kind: ClusterRole
   name: system:cloud-controller-manager
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: cloud-controller-manager
   namespace: kube-system
 

--- a/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
@@ -124,6 +124,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -222,6 +229,8 @@ rules:
   resourceNames:
   - cloud-controller-manager
   verbs:
+  - create
+  - patch
   - get
   - update
 ---
@@ -306,7 +315,6 @@ roleRef:
   name: system:cloud-controller-manager
 subjects:
 - kind: ServiceAccount
-  apiGroup: ""
   name: cloud-controller-manager
   namespace: kube-system
 ---


### PR DESCRIPTION
I'm confused about something.

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-ci-kubernetes-e2e-cos-gce-slow-canary/1707140514421149696

kops deploys the ccm like this:
```yaml
# trimmed it, complete manifest at https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-ci-kubernetes-e2e-cos-gce-slow-canary/1707140514421149696/artifacts/cluster-info/kube-system/daemonsets.yaml
- metadata:
    name: cloud-controller-manager
    namespace: kube-system
    resourceVersion: "428"
    uid: 1a8d26de-01fa-4248-bc40-9e4eca30d70e
  spec:
      spec:
        containers:
        - args:
          - --allocate-node-cidrs=true
          - --cidr-allocator-type=CloudAllocator
          - --cluster-cidr=100.96.0.0/11
          - --cluster-name=e2e-e2e-ci-kubernetes-e2e-cos-gce-slow-canary-k8s-local
          - --leader-elect=true
          - --v=2
          - --cloud-provider=gce
          - --use-service-account-credentials=true
          - --cloud-config=/etc/kubernetes/cloud.config
          command:
          - /cloud-controller-manager
          env:
          - name: KUBERNETES_SERVICE_HOST
            value: 127.0.0.1
          image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v26.2.4
          name: cloud-controller-manager
        hostNetwork: true
        priorityClassName: system-cluster-critical
        restartPolicy: Always
        schedulerName: default-scheduler
        securityContext: {}
        serviceAccount: cloud-controller-manager
        serviceAccountName: cloud-controller-manager
        volumes:
        - hostPath:
            path: /etc/kubernetes/cloud.config
            type: ""
          name: cloudconfig
```

We set this flag `--use-service-account-credentials=true` which means the CCM should use the service account configured on the pod instead of another one. However, I'm seeing the following lines in the ccm logs:

```
E0927 21:24:46.306277       1 gce_loadbalancer.go:174] Failed to EnsureLoadBalancer(e2e-e2e-ci-kubernetes-e2e-cos-gce-slow-canary-k8s-local, loadbalancers-7082, lb-internal, a3b49aa0789f44068b84b25579f9409a, us-east4), err: services "lb-internal" is forbidden: User "system:serviceaccount:kube-system:cloud-provider" cannot patch resource "services/status" in API group "" in the namespace "loadbalancers-7082"
E0927 21:24:46.306427       1 controller.go:289] error processing service loadbalancers-7082/lb-internal (will retry): failed to ensure load balancer: services "lb-internal" is forbidden: User "system:serviceaccount:kube-system:cloud-provider" cannot patch resource "services/status" in API group "" in the namespace "loadbalancers-7082"
```

https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-ci-kubernetes-e2e-cos-gce-slow-canary/1707140514421149696/artifacts/cluster-info/kube-system/cloud-controller-manager-6hqn7/logs.txt

I see the kube-up clusters deploy this ancient manifest https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/addons/loadbalancing/cloud-provider-role.yaml which rely on deprecated/removed behaviour


What am I missing?

@aojea @justinsb 