### PR TITLE
Thread context through some slower AWS tasks

### DIFF
--- a/cloudmock/aws/mockautoscaling/group.go
+++ b/cloudmock/aws/mockautoscaling/group.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mockautoscaling
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -44,7 +45,7 @@ func (m *MockAutoscaling) AttachInstances(input *autoscaling.AttachInstancesInpu
 	return &autoscaling.AttachInstancesOutput{}, nil
 }
 
-func (m *MockAutoscaling) CreateAutoScalingGroup(input *autoscaling.CreateAutoScalingGroupInput) (*autoscaling.CreateAutoScalingGroupOutput, error) {
+func (m *MockAutoscaling) CreateAutoScalingGroupWithContext(ctx aws.Context, input *autoscaling.CreateAutoScalingGroupInput, options ...request.Option) (*autoscaling.CreateAutoScalingGroupOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -102,7 +103,7 @@ func (m *MockAutoscaling) CreateAutoScalingGroup(input *autoscaling.CreateAutoSc
 	return &autoscaling.CreateAutoScalingGroupOutput{}, nil
 }
 
-func (m *MockAutoscaling) UpdateAutoScalingGroup(request *autoscaling.UpdateAutoScalingGroupInput) (*autoscaling.UpdateAutoScalingGroupOutput, error) {
+func (m *MockAutoscaling) UpdateAutoScalingGroupWithContext(ctx context.Context, request *autoscaling.UpdateAutoScalingGroupInput, opts ...request.Option) (*autoscaling.UpdateAutoScalingGroupOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	klog.V(2).Infof("Mock UpdateAutoScalingGroup %v", request)
@@ -163,7 +164,7 @@ func (m *MockAutoscaling) UpdateAutoScalingGroup(request *autoscaling.UpdateAuto
 	return &autoscaling.UpdateAutoScalingGroupOutput{}, nil
 }
 
-func (m *MockAutoscaling) EnableMetricsCollection(request *autoscaling.EnableMetricsCollectionInput) (*autoscaling.EnableMetricsCollectionOutput, error) {
+func (m *MockAutoscaling) EnableMetricsCollectionWithContext(ctx aws.Context, request *autoscaling.EnableMetricsCollectionInput, opts ...request.Option) (*autoscaling.EnableMetricsCollectionOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -195,7 +196,7 @@ func (m *MockAutoscaling) EnableMetricsCollection(request *autoscaling.EnableMet
 	return response, nil
 }
 
-func (m *MockAutoscaling) SuspendProcesses(input *autoscaling.ScalingProcessQuery) (*autoscaling.SuspendProcessesOutput, error) {
+func (m *MockAutoscaling) SuspendProcessesWithContext(ctx aws.Context, input *autoscaling.ScalingProcessQuery, opts ...request.Option) (*autoscaling.SuspendProcessesOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -290,7 +291,7 @@ func (m *MockAutoscaling) DescribeAutoScalingGroupsRequest(*autoscaling.Describe
 	return nil, nil
 }
 
-func (m *MockAutoscaling) DescribeAutoScalingGroupsPages(request *autoscaling.DescribeAutoScalingGroupsInput, callback func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool) error {
+func (m *MockAutoscaling) DescribeAutoScalingGroupsPagesWithContext(ctx aws.Context, request *autoscaling.DescribeAutoScalingGroupsInput, callback func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool, options ...request.Option) error {
 	if request.MaxRecords != nil {
 		klog.Fatalf("MaxRecords not implemented")
 	}
@@ -309,12 +310,11 @@ func (m *MockAutoscaling) DescribeAutoScalingGroupsPages(request *autoscaling.De
 	return nil
 }
 
-func (m *MockAutoscaling) DescribeAutoScalingGroupsPagesWithContext(aws.Context, *autoscaling.DescribeAutoScalingGroupsInput, func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool, ...request.Option) error {
-	klog.Fatalf("Not implemented")
-	return nil
+func (m *MockAutoscaling) DescribeAutoScalingGroupsPages(request *autoscaling.DescribeAutoScalingGroupsInput, callback func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool) error {
+	return m.DescribeAutoScalingGroupsPagesWithContext(context.TODO(), request, callback)
 }
 
-func (m *MockAutoscaling) DeleteAutoScalingGroup(request *autoscaling.DeleteAutoScalingGroupInput) (*autoscaling.DeleteAutoScalingGroupOutput, error) {
+func (m *MockAutoscaling) DeleteAutoScalingGroupWithContext(ctx aws.Context, request *autoscaling.DeleteAutoScalingGroupInput, options ...request.Option) (*autoscaling.DeleteAutoScalingGroupOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -330,17 +330,12 @@ func (m *MockAutoscaling) DeleteAutoScalingGroup(request *autoscaling.DeleteAuto
 	return &autoscaling.DeleteAutoScalingGroupOutput{}, nil
 }
 
-func (m *MockAutoscaling) DeleteAutoScalingGroupWithContext(aws.Context, *autoscaling.DeleteAutoScalingGroupInput, ...request.Option) (*autoscaling.DeleteAutoScalingGroupOutput, error) {
-	klog.Fatalf("Not implemented")
-	return nil, nil
-}
-
 func (m *MockAutoscaling) DeleteAutoScalingGroupRequest(*autoscaling.DeleteAutoScalingGroupInput) (*request.Request, *autoscaling.DeleteAutoScalingGroupOutput) {
 	klog.Fatalf("Not implemented")
 	return nil, nil
 }
 
-func (m *MockAutoscaling) PutLifecycleHook(input *autoscaling.PutLifecycleHookInput) (*autoscaling.PutLifecycleHookOutput, error) {
+func (m *MockAutoscaling) PutLifecycleHookWithContext(ctx aws.Context, input *autoscaling.PutLifecycleHookInput, options ...request.Option) (*autoscaling.PutLifecycleHookOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	hook := &autoscaling.LifecycleHook{
@@ -364,7 +359,7 @@ func (m *MockAutoscaling) PutLifecycleHook(input *autoscaling.PutLifecycleHookIn
 	return &autoscaling.PutLifecycleHookOutput{}, nil
 }
 
-func (m *MockAutoscaling) DescribeLifecycleHooks(input *autoscaling.DescribeLifecycleHooksInput) (*autoscaling.DescribeLifecycleHooksOutput, error) {
+func (m *MockAutoscaling) DescribeLifecycleHooksWithContext(ctx aws.Context, input *autoscaling.DescribeLifecycleHooksInput, options ...request.Option) (*autoscaling.DescribeLifecycleHooksOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/cloudmock/aws/mockautoscaling/tags.go
+++ b/cloudmock/aws/mockautoscaling/tags.go
@@ -72,7 +72,7 @@ func (m *MockAutoscaling) DescribeTagsRequest(*autoscaling.DescribeTagsInput) (*
 	return nil, nil
 }
 
-func (m *MockAutoscaling) DescribeTagsPages(request *autoscaling.DescribeTagsInput, callback func(*autoscaling.DescribeTagsOutput, bool) bool) error {
+func (m *MockAutoscaling) DescribeTagsPagesWithContext(ctx aws.Context, request *autoscaling.DescribeTagsInput, callback func(*autoscaling.DescribeTagsOutput, bool) bool, options ...request.Option) error {
 	// For the mock, we just send everything in one page
 	page, err := m.DescribeTags(request)
 	if err != nil {
@@ -81,10 +81,5 @@ func (m *MockAutoscaling) DescribeTagsPages(request *autoscaling.DescribeTagsInp
 
 	callback(page, false)
 
-	return nil
-}
-
-func (m *MockAutoscaling) DescribeTagsPagesWithContext(aws.Context, *autoscaling.DescribeTagsInput, func(*autoscaling.DescribeTagsOutput, bool) bool, ...request.Option) error {
-	klog.Fatalf("Not implemented")
 	return nil
 }

--- a/cloudmock/aws/mockautoscaling/warmpool.go
+++ b/cloudmock/aws/mockautoscaling/warmpool.go
@@ -16,9 +16,13 @@ limitations under the License.
 
 package mockautoscaling
 
-import "github.com/aws/aws-sdk-go/service/autoscaling"
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+)
 
-func (m *MockAutoscaling) DescribeWarmPool(input *autoscaling.DescribeWarmPoolInput) (*autoscaling.DescribeWarmPoolOutput, error) {
+func (m *MockAutoscaling) DescribeWarmPoolWithContext(ctx aws.Context, input *autoscaling.DescribeWarmPoolInput, options ...request.Option) (*autoscaling.DescribeWarmPoolOutput, error) {
 	instances, found := m.WarmPoolInstances[*input.AutoScalingGroupName]
 	if !found {
 		return &autoscaling.DescribeWarmPoolOutput{}, nil

--- a/cloudmock/aws/mockec2/launch_templates.go
+++ b/cloudmock/aws/mockec2/launch_templates.go
@@ -17,10 +17,12 @@ limitations under the License.
 package mockec2
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 )
@@ -41,6 +43,11 @@ func (m *MockEC2) DescribeLaunchTemplatesPages(request *ec2.DescribeLaunchTempla
 	callback(page, false)
 
 	return nil
+}
+
+// DescribeLaunchTemplatesPagesWithContext mocks the describing the launch templates
+func (m *MockEC2) DescribeLaunchTemplatesPagesWithContext(ctx context.Context, request *ec2.DescribeLaunchTemplatesInput, callback func(*ec2.DescribeLaunchTemplatesOutput, bool) bool, option ...request.Option) error {
+	return m.DescribeLaunchTemplatesPages(request, callback)
 }
 
 // DescribeLaunchTemplates mocks the describing the launch templates
@@ -114,6 +121,11 @@ func (m *MockEC2) DescribeLaunchTemplateVersions(request *ec2.DescribeLaunchTemp
 		})
 	}
 	return o, nil
+}
+
+// DescribeLaunchTemplateVersionsWithContext mocks the retrieval of launch template versions - we don't use this at the moment so we can just return the template
+func (m *MockEC2) DescribeLaunchTemplateVersionsWithContext(ctx context.Context, request *ec2.DescribeLaunchTemplateVersionsInput, option ...request.Option) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
+	return m.DescribeLaunchTemplateVersions(request)
 }
 
 // CreateLaunchTemplate mocks the ec2 create launch template

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -947,6 +948,10 @@ func (m *disabledSurgeTest) DetachInstances(input *autoscaling.DetachInstancesIn
 		m.numDetached++
 	}
 	return &autoscaling.DetachInstancesOutput{}, nil
+}
+
+func (m *disabledSurgeTest) DetachInstancesWithContext(ctx context.Context, input *autoscaling.DetachInstancesInput, option ...request.Option) (*autoscaling.DetachInstancesOutput, error) {
+	return m.DetachInstances(input)
 }
 
 func TestRollingUpdateDisabledSurge(t *testing.T) {

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -1199,6 +1200,8 @@ func DescribeEgressOnlyInternetGateways(cloud fi.Cloud) ([]*ec2.EgressOnlyIntern
 }
 
 func DeleteAutoScalingGroup(cloud fi.Cloud, r *resources.Resource) error {
+	ctx := context.TODO()
+
 	c := cloud.(awsup.AWSCloud)
 
 	id := r.ID
@@ -1208,7 +1211,7 @@ func DeleteAutoScalingGroup(cloud fi.Cloud, r *resources.Resource) error {
 		AutoScalingGroupName: &id,
 		ForceDelete:          aws.Bool(true),
 	}
-	_, err := c.Autoscaling().DeleteAutoScalingGroup(request)
+	_, err := c.Autoscaling().DeleteAutoScalingGroupWithContext(ctx, request)
 	if err != nil {
 		if IsDependencyViolation(err) {
 			return err

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awstasks
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -53,6 +54,7 @@ func (h *AutoscalingLifecycleHook) CompareWithID() *string {
 }
 
 func (h *AutoscalingLifecycleHook) Find(c *fi.CloudupContext) (*AutoscalingLifecycleHook, error) {
+	ctx := c.Context()
 	cloud := c.T.Cloud.(awsup.AWSCloud)
 
 	request := &autoscaling.DescribeLifecycleHooksInput{
@@ -60,7 +62,7 @@ func (h *AutoscalingLifecycleHook) Find(c *fi.CloudupContext) (*AutoscalingLifec
 		LifecycleHookNames:   []*string{h.GetHookName()},
 	}
 
-	response, err := cloud.Autoscaling().DescribeLifecycleHooks(request)
+	response, err := cloud.Autoscaling().DescribeLifecycleHooksWithContext(ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing ASG Lifecycle Hooks: %v", err)
 	}
@@ -109,6 +111,8 @@ func (_ *AutoscalingLifecycleHook) CheckChanges(a, e, changes *AutoscalingLifecy
 }
 
 func (*AutoscalingLifecycleHook) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *AutoscalingLifecycleHook) error {
+	ctx := context.TODO()
+
 	if changes != nil {
 		if fi.ValueOf(e.Enabled) {
 			request := &autoscaling.PutLifecycleHookInput{
@@ -118,7 +122,7 @@ func (*AutoscalingLifecycleHook) RenderAWS(t *awsup.AWSAPITarget, a, e, changes 
 				LifecycleHookName:    e.GetHookName(),
 				LifecycleTransition:  e.LifecycleTransition,
 			}
-			_, err := t.Cloud.Autoscaling().PutLifecycleHook(request)
+			_, err := t.Cloud.Autoscaling().PutLifecycleHookWithContext(ctx, request)
 			if err != nil {
 				return err
 			}
@@ -127,7 +131,7 @@ func (*AutoscalingLifecycleHook) RenderAWS(t *awsup.AWSAPITarget, a, e, changes 
 				AutoScalingGroupName: e.AutoscalingGroup.Name,
 				LifecycleHookName:    e.GetHookName(),
 			}
-			_, err := t.Cloud.Autoscaling().DeleteLifecycleHook(request)
+			_, err := t.Cloud.Autoscaling().DeleteLifecycleHookWithContext(ctx, request)
 			if err != nil {
 				return err
 			}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -342,6 +342,8 @@ func (t *LaunchTemplate) Find(c *fi.CloudupContext) (*LaunchTemplate, error) {
 
 // findAllLaunchTemplates returns all the launch templates for us
 func (t *LaunchTemplate) findAllLaunchTemplates(c *fi.CloudupContext) ([]*ec2.LaunchTemplate, error) {
+	ctx := c.Context()
+
 	cloud, ok := c.T.Cloud.(awsup.AWSCloud)
 	if !ok {
 		return nil, fmt.Errorf("invalid cloud provider: %v, expected: %s", c.T.Cloud, "awsup.AWSCloud")
@@ -357,7 +359,7 @@ func (t *LaunchTemplate) findAllLaunchTemplates(c *fi.CloudupContext) ([]*ec2.La
 	}
 
 	var list []*ec2.LaunchTemplate
-	err := cloud.EC2().DescribeLaunchTemplatesPages(input, func(p *ec2.DescribeLaunchTemplatesOutput, lastPage bool) (shouldContinue bool) {
+	err := cloud.EC2().DescribeLaunchTemplatesPagesWithContext(ctx, input, func(p *ec2.DescribeLaunchTemplatesOutput, lastPage bool) (shouldContinue bool) {
 		list = append(list, p.LaunchTemplates...)
 		return true
 	})
@@ -370,6 +372,8 @@ func (t *LaunchTemplate) findAllLaunchTemplates(c *fi.CloudupContext) ([]*ec2.La
 
 // findLatestLaunchTemplateVersion returns the latest template version
 func (t *LaunchTemplate) findLatestLaunchTemplateVersion(c *fi.CloudupContext) (*ec2.LaunchTemplateVersion, error) {
+	ctx := c.Context()
+
 	cloud, ok := c.T.Cloud.(awsup.AWSCloud)
 	if !ok {
 		return nil, fmt.Errorf("invalid cloud provider: %v, expected: awsup.AWSCloud", c.T.Cloud)
@@ -380,7 +384,7 @@ func (t *LaunchTemplate) findLatestLaunchTemplateVersion(c *fi.CloudupContext) (
 		Versions:           []*string{aws.String("$Latest")},
 	}
 
-	output, err := cloud.EC2().DescribeLaunchTemplateVersions(input)
+	output, err := cloud.EC2().DescribeLaunchTemplateVersionsWithContext(ctx, input)
 	if err != nil {
 		if awsup.AWSErrorCode(err) == "InvalidLaunchTemplateName.NotFoundException" {
 			klog.V(4).Infof("Got InvalidLaunchTemplateName.NotFoundException error describing latest launch template version: %q", aws.StringValue(t.Name))

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awsup
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -90,7 +91,9 @@ type MockCloud struct {
 }
 
 func (c *MockAWSCloud) DeleteGroup(g *cloudinstances.CloudInstanceGroup) error {
-	return deleteGroup(c, g)
+	ctx := context.TODO()
+
+	return deleteGroup(ctx, c, g)
 }
 
 func (c *MockAWSCloud) DeleteInstance(i *cloudinstances.CloudInstance) error {
@@ -102,11 +105,14 @@ func (c *MockAWSCloud) DeregisterInstance(i *cloudinstances.CloudInstance) error
 }
 
 func (c *MockAWSCloud) DetachInstance(i *cloudinstances.CloudInstance) error {
-	return detachInstance(c, i)
+	ctx := context.TODO()
+
+	return detachInstance(ctx, c, i)
 }
 
 func (c *MockAWSCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
-	return getCloudGroups(c, cluster, instancegroups, warnUnmatched, nodes)
+	ctx := context.TODO()
+	return getCloudGroups(ctx, c, cluster, instancegroups, warnUnmatched, nodes)
 }
 
 func (c *MockCloud) ProviderID() kops.CloudProviderID {


### PR DESCRIPTION
There are still too many context.TODOs here for this to join all the
way up, but we should be able to better understand the slowest tasks.
