### PR TITLE
Fix: Prometheus port issue for pod-identity-webhook service

### DIFF
--- a/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
@@ -192,6 +192,9 @@ spec:
   - port: 443
     targetPort: 443
     protocol: TCP
+  - port: 9999
+    targetPort: 9999
+    protocol: TCP
   selector:
     app: pod-identity-webhook
 ---


### PR DESCRIPTION
### What does this PR introduce?

This PR addresses the issue where port 9999 was missing in the `pod-identity-webhook` service definition, causing problems with Prometheus scraping.

### Why is this change needed?

The missing port 9999 was required for Prometheus to scrape metrics from the `pod-identity-webhook` service. Without this port, monitoring and metrics collection were incomplete.

### How does it address the issue?

This PR modifies the service definition to include port 9999 in the `spec.ports` section, ensuring that Prometheus can scrape metrics correctly.

### Related Issue

Fixes #15946
