### PR TITLE
Enable additional admission plugins

### DIFF
--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -143,20 +143,21 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 		}
 	}
 
-	// TODO: We can probably rewrite these more clearly in descending order
-	// Based on recommendations from:
-	// https://kubernetes.io/docs/admin/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use
 	{
 		c.EnableAdmissionPlugins = []string{
 			"NamespaceLifecycle",
 			"LimitRanger",
 			"ServiceAccount",
-			//"PersistentVolumeLabel",
+			"PersistentVolumeLabel",
 			"DefaultStorageClass",
 			"DefaultTolerationSeconds",
+			"NodeRestriction",
+			"Priority",
+			"StorageObjectInUseProtection",
+			"PersistentVolumeClaimResize",
+			"RuntimeClass",
 			"MutatingAdmissionWebhook",
 			"ValidatingAdmissionWebhook",
-			"NodeRestriction",
 			"ResourceQuota",
 		}
 		c.EnableAdmissionPlugins = append(c.EnableAdmissionPlugins, c.AppendAdmissionPlugins...)


### PR DESCRIPTION
1. I delete the comments because the link is dead
2. These are the admission controllers that are currently enabled with kubeup. According to git blame, they haven't been changed for the last 3 years.
3. https://github.com/kubernetes/kubernetes/blame/9ae55e98868d78a7103358e1feb7d15b8403d0fa/cluster/gce/config-test.sh#L410

Examples of tests failing because of missing admission controllers: https://testgrid.k8s.io/sig-cluster-lifecycle-kubeup-to-kops#ci-kubernetes-e2e-cos-gce-serial-canary&include-filter-by-regex=RuntimeClass

