### PR TITLE
Automated cherry pick of #15987: aws: Don't add dependency on additional CIDR for shared VPC

### DIFF
--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -295,17 +295,19 @@ func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 
 		if subnetSpec.CIDR != "" {
 			subnet.CIDR = fi.PtrTo(subnetSpec.CIDR)
-			for _, cidr := range b.Cluster.Spec.Networking.AdditionalNetworkCIDRs {
-				_, additionalCIDR, err := net.ParseCIDR(cidr)
-				if err != nil {
-					return err
-				}
-				subnetIP, _, err := net.ParseCIDR(subnetSpec.CIDR)
-				if err != nil {
-					return err
-				}
-				if additionalCIDR.Contains(subnetIP) {
-					subnet.VPCCIDRBlock = &awstasks.VPCCIDRBlock{Name: fi.PtrTo(cidr)}
+			if !sharedVPC {
+				for _, cidr := range b.Cluster.Spec.Networking.AdditionalNetworkCIDRs {
+					_, additionalCIDR, err := net.ParseCIDR(cidr)
+					if err != nil {
+						return err
+					}
+					subnetIP, _, err := net.ParseCIDR(subnetSpec.CIDR)
+					if err != nil {
+						return err
+					}
+					if additionalCIDR.Contains(subnetIP) {
+						subnet.VPCCIDRBlock = &awstasks.VPCCIDRBlock{Name: fi.PtrTo(cidr)}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Cherry pick of #15987 on release-1.28.

#15987: aws: Don't add dependency on additional CIDR for shared VPC

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```