### PR TITLE
Add support for publishing Service Account Issuer documents to GCS.

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -1568,7 +1568,7 @@ spec:
 ```
 
 The `discoveryStore` option causes kOps to publish an OIDC-compatible discovery document
-to a path in an S3 bucket. This would ordinarily be a different bucket than the state store.
+to a path in an object storage bucket (such as S3 or GCS). This would ordinarily be a different bucket than the state store.
 kOps will automatically configure `spec.kubeAPIServer.serviceAccountIssuer` and default
 `spec.kubeAPIServer.serviceAccountJWKSURI` to the corresponding
 HTTPS URL.

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -220,6 +220,8 @@ func validateServiceAccountIssuerDiscovery(c *kops.Cluster, said *kops.ServiceAc
 				if strings.Contains(base.Bucket(), ".") {
 					allErrs = append(allErrs, field.Invalid(saidStoreField, saidStore, "Bucket name cannot contain dots"))
 				}
+			case *vfs.GSPath:
+				// No known restrictions currently. Added here to avoid falling into the default catch all below.
 			case *vfs.MemFSPath:
 				// memfs is ok for tests; not OK otherwise
 				if !base.IsClusterReadable() {

--- a/pkg/model/components/discovery.go
+++ b/pkg/model/components/discovery.go
@@ -61,6 +61,11 @@ func (b *DiscoveryOptionsBuilder) BuildOptions(o interface{}) error {
 				if err != nil {
 					return err
 				}
+			case *vfs.GSPath:
+				serviceAccountIssuer, err = base.GetHTTPsUrl()
+				if err != nil {
+					return err
+				}
 			case *vfs.MemFSPath:
 				if !base.IsClusterReadable() {
 					// If this _is_ a test, we should call MarkClusterReadable


### PR DESCRIPTION
This change adds for support for GCS as a target for `cluster.spec.serviceAccountIssuerDiscovery.discoveryStore`.

The generated the service account issuer URL is in the form:
`https://storage.googleapis.com/<BUCKET>` 
meaning the JWKS URI becomes:
`https://storage.googleapis.com/<BUCKET>/openid/v1/jwks`

This is the first step towards supporting Workload Identity on GCP kOps clusters.