### PR TITLE
Automated cherry pick of #16038: Add support for --cluster-signing-duration KCM flag

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2042,6 +2042,10 @@ spec:
                 description: KubeControllerManagerConfig is the configuration for
                   the controller
                 properties:
+                  ClusterSigningDuration:
+                    description: ClusterSigningDuration is the max length of duration
+                      that the signed certificates will be given. (default 365*24h)
+                    type: string
                   allocateNodeCIDRs:
                     description: AllocateNodeCIDRs enables CIDRs for Pods to be allocated
                       and, if ConfigureCloudRoutes is true, to be set on the cloud
@@ -2158,9 +2162,9 @@ spec:
                       latency, but lower number of endpoints revision generated
                     type: string
                   experimentalClusterSigningDuration:
-                    description: ExperimentalClusterSigningDuration is the duration
-                      that determines the length of duration that the signed certificates
-                      will be given. (default 8760h0m0s)
+                    description: ExperimentalClusterSigningDuration is the max length
+                      of duration that the signed certificates will be given. (default
+                      365*24h) Deprecated - use cluster-signing-duration instead
                     type: string
                   externalCloudVolumePlugin:
                     description: ExternalCloudVolumePlugin is a fallback mechanism

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -616,9 +616,11 @@ type KubeControllerManagerConfig struct {
 	// HorizontalPodAutoscalerUseRestClients determines if the new-style clients
 	// should be used if support for custom metrics is enabled.
 	HorizontalPodAutoscalerUseRestClients *bool `json:"horizontalPodAutoscalerUseRestClients,omitempty" flag:"horizontal-pod-autoscaler-use-rest-clients"`
-	// ExperimentalClusterSigningDuration is the duration that determines
-	// the length of duration that the signed certificates will be given. (default 8760h0m0s)
+	// ExperimentalClusterSigningDuration is the max length of duration that the signed certificates will be given. (default 365*24h)
+	// Deprecated - use cluster-signing-duration instead
 	ExperimentalClusterSigningDuration *metav1.Duration `json:"experimentalClusterSigningDuration,omitempty" flag:"experimental-cluster-signing-duration"`
+	// ClusterSigningDuration is the max length of duration that the signed certificates will be given. (default 365*24h)
+	ClusterSigningDuration *metav1.Duration `json:"ClusterSigningDuration,omitempty" flag:"cluster-signing-duration"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 	// TLSCertFile is the file containing the TLS server certificate.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -623,9 +623,11 @@ type KubeControllerManagerConfig struct {
 	// HorizontalPodAutoscalerUseRestClients determines if the new-style clients
 	// should be used if support for custom metrics is enabled.
 	HorizontalPodAutoscalerUseRestClients *bool `json:"horizontalPodAutoscalerUseRestClients,omitempty" flag:"horizontal-pod-autoscaler-use-rest-clients"`
-	// ExperimentalClusterSigningDuration is the duration that determines
-	// the length of duration that the signed certificates will be given. (default 8760h0m0s)
+	// ExperimentalClusterSigningDuration is the max length of duration that the signed certificates will be given. (default 365*24h)
+	// Deprecated - use cluster-signing-duration instead
 	ExperimentalClusterSigningDuration *metav1.Duration `json:"experimentalClusterSigningDuration,omitempty" flag:"experimental-cluster-signing-duration"`
+	// ClusterSigningDuration is the max length of duration that the signed certificates will be given. (default 365*24h)
+	ClusterSigningDuration *metav1.Duration `json:"ClusterSigningDuration,omitempty" flag:"cluster-signing-duration"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 	// TLSCertFile is the file containing the TLS server certificate.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5020,6 +5020,7 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.HorizontalPodAutoscalerTolerance = in.HorizontalPodAutoscalerTolerance
 	out.HorizontalPodAutoscalerUseRestClients = in.HorizontalPodAutoscalerUseRestClients
 	out.ExperimentalClusterSigningDuration = in.ExperimentalClusterSigningDuration
+	out.ClusterSigningDuration = in.ClusterSigningDuration
 	out.FeatureGates = in.FeatureGates
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSCipherSuites = in.TLSCipherSuites
@@ -5092,6 +5093,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.HorizontalPodAutoscalerTolerance = in.HorizontalPodAutoscalerTolerance
 	out.HorizontalPodAutoscalerUseRestClients = in.HorizontalPodAutoscalerUseRestClients
 	out.ExperimentalClusterSigningDuration = in.ExperimentalClusterSigningDuration
+	out.ClusterSigningDuration = in.ClusterSigningDuration
 	out.FeatureGates = in.FeatureGates
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSCipherSuites = in.TLSCipherSuites

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3365,6 +3365,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.ClusterSigningDuration != nil {
+		in, out := &in.ClusterSigningDuration, &out.ClusterSigningDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]string, len(*in))

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -614,9 +614,11 @@ type KubeControllerManagerConfig struct {
 	// HorizontalPodAutoscalerUseRestClients determines if the new-style clients
 	// should be used if support for custom metrics is enabled.
 	HorizontalPodAutoscalerUseRestClients *bool `json:"horizontalPodAutoscalerUseRestClients,omitempty" flag:"horizontal-pod-autoscaler-use-rest-clients"`
-	// ExperimentalClusterSigningDuration is the duration that determines
-	// the length of duration that the signed certificates will be given. (default 8760h0m0s)
+	// ExperimentalClusterSigningDuration is the max length of duration that the signed certificates will be given. (default 365*24h)
+	// Deprecated - use cluster-signing-duration instead
 	ExperimentalClusterSigningDuration *metav1.Duration `json:"experimentalClusterSigningDuration,omitempty" flag:"experimental-cluster-signing-duration"`
+	// ClusterSigningDuration is the max length of duration that the signed certificates will be given. (default 365*24h)
+	ClusterSigningDuration *metav1.Duration `json:"ClusterSigningDuration,omitempty" flag:"cluster-signing-duration"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
 	// TLSCertFile is the file containing the TLS server certificate.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5413,6 +5413,7 @@ func autoConvert_v1alpha3_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.HorizontalPodAutoscalerTolerance = in.HorizontalPodAutoscalerTolerance
 	out.HorizontalPodAutoscalerUseRestClients = in.HorizontalPodAutoscalerUseRestClients
 	out.ExperimentalClusterSigningDuration = in.ExperimentalClusterSigningDuration
+	out.ClusterSigningDuration = in.ClusterSigningDuration
 	out.FeatureGates = in.FeatureGates
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSCipherSuites = in.TLSCipherSuites
@@ -5485,6 +5486,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha3_KubeControllerMana
 	out.HorizontalPodAutoscalerTolerance = in.HorizontalPodAutoscalerTolerance
 	out.HorizontalPodAutoscalerUseRestClients = in.HorizontalPodAutoscalerUseRestClients
 	out.ExperimentalClusterSigningDuration = in.ExperimentalClusterSigningDuration
+	out.ClusterSigningDuration = in.ClusterSigningDuration
 	out.FeatureGates = in.FeatureGates
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSCipherSuites = in.TLSCipherSuites

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3334,6 +3334,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.ClusterSigningDuration != nil {
+		in, out := &in.ClusterSigningDuration, &out.ClusterSigningDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]string, len(*in))

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3513,6 +3513,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.ClusterSigningDuration != nil {
+		in, out := &in.ClusterSigningDuration, &out.ClusterSigningDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]string, len(*in))


### PR DESCRIPTION
Cherry pick of #16038 on release-1.28.

#16038: Add support for --cluster-signing-duration KCM flag

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```