### PR TITLE
Introduce KubernetesE2ETesting feature flag

### DIFF
--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 	"k8s.io/kops/util/pkg/distributions"
@@ -55,6 +56,11 @@ func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		for _, additionalPackage := range b.NodeupConfig.Packages {
 			c.EnsureTask(&nodetasks.Package{Name: additionalPackage})
 		}
+		// Add packages required for Kubernetes E2E testing to work
+		if featureflag.KubernetesE2ETesting.Enabled() {
+			c.AddTask(&nodetasks.Package{Name: "nfs-common"})
+			c.AddTask(&nodetasks.Package{Name: "net-tools"})
+		}
 	} else if b.Distribution.IsRHELFamily() {
 		// From containerd: https://github.com/containerd/cri/blob/master/contrib/ansible/tasks/bootstrap_centos.yaml
 		c.AddTask(&nodetasks.Package{Name: "conntrack-tools"})
@@ -78,6 +84,11 @@ func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		// Additional packages
 		for _, additionalPackage := range b.NodeupConfig.Packages {
 			c.EnsureTask(&nodetasks.Package{Name: additionalPackage})
+		}
+		// Add packages required for Kubernetes E2E testing to work
+		if featureflag.KubernetesE2ETesting.Enabled() {
+			c.AddTask(&nodetasks.Package{Name: "nfs-utils"})
+			c.AddTask(&nodetasks.Package{Name: "net-tools"})
 		}
 	} else {
 		// Hopefully they are already installed

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -94,6 +94,8 @@ var (
 	SELinuxMount = new("SELinuxMount", Bool(false))
 	// DO Terraform toggles the DO terraform support.
 	DOTerraform = new("DOTerraform", Bool(false))
+	// KubernetesE2ETesting enables cluster configuration that is useful for e2e testing upstream kubernetes.
+	KubernetesE2ETesting = new("KubernetesE2ETesting", Bool(false))
 )
 
 // FeatureFlag defines a feature flag


### PR DESCRIPTION
We want kops to do things in E2E clusters that it shouldn't be doing by default in prod clusters.

One of these examples is installing nfs clients. kops used to do this but it was changed last year in #13577