### PR TITLE
aws: Attach security groups to NLBs

### DIFF
--- a/cloudmock/aws/mockelbv2/loadbalancers.go
+++ b/cloudmock/aws/mockelbv2/loadbalancers.go
@@ -83,6 +83,7 @@ func (m *MockELBV2) CreateLoadBalancer(request *elbv2.CreateLoadBalancerInput) (
 	lb := elbv2.LoadBalancer{
 		LoadBalancerName:      request.Name,
 		Scheme:                request.Scheme,
+		SecurityGroups:        request.SecurityGroups,
 		Type:                  request.Type,
 		IpAddressType:         request.IpAddressType,
 		DNSName:               aws.String(fmt.Sprintf("%v.amazonaws.com", aws.StringValue(request.Name))),
@@ -189,6 +190,19 @@ func (m *MockELBV2) ModifyLoadBalancerAttributes(request *elbv2.ModifyLoadBalanc
 		}
 		return &elbv2.ModifyLoadBalancerAttributesOutput{
 			Attributes: m.LBAttributes[arn],
+		}, nil
+	}
+	return nil, fmt.Errorf("LoadBalancerNotFound: %v", aws.StringValue(request.LoadBalancerArn))
+}
+
+func (m *MockELBV2) SetSecurityGroups(request *elbv2.SetSecurityGroupsInput) (*elbv2.SetSecurityGroupsOutput, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	arn := aws.StringValue(request.LoadBalancerArn)
+	if lb, ok := m.LoadBalancers[arn]; ok {
+		lb.description.SecurityGroups = request.SecurityGroups
+		return &elbv2.SetSecurityGroupsOutput{
+			SecurityGroupIds: request.SecurityGroups,
 		}, nil
 	}
 	return nil, fmt.Errorf("LoadBalancerNotFound: %v", aws.StringValue(request.LoadBalancerArn))

--- a/docs/releases/1.29-NOTES.md
+++ b/docs/releases/1.29-NOTES.md
@@ -8,6 +8,11 @@ This is a document to gather the release notes prior to the release.
 
 ## AWS
 
+* Network Load Balancers in front of the Kubernetes API and bastion hosts now
+have a security group attached. These security groups are used for security group rules
+allowing incoming traffic to the NLBs as well as traffic between the NLBs and their target
+instances.
+
 ## GCP
 
 ## Openstack

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -1643,6 +1643,60 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
+resource "aws_security_group_rule" "icmp-pmtu-cp-sg-master-1a-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = "sg-elb"
+  source_security_group_id = "sg-master-1a"
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-cp-sg-master-1b-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = "sg-elb"
+  source_security_group_id = "sg-master-1b"
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = "sg-elb"
+  source_security_group_id = aws_security_group.masters-existingsg-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-existingsg-example-com.id
+  source_security_group_id = "sg-elb"
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp-sg-master-1a" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = "sg-master-1a"
+  source_security_group_id = "sg-elb"
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp-sg-master-1b" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = "sg-master-1b"
+  source_security_group_id = "sg-elb"
+  to_port                  = 4
+  type                     = "ingress"
+}
+
 resource "aws_sqs_queue" "existingsg-example-com-nth" {
   message_retention_seconds = 300
   name                      = "existingsg-example-com-nth"

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -1052,6 +1052,24 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.api-elb-externalpolicies-example-com.id
+  source_security_group_id = aws_security_group.masters-externalpolicies-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-externalpolicies-example-com.id
+  source_security_group_id = aws_security_group.api-elb-externalpolicies-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "nodeport-tcp-external-to-node-1-2-3-4--32" {
   cidr_blocks       = ["1.2.3.4/32"]
   from_port         = 28000

--- a/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
@@ -572,6 +572,7 @@ resource "aws_lb" "api-minimal-example-com" {
   internal                         = false
   load_balancer_type               = "network"
   name                             = "api-minimal-example-com-gecgf7"
+  security_groups                  = [aws_security_group.api-elb-minimal-example-com.id]
   subnet_mapping {
     subnet_id = aws_subnet.us-test-1a-minimal-example-com.id
   }
@@ -864,11 +865,11 @@ resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-nodes-min
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-masters-minimal-example-com" {
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-api-elb-minimal-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 443
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-example-com.id
   to_port           = 443
   type              = "ingress"
 }
@@ -891,13 +892,31 @@ resource "aws_security_group_rule" "from-__--0-ingress-tcp-22to22-nodes-minimal-
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-masters-minimal-example-com" {
+resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-api-elb-minimal-example-com" {
   from_port         = 443
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-example-com.id
   to_port           = 443
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-example-com-egress-all-0to0-0-0-0-0--0" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-example-com-egress-all-0to0-__--0" {
+  from_port         = 0
+  ipv6_cidr_blocks  = ["::/0"]
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-example-com.id
+  to_port           = 0
+  type              = "egress"
 }
 
 resource "aws_security_group_rule" "from-masters-minimal-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1000,38 +1019,47 @@ resource "aws_security_group_rule" "from-nodes-minimal-example-com-ingress-udp-1
 }
 
 resource "aws_security_group_rule" "https-elb-to-master" {
-  cidr_blocks       = ["172.20.0.0/16"]
-  from_port         = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-example-com.id
-  to_port           = 443
-  type              = "ingress"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-minimal-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.masters-minimal-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-example-com.id
   to_port           = 4
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.api-elb-minimal-example-com.id
+  source_security_group_id = aws_security_group.masters-minimal-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-minimal-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   from_port         = -1
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "icmpv6"
-  security_group_id = aws_security_group.masters-minimal-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-example-com.id
   to_port           = -1
-  type              = "ingress"
-}
-
-resource "aws_security_group_rule" "kops-controller-lb-to-master" {
-  cidr_blocks       = ["172.20.0.0/16"]
-  from_port         = 3988
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-example-com.id
-  to_port           = 3988
   type              = "ingress"
 }
 

--- a/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
@@ -619,6 +619,7 @@ resource "aws_lb" "api-minimal-ipv6-example-com" {
   ip_address_type                  = "dualstack"
   load_balancer_type               = "network"
   name                             = "api-minimal-ipv6-example--jhj9te"
+  security_groups                  = [aws_security_group.api-elb-minimal-ipv6-example-com.id]
   subnet_mapping {
     subnet_id = aws_subnet.utility-us-test-1a-minimal-ipv6-example-com.id
   }
@@ -1031,11 +1032,11 @@ resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-nodes-min
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-masters-minimal-ipv6-example-com" {
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-api-elb-minimal-ipv6-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 443
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 443
   type              = "ingress"
 }
@@ -1058,13 +1059,31 @@ resource "aws_security_group_rule" "from-__--0-ingress-tcp-22to22-nodes-minimal-
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-masters-minimal-ipv6-example-com" {
+resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-api-elb-minimal-ipv6-example-com" {
   from_port         = 443
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 443
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-ipv6-example-com-egress-all-0to0-0-0-0-0--0" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-ipv6-example-com-egress-all-0to0-__--0" {
+  from_port         = 0
+  ipv6_cidr_blocks  = ["::/0"]
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port           = 0
+  type              = "egress"
 }
 
 resource "aws_security_group_rule" "from-masters-minimal-ipv6-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1176,28 +1195,46 @@ resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-
 }
 
 resource "aws_security_group_rule" "https-elb-to-master" {
-  cidr_blocks       = ["172.20.0.0/16"]
-  from_port         = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port           = 443
-  type              = "ingress"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 4
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   from_port         = -1
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "icmpv6"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = -1
   type              = "ingress"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
@@ -619,6 +619,7 @@ resource "aws_lb" "api-minimal-ipv6-example-com" {
   ip_address_type                  = "dualstack"
   load_balancer_type               = "network"
   name                             = "api-minimal-ipv6-example--jhj9te"
+  security_groups                  = [aws_security_group.api-elb-minimal-ipv6-example-com.id]
   subnet_mapping {
     subnet_id = aws_subnet.utility-us-test-1a-minimal-ipv6-example-com.id
   }
@@ -1031,11 +1032,11 @@ resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-nodes-min
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-masters-minimal-ipv6-example-com" {
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-api-elb-minimal-ipv6-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 443
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 443
   type              = "ingress"
 }
@@ -1058,13 +1059,31 @@ resource "aws_security_group_rule" "from-__--0-ingress-tcp-22to22-nodes-minimal-
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-masters-minimal-ipv6-example-com" {
+resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-api-elb-minimal-ipv6-example-com" {
   from_port         = 443
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 443
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-ipv6-example-com-egress-all-0to0-0-0-0-0--0" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-ipv6-example-com-egress-all-0to0-__--0" {
+  from_port         = 0
+  ipv6_cidr_blocks  = ["::/0"]
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port           = 0
+  type              = "egress"
 }
 
 resource "aws_security_group_rule" "from-masters-minimal-ipv6-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1167,28 +1186,46 @@ resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-
 }
 
 resource "aws_security_group_rule" "https-elb-to-master" {
-  cidr_blocks       = ["172.20.0.0/16"]
-  from_port         = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port           = 443
-  type              = "ingress"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 4
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   from_port         = -1
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "icmpv6"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = -1
   type              = "ingress"
 }

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
@@ -619,6 +619,7 @@ resource "aws_lb" "api-minimal-ipv6-example-com" {
   ip_address_type                  = "dualstack"
   load_balancer_type               = "network"
   name                             = "api-minimal-ipv6-example--jhj9te"
+  security_groups                  = [aws_security_group.api-elb-minimal-ipv6-example-com.id]
   subnet_mapping {
     subnet_id = aws_subnet.utility-us-test-1a-minimal-ipv6-example-com.id
   }
@@ -1023,11 +1024,11 @@ resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-nodes-min
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-masters-minimal-ipv6-example-com" {
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-api-elb-minimal-ipv6-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 443
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 443
   type              = "ingress"
 }
@@ -1050,13 +1051,31 @@ resource "aws_security_group_rule" "from-__--0-ingress-tcp-22to22-nodes-minimal-
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-masters-minimal-ipv6-example-com" {
+resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-api-elb-minimal-ipv6-example-com" {
   from_port         = 443
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 443
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-ipv6-example-com-egress-all-0to0-0-0-0-0--0" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-ipv6-example-com-egress-all-0to0-__--0" {
+  from_port         = 0
+  ipv6_cidr_blocks  = ["::/0"]
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port           = 0
+  type              = "egress"
 }
 
 resource "aws_security_group_rule" "from-masters-minimal-ipv6-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1159,28 +1178,46 @@ resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-
 }
 
 resource "aws_security_group_rule" "https-elb-to-master" {
-  cidr_blocks       = ["172.20.0.0/16"]
-  from_port         = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port           = 443
-  type              = "ingress"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 4
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   from_port         = -1
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "icmpv6"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = -1
   type              = "ingress"
 }

--- a/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
@@ -619,6 +619,7 @@ resource "aws_lb" "api-minimal-ipv6-example-com" {
   ip_address_type                  = "dualstack"
   load_balancer_type               = "network"
   name                             = "api-minimal-ipv6-example--jhj9te"
+  security_groups                  = [aws_security_group.api-elb-minimal-ipv6-example-com.id]
   subnet_mapping {
     subnet_id = aws_subnet.utility-us-test-1a-minimal-ipv6-example-com.id
   }
@@ -1023,11 +1024,11 @@ resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-nodes-min
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-masters-minimal-ipv6-example-com" {
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-api-elb-minimal-ipv6-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 443
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 443
   type              = "ingress"
 }
@@ -1050,13 +1051,31 @@ resource "aws_security_group_rule" "from-__--0-ingress-tcp-22to22-nodes-minimal-
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-masters-minimal-ipv6-example-com" {
+resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-api-elb-minimal-ipv6-example-com" {
   from_port         = 443
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 443
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-ipv6-example-com-egress-all-0to0-0-0-0-0--0" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-ipv6-example-com-egress-all-0to0-__--0" {
+  from_port         = 0
+  ipv6_cidr_blocks  = ["::/0"]
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port           = 0
+  type              = "egress"
 }
 
 resource "aws_security_group_rule" "from-masters-minimal-ipv6-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1159,28 +1178,46 @@ resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-
 }
 
 resource "aws_security_group_rule" "https-elb-to-master" {
-  cidr_blocks       = ["172.20.0.0/16"]
-  from_port         = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port           = 443
-  type              = "ingress"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 4
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   from_port         = -1
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "icmpv6"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = -1
   type              = "ingress"
 }

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -754,6 +754,7 @@ resource "aws_lb" "bastion-private-shared-ip-example-com" {
   internal                         = false
   load_balancer_type               = "network"
   name                             = "bastion-private-shared-ip-eepmph"
+  security_groups                  = [aws_security_group.bastion-elb-private-shared-ip-example-com.id]
   subnet_mapping {
     subnet_id = aws_subnet.utility-us-test-1a-private-shared-ip-example-com.id
   }
@@ -1037,6 +1038,17 @@ resource "aws_security_group" "api-elb-private-shared-ip-example-com" {
   vpc_id = "vpc-12345678"
 }
 
+resource "aws_security_group" "bastion-elb-private-shared-ip-example-com" {
+  description = "Security group for bastion ELB"
+  name        = "bastion-elb.private-shared-ip.example.com"
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "bastion-elb.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
 resource "aws_security_group" "bastion-private-shared-ip-example-com" {
   description = "Security group for bastion"
   name        = "bastion.private-shared-ip.example.com"
@@ -1070,11 +1082,11 @@ resource "aws_security_group" "nodes-private-shared-ip-example-com" {
   vpc_id = "vpc-12345678"
 }
 
-resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-private-shared-ip-example-com" {
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-private-shared-ip-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
   protocol          = "tcp"
-  security_group_id = aws_security_group.bastion-private-shared-ip-example-com.id
+  security_group_id = aws_security_group.bastion-elb-private-shared-ip-example-com.id
   to_port           = 22
   type              = "ingress"
 }
@@ -1088,11 +1100,11 @@ resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-api-elb
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-172-20-4-0--22-ingress-tcp-22to22-bastion-private-shared-ip-example-com" {
+resource "aws_security_group_rule" "from-172-20-4-0--22-ingress-tcp-22to22-bastion-elb-private-shared-ip-example-com" {
   cidr_blocks       = ["172.20.4.0/22"]
   from_port         = 22
   protocol          = "tcp"
-  security_group_id = aws_security_group.bastion-private-shared-ip-example-com.id
+  security_group_id = aws_security_group.bastion-elb-private-shared-ip-example-com.id
   to_port           = 22
   type              = "ingress"
 }
@@ -1115,6 +1127,42 @@ resource "aws_security_group_rule" "from-api-elb-private-shared-ip-example-com-e
   type              = "egress"
 }
 
+resource "aws_security_group_rule" "from-bastion-elb-private-shared-ip-example-com-egress-all-0to0-0-0-0-0--0" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.bastion-elb-private-shared-ip-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-private-shared-ip-example-com-egress-all-0to0-__--0" {
+  from_port         = 0
+  ipv6_cidr_blocks  = ["::/0"]
+  protocol          = "-1"
+  security_group_id = aws_security_group.bastion-elb-private-shared-ip-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-private-shared-ip-example-com-ingress-icmp-3to4-bastion-private-shared-ip-example-com" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.bastion-private-shared-ip-example-com.id
+  source_security_group_id = aws_security_group.bastion-elb-private-shared-ip-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-private-shared-ip-example-com-ingress-tcp-22to22-bastion-private-shared-ip-example-com" {
+  from_port                = 22
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.bastion-private-shared-ip-example-com.id
+  source_security_group_id = aws_security_group.bastion-elb-private-shared-ip-example-com.id
+  to_port                  = 22
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "from-bastion-private-shared-ip-example-com-egress-all-0to0-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 0
@@ -1131,6 +1179,15 @@ resource "aws_security_group_rule" "from-bastion-private-shared-ip-example-com-e
   security_group_id = aws_security_group.bastion-private-shared-ip-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-private-shared-ip-example-com-ingress-icmp-3to4-bastion-elb-private-shared-ip-example-com" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.bastion-elb-private-shared-ip-example-com.id
+  source_security_group_id = aws_security_group.bastion-private-shared-ip-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-private-shared-ip-example-com-ingress-tcp-22to22-masters-private-shared-ip-example-com" {
@@ -1268,11 +1325,29 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.api-elb-private-shared-ip-example-com.id
+  source_security_group_id = aws_security_group.masters-private-shared-ip-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-private-shared-ip-example-com.id
+  source_security_group_id = aws_security_group.api-elb-private-shared-ip-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "icmp-pmtu-ssh-nlb-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.bastion-private-shared-ip-example-com.id
+  security_group_id = aws_security_group.bastion-elb-private-shared-ip-example-com.id
   to_port           = 4
   type              = "ingress"
 }
@@ -1281,7 +1356,7 @@ resource "aws_security_group_rule" "icmp-pmtu-ssh-nlb-172-20-4-0--22" {
   cidr_blocks       = ["172.20.4.0/22"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.bastion-private-shared-ip-example-com.id
+  security_group_id = aws_security_group.bastion-elb-private-shared-ip-example-com.id
   to_port           = 4
   type              = "ingress"
 }

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -772,6 +772,7 @@ resource "aws_lb" "bastion-privatecilium-example-com" {
   internal                         = false
   load_balancer_type               = "network"
   name                             = "bastion-privatecilium-exa-l2ms01"
+  security_groups                  = [aws_security_group.bastion-elb-privatecilium-example-com.id]
   subnet_mapping {
     subnet_id = aws_subnet.utility-us-test-1a-privatecilium-example-com.id
   }
@@ -1079,6 +1080,17 @@ resource "aws_security_group" "api-elb-privatecilium-example-com" {
   vpc_id = aws_vpc.privatecilium-example-com.id
 }
 
+resource "aws_security_group" "bastion-elb-privatecilium-example-com" {
+  description = "Security group for bastion ELB"
+  name        = "bastion-elb.privatecilium.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "bastion-elb.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privatecilium-example-com.id
+}
+
 resource "aws_security_group" "bastion-privatecilium-example-com" {
   description = "Security group for bastion"
   name        = "bastion.privatecilium.example.com"
@@ -1112,11 +1124,11 @@ resource "aws_security_group" "nodes-privatecilium-example-com" {
   vpc_id = aws_vpc.privatecilium-example-com.id
 }
 
-resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-privatecilium-example-com" {
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privatecilium-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
   protocol          = "tcp"
-  security_group_id = aws_security_group.bastion-privatecilium-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatecilium-example-com.id
   to_port           = 22
   type              = "ingress"
 }
@@ -1130,11 +1142,11 @@ resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-api-elb
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-172-20-4-0--22-ingress-tcp-22to22-bastion-privatecilium-example-com" {
+resource "aws_security_group_rule" "from-172-20-4-0--22-ingress-tcp-22to22-bastion-elb-privatecilium-example-com" {
   cidr_blocks       = ["172.20.4.0/22"]
   from_port         = 22
   protocol          = "tcp"
-  security_group_id = aws_security_group.bastion-privatecilium-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatecilium-example-com.id
   to_port           = 22
   type              = "ingress"
 }
@@ -1157,6 +1169,42 @@ resource "aws_security_group_rule" "from-api-elb-privatecilium-example-com-egres
   type              = "egress"
 }
 
+resource "aws_security_group_rule" "from-bastion-elb-privatecilium-example-com-egress-all-0to0-0-0-0-0--0" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.bastion-elb-privatecilium-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-privatecilium-example-com-egress-all-0to0-__--0" {
+  from_port         = 0
+  ipv6_cidr_blocks  = ["::/0"]
+  protocol          = "-1"
+  security_group_id = aws_security_group.bastion-elb-privatecilium-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-privatecilium-example-com-ingress-icmp-3to4-bastion-privatecilium-example-com" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.bastion-privatecilium-example-com.id
+  source_security_group_id = aws_security_group.bastion-elb-privatecilium-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-privatecilium-example-com-ingress-tcp-22to22-bastion-privatecilium-example-com" {
+  from_port                = 22
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.bastion-privatecilium-example-com.id
+  source_security_group_id = aws_security_group.bastion-elb-privatecilium-example-com.id
+  to_port                  = 22
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "from-bastion-privatecilium-example-com-egress-all-0to0-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 0
@@ -1173,6 +1221,15 @@ resource "aws_security_group_rule" "from-bastion-privatecilium-example-com-egres
   security_group_id = aws_security_group.bastion-privatecilium-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-privatecilium-example-com-ingress-icmp-3to4-bastion-elb-privatecilium-example-com" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.bastion-elb-privatecilium-example-com.id
+  source_security_group_id = aws_security_group.bastion-privatecilium-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-privatecilium-example-com-ingress-tcp-22to22-masters-privatecilium-example-com" {
@@ -1310,11 +1367,29 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.api-elb-privatecilium-example-com.id
+  source_security_group_id = aws_security_group.masters-privatecilium-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-privatecilium-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privatecilium-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "icmp-pmtu-ssh-nlb-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.bastion-privatecilium-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatecilium-example-com.id
   to_port           = 4
   type              = "ingress"
 }
@@ -1323,7 +1398,7 @@ resource "aws_security_group_rule" "icmp-pmtu-ssh-nlb-172-20-4-0--22" {
   cidr_blocks       = ["172.20.4.0/22"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.bastion-privatecilium-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatecilium-example-com.id
   to_port           = 4
   type              = "ingress"
 }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -763,6 +763,7 @@ resource "aws_lb" "bastion-privatedns2-example-com" {
   internal                         = false
   load_balancer_type               = "network"
   name                             = "bastion-privatedns2-examp-e704o2"
+  security_groups                  = [aws_security_group.bastion-elb-privatedns2-example-com.id]
   subnet_mapping {
     subnet_id = aws_subnet.utility-us-test-1a-privatedns2-example-com.id
   }
@@ -1046,6 +1047,17 @@ resource "aws_security_group" "api-elb-privatedns2-example-com" {
   vpc_id = "vpc-12345678"
 }
 
+resource "aws_security_group" "bastion-elb-privatedns2-example-com" {
+  description = "Security group for bastion ELB"
+  name        = "bastion-elb.privatedns2.example.com"
+  tags = {
+    "KubernetesCluster"                             = "privatedns2.example.com"
+    "Name"                                          = "bastion-elb.privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
 resource "aws_security_group" "bastion-privatedns2-example-com" {
   description = "Security group for bastion"
   name        = "bastion.privatedns2.example.com"
@@ -1079,11 +1091,11 @@ resource "aws_security_group" "nodes-privatedns2-example-com" {
   vpc_id = "vpc-12345678"
 }
 
-resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-privatedns2-example-com" {
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privatedns2-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
   protocol          = "tcp"
-  security_group_id = aws_security_group.bastion-privatedns2-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatedns2-example-com.id
   to_port           = 22
   type              = "ingress"
 }
@@ -1097,11 +1109,11 @@ resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-api-elb
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-172-20-4-0--22-ingress-tcp-22to22-bastion-privatedns2-example-com" {
+resource "aws_security_group_rule" "from-172-20-4-0--22-ingress-tcp-22to22-bastion-elb-privatedns2-example-com" {
   cidr_blocks       = ["172.20.4.0/22"]
   from_port         = 22
   protocol          = "tcp"
-  security_group_id = aws_security_group.bastion-privatedns2-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatedns2-example-com.id
   to_port           = 22
   type              = "ingress"
 }
@@ -1124,6 +1136,42 @@ resource "aws_security_group_rule" "from-api-elb-privatedns2-example-com-egress-
   type              = "egress"
 }
 
+resource "aws_security_group_rule" "from-bastion-elb-privatedns2-example-com-egress-all-0to0-0-0-0-0--0" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.bastion-elb-privatedns2-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-privatedns2-example-com-egress-all-0to0-__--0" {
+  from_port         = 0
+  ipv6_cidr_blocks  = ["::/0"]
+  protocol          = "-1"
+  security_group_id = aws_security_group.bastion-elb-privatedns2-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-privatedns2-example-com-ingress-icmp-3to4-bastion-privatedns2-example-com" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.bastion-privatedns2-example-com.id
+  source_security_group_id = aws_security_group.bastion-elb-privatedns2-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-privatedns2-example-com-ingress-tcp-22to22-bastion-privatedns2-example-com" {
+  from_port                = 22
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.bastion-privatedns2-example-com.id
+  source_security_group_id = aws_security_group.bastion-elb-privatedns2-example-com.id
+  to_port                  = 22
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "from-bastion-privatedns2-example-com-egress-all-0to0-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 0
@@ -1140,6 +1188,15 @@ resource "aws_security_group_rule" "from-bastion-privatedns2-example-com-egress-
   security_group_id = aws_security_group.bastion-privatedns2-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-privatedns2-example-com-ingress-icmp-3to4-bastion-elb-privatedns2-example-com" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.bastion-elb-privatedns2-example-com.id
+  source_security_group_id = aws_security_group.bastion-privatedns2-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-privatedns2-example-com-ingress-tcp-22to22-masters-privatedns2-example-com" {
@@ -1277,11 +1334,29 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.api-elb-privatedns2-example-com.id
+  source_security_group_id = aws_security_group.masters-privatedns2-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-privatedns2-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privatedns2-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "icmp-pmtu-ssh-nlb-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.bastion-privatedns2-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatedns2-example-com.id
   to_port           = 4
   type              = "ingress"
 }
@@ -1290,7 +1365,7 @@ resource "aws_security_group_rule" "icmp-pmtu-ssh-nlb-172-20-4-0--22" {
   cidr_blocks       = ["172.20.4.0/22"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.bastion-privatedns2-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatedns2-example-com.id
   to_port           = 4
   type              = "ingress"
 }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -778,6 +778,7 @@ resource "aws_lb" "bastion-privatekopeio-example-com" {
   internal                         = false
   load_balancer_type               = "network"
   name                             = "bastion-privatekopeio-exa-d8ef8e"
+  security_groups                  = [aws_security_group.bastion-elb-privatekopeio-example-com.id]
   subnet_mapping {
     subnet_id = aws_subnet.utility-us-test-1a-privatekopeio-example-com.id
   }
@@ -1088,6 +1089,17 @@ resource "aws_security_group" "api-elb-privatekopeio-example-com" {
   vpc_id = aws_vpc.privatekopeio-example-com.id
 }
 
+resource "aws_security_group" "bastion-elb-privatekopeio-example-com" {
+  description = "Security group for bastion ELB"
+  name        = "bastion-elb.privatekopeio.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "bastion-elb.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privatekopeio-example-com.id
+}
+
 resource "aws_security_group" "bastion-privatekopeio-example-com" {
   description = "Security group for bastion"
   name        = "bastion.privatekopeio.example.com"
@@ -1121,11 +1133,11 @@ resource "aws_security_group" "nodes-privatekopeio-example-com" {
   vpc_id = aws_vpc.privatekopeio-example-com.id
 }
 
-resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-privatekopeio-example-com" {
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privatekopeio-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
   protocol          = "tcp"
-  security_group_id = aws_security_group.bastion-privatekopeio-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatekopeio-example-com.id
   to_port           = 22
   type              = "ingress"
 }
@@ -1139,20 +1151,20 @@ resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-api-elb
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-172-20-4-0--22-ingress-tcp-22to22-bastion-privatekopeio-example-com" {
+resource "aws_security_group_rule" "from-172-20-4-0--22-ingress-tcp-22to22-bastion-elb-privatekopeio-example-com" {
   cidr_blocks       = ["172.20.4.0/22"]
   from_port         = 22
   protocol          = "tcp"
-  security_group_id = aws_security_group.bastion-privatekopeio-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatekopeio-example-com.id
   to_port           = 22
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-172-20-8-0--22-ingress-tcp-22to22-bastion-privatekopeio-example-com" {
+resource "aws_security_group_rule" "from-172-20-8-0--22-ingress-tcp-22to22-bastion-elb-privatekopeio-example-com" {
   cidr_blocks       = ["172.20.8.0/22"]
   from_port         = 22
   protocol          = "tcp"
-  security_group_id = aws_security_group.bastion-privatekopeio-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatekopeio-example-com.id
   to_port           = 22
   type              = "ingress"
 }
@@ -1175,6 +1187,42 @@ resource "aws_security_group_rule" "from-api-elb-privatekopeio-example-com-egres
   type              = "egress"
 }
 
+resource "aws_security_group_rule" "from-bastion-elb-privatekopeio-example-com-egress-all-0to0-0-0-0-0--0" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.bastion-elb-privatekopeio-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-privatekopeio-example-com-egress-all-0to0-__--0" {
+  from_port         = 0
+  ipv6_cidr_blocks  = ["::/0"]
+  protocol          = "-1"
+  security_group_id = aws_security_group.bastion-elb-privatekopeio-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-privatekopeio-example-com-ingress-icmp-3to4-bastion-privatekopeio-example-com" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.bastion-privatekopeio-example-com.id
+  source_security_group_id = aws_security_group.bastion-elb-privatekopeio-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-privatekopeio-example-com-ingress-tcp-22to22-bastion-privatekopeio-example-com" {
+  from_port                = 22
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.bastion-privatekopeio-example-com.id
+  source_security_group_id = aws_security_group.bastion-elb-privatekopeio-example-com.id
+  to_port                  = 22
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "from-bastion-privatekopeio-example-com-egress-all-0to0-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 0
@@ -1191,6 +1239,15 @@ resource "aws_security_group_rule" "from-bastion-privatekopeio-example-com-egres
   security_group_id = aws_security_group.bastion-privatekopeio-example-com.id
   to_port           = 0
   type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-privatekopeio-example-com-ingress-icmp-3to4-bastion-elb-privatekopeio-example-com" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.bastion-elb-privatekopeio-example-com.id
+  source_security_group_id = aws_security_group.bastion-privatekopeio-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "from-bastion-privatekopeio-example-com-ingress-tcp-22to22-masters-privatekopeio-example-com" {
@@ -1328,11 +1385,29 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.api-elb-privatekopeio-example-com.id
+  source_security_group_id = aws_security_group.masters-privatekopeio-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-privatekopeio-example-com.id
+  source_security_group_id = aws_security_group.api-elb-privatekopeio-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "icmp-pmtu-ssh-nlb-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.bastion-privatekopeio-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatekopeio-example-com.id
   to_port           = 4
   type              = "ingress"
 }
@@ -1341,7 +1416,7 @@ resource "aws_security_group_rule" "icmp-pmtu-ssh-nlb-172-20-4-0--22" {
   cidr_blocks       = ["172.20.4.0/22"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.bastion-privatekopeio-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatekopeio-example-com.id
   to_port           = 4
   type              = "ingress"
 }
@@ -1350,7 +1425,7 @@ resource "aws_security_group_rule" "icmp-pmtu-ssh-nlb-172-20-8-0--22" {
   cidr_blocks       = ["172.20.8.0/22"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.bastion-privatekopeio-example-com.id
+  security_group_id = aws_security_group.bastion-elb-privatekopeio-example-com.id
   to_port           = 4
   type              = "ingress"
 }

--- a/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
@@ -601,6 +601,7 @@ resource "aws_lb" "api-minimal-ipv6-example-com" {
   ip_address_type                  = "dualstack"
   load_balancer_type               = "network"
   name                             = "api-minimal-ipv6-example--jhj9te"
+  security_groups                  = [aws_security_group.api-elb-minimal-ipv6-example-com.id]
   subnet_mapping {
     subnet_id = aws_subnet.utility-us-test-1a-minimal-ipv6-example-com.id
   }
@@ -1005,11 +1006,11 @@ resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-nodes-min
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-masters-minimal-ipv6-example-com" {
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-api-elb-minimal-ipv6-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 443
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 443
   type              = "ingress"
 }
@@ -1032,13 +1033,31 @@ resource "aws_security_group_rule" "from-__--0-ingress-tcp-22to22-nodes-minimal-
   type              = "ingress"
 }
 
-resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-masters-minimal-ipv6-example-com" {
+resource "aws_security_group_rule" "from-__--0-ingress-tcp-443to443-api-elb-minimal-ipv6-example-com" {
   from_port         = 443
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 443
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-ipv6-example-com-egress-all-0to0-0-0-0-0--0" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-api-elb-minimal-ipv6-example-com-egress-all-0to0-__--0" {
+  from_port         = 0
+  ipv6_cidr_blocks  = ["::/0"]
+  protocol          = "-1"
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port           = 0
+  type              = "egress"
 }
 
 resource "aws_security_group_rule" "from-masters-minimal-ipv6-example-com-egress-all-0to0-0-0-0-0--0" {
@@ -1141,28 +1160,46 @@ resource "aws_security_group_rule" "from-nodes-minimal-ipv6-example-com-ingress-
 }
 
 resource "aws_security_group_rule" "https-elb-to-master" {
-  cidr_blocks       = ["172.20.0.0/16"]
-  from_port         = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
-  to_port           = 443
-  type              = "ingress"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = 443
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 3
   protocol          = "icmp"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = 4
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-cp-to-elb" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "icmp-pmtu-elb-to-cp" {
+  from_port                = 3
+  protocol                 = "icmp"
+  security_group_id        = aws_security_group.masters-minimal-ipv6-example-com.id
+  source_security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
+  to_port                  = 4
+  type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   from_port         = -1
   ipv6_cidr_blocks  = ["::/0"]
   protocol          = "icmpv6"
-  security_group_id = aws_security_group.masters-minimal-ipv6-example-com.id
+  security_group_id = aws_security_group.api-elb-minimal-ipv6-example-com.id
   to_port           = -1
   type              = "ingress"
 }


### PR DESCRIPTION
NLBs can now have security groups.

Things to do:

- [x] Probably have to add rules to allow ICMP between the NLBs and their backend instances.
- [x] Make sure all the old rules get cleaned up
- [x] Add release note
