### PR TITLE
Use hostnames for node names in DO

### DIFF
--- a/docs/releases/1.29-NOTES.md
+++ b/docs/releases/1.29-NOTES.md
@@ -12,6 +12,10 @@ This is a document to gather the release notes prior to the release.
 
 ## Openstack
 
+## DigitalOcean
+
+* Node names have changed from the droplet's private IP to the droplet hostname
+
 # Breaking changes
 
 ## Other breaking changes

--- a/upup/pkg/fi/cloudup/do/verifier.go
+++ b/upup/pkg/fi/cloudup/do/verifier.go
@@ -98,20 +98,12 @@ func (o digitalOceanVerifier) VerifyToken(ctx context.Context, rawRequest *http.
 
 	// The node challenge is important here though, verifying the caller has control of the IP address.
 
-	nodeName := ""
-	if len(addresses) == 0 {
-		// Name seems a better default than the first IP, but we have to match what other components are expecting
-		nodeName = droplet.Name
-	} else {
-		nodeName = addresses[0]
-	}
-
 	if len(challengeEndpoints) == 0 {
 		return nil, fmt.Errorf("cannot determine challenge endpoint for server %q", serverID)
 	}
 
 	result := &bootstrap.VerifyResult{
-		NodeName:          nodeName,
+		NodeName:          droplet.Name,
 		CertificateNames:  addresses,
 		ChallengeEndpoint: challengeEndpoints[0],
 	}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -460,14 +460,14 @@ func evaluateHostnameOverride(cloudProvider api.CloudProviderID) (string, error)
 		bareHostname := strings.Split(fullyQualified, ".")[0]
 		return bareHostname, nil
 	case api.CloudProviderDO:
-		vBytes, err := vfs.Context.ReadFile("metadata://digitalocean/interfaces/private/0/ipv4/address")
+		vBytes, err := vfs.Context.ReadFile("metadata://digitalocean/hostname")
 		if err != nil {
-			return "", fmt.Errorf("error reading droplet private IP from DigitalOcean metadata: %v", err)
+			return "", fmt.Errorf("error reading droplet hostname from DigitalOcean metadata: %v", err)
 		}
 
 		hostname := string(vBytes)
 		if hostname == "" {
-			return "", errors.New("private IP for digitalocean droplet was empty")
+			return "", errors.New("hostname for digitalocean droplet was empty")
 		}
 
 		return hostname, nil


### PR DESCRIPTION
This matches GCE and AWS and matches an assumption in failing e2e tests that node names match their hostname

https://testgrid.k8s.io/kops-misc#e2e-kops-do-calico-dns-none

Using [this](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-do-calico-dns-none/1709688569984978944) job run as an example, the pause pods [get the hostname](https://github.com/kubernetes/kubernetes/blame/f19b62fc0914b38941922afefd1e34eb55f87ee7/test/e2e/network/service.go#L2670) of the hostNetwork webserver pod, with a value of `nodes-lon1`:

```
STEP: Creating 2 pause pods that will try to connect to the webserver @ 10/04/23 22:17:40.592
  Oct  4 22:17:45.189: INFO: Waiting up to 2m0s to get response from 100.67.42.185:80
  Oct  4 22:17:45.189: INFO: Running '/home/prow/go/src/k8s.io/kops/_rundir/3d3018eb-c001-49f5-a5d1-c8ec1e04961f/kubectl --server=https://143.198.241.206/ --kubeconfig=/root/.kube/config --namespace=services-922 exec pause-pod-0 -- /bin/sh -x -c curl -q -s --max-time 30 100.67.42.185:80/hostname'
  Oct  4 22:17:46.206: INFO: stderr: "+ curl -q -s --max-time 30 100.67.42.185:80/hostname\n"
  Oct  4 22:17:46.206: INFO: stdout: "nodes-lon1"
  [FAILED] in [It] - test/e2e/network/util.go:181 @ 10/04/23 22:17:46.206
```

However the test expects that to match the node name:
https://github.com/kubernetes/kubernetes/blob/f19b62fc0914b38941922afefd1e34eb55f87ee7/test/e2e/network/service.go#L2665-L2670

and the cluster-info dump for this job run shows that the [node names are actually IP addresses](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-do-calico-dns-none/1709688569984978944/artifacts/cluster-info/nodes.yaml), set by kubelet's --hostname-override flag. This updates --hostname-override to use the droplet's hostname instead.
