### PR TITLE
Add missing kube api-server config for alpha tests

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -48,14 +48,16 @@ type deployer struct {
 	KopsBaseURL          string `flag:"-"`
 	PublishVersionMarker string `flag:"publish-version-marker" desc:"The GCS path to which the --kops-version-marker is uploaded if the tests pass"`
 
-	ClusterName            string   `flag:"cluster-name" desc:"The FQDN to use for the cluster name"`
-	CloudProvider          string   `flag:"cloud-provider" desc:"Which cloud provider to use"`
-	GCPProject             string   `flag:"gcp-project" desc:"Which GCP Project to use when --cloud-provider=gce"`
-	Env                    []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`
-	CreateArgs             string   `flag:"create-args" desc:"Extra space-separated arguments passed to 'kops create cluster'"`
-	KopsBinaryPath         string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
-	KubernetesFeatureGates string   `flag:"kubernetes-feature-gates" desc:"Feature Gates to enable on Kubernetes components"`
-	createBucket           bool     `flag:"-"`
+	ClusterName                   string   `flag:"cluster-name" desc:"The FQDN to use for the cluster name"`
+	CloudProvider                 string   `flag:"cloud-provider" desc:"Which cloud provider to use"`
+	GCPProject                    string   `flag:"gcp-project" desc:"Which GCP Project to use when --cloud-provider=gce"`
+	Env                           []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`
+	CreateArgs                    string   `flag:"create-args" desc:"Extra space-separated arguments passed to 'kops create cluster'"`
+	KopsBinaryPath                string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
+	KubernetesFeatureGates        string   `flag:"kubernetes-feature-gates" desc:"Feature Gates to enable on Kubernetes components"`
+	KubeAPIServerAdmissionPlugins string   `flag:"kube-apiserver-admission-plugins" desc:"A list of API Server Admissions controler to run"`
+	KubeAPIServerRuntimeConfig    string   `flag:"kube-apiserver-runtime-config" desc:"RuntimeConfig values"`
+	createBucket                  bool     `flag:"-"`
 
 	// ControlPlaneCount specifies the number of VMs in the control-plane.
 	ControlPlaneCount int `flag:"control-plane-count" desc:"Number of control-plane instances"`
@@ -109,9 +111,11 @@ func (d *deployer) Provider() string {
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	// create a deployer object and set fields that are not flag controlled
 	d := &deployer{
-		commonOptions:        opts,
-		BuildOptions:         &builder.BuildOptions{},
-		boskosHeartbeatClose: make(chan struct{}),
+		commonOptions:                 opts,
+		BuildOptions:                  &builder.BuildOptions{},
+		boskosHeartbeatClose:          make(chan struct{}),
+		KubeAPIServerAdmissionPlugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection,PersistentVolumeClaimResize,RuntimeClass,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+		KubeAPIServerRuntimeConfig:    "extensions/v1beta1=true,scheduling.k8s.io/v1alpha1=true",
 	}
 
 	dir, err := defaultArtifactsDir()

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -178,6 +178,16 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		args = appendIfUnset(args, "--gce-service-account", "default")
 		args = appendIfUnset(args, "--networking", "kubenet")
 
+		// kubeapi server config https://github.com/kubernetes/kubernetes/blob/622509830c1038535e539f7d364f5cd7c3b38791/cluster/gce/gci/configure-kubeapiserver.sh#L106
+		for _, v := range strings.Split(d.KubeAPIServerAdmissionPlugins, ",") {
+			args = append(args, "--set", fmt.Sprintf("spec.kubeAPIServer.enableAdmissionPlugins=%s", v))
+		}
+		if strings.Contains(d.KubernetesFeatureGates, "AllAlpha") {
+			d.KubeAPIServerRuntimeConfig = "api/all=true"
+		}
+		for _, v := range strings.Split(d.KubeAPIServerRuntimeConfig, ",") {
+			args = append(args, "--set", fmt.Sprintf("spec.kubeAPIServer.runtimeConfig=%s", v))
+		}
 		// We used to set the --vpc flag to split clusters into different networks, this is now the default.
 		// args = appendIfUnset(args, "--vpc", strings.Split(d.ClusterName, ".")[0])
 	case "digitalocean":


### PR DESCRIPTION
/cc @hakman 

stuck on this error

apiserver flag diffs https://www.diffchecker.com/66T6W3uy/ (left is kops, right is kube-up)

```
I1001 14:57:02.957864  301351 local.go:42] ⚙️ /home/ubuntu/go/src/k8s.io/kops/.build/dist/linux/amd64/kops create cluster --name amd64.k8s.local --cloud gce --kubernetes-version https://storage.googleapis.com/k8s-release-dev/ci/v1.29.0-alpha.1.62+622509830c1038 --ssh-public-key  --set cluster.spec.nodePortAccess=0.0.0.0/0 --image=ubuntu-os-cloud/ubuntu-2204-jammy-v20230908 --channel=alpha --zones=us-central1-a --node-count=2 --admin-access 0.0.0.0/0 --master-count 1 --master-volume-size 48 --node-volume-size 48 --kubernetes-feature-gates +AllAlpha,-InTreePluginGCEUnregister,+DisableCloudProviders,+DisableKubeletCloudCredentialProviders --master-size e2-standard-2 --node-size e2-standard-2 --project borg-env --gce-service-account default --networking kubenet --set spec.kubeAPIServer.enableAdmissionPlugins=NamespaceLifecycle --set spec.kubeAPIServer.enableAdmissionPlugins=LimitRanger --set spec.kubeAPIServer.enableAdmissionPlugins=ServiceAccount --set spec.kubeAPIServer.enableAdmissionPlugins=PersistentVolumeLabel --set spec.kubeAPIServer.enableAdmissionPlugins=DefaultStorageClass --set spec.kubeAPIServer.enableAdmissionPlugins=DefaultTolerationSeconds --set spec.kubeAPIServer.enableAdmissionPlugins=NodeRestriction --set spec.kubeAPIServer.enableAdmissionPlugins=Priority --set spec.kubeAPIServer.enableAdmissionPlugins=StorageObjectInUseProtection --set spec.kubeAPIServer.enableAdmissionPlugins=PersistentVolumeClaimResize --set spec.kubeAPIServer.enableAdmissionPlugins=RuntimeClass --set spec.kubeAPIServer.enableAdmissionPlugins=MutatingAdmissionWebhook --set spec.kubeAPIServer.enableAdmissionPlugins=ValidatingAdmissionWebhook --set spec.kubeAPIServer.enableAdmissionPlugins=ResourceQuota --set spec.kubeAPIServer.runtimeConfig=api/all=true,extensions/v1beta1=true,scheduling.k8s.io/v1alpha1=true --set spec.kubeAPIServer.enableAggregatorRouting=true --set spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --set spec.kubeAPIServer.auditLogMaxSize=2000000000 --set spec.kubeAPIServer.logLevel=4
Flag --master-count has been deprecated, use --control-plane-count instead
Flag --master-volume-size has been deprecated, use --control-plane-volume-size instead
Flag --master-size has been deprecated, use --control-plane-size instead
I1001 14:57:03.492401  305295 new_cluster.go:581] VMs will be configured to use specified Service Account: default
I1001 14:57:03.492504  305295 new_cluster.go:1404] Cloud Provider ID: "gce"
Error: field extensions/v1beta1 not found in *Cluster
```