### PR TITLE
scaleway: IPAM integration

### DIFF
--- a/upup/pkg/fi/cloudup/scaleway/cloud.go
+++ b/upup/pkg/fi/cloudup/scaleway/cloud.go
@@ -80,6 +80,7 @@ type ScwCloud interface {
 	GetClusterServers(clusterName string, instanceGroupName *string) ([]*instance.Server, error)
 	GetClusterSSHKeys(clusterName string) ([]*iam.SSHKey, error)
 	GetClusterVolumes(clusterName string) ([]*instance.Volume, error)
+	GetServerIP(serverID string, zone scw.Zone) (string, error)
 
 	DeleteDNSRecord(record *domain.Record, clusterName string) error
 	DeleteLoadBalancer(loadBalancer *lb.LB) error
@@ -110,16 +111,11 @@ type scwCloudImplementation struct {
 // NewScwCloud returns a Cloud with a Scaleway Client using the env vars SCW_PROFILE or
 // SCW_ACCESS_KEY, SCW_SECRET_KEY and SCW_DEFAULT_PROJECT_ID
 func NewScwCloud(tags map[string]string) (ScwCloud, error) {
-	region, err := scw.ParseRegion(tags["region"])
-	if err != nil {
-		return nil, err
-	}
-	zone, err := scw.ParseZone(tags["zone"])
-	if err != nil {
-		return nil, err
-	}
-
 	var scwClient *scw.Client
+	var region scw.Region
+	var zone scw.Zone
+	var err error
+
 	if profileName := os.Getenv("SCW_PROFILE"); profileName == "REDACTED" {
 		// If the profile is REDACTED, we're running integration tests so no need for authentication
 		scwClient, err = scw.NewClient(scw.WithoutAuth())
@@ -137,6 +133,19 @@ func NewScwCloud(tags map[string]string) (ScwCloud, error) {
 		)
 		if err != nil {
 			return nil, fmt.Errorf("creating client for Scaleway Cloud: %w", err)
+		}
+		region = scw.Region(fi.ValueOf(profile.DefaultRegion))
+		zone = scw.Zone(fi.ValueOf(profile.DefaultZone))
+	}
+
+	if tags != nil {
+		region, err = scw.ParseRegion(tags["region"])
+		if err != nil {
+			return nil, err
+		}
+		zone, err = scw.ParseZone(tags["zone"])
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -156,7 +165,13 @@ func NewScwCloud(tags map[string]string) (ScwCloud, error) {
 }
 
 func (s *scwCloudImplementation) ClusterName(tags []string) string {
-	return ClusterNameFromTags(tags)
+	if tags != nil {
+		return ClusterNameFromTags(tags)
+	}
+	if clusterName, ok := s.tags[TagClusterName]; ok {
+		return clusterName
+	}
+	return ""
 }
 
 func (s *scwCloudImplementation) DNS() (dnsprovider.Interface, error) {
@@ -243,6 +258,10 @@ func (s *scwCloudImplementation) DeregisterInstance(i *cloudinstances.CloudInsta
 	if err != nil {
 		return fmt.Errorf("deregistering cloud instance %s of group %q: %w", i.ID, i.CloudInstanceGroup.HumanName, err)
 	}
+	serverIP, err := s.GetServerIP(server.Server.ID, server.Server.Zone)
+	if err != nil {
+		return fmt.Errorf("deregistering cloud instance %s of group %q: %w", i.ID, i.CloudInstanceGroup.HumanName, err)
+	}
 
 	// We remove the instance's IP from load-balancers
 	lbs, err := s.GetClusterLoadBalancers(s.ClusterName(server.Server.Tags))
@@ -258,8 +277,8 @@ func (s *scwCloudImplementation) DeregisterInstance(i *cloudinstances.CloudInsta
 			return fmt.Errorf("deregistering cloud instance %s of group %q: listing load-balancer's back-ends for instance creation: %w", i.ID, i.CloudInstanceGroup.HumanName, err)
 		}
 		for _, backEnd := range backEnds.Backends {
-			for _, serverIP := range backEnd.Pool {
-				if serverIP == fi.ValueOf(server.Server.PrivateIP) {
+			for _, ip := range backEnd.Pool {
+				if ip == serverIP {
 					_, err := s.lbAPI.RemoveBackendServers(&lb.ZonedAPIRemoveBackendServersRequest{
 						Zone:      s.zone,
 						BackendID: backEnd.ID,
@@ -340,7 +359,7 @@ func (s *scwCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instanceg
 			continue
 		}
 
-		groups[ig.Name], err = buildCloudGroup(ig, serverGroup, nodeMap)
+		groups[ig.Name], err = buildCloudGroup(s, ig, serverGroup, nodeMap)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build cloud group for instance group %q: %w", ig.Name, err)
 		}
@@ -364,7 +383,7 @@ func findServerGroups(s *scwCloudImplementation, clusterName string) (map[string
 	return serverGroups, nil
 }
 
-func buildCloudGroup(ig *kops.InstanceGroup, sg []*instance.Server, nodeMap map[string]*v1.Node) (*cloudinstances.CloudInstanceGroup, error) {
+func buildCloudGroup(s *scwCloudImplementation, ig *kops.InstanceGroup, sg []*instance.Server, nodeMap map[string]*v1.Node) (*cloudinstances.CloudInstanceGroup, error) {
 	cloudInstanceGroup := &cloudinstances.CloudInstanceGroup{
 		HumanName:     ig.Name,
 		InstanceGroup: ig,
@@ -388,9 +407,11 @@ func buildCloudGroup(ig *kops.InstanceGroup, sg []*instance.Server, nodeMap map[
 		cloudInstance.State = cloudinstances.State(server.State)
 		cloudInstance.MachineType = server.CommercialType
 		cloudInstance.Roles = append(cloudInstance.Roles, InstanceRoleFromTags(server.Tags))
-		if server.PrivateIP != nil {
-			cloudInstance.PrivateIP = *server.PrivateIP
+		ip, err := s.GetServerIP(server.ID, server.Zone)
+		if err != nil {
+			return nil, fmt.Errorf("getting server IP: %w", err)
 		}
+		cloudInstance.PrivateIP = ip
 	}
 
 	return cloudInstanceGroup, nil
@@ -472,6 +493,32 @@ func (s *scwCloudImplementation) GetClusterVolumes(clusterName string) ([]*insta
 		return nil, fmt.Errorf("failed to list cluster volumes: %w", err)
 	}
 	return volumes.Volumes, nil
+}
+
+func (s *scwCloudImplementation) GetServerIP(serverID string, zone scw.Zone) (string, error) {
+	region, err := zone.Region()
+	if err != nil {
+		return "", fmt.Errorf("converting zone %s to region: %w", zone, err)
+	}
+
+	ips, err := s.ipamAPI.ListIPs(&ipam.ListIPsRequest{
+		Region:     region,
+		IsIPv6:     fi.PtrTo(false),
+		ResourceID: &serverID,
+		Zonal:      fi.PtrTo(zone.String()),
+	}, scw.WithAllPages())
+	if err != nil {
+		return "", fmt.Errorf("listing IPs for server %s: %w", serverID, err)
+	}
+
+	if len(ips.IPs) < 1 {
+		return "", fmt.Errorf("could not find IP for server %s", serverID)
+	}
+	if len(ips.IPs) > 1 {
+		klog.V(10).Infof("Found more than 1 IP for server %s, using %s", serverID, ips.IPs[0].Address.IP.String())
+	}
+
+	return ips.IPs[0].Address.IP.String(), nil
 }
 
 func (s *scwCloudImplementation) DeleteDNSRecord(record *domain.Record, clusterName string) error {

--- a/upup/pkg/fi/cloudup/scaleway/cloud.go
+++ b/upup/pkg/fi/cloudup/scaleway/cloud.go
@@ -24,6 +24,7 @@ import (
 	domain "github.com/scaleway/scaleway-sdk-go/api/domain/v2beta1"
 	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	ipam "github.com/scaleway/scaleway-sdk-go/api/ipam/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/api/lb/v1"
 	"github.com/scaleway/scaleway-sdk-go/api/marketplace/v2"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -61,6 +62,7 @@ type ScwCloud interface {
 	DomainService() *domain.API
 	IamService() *iam.API
 	InstanceService() *instance.API
+	IPAMService() *ipam.API
 	LBService() *lb.ZonedAPI
 	MarketplaceService() *marketplace.API
 
@@ -100,6 +102,7 @@ type scwCloudImplementation struct {
 	domainAPI      *domain.API
 	iamAPI         *iam.API
 	instanceAPI    *instance.API
+	ipamAPI        *ipam.API
 	lbAPI          *lb.ZonedAPI
 	marketplaceAPI *marketplace.API
 }
@@ -146,6 +149,7 @@ func NewScwCloud(tags map[string]string) (ScwCloud, error) {
 		domainAPI:      domain.NewAPI(scwClient),
 		iamAPI:         iam.NewAPI(scwClient),
 		instanceAPI:    instance.NewAPI(scwClient),
+		ipamAPI:        ipam.NewAPI(scwClient),
 		lbAPI:          lb.NewZonedAPI(scwClient),
 		marketplaceAPI: marketplace.NewAPI(scwClient),
 	}, nil
@@ -185,6 +189,10 @@ func (s *scwCloudImplementation) IamService() *iam.API {
 
 func (s *scwCloudImplementation) InstanceService() *instance.API {
 	return s.instanceAPI
+}
+
+func (s *scwCloudImplementation) IPAMService() *ipam.API {
+	return s.ipamAPI
 }
 
 func (s *scwCloudImplementation) LBService() *lb.ZonedAPI {

--- a/upup/pkg/fi/cloudup/scaleway/verifier.go
+++ b/upup/pkg/fi/cloudup/scaleway/verifier.go
@@ -25,10 +25,12 @@ import (
 	"strings"
 
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	ipam "github.com/scaleway/scaleway-sdk-go/api/ipam/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	kopsv "k8s.io/kops"
 	"k8s.io/kops/pkg/bootstrap"
 	"k8s.io/kops/pkg/wellknownports"
+	"k8s.io/kops/upup/pkg/fi"
 )
 
 type ScalewayVerifierOptions struct{}
@@ -71,6 +73,10 @@ func (v scalewayVerifier) VerifyToken(ctx context.Context, rawRequest *http.Requ
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse Scaleway zone %q: %w", metadata.Location.ZoneID, err)
 	}
+	region, err := zone.Region()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine region from zone %s", zone)
+	}
 
 	profile, err := CreateValidScalewayProfile()
 	if err != nil {
@@ -84,25 +90,33 @@ func (v scalewayVerifier) VerifyToken(ctx context.Context, rawRequest *http.Requ
 		return nil, fmt.Errorf("creating client for Scaleway Verifier: %w", err)
 	}
 
-	instanceAPI := instance.NewAPI(scwClient)
-	serverResponse, err := instanceAPI.GetServer(&instance.GetServerRequest{
+	serverResponse, err := instance.NewAPI(scwClient).GetServer(&instance.GetServerRequest{
 		ServerID: serverID,
 		Zone:     zone,
 	}, scw.WithContext(ctx))
-	if err != nil || serverResponse == nil {
+	if err != nil || serverResponse == nil || serverResponse.Server == nil {
 		return nil, fmt.Errorf("failed to get server %s: %w", serverID, err)
 	}
 	server := serverResponse.Server
 
+	ips, err := ipam.NewAPI(scwClient).ListIPs(&ipam.ListIPsRequest{
+		Region:     region,
+		ResourceID: fi.PtrTo(server.ID),
+		IsIPv6:     fi.PtrTo(false),
+		Zonal:      fi.PtrTo(zone.String()),
+	}, scw.WithContext(ctx), scw.WithAllPages())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get IP for server %q: %w", server.Name, err)
+	}
+	if ips.TotalCount == 0 {
+		return nil, fmt.Errorf("no IP found for server %q: %w", server.Name, err)
+	}
+
 	addresses := []string(nil)
 	challengeEndPoints := []string(nil)
-	if server.PrivateIP != nil {
-		addresses = append(addresses, *server.PrivateIP)
-		challengeEndPoints = append(challengeEndPoints, net.JoinHostPort(*server.PrivateIP, strconv.Itoa(wellknownports.NodeupChallenge)))
-	}
-	if server.IPv6 != nil {
-		addresses = append(addresses, server.IPv6.Address.String())
-		challengeEndPoints = append(challengeEndPoints, net.JoinHostPort(server.IPv6.Address.String(), strconv.Itoa(wellknownports.NodeupChallenge)))
+	for _, ip := range ips.IPs {
+		addresses = append(addresses, ip.Address.IP.String())
+		challengeEndPoints = append(challengeEndPoints, net.JoinHostPort(ip.Address.IP.String(), strconv.Itoa(wellknownports.NodeupChallenge)))
 	}
 
 	result := &bootstrap.VerifyResult{

--- a/upup/pkg/fi/cloudup/scalewaytasks/instance.go
+++ b/upup/pkg/fi/cloudup/scalewaytasks/instance.go
@@ -222,11 +222,12 @@ func (_ *Instance) RenderScw(t *scaleway.ScwAPITarget, actual, expected, changes
 		}
 
 		createServerRequest := instance.CreateServerRequest{
-			Zone:           zone,
-			Name:           uniqueName,
-			CommercialType: fi.ValueOf(expected.CommercialType),
-			Image:          fi.ValueOf(expected.Image),
-			Tags:           expected.Tags,
+			Zone:            zone,
+			Name:            uniqueName,
+			CommercialType:  fi.ValueOf(expected.CommercialType),
+			Image:           fi.ValueOf(expected.Image),
+			Tags:            expected.Tags,
+			RoutedIPEnabled: fi.PtrTo(true),
 		}
 
 		// We resize the root volume if needed (for instance types with no local storage)

--- a/vendor/github.com/scaleway/scaleway-sdk-go/api/ipam/v1alpha1/ipam_sdk.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/api/ipam/v1alpha1/ipam_sdk.go
@@ -1,0 +1,317 @@
+// This file was automatically generated. DO NOT EDIT.
+// If you have any remark or suggestion do not hesitate to open an issue.
+
+// Package ipam provides methods and message types of the ipam v1alpha1 API.
+package ipam
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/scaleway/scaleway-sdk-go/internal/errors"
+	"github.com/scaleway/scaleway-sdk-go/internal/marshaler"
+	"github.com/scaleway/scaleway-sdk-go/internal/parameter"
+	"github.com/scaleway/scaleway-sdk-go/namegenerator"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+// always import dependencies
+var (
+	_ fmt.Stringer
+	_ json.Unmarshaler
+	_ url.URL
+	_ net.IP
+	_ http.Header
+	_ bytes.Reader
+	_ time.Time
+	_ = strings.Join
+
+	_ scw.ScalewayRequest
+	_ marshaler.Duration
+	_ scw.File
+	_ = parameter.AddToQuery
+	_ = namegenerator.GetRandomName
+)
+
+// API: iPAM API.
+type API struct {
+	client *scw.Client
+}
+
+// NewAPI returns a API object from a Scaleway client.
+func NewAPI(client *scw.Client) *API {
+	return &API{
+		client: client,
+	}
+}
+
+type ListIPsRequestOrderBy string
+
+const (
+	ListIPsRequestOrderByCreatedAtDesc  = ListIPsRequestOrderBy("created_at_desc")
+	ListIPsRequestOrderByCreatedAtAsc   = ListIPsRequestOrderBy("created_at_asc")
+	ListIPsRequestOrderByUpdatedAtDesc  = ListIPsRequestOrderBy("updated_at_desc")
+	ListIPsRequestOrderByUpdatedAtAsc   = ListIPsRequestOrderBy("updated_at_asc")
+	ListIPsRequestOrderByAttachedAtDesc = ListIPsRequestOrderBy("attached_at_desc")
+	ListIPsRequestOrderByAttachedAtAsc  = ListIPsRequestOrderBy("attached_at_asc")
+)
+
+func (enum ListIPsRequestOrderBy) String() string {
+	if enum == "" {
+		// return default value if empty
+		return "created_at_desc"
+	}
+	return string(enum)
+}
+
+func (enum ListIPsRequestOrderBy) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, enum)), nil
+}
+
+func (enum *ListIPsRequestOrderBy) UnmarshalJSON(data []byte) error {
+	tmp := ""
+
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	*enum = ListIPsRequestOrderBy(ListIPsRequestOrderBy(tmp).String())
+	return nil
+}
+
+type ResourceType string
+
+const (
+	ResourceTypeUnknownType         = ResourceType("unknown_type")
+	ResourceTypeInstanceServer      = ResourceType("instance_server")
+	ResourceTypeInstanceIP          = ResourceType("instance_ip")
+	ResourceTypeInstancePrivateNic  = ResourceType("instance_private_nic")
+	ResourceTypeLBServer            = ResourceType("lb_server")
+	ResourceTypeFipIP               = ResourceType("fip_ip")
+	ResourceTypeVpcGateway          = ResourceType("vpc_gateway")
+	ResourceTypeVpcGatewayNetwork   = ResourceType("vpc_gateway_network")
+	ResourceTypeK8sNode             = ResourceType("k8s_node")
+	ResourceTypeRdbInstance         = ResourceType("rdb_instance")
+	ResourceTypeRedisCluster        = ResourceType("redis_cluster")
+	ResourceTypeBaremetalServer     = ResourceType("baremetal_server")
+	ResourceTypeBaremetalPrivateNic = ResourceType("baremetal_private_nic")
+)
+
+func (enum ResourceType) String() string {
+	if enum == "" {
+		// return default value if empty
+		return "unknown_type"
+	}
+	return string(enum)
+}
+
+func (enum ResourceType) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, enum)), nil
+}
+
+func (enum *ResourceType) UnmarshalJSON(data []byte) error {
+	tmp := ""
+
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	*enum = ResourceType(ResourceType(tmp).String())
+	return nil
+}
+
+type IP struct {
+	ID string `json:"id"`
+
+	Address scw.IPNet `json:"address"`
+
+	ProjectID string `json:"project_id"`
+
+	IsIPv6 bool `json:"is_ipv6"`
+
+	CreatedAt *time.Time `json:"created_at"`
+
+	UpdatedAt *time.Time `json:"updated_at"`
+
+	// Precisely one of Regional, SubnetID, Zonal, ZonalNat must be set.
+	Regional *bool `json:"regional,omitempty"`
+
+	// Precisely one of Regional, SubnetID, Zonal, ZonalNat must be set.
+	Zonal *string `json:"zonal,omitempty"`
+
+	// Precisely one of Regional, SubnetID, Zonal, ZonalNat must be set.
+	ZonalNat *string `json:"zonal_nat,omitempty"`
+
+	// Precisely one of Regional, SubnetID, Zonal, ZonalNat must be set.
+	SubnetID *string `json:"subnet_id,omitempty"`
+
+	Resource *Resource `json:"resource"`
+
+	Tags []string `json:"tags"`
+
+	Region scw.Region `json:"region"`
+
+	Zone *scw.Zone `json:"zone"`
+}
+
+type ListIPsResponse struct {
+	TotalCount uint64 `json:"total_count"`
+
+	IPs []*IP `json:"ips"`
+}
+
+type Resource struct {
+	// Type: default value: unknown_type
+	Type ResourceType `json:"type"`
+
+	ID string `json:"id"`
+
+	MacAddress *string `json:"mac_address"`
+
+	Name *string `json:"name"`
+}
+
+type Source struct {
+
+	// Precisely one of PrivateNetworkID, Regional, SubnetID, Zonal, ZonalNat must be set.
+	Zonal *string `json:"zonal,omitempty"`
+
+	// Precisely one of PrivateNetworkID, Regional, SubnetID, Zonal, ZonalNat must be set.
+	ZonalNat *string `json:"zonal_nat,omitempty"`
+
+	// Precisely one of PrivateNetworkID, Regional, SubnetID, Zonal, ZonalNat must be set.
+	Regional *bool `json:"regional,omitempty"`
+
+	// Precisely one of PrivateNetworkID, Regional, SubnetID, Zonal, ZonalNat must be set.
+	PrivateNetworkID *string `json:"private_network_id,omitempty"`
+
+	// Precisely one of PrivateNetworkID, Regional, SubnetID, Zonal, ZonalNat must be set.
+	SubnetID *string `json:"subnet_id,omitempty"`
+}
+
+// Service API
+
+// Regions list localities the api is available in
+func (s *API) Regions() []scw.Region {
+	return []scw.Region{scw.RegionFrPar, scw.RegionNlAms, scw.RegionPlWaw}
+}
+
+type ListIPsRequest struct {
+	// Region: region to target. If none is passed will use default region from the config.
+	Region scw.Region `json:"-"`
+
+	Page *int32 `json:"-"`
+
+	PageSize *uint32 `json:"-"`
+	// OrderBy: default value: created_at_desc
+	OrderBy ListIPsRequestOrderBy `json:"-"`
+
+	ProjectID *string `json:"-"`
+
+	OrganizationID *string `json:"-"`
+
+	Zonal *string `json:"-"`
+
+	ZonalNat *string `json:"-"`
+
+	Regional *bool `json:"-"`
+
+	PrivateNetworkID *string `json:"-"`
+
+	SubnetID *string `json:"-"`
+
+	Attached *bool `json:"-"`
+
+	ResourceID *string `json:"-"`
+	// ResourceType: default value: unknown_type
+	ResourceType ResourceType `json:"-"`
+
+	MacAddress *string `json:"-"`
+
+	Tags *[]string `json:"-"`
+
+	IsIPv6 *bool `json:"-"`
+
+	ResourceName *string `json:"-"`
+
+	ResourceIDs []string `json:"-"`
+}
+
+// ListIPs: find IP addresses.
+func (s *API) ListIPs(req *ListIPsRequest, opts ...scw.RequestOption) (*ListIPsResponse, error) {
+	var err error
+
+	if req.Region == "" {
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
+	}
+
+	defaultPageSize, exist := s.client.GetDefaultPageSize()
+	if (req.PageSize == nil || *req.PageSize == 0) && exist {
+		req.PageSize = &defaultPageSize
+	}
+
+	query := url.Values{}
+	parameter.AddToQuery(query, "page", req.Page)
+	parameter.AddToQuery(query, "page_size", req.PageSize)
+	parameter.AddToQuery(query, "order_by", req.OrderBy)
+	parameter.AddToQuery(query, "project_id", req.ProjectID)
+	parameter.AddToQuery(query, "organization_id", req.OrganizationID)
+	parameter.AddToQuery(query, "zonal", req.Zonal)
+	parameter.AddToQuery(query, "zonal_nat", req.ZonalNat)
+	parameter.AddToQuery(query, "regional", req.Regional)
+	parameter.AddToQuery(query, "private_network_id", req.PrivateNetworkID)
+	parameter.AddToQuery(query, "subnet_id", req.SubnetID)
+	parameter.AddToQuery(query, "attached", req.Attached)
+	parameter.AddToQuery(query, "resource_id", req.ResourceID)
+	parameter.AddToQuery(query, "resource_type", req.ResourceType)
+	parameter.AddToQuery(query, "mac_address", req.MacAddress)
+	parameter.AddToQuery(query, "tags", req.Tags)
+	parameter.AddToQuery(query, "is_ipv6", req.IsIPv6)
+	parameter.AddToQuery(query, "resource_name", req.ResourceName)
+	parameter.AddToQuery(query, "resource_ids", req.ResourceIDs)
+
+	if fmt.Sprint(req.Region) == "" {
+		return nil, errors.New("field Region cannot be empty in request")
+	}
+
+	scwReq := &scw.ScalewayRequest{
+		Method:  "GET",
+		Path:    "/ipam/v1alpha1/regions/" + fmt.Sprint(req.Region) + "/ips",
+		Query:   query,
+		Headers: http.Header{},
+	}
+
+	var resp ListIPsResponse
+
+	err = s.client.Do(scwReq, &resp, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UnsafeGetTotalCount should not be used
+// Internal usage only
+func (r *ListIPsResponse) UnsafeGetTotalCount() uint64 {
+	return r.TotalCount
+}
+
+// UnsafeAppend should not be used
+// Internal usage only
+func (r *ListIPsResponse) UnsafeAppend(res interface{}) (uint64, error) {
+	results, ok := res.(*ListIPsResponse)
+	if !ok {
+		return 0, errors.New("%T type cannot be appended to type %T", res, r)
+	}
+
+	r.IPs = append(r.IPs, results.IPs...)
+	r.TotalCount += uint64(len(results.IPs))
+	return uint64(len(results.IPs)), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -792,6 +792,7 @@ github.com/sahilm/fuzzy
 github.com/scaleway/scaleway-sdk-go/api/domain/v2beta1
 github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1
 github.com/scaleway/scaleway-sdk-go/api/instance/v1
+github.com/scaleway/scaleway-sdk-go/api/ipam/v1alpha1
 github.com/scaleway/scaleway-sdk-go/api/lb/v1
 github.com/scaleway/scaleway-sdk-go/api/marketplace/v1
 github.com/scaleway/scaleway-sdk-go/api/marketplace/v2


### PR DESCRIPTION
Since the release of IPAM at Scaleway, some services (like load-balancers) no longer work with the IP provided by the instance API.
This PR makes all kOps components use the IPs from IPAM instead.

A PR has also been made on the [etcd-manager](https://github.com/kubernetes-sigs/etcdadm/pull/385) and works together with this one. 

This is the first step for the integration of private networks, which is coming soon.
