### PR TITLE
Allow setting map[string]string from the command line

### DIFF
--- a/util/pkg/reflectutils/access.go
+++ b/util/pkg/reflectutils/access.go
@@ -134,6 +134,23 @@ func setType(v reflect.Value, newValue string) error {
 
 	t := v.Type().String()
 
+	if v.Type().Kind() == reflect.Map {
+		if v.IsNil() {
+			v.Set(reflect.MakeMap(v.Type()))
+		}
+
+		switch t {
+		case "map[string]string":
+			name, value, _ := strings.Cut(newValue, "=")
+			v.SetMapIndex(reflect.ValueOf(name), reflect.ValueOf(value))
+
+		default:
+			return fmt.Errorf("unhandled type %q", t)
+		}
+
+		return nil
+	}
+
 	var newV reflect.Value
 
 	switch t {
@@ -168,6 +185,7 @@ func setType(v reflect.Value, newValue string) error {
 		default:
 			panic("missing case in int switch")
 		}
+
 	case "uint64", "uint32", "uint16", "uint":
 		v, err := strconv.Atoi(newValue)
 		if err != nil {
@@ -189,6 +207,7 @@ func setType(v reflect.Value, newValue string) error {
 		default:
 			panic("missing case in uint switch")
 		}
+
 	case "intstr.IntOrString":
 		newV = reflect.ValueOf(intstr.Parse(newValue))
 

--- a/util/pkg/reflectutils/access_test.go
+++ b/util/pkg/reflectutils/access_test.go
@@ -65,6 +65,8 @@ type fakeObjectContainers struct {
 
 	Enum      fakeEnum   `json:"enum"`
 	EnumSlice []fakeEnum `json:"enumSlice"`
+
+	StringMap map[string]string `json:"stringMap"`
 }
 
 type fakeObjectPolicy struct {
@@ -196,6 +198,27 @@ func TestSet(t *testing.T) {
 			Expected: "{ 'spec': { 'containers': [ { 'duration': '500ms' } ] } }",
 			Path:     "spec.containers[0].duration",
 			Value:    "500ms",
+		},
+		{
+			Name:     "set new map key",
+			Input:    "{ 'spec': { 'containers': [ {} ] } }",
+			Expected: "{ 'spec': { 'containers': [ { 'stringMap': { 'ABC': '' } } ] } }",
+			Path:     "spec.containers[0].stringMap",
+			Value:    "ABC",
+		},
+		{
+			Name:     "set new map key with val",
+			Input:    "{ 'spec': { 'containers': [ {} ] } }",
+			Expected: "{ 'spec': { 'containers': [ { 'stringMap': { 'ABC': 'DEF' } } ] } }",
+			Path:     "spec.containers[0].stringMap",
+			Value:    "ABC=DEF",
+		},
+		{
+			Name:     "set existing map key with val",
+			Input:    "{ 'spec': { 'containers': [ { 'stringMap': { 'ABC': 'DEF' } } ] } }",
+			Expected: "{ 'spec': { 'containers': [ { 'stringMap': { 'ABC': 'DEF', 'GHI': 'JKL' } } ] } }",
+			Path:     "spec.containers[0].stringMap",
+			Value:    "GHI=JKL",
 		},
 		// Not sure if we should do this...
 		// {

--- a/util/pkg/reflectutils/field_path.go
+++ b/util/pkg/reflectutils/field_path.go
@@ -95,8 +95,7 @@ func ParseFieldPath(s string) (*FieldPath, error) {
 				token: field,
 			})
 
-		case '.':
-			// TODO: Validate that we don't have two dots?
+		case '.', '/':
 			// Skip
 
 		case '[':


### PR DESCRIPTION
```shell
> kops create cluster \
    --set spec.kubeAPIServer.runtimeConfig=extensions/v1beta1=true \
    --set spec.kubeAPIServer.runtimeConfig=scheduling.k8s.io/v1alpha1=true
...

> kops get cluster -o yaml
...
  kubeAPIServer:
    runtimeConfig:
      extensions/v1beta1: "true"
      scheduling.k8s.io/v1alpha1: "true"
...
```
/cc @upodroid 