### PR TITLE
 If specified, posts event data to URL upon instance interruption action. 

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -279,6 +279,7 @@ spec:
     enableSQSTerminationDraining: true
     managedASGTag: "aws-node-termination-handler/managed"
     prometheusEnable: true
+    webhookURL: "https://hooks.slack.com/services/YOUR/SLACK/URL"
 ```
 
 ##### Queue Processor Mode

--- a/docs/releases/1.28-NOTES.md
+++ b/docs/releases/1.28-NOTES.md
@@ -6,8 +6,6 @@
 
 * Node Termination Handler is now enabled by default.
 
-* Posts event data to URL upon instance interruption action in aws-node-termination-handler with `WEBHOOK_URL`.
-
 ## GCP
 
 * [metadata-proxy](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/metadata-proxy) is no longer deployed on GCP clusters for Kubernetes 1.29+.

--- a/docs/releases/1.28-NOTES.md
+++ b/docs/releases/1.28-NOTES.md
@@ -6,6 +6,8 @@
 
 * Node Termination Handler is now enabled by default.
 
+* Posts event data to URL upon instance interruption action in aws-node-termination-handler with `WEBHOOK_URL`.
+
 ## GCP
 
 * [metadata-proxy](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/metadata-proxy) is no longer deployed on GCP clusters for Kubernetes 1.29+.

--- a/docs/releases/1.29-NOTES.md
+++ b/docs/releases/1.29-NOTES.md
@@ -13,6 +13,8 @@ have a security group attached. These security groups are used for security grou
 allowing incoming traffic to the NLBs as well as traffic between the NLBs and their target
 instances.
 
+* Posts event data to URL upon instance interruption action in aws-node-termination-handler with `WEBHOOK_URL`.
+
 ## GCP
 
 * As of Kubernetes version 1.29, credentials for private GCR/AR repositories will be handled by the out-of-tree credential provider. This is an additional binary that each instance downloads from the assets repository.

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5596,6 +5596,10 @@ spec:
                   version:
                     description: Version is the container image tag used.
                     type: string
+                  webhookURL:
+                    description: If specified, posts event data to URL upon instance
+                      interruption action.
+                    type: string
                 type: object
               nonMasqueradeCIDR:
                 description: MasterIPRange                 string `json:",omitempty"`

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -975,6 +975,9 @@ type NodeTerminationHandlerSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// Version is the container image tag used.
 	Version *string `json:"version,omitempty"`
+
+	// If specified, posts event data to URL upon instance interruption action.
+	WebhookURL *string `json:"webhookURL,omitempty"`
 }
 
 func (n *NodeTerminationHandlerSpec) IsQueueMode() bool {

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -1042,6 +1042,9 @@ type NodeTerminationHandlerSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// Version is the container image tag used.
 	Version *string `json:"version,omitempty"`
+
+	// If specified, posts event data to URL upon instance interruption action.
+	WebhookURL *string `json:"webhookURL,omitempty"`
 }
 
 // NodeProblemDetector determines the node problem detector configuration.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -6453,6 +6453,7 @@ func autoConvert_v1alpha2_NodeTerminationHandlerSpec_To_kops_NodeTerminationHand
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.Version = in.Version
+	out.WebhookURL = in.WebhookURL
 	return nil
 }
 
@@ -6474,6 +6475,7 @@ func autoConvert_kops_NodeTerminationHandlerSpec_To_v1alpha2_NodeTerminationHand
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.Version = in.Version
+	out.WebhookURL = in.WebhookURL
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -4762,6 +4762,11 @@ func (in *NodeTerminationHandlerSpec) DeepCopyInto(out *NodeTerminationHandlerSp
 		*out = new(string)
 		**out = **in
 	}
+	if in.WebhookURL != nil {
+		in, out := &in.WebhookURL, &out.WebhookURL
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -971,6 +971,9 @@ type NodeTerminationHandlerSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// Version is the container image tag used.
 	Version *string `json:"version,omitempty"`
+
+	// If specified, posts event data to URL upon instance interruption action.
+	WebhookURL *string `json:"webhookURL,omitempty"`
 }
 
 // NodeProblemDetector determines the node problem detector configuration.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -6708,6 +6708,7 @@ func autoConvert_v1alpha3_NodeTerminationHandlerSpec_To_kops_NodeTerminationHand
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.Version = in.Version
+	out.WebhookURL = in.WebhookURL
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -6730,6 +6730,7 @@ func autoConvert_kops_NodeTerminationHandlerSpec_To_v1alpha3_NodeTerminationHand
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.Version = in.Version
+	out.WebhookURL = in.WebhookURL
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -4656,6 +4656,11 @@ func (in *NodeTerminationHandlerSpec) DeepCopyInto(out *NodeTerminationHandlerSp
 		*out = new(string)
 		**out = **in
 	}
+	if in.WebhookURL != nil {
+		in, out := &in.WebhookURL, &out.WebhookURL
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -4931,6 +4931,11 @@ func (in *NodeTerminationHandlerSpec) DeepCopyInto(out *NodeTerminationHandlerSp
 		*out = new(string)
 		**out = **in
 	}
+	if in.WebhookURL != nil {
+		in, out := &in.WebhookURL, &out.WebhookURL
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -212,6 +212,10 @@ spec:
               value: "{{ DefaultQueueName }}"
             - name: WORKERS
               value: "10"
+            {{ if .WebhookURL }}
+            - name: WEBHOOK_URL
+              value: {{ .WebhookURL }}
+            {{ end }}
           ports:
           - name: liveness-probe
             protocol: TCP


### PR DESCRIPTION
New attempt to fix: https://github.com/kubernetes/kops/issues/14561

(From: https://github.com/kubernetes/kops/pull/14562)