### PR TITLE
aws: Don't add dependency on additional CIDR for shared VPC

### DIFF
--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -295,17 +295,19 @@ func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 
 		if subnetSpec.CIDR != "" {
 			subnet.CIDR = fi.PtrTo(subnetSpec.CIDR)
-			for _, cidr := range b.Cluster.Spec.Networking.AdditionalNetworkCIDRs {
-				_, additionalCIDR, err := net.ParseCIDR(cidr)
-				if err != nil {
-					return err
-				}
-				subnetIP, _, err := net.ParseCIDR(subnetSpec.CIDR)
-				if err != nil {
-					return err
-				}
-				if additionalCIDR.Contains(subnetIP) {
-					subnet.VPCCIDRBlock = &awstasks.VPCCIDRBlock{Name: fi.PtrTo(cidr)}
+			if !sharedVPC {
+				for _, cidr := range b.Cluster.Spec.Networking.AdditionalNetworkCIDRs {
+					_, additionalCIDR, err := net.ParseCIDR(cidr)
+					if err != nil {
+						return err
+					}
+					subnetIP, _, err := net.ParseCIDR(subnetSpec.CIDR)
+					if err != nil {
+						return err
+					}
+					if additionalCIDR.Contains(subnetIP) {
+						subnet.VPCCIDRBlock = &awstasks.VPCCIDRBlock{Name: fi.PtrTo(cidr)}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
`VPCCIDRBlock` tasks are not created when the VPC is shared:
https://github.com/kubernetes/kops/blob/ecda9e8652e660e29dc8f25a56e7a8b834eeb574/pkg/model/awsmodel/network.go#L97-L116