### PR TITLE
fix(service): Add missing port 9999 to pod-identity-webhook service

### DIFF
--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
@@ -257,6 +257,9 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: 443
+  - port: 9999
+    protocol: TCP
+    targetPort: 9999
   selector:
     app: pod-identity-webhook
 


### PR DESCRIPTION
### What does this PR introduce?

This PR addresses the issue where port 9999 was missing in the `pod-identity-webhook` service definition, causing problems with Prometheus scraping.

### Why is this change needed?

The missing port 9999 was required for Prometheus to scrape metrics from the `pod-identity-webhook` service. Without this port, monitoring and metrics collection were incomplete.

### How does it address the issue?

This PR modifies the service definition to include port 9999 in the `spec.ports` section, ensuring that Prometheus can scrape metrics correctly.

### Related Issue

Fixes #15946