### PR TITLE
Fix tests for multi-arch clusters

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -73,6 +73,8 @@ func (d *deployer) verifyBuildFlags() error {
 	if d.BuildOptions.TargetBuildArch != "" {
 		if !strings.HasPrefix(d.BuildOptions.TargetBuildArch, "linux/") {
 			return errors.New("--target-build-arch supports linux/amd64 and linux/arm64 only")
+		} else if d.BuildOptions.BuildKubernetes {
+			d.BuildOptions.TargetBuildArch = "linux/amd64"
 		}
 	}
 

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -181,9 +181,12 @@ func (d *deployer) env() []string {
 		fmt.Sprintf("HOME=%v", os.Getenv("HOME")),
 		fmt.Sprintf("KOPS_STATE_STORE=%v", d.stateStore()),
 		fmt.Sprintf("KOPS_FEATURE_FLAGS=%v", d.featureFlags()),
-		fmt.Sprintf("KOPS_ARCH=%s", strings.Trim(d.BuildOptions.TargetBuildArch, "linux/")),
 		"KOPS_RUN_TOO_NEW_VERSION=1",
 	}...)
+
+	if d.BuildOptions.TargetBuildArch != "" {
+		vars = append(vars, fmt.Sprintf("KOPS_ARCH=%s", strings.Trim(d.BuildOptions.TargetBuildArch, "linux/")))
+	}
 
 	// Pass-through some env vars if set (on all clouds)
 	for _, k := range []string{"KOPS_ARCH"} {

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -113,7 +113,6 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	d := &deployer{
 		commonOptions: opts,
 		BuildOptions: &builder.BuildOptions{
-			TargetBuildArch: "linux/amd64",
 			BuildKubernetes: false,
 		},
 		boskosHeartbeatClose: make(chan struct{}),


### PR DESCRIPTION
kOps assumes that both ARM64 and AMD64 binaries are built when creating a new cluster.
When building Kubernetes for testing, we want a specific build arch, but only in that case.

/cc @upodroid @aojea @justinsb 