### PR TITLE
Create a temporary staging bucket for kops builds

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/down.go
+++ b/tests/e2e/kubetest2-kops/deployer/down.go
@@ -56,6 +56,7 @@ func (d *deployer) Down() error {
 
 	if d.CloudProvider == "gce" && d.createBucket {
 		gce.DeleteGCSBucket(d.stateStore(), d.GCPProject)
+		gce.DeleteGCSBucket(d.stagingStore(), d.GCPProject)
 	}
 
 	if d.boskos != nil {

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -49,7 +49,7 @@ func (d *deployer) Up() error {
 	}
 
 	if d.CloudProvider == "gce" && d.createBucket {
-		if err := gce.EnsureGCSBucket(d.stateStore(), d.GCPProject); err != nil {
+		if err := gce.EnsureGCSBucket(d.stateStore(), d.GCPProject, false); err != nil {
 			return err
 		}
 	}

--- a/tests/e2e/kubetest2-kops/gce/gcs.go
+++ b/tests/e2e/kubetest2-kops/gce/gcs.go
@@ -21,25 +21,26 @@ import (
 	"encoding/hex"
 	"os"
 	"strings"
+	"time"
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
-func GCSBucketName(projectID string) string {
+func GCSBucketName(projectID, prefix string) string {
 	var s string
-	if jobID := os.Getenv("PROW_JOB_ID"); len(jobID) >= 2 {
-		s = jobID[:2]
+	if jobID := os.Getenv("PROW_JOB_ID"); len(jobID) >= 4 {
+		s = jobID[:4]
 	} else {
 		b := make([]byte, 2)
 		rand.Read(b)
 		s = hex.EncodeToString(b)
 	}
-	bucket := strings.Join([]string{projectID, "state", s}, "-")
+	bucket := strings.Join([]string{projectID, prefix, s}, "-")
 	return bucket
 }
 
-func EnsureGCSBucket(bucketPath, projectID string) error {
+func EnsureGCSBucket(bucketPath, projectID string, public bool) error {
 	lsArgs := []string{
 		"gsutil", "ls", "-b",
 	}
@@ -74,6 +75,22 @@ func EnsureGCSBucket(bucketPath, projectID string) error {
 	err = cmd.Run()
 	if err != nil {
 		return err
+	}
+
+	if public {
+		iamArgs := []string{
+			"gsutil", "iam", "ch", "allUsers:objectViewer",
+		}
+		iamArgs = append(iamArgs, bucketPath)
+		klog.Info(strings.Join(iamArgs, " "))
+		// GCS APIs are strongly consistent but this should help with flakes
+		time.Sleep(10 * time.Second)
+		cmd = exec.Command(iamArgs[0], iamArgs[1:]...)
+		exec.InheritOutput(cmd)
+		err = cmd.Run()
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Right now, kops assets get staged at the `kops-ci` bucket which is not writable if you migrate the job to the community cluster.

This change creates a public temporary staging bucket if you lease a project from boskos, similar to how we create the state buckets today.

@rjsadow You should be able to migrate kops GCE presubmits after this is merged.

Part of https://github.com/kubernetes/test-infra/issues/29722