### PR TITLE
Automated cherry pick of #16043: Update containerd to v1.7.7

### DIFF
--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -59,14 +59,14 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 					Version: fi.PtrTo("1.1.5"),
 				}
 			case b.IsKubernetesGTE("1.27.2"):
-				containerd.Version = fi.PtrTo("1.7.2")
+				containerd.Version = fi.PtrTo("1.7.7")
 				containerd.Runc = &kops.Runc{
-					Version: fi.PtrTo("1.1.7"),
+					Version: fi.PtrTo("1.1.9"),
 				}
 			default:
-				containerd.Version = fi.PtrTo("1.6.21")
+				containerd.Version = fi.PtrTo("1.6.24")
 				containerd.Runc = &kops.Runc{
-					Version: fi.PtrTo("1.1.7"),
+					Version: fi.PtrTo("1.1.9"),
 				}
 			}
 		}

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -128,7 +128,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: LifNsF2HPOr8pHO/9q2F4tuTmxeKphWVPscQHAkNU4s=
+NodeupConfigHash: YQH+U51wcXcatTLu+/A7ZAqpey/0ZVOQOPqdvR5XB2A=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -151,7 +151,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: nc/JJC1zEzaKHX9KRE1LLn7zvJk1IosWeFAcokQidTc=
+NodeupConfigHash: Hiwuza3/nunGR0maTsDAu+W90F89A37sQivnrnfdmE4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_cluster-completed.spec_content
@@ -29,8 +29,8 @@ spec:
   containerd:
     logLevel: info
     runc:
-      version: 1.1.7
-    version: 1.7.2
+      version: 1.1.9
+    version: 1.7.7
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -62,8 +62,8 @@ Assets:
   - 4f38ee903f35b300d3b005a9c6bfb9a46a57f92e89ae602ef9c129b91dc6c5a5@https://dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl,https://cdn.dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl
   - 5035d7814c95cd3cedbc5efb447ef25a4942ef05caab2159746d55ce1698c74a@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/amd64/ecr-credential-provider-linux-amd64
   - f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz
-  - 2755c70152ab40856510b4549c2dd530e15f5355eb7bf82868e813c9380e22a7@https://github.com/containerd/containerd/releases/download/v1.7.2/containerd-1.7.2-linux-amd64.tar.gz
-  - c3aadb419e5872af49504b6de894055251d2e685fddddb981a79703e7f895cbd@https://github.com/opencontainers/runc/releases/download/v1.1.7/runc.amd64
+  - 371de359d6102c51f6ee2361d08297948d134ce7379e01cb965ceeffa4365fba@https://github.com/containerd/containerd/releases/download/v1.7.7/containerd-1.7.7-linux-amd64.tar.gz
+  - b9bfdd4cb27cddbb6172a442df165a80bfc0538a676fbca1a6a6c8f4c6933b43@https://github.com/opencontainers/runc/releases/download/v1.1.9/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
   arm64:
@@ -71,8 +71,8 @@ Assets:
   - 1b0966692e398efe71fe59f913eaec44ffd4468cc1acd00bf91c29fa8ff8f578@https://dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubectl,https://cdn.dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubectl
   - b3d567bda9e2996fc1fbd9d13506bd16763d3865b5c7b0b3c4b48c6088c04481@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/arm64/ecr-credential-provider-linux-arm64
   - 525e2b62ba92a1b6f3dc9612449a84aa61652e680f7ebf4eff579795fe464b57@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-arm64-v1.2.0.tgz
-  - d75a4ca53d9addd0b2c50172d168b12957e18b2d8b802db2658f2767f15889a6@https://github.com/containerd/containerd/releases/download/v1.7.2/containerd-1.7.2-linux-arm64.tar.gz
-  - 1b309c4d5aa4cc7b888b2f79c385ecee26ca3d55dae0852e7c4a692196d5faab@https://github.com/opencontainers/runc/releases/download/v1.1.7/runc.arm64
+  - 0a104f487193665d2681fcb5ed83f2baa5f97849fe2661188da835c9d4eaf9e3@https://github.com/containerd/containerd/releases/download/v1.7.7/containerd-1.7.7-linux-arm64.tar.gz
+  - b43e9f561e85906f469eef5a7b7992fc586f750f44a0e011da4467e7008c33a0@https://github.com/opencontainers/runc/releases/download/v1.1.9/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
 CAs:
@@ -318,8 +318,8 @@ configStore:
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.1.7
-  version: 1.7.2
+    version: 1.1.9
+  version: 1.7.7
 docker:
   skipInstall: true
 etcdManifests:

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_nodeupconfig-nodes_content
@@ -4,15 +4,15 @@ Assets:
   - 4f38ee903f35b300d3b005a9c6bfb9a46a57f92e89ae602ef9c129b91dc6c5a5@https://dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl,https://cdn.dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl
   - 5035d7814c95cd3cedbc5efb447ef25a4942ef05caab2159746d55ce1698c74a@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/amd64/ecr-credential-provider-linux-amd64
   - f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz
-  - 2755c70152ab40856510b4549c2dd530e15f5355eb7bf82868e813c9380e22a7@https://github.com/containerd/containerd/releases/download/v1.7.2/containerd-1.7.2-linux-amd64.tar.gz
-  - c3aadb419e5872af49504b6de894055251d2e685fddddb981a79703e7f895cbd@https://github.com/opencontainers/runc/releases/download/v1.1.7/runc.amd64
+  - 371de359d6102c51f6ee2361d08297948d134ce7379e01cb965ceeffa4365fba@https://github.com/containerd/containerd/releases/download/v1.7.7/containerd-1.7.7-linux-amd64.tar.gz
+  - b9bfdd4cb27cddbb6172a442df165a80bfc0538a676fbca1a6a6c8f4c6933b43@https://github.com/opencontainers/runc/releases/download/v1.1.9/runc.amd64
   arm64:
   - 810cd9a611e9f084e57c9ee466e33c324b2228d4249ff38c2588a0cc3224f10d@https://dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubelet,https://cdn.dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubelet
   - 1b0966692e398efe71fe59f913eaec44ffd4468cc1acd00bf91c29fa8ff8f578@https://dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubectl,https://cdn.dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubectl
   - b3d567bda9e2996fc1fbd9d13506bd16763d3865b5c7b0b3c4b48c6088c04481@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/arm64/ecr-credential-provider-linux-arm64
   - 525e2b62ba92a1b6f3dc9612449a84aa61652e680f7ebf4eff579795fe464b57@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-arm64-v1.2.0.tgz
-  - d75a4ca53d9addd0b2c50172d168b12957e18b2d8b802db2658f2767f15889a6@https://github.com/containerd/containerd/releases/download/v1.7.2/containerd-1.7.2-linux-arm64.tar.gz
-  - 1b309c4d5aa4cc7b888b2f79c385ecee26ca3d55dae0852e7c4a692196d5faab@https://github.com/opencontainers/runc/releases/download/v1.1.7/runc.arm64
+  - 0a104f487193665d2681fcb5ed83f2baa5f97849fe2661188da835c9d4eaf9e3@https://github.com/containerd/containerd/releases/download/v1.7.7/containerd-1.7.7-linux-arm64.tar.gz
+  - b43e9f561e85906f469eef5a7b7992fc586f750f44a0e011da4467e7008c33a0@https://github.com/opencontainers/runc/releases/download/v1.1.9/runc.arm64
 CAs: {}
 ClusterName: minimal.example.com
 ContainerRuntime: containerd
@@ -56,8 +56,8 @@ UpdatePolicy: automatic
 containerdConfig:
   logLevel: info
   runc:
-    version: 1.1.7
-  version: 1.7.2
+    version: 1.1.9
+  version: 1.7.7
 docker:
   skipInstall: true
 useInstanceIDForNodeName: true

--- a/upup/pkg/fi/cloudup/runc.go
+++ b/upup/pkg/fi/cloudup/runc.go
@@ -162,6 +162,8 @@ func findAllRuncHashesAmd64() map[string]string {
 		"1.1.5": "f00b144e86f8c1db347a2e8f22caade07d55382c5f76dd5c0a5b1ab64eaec8bb",
 		"1.1.6": "868bee5b8dc2a01df0ca41d0accfad6a3372dc1165ebfb76143d2c6672e86115",
 		"1.1.7": "c3aadb419e5872af49504b6de894055251d2e685fddddb981a79703e7f895cbd",
+		"1.1.8": "1d05ed79854efc707841dfc7afbf3b86546fc1d0b3a204435ca921c14af8385b",
+		"1.1.9": "b9bfdd4cb27cddbb6172a442df165a80bfc0538a676fbca1a6a6c8f4c6933b43",
 	}
 
 	return hashes
@@ -177,6 +179,8 @@ func findAllRuncHashesArm64() map[string]string {
 		"1.1.5": "54e79e4d48b9e191767e4abc08be1a8476a1c757e9a9f8c45c6ded001226867f",
 		"1.1.6": "da5b2ed26a173a69ea66eae7c369feebf59c1031e14985f512a0a293bb5f76fb",
 		"1.1.7": "1b309c4d5aa4cc7b888b2f79c385ecee26ca3d55dae0852e7c4a692196d5faab",
+		"1.1.8": "7c22cb618116d1d5216d79e076349f93a672253d564b19928a099c20e4acd658",
+		"1.1.9": "b43e9f561e85906f469eef5a7b7992fc586f750f44a0e011da4467e7008c33a0",
 	}
 
 	return hashes


### PR DESCRIPTION
Cherry pick of #16043 on release-1.28.

#16043: Update containerd to v1.7.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```