### PR TITLE
WIP Put control-plane and apiserver nodes in IPv6-only subnets

### DIFF
--- a/cloudmock/aws/mockelbv2/targetgroups.go
+++ b/cloudmock/aws/mockelbv2/targetgroups.go
@@ -95,6 +95,7 @@ func (m *MockELBV2) CreateTargetGroup(request *elbv2.CreateTargetGroupInput) (*e
 
 	tg := elbv2.TargetGroup{
 		TargetGroupName:         request.Name,
+		IpAddressType:           request.IpAddressType,
 		Port:                    request.Port,
 		Protocol:                request.Protocol,
 		VpcId:                   request.VpcId,

--- a/docs/networking/ipv6.md
+++ b/docs/networking/ipv6.md
@@ -23,7 +23,7 @@ For example, if the VPC's CIDR is `2001:db8::/56` then the syntax `/64#a` would 
 
 Public and utility subnets are expected to be dual-stack. Subnets of type `Private` are expected to be IPv6-only.
 There is a new type of subnet `DualStack` which is like `Private` but is dual-stack.
-The `DualStack` subnets are used by default for the control plane and APIServer nodes.
+Prior to kOps 1.29, `DualStack` subnets are used by default for bastion servers, the control plane, and APIServer nodes.
 
 IPv6-only subnets require Kubernetes 1.22 or later. For this reason, private topology on an IPv6 cluster also
 requires Kubernetes 1.22 or later.

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -37,7 +37,7 @@ NAT64 range `64:ff9b::/96` is typically routed to a NAT64 device, such as an AWS
 
 A subnet of type `DualStack` is like `Private`, but supports both IPv4 and IPv6.
 
-On AWS, this subnet type is used for nodes, such as control plane nodes and bastions,
+On AWS prior to kOps 1.29, this subnet type is used for nodes, such as control plane nodes and bastions,
 which need to be instance targets of a load balancer.
 
 ## Utility Subnet

--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -47,6 +47,9 @@ func awsValidateCluster(c *kops.Cluster, strict bool) field.ErrorList {
 		if lbSpec.Class == kops.LoadBalancerClassNetwork && lbSpec.UseForInternalAPI && lbSpec.Type == kops.LoadBalancerTypeInternal {
 			allErrs = append(allErrs, field.Forbidden(lbPath.Child("useForInternalAPI"), "useForInternalAPI cannot be used with internal NLB due lack of hairpinning support"))
 		}
+		if lbSpec.Class == kops.LoadBalancerClassClassic && c.Spec.IsIPv6Only() {
+			allErrs = append(allErrs, field.Forbidden(lbPath.Child("class"), "IPv6 clusters do not support classic load balancers"))
+		}
 		if lbSpec.SSLCertificate != "" && lbSpec.Class != kops.LoadBalancerClassNetwork {
 			allErrs = append(allErrs, field.Forbidden(lbPath.Child("sslCertificate"), "sslCertificate requires a network load balancer. See https://github.com/kubernetes/kops/blob/master/permalinks/acm_nlb.md"))
 		}

--- a/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
@@ -87,7 +87,7 @@ spec:
   minSize: 1
   role: Master
   subnets:
-  - dualstack-us-test-1a
+  - us-test-1a
 
 ---
 

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -803,9 +803,10 @@ resource "aws_lb_target_group" "bastion-bastionuserdata-e-4grhsv" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-bastionuserdata-e-4grhsv"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-bastionuserdata-e-4grhsv"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                                 = "bastionuserdata.example.com"
     "Name"                                              = "bastion-bastionuserdata-e-4grhsv"

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -683,9 +683,10 @@ resource "aws_lb_target_group" "tcp-complex-example-com-vpjolq" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "tcp-complex-example-com-vpjolq"
-  port     = 443
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "tcp-complex-example-com-vpjolq"
+  port            = 443
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "tcp-complex-example-com-vpjolq"
@@ -705,9 +706,10 @@ resource "aws_lb_target_group" "tls-complex-example-com-5nursn" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "tls-complex-example-com-5nursn"
-  port     = 443
-  protocol = "TLS"
+  ip_address_type = "ipv4"
+  name            = "tls-complex-example-com-5nursn"
+  port            = 443
+  protocol        = "TLS"
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "tls-complex-example-com-5nursn"

--- a/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
@@ -612,9 +612,10 @@ resource "aws_lb_target_group" "kops-controller-minimal-e-uvauf3" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "kops-controller-minimal-e-uvauf3"
-  port     = 3988
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "kops-controller-minimal-e-uvauf3"
+  port            = 3988
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
     "Name"                                      = "kops-controller-minimal-e-uvauf3"
@@ -632,9 +633,10 @@ resource "aws_lb_target_group" "tcp-minimal-example-com-5905t8" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "tcp-minimal-example-com-5905t8"
-  port     = 443
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "tcp-minimal-example-com-5905t8"
+  port            = 443
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
     "Name"                                      = "tcp-minimal-example-com-5905t8"

--- a/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
@@ -652,9 +652,10 @@ resource "aws_lb_target_group" "tcp-minimal-ipv6-example--bne5ih" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "tcp-minimal-ipv6-example--bne5ih"
-  port     = 443
-  protocol = "TCP"
+  ip_address_type = "ipv6"
+  name            = "tcp-minimal-ipv6-example--bne5ih"
+  port            = 443
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "tcp-minimal-ipv6-example--bne5ih"
@@ -1212,24 +1213,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
-  from_port                = 3
-  protocol                 = "icmp"
-  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
-  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port                  = 4
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
-  from_port                = 3
-  protocol                 = "icmp"
-  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
-  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
-  to_port                  = 4
-  type                     = "ingress"
-}
-
 resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   from_port         = -1
   ipv6_cidr_blocks  = ["::/0"]
@@ -1237,6 +1220,24 @@ resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = -1
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "icmpv6-pmtu-cp-to-elb" {
+  from_port                = -1
+  protocol                 = "icmpv6"
+  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port                  = -1
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmpv6-pmtu-elb-to-cp" {
+  from_port                = -1
+  protocol                 = "icmpv6"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = -1
+  type                     = "ingress"
 }
 
 resource "aws_sqs_queue" "minimal-ipv6-example-com-nth" {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
@@ -652,9 +652,10 @@ resource "aws_lb_target_group" "tcp-minimal-ipv6-example--bne5ih" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "tcp-minimal-ipv6-example--bne5ih"
-  port     = 443
-  protocol = "TCP"
+  ip_address_type = "ipv6"
+  name            = "tcp-minimal-ipv6-example--bne5ih"
+  port            = 443
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "tcp-minimal-ipv6-example--bne5ih"
@@ -1203,24 +1204,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
-  from_port                = 3
-  protocol                 = "icmp"
-  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
-  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port                  = 4
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
-  from_port                = 3
-  protocol                 = "icmp"
-  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
-  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
-  to_port                  = 4
-  type                     = "ingress"
-}
-
 resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   from_port         = -1
   ipv6_cidr_blocks  = ["::/0"]
@@ -1228,6 +1211,24 @@ resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = -1
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "icmpv6-pmtu-cp-to-elb" {
+  from_port                = -1
+  protocol                 = "icmpv6"
+  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port                  = -1
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmpv6-pmtu-elb-to-cp" {
+  from_port                = -1
+  protocol                 = "icmpv6"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = -1
+  type                     = "ingress"
 }
 
 resource "aws_sqs_queue" "minimal-ipv6-example-com-nth" {

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
@@ -652,9 +652,10 @@ resource "aws_lb_target_group" "tcp-minimal-ipv6-example--bne5ih" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "tcp-minimal-ipv6-example--bne5ih"
-  port     = 443
-  protocol = "TCP"
+  ip_address_type = "ipv6"
+  name            = "tcp-minimal-ipv6-example--bne5ih"
+  port            = 443
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "tcp-minimal-ipv6-example--bne5ih"
@@ -1195,24 +1196,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
-  from_port                = 3
-  protocol                 = "icmp"
-  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
-  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port                  = 4
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
-  from_port                = 3
-  protocol                 = "icmp"
-  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
-  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
-  to_port                  = 4
-  type                     = "ingress"
-}
-
 resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   from_port         = -1
   ipv6_cidr_blocks  = ["::/0"]
@@ -1220,6 +1203,24 @@ resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = -1
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "icmpv6-pmtu-cp-to-elb" {
+  from_port                = -1
+  protocol                 = "icmpv6"
+  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port                  = -1
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmpv6-pmtu-elb-to-cp" {
+  from_port                = -1
+  protocol                 = "icmpv6"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = -1
+  type                     = "ingress"
 }
 
 resource "aws_sqs_queue" "minimal-ipv6-example-com-nth" {

--- a/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
@@ -652,9 +652,10 @@ resource "aws_lb_target_group" "tcp-minimal-ipv6-example--bne5ih" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "tcp-minimal-ipv6-example--bne5ih"
-  port     = 443
-  protocol = "TCP"
+  ip_address_type = "ipv6"
+  name            = "tcp-minimal-ipv6-example--bne5ih"
+  port            = 443
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "tcp-minimal-ipv6-example--bne5ih"
@@ -1195,24 +1196,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
-  from_port                = 3
-  protocol                 = "icmp"
-  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
-  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port                  = 4
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
-  from_port                = 3
-  protocol                 = "icmp"
-  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
-  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
-  to_port                  = 4
-  type                     = "ingress"
-}
-
 resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   from_port         = -1
   ipv6_cidr_blocks  = ["::/0"]
@@ -1220,6 +1203,24 @@ resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = -1
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "icmpv6-pmtu-cp-to-elb" {
+  from_port                = -1
+  protocol                 = "icmpv6"
+  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port                  = -1
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmpv6-pmtu-elb-to-cp" {
+  from_port                = -1
+  protocol                 = "icmpv6"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = -1
+  type                     = "ingress"
 }
 
 resource "aws_sqs_queue" "minimal-ipv6-example-com-nth" {

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -784,9 +784,10 @@ resource "aws_lb_target_group" "bastion-private-shared-ip-eepmph" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-private-shared-ip-eepmph"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-private-shared-ip-eepmph"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                                   = "private-shared-ip.example.com"
     "Name"                                                = "bastion-private-shared-ip-eepmph"

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -779,9 +779,10 @@ resource "aws_lb_target_group" "bastion-private-shared-su-5ol32q" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-private-shared-su-5ol32q"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-private-shared-su-5ol32q"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                                       = "private-shared-subnet.example.com"
     "Name"                                                    = "bastion-private-shared-su-5ol32q"

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -798,9 +798,10 @@ resource "aws_lb_target_group" "bastion-privatecalico-exa-hocohm" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-privatecalico-exa-hocohm"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-privatecalico-exa-hocohm"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                               = "privatecalico.example.com"
     "Name"                                            = "bastion-privatecalico-exa-hocohm"

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -802,9 +802,10 @@ resource "aws_lb_target_group" "bastion-privatecanal-exam-hmhsp5" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-privatecanal-exam-hmhsp5"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-privatecanal-exam-hmhsp5"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                              = "privatecanal.example.com"
     "Name"                                           = "bastion-privatecanal-exam-hmhsp5"

--- a/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
@@ -802,9 +802,10 @@ resource "aws_lb_target_group" "bastion-privatecilium-exa-l2ms01" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-privatecilium-exa-l2ms01"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-privatecilium-exa-l2ms01"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"
     "Name"                                            = "bastion-privatecilium-exa-l2ms01"

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -802,9 +802,10 @@ resource "aws_lb_target_group" "bastion-privatecilium-exa-l2ms01" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-privatecilium-exa-l2ms01"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-privatecilium-exa-l2ms01"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"
     "Name"                                            = "bastion-privatecilium-exa-l2ms01"

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -802,9 +802,10 @@ resource "aws_lb_target_group" "bastion-privatecilium-exa-l2ms01" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-privatecilium-exa-l2ms01"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-privatecilium-exa-l2ms01"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"
     "Name"                                            = "bastion-privatecilium-exa-l2ms01"

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -819,9 +819,10 @@ resource "aws_lb_target_group" "bastion-privateciliumadva-0jni40" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-privateciliumadva-0jni40"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-privateciliumadva-0jni40"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
     "Name"                                                    = "bastion-privateciliumadva-0jni40"

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -884,9 +884,10 @@ resource "aws_lb_target_group" "bastion-privatedns1-examp-mbgbef" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-privatedns1-examp-mbgbef"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-privatedns1-examp-mbgbef"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "bastion-privatedns1-examp-mbgbef"

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -793,9 +793,10 @@ resource "aws_lb_target_group" "bastion-privatedns2-examp-e704o2" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-privatedns2-examp-e704o2"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-privatedns2-examp-e704o2"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                             = "privatedns2.example.com"
     "Name"                                          = "bastion-privatedns2-examp-e704o2"

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -802,9 +802,10 @@ resource "aws_lb_target_group" "bastion-privateflannel-ex-753531" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-privateflannel-ex-753531"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-privateflannel-ex-753531"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                                = "privateflannel.example.com"
     "Name"                                             = "bastion-privateflannel-ex-753531"

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -811,9 +811,10 @@ resource "aws_lb_target_group" "bastion-privatekopeio-exa-d8ef8e" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-privatekopeio-exa-d8ef8e"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-privatekopeio-exa-d8ef8e"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                               = "privatekopeio.example.com"
     "Name"                                            = "bastion-privatekopeio-exa-d8ef8e"

--- a/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
@@ -634,9 +634,10 @@ resource "aws_lb_target_group" "tcp-minimal-ipv6-example--bne5ih" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "tcp-minimal-ipv6-example--bne5ih"
-  port     = 443
-  protocol = "TCP"
+  ip_address_type = "ipv6"
+  name            = "tcp-minimal-ipv6-example--bne5ih"
+  port            = 443
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "tcp-minimal-ipv6-example--bne5ih"
@@ -1177,24 +1178,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
-  from_port                = 3
-  protocol                 = "icmp"
-  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
-  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port                  = 4
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
-  from_port                = 3
-  protocol                 = "icmp"
-  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
-  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
-  to_port                  = 4
-  type                     = "ingress"
-}
-
 resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   from_port         = -1
   ipv6_cidr_blocks  = ["::/0"]
@@ -1202,6 +1185,24 @@ resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = -1
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "icmpv6-pmtu-cp-to-elb" {
+  from_port                = -1
+  protocol                 = "icmpv6"
+  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port                  = -1
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmpv6-pmtu-elb-to-cp" {
+  from_port                = -1
+  protocol                 = "icmpv6"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = -1
+  type                     = "ingress"
 }
 
 resource "aws_sqs_queue" "minimal-ipv6-example-com-nth" {

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -787,9 +787,10 @@ resource "aws_lb_target_group" "bastion-unmanaged-example-d7bn3d" {
     protocol            = "TCP"
     unhealthy_threshold = 2
   }
-  name     = "bastion-unmanaged-example-d7bn3d"
-  port     = 22
-  protocol = "TCP"
+  ip_address_type = "ipv4"
+  name            = "bastion-unmanaged-example-d7bn3d"
+  port            = 22
+  protocol        = "TCP"
   tags = {
     "KubernetesCluster"                           = "unmanaged.example.com"
     "Name"                                        = "bastion-unmanaged-example-d7bn3d"

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -38,6 +38,11 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchT
 		return err
 	}
 
+	primaryIPv6 := false
+	if fi.ValueOf(t.IPv6AddressCount) > 0 {
+		primaryIPv6 = true
+	}
+
 	// @step: lets build the launch template data
 	data := &ec2.RequestLaunchTemplateData{
 		DisableApiTermination: fi.PtrTo(false),
@@ -55,6 +60,7 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchT
 				DeleteOnTermination:      aws.Bool(true),
 				DeviceIndex:              fi.PtrTo(int64(0)),
 				Ipv6AddressCount:         t.IPv6AddressCount,
+				PrimaryIpv6:              fi.PtrTo(primaryIPv6),
 			},
 		},
 	}

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -493,14 +493,6 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 			if len(ig.Spec.Subnets) == 0 {
 				return nil, fmt.Errorf("control-plane InstanceGroup %s did not specify any Subnets", g.ObjectMeta.Name)
 			}
-		} else if ig.IsAPIServerOnly() && cluster.Spec.IsIPv6Only() {
-			if len(ig.Spec.Subnets) == 0 {
-				for _, subnet := range cluster.Spec.Networking.Subnets {
-					if subnet.Type != api.SubnetTypePrivate && subnet.Type != api.SubnetTypeUtility {
-						ig.Spec.Subnets = append(g.Spec.Subnets, subnet.Name)
-					}
-				}
-			}
 		} else {
 			if len(ig.Spec.Subnets) == 0 {
 				for _, subnet := range cluster.Spec.Networking.Subnets {
@@ -903,11 +895,7 @@ func setupControlPlane(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubne
 			default:
 				// Use only the main subnet for control-plane nodes
 				subnet := subnets[0]
-				if opt.IPv6 && opt.Topology == api.TopologyPrivate {
-					g.Spec.Subnets = append(g.Spec.Subnets, "dualstack-"+subnet.Name)
-				} else {
-					g.Spec.Subnets = append(g.Spec.Subnets, subnet.Name)
-				}
+				g.Spec.Subnets = append(g.Spec.Subnets, subnet.Name)
 			}
 
 			if cloudProvider == api.CloudProviderGCE || cloudProvider == api.CloudProviderAzure {

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -157,14 +157,6 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 		if len(ig.Spec.Subnets) == 0 {
 			return nil, fmt.Errorf("control-plane InstanceGroup %s did not specify any Subnets", ig.ObjectMeta.Name)
 		}
-	} else if ig.IsAPIServerOnly() && cluster.Spec.IsIPv6Only() {
-		if len(ig.Spec.Subnets) == 0 {
-			for _, subnet := range cluster.Spec.Networking.Subnets {
-				if subnet.Type != kops.SubnetTypePrivate && subnet.Type != kops.SubnetTypeUtility {
-					ig.Spec.Subnets = append(ig.Spec.Subnets, subnet.Name)
-				}
-			}
-		}
 	} else {
 		if len(ig.Spec.Subnets) == 0 {
 			for _, subnet := range cluster.Spec.Networking.Subnets {


### PR DESCRIPTION
AWS now supports IPv6 instance targets, which means we can stop using `DualStack` subnets for the control plane, APIServer nodes, and bastion hosts.