### PR TITLE
Use dns=none for newly created clusters except for AWS and GCE

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -68,7 +68,6 @@ type CreateClusterOptions struct {
 	ContainerRuntime           string
 	OutDir                     string
 	DisableSubnetTags          bool
-	DNSZone                    string
 	NodeSecurityGroups         []string
 	ControlPlaneSecurityGroups []string
 	AssociatePublicIP          *bool

--- a/tests/integration/create_cluster/different-amis/options.yaml
+++ b/tests/integration/create_cluster/different-amis/options.yaml
@@ -9,4 +9,5 @@ ControlPlaneImage: ami-control-plane
 NodeImage: ami-worker-image
 Bastion: true
 Topology: private
+DNSType: public
 APIServerCount: 1

--- a/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack/expected-v1alpha2.yaml
@@ -74,7 +74,7 @@ spec:
     zone: us-test1
   topology:
     dns:
-      type: Private
+      type: None
 
 ---
 

--- a/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_openstack_octavia/expected-v1alpha2.yaml
@@ -84,7 +84,7 @@ spec:
     zone: us-test1
   topology:
     dns:
-      type: Private
+      type: None
 
 ---
 

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -145,6 +145,8 @@ type NewClusterOptions struct {
 	Topology string
 	// DNSType is the DNS type to use; "public" or "private". Defaults to "public".
 	DNSType string
+	// DNSZone is the DNS zone to use.
+	DNSZone string
 
 	// APILoadBalancerClass determines whether to use classic or network load balancers for the API
 	APILoadBalancerClass string
@@ -1376,16 +1378,17 @@ func setupTopology(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.S
 func setupDNSTopology(opt *NewClusterOptions, cluster *api.Cluster) error {
 	switch strings.ToLower(opt.DNSType) {
 	case "":
-		switch cluster.Spec.GetCloudProvider() {
-		case api.CloudProviderHetzner, api.CloudProviderDO, api.CloudProviderAzure:
-			// Use dns=none if not specified
+		if opt.DNSZone != "" {
+			// Use dns=public if zone is specified
+			cluster.Spec.Networking.Topology.DNS = api.DNSTypePublic
+		} else if cluster.UsesLegacyGossip() {
+			// Use dns=none if .k8s.local is specified instead of Gossip
+			klog.Warningf("Gossip is deprecated, using None DNS instead")
 			cluster.Spec.Networking.Topology.DNS = api.DNSTypeNone
-		default:
-			if cluster.UsesLegacyGossip() {
-				cluster.Spec.Networking.Topology.DNS = api.DNSTypePrivate
-			} else {
-				cluster.Spec.Networking.Topology.DNS = api.DNSTypePublic
-			}
+		} else if cluster.Spec.GetCloudProvider() == api.CloudProviderAWS || cluster.Spec.GetCloudProvider() == api.CloudProviderGCE {
+			cluster.Spec.Networking.Topology.DNS = api.DNSTypePublic
+		} else {
+			cluster.Spec.Networking.Topology.DNS = api.DNSTypeNone
 		}
 	case "public":
 		cluster.Spec.Networking.Topology.DNS = api.DNSTypePublic


### PR DESCRIPTION
/cc @justinsb @johngmyers @rifelpet @zetaab 