### PR TITLE
Document breaking changes for serviceClusterIPRange and OpenStack with S3 state store

### DIFF
--- a/docs/releases/1.27-NOTES.md
+++ b/docs/releases/1.27-NOTES.md
@@ -33,6 +33,10 @@ they would do so when the respective `topology` was set to `public`.
 
 # Breaking changes
 
+## OpenStack
+
+* If storing the state in an S3 bucket, it is now required to either [deactivate gossip support](https://github.com/kubernetes/kops/issues/15684#issuecomment-1645384421) (`--dns=none`) or - for example - provide the credentials via cloud-init. Due to changes in [PR#15646](https://github.com/kubernetes/kops/pull/15646/files#diff-c1c852aea92883d3117fae99c1610c5cdcbc217f5aa3b340f23b5dd02e971d99L136-L145) the `S3_*` variables will not get passed on to the boot script of the [nodes anymore](https://github.com/kubernetes/kops/pull/15691). As a result the `kops-configuration.service` will throw an `EnvAccessKeyNotFound: failed to find credentials in the environment.` error and they will not join the cluster. Deactivating the gossip support will make the nodes contact the API servers for the bootstrap information.
+
 ## Other breaking changes
 
 * Support for Kubernetes version 1.21 has been removed.

--- a/docs/releases/1.28-NOTES.md
+++ b/docs/releases/1.28-NOTES.md
@@ -30,6 +30,8 @@
 
 * RHEL-based distros will no longer have `wget`, `curl`, `python2`, and `git` packages installed. Install them with [hooks](/cluster_spec/#hooks) if needed.
 
+* The [default IPv4 service cluster range](https://github.com/kubernetes/kops/pull/15866) is now `100.64.0.0/13`. As this was previously calculated from `nonMasqueradeCIDR` if `serviceClusterIPRange` was not explicitly set, it may be necessary to set it to this value ([the first 1/8](https://github.com/kubernetes/kops/pull/15866/files#diff-5e44add4b8da1d5b1c7119b6cc5a5f42a45c555332f51262162b29790e78f479L397-L404) of the `nonMasqueradeCIDR`).
+
 # Deprecations
 
 * Support for Kubernetes version 1.23 is deprecated and will be removed in kOps 1.29.

--- a/docs/releases/1.28-NOTES.md
+++ b/docs/releases/1.28-NOTES.md
@@ -16,6 +16,10 @@
 
 * The `kops get assets --copy` command no longer sets object-level public-read ACLs in the destination fileRepository.
 
+## OpenStack
+
+* If storing the state in an S3 bucket, it is now required to either [deactivate gossip support](https://github.com/kubernetes/kops/issues/15684#issuecomment-1645384421) (`--dns=none`) or - for example - provide the credentials via cloud-init. Due to changes in [PR#15646](https://github.com/kubernetes/kops/pull/15646/files#diff-c1c852aea92883d3117fae99c1610c5cdcbc217f5aa3b340f23b5dd02e971d99L136-L145) the `S3_*` variables will not get passed on to the boot script of the [nodes anymore](https://github.com/kubernetes/kops/pull/15691). As a result the `kops-configuration.service` will throw an `EnvAccessKeyNotFound: failed to find credentials in the environment.` error and they will not join the cluster. Deactivating the gossip support will make the nodes contact the API servers for the bootstrap information.
+
 ## Other breaking changes
 
 * Support for Kubernetes version 1.22 has been removed.


### PR DESCRIPTION
When upgrading from kOps 1.25/26 to 1.27/1.28 I experienced some breaking changes:

I relied on the calculation of the `serviceClusterIPRange` from `nonMasqueradeCIDR` which was removed in https://github.com/kubernetes/kops/pull/15866. This resulted in an error with the certificate as the certificate for the API was still issued for the previous service IP. Setting the `serviceClusterIPRange` to the previously calculated one was doing the trick.

Also, when having clusters running on OpenStack with gossip and the state stored in S3, newly created nodes will not join the cluster, as the `S3_*` variables are not passed on to the nodes anymore, [due to the change here](https://github.com/kubernetes/kops/pull/15646/files#diff-c1c852aea92883d3117fae99c1610c5cdcbc217f5aa3b340f23b5dd02e971d99L137-L142). The [attempt to fix this was closed](https://github.com/kubernetes/kops/pull/15691). Could be that this affects other clouds as well, but I have not checked this.

So, if those changes are legit (and not bugs), then I'd say let's document them at least as breaking changes.