### PR TITLE
dump: actually dump the gateway objects

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -142,6 +142,7 @@ func ListResourcesAWS(cloud awsup.AWSCloud, clusterInfo resources.ClusterInfo) (
 					resourceTrackers["internet-gateway:"+igwID] = &resources.Resource{
 						Name:    FindName(igw.Tags),
 						ID:      igwID,
+						Obj:     igw,
 						Type:    "internet-gateway",
 						Dumper:  DumpInternetGateway,
 						Deleter: DeleteInternetGateway,
@@ -1159,6 +1160,7 @@ func ListEgressOnlyInternetGateways(cloud fi.Cloud, vpcID, clusterName string) (
 			Name:    FindName(o.Tags),
 			ID:      aws.StringValue(o.EgressOnlyInternetGatewayId),
 			Type:    "egress-only-internet-gateway",
+			Obj:     o,
 			Dumper:  DumpEgressOnlyInternetGateway,
 			Deleter: DeleteEgressOnlyInternetGateway,
 			Shared:  HasSharedTag(ec2.ResourceTypeEgressOnlyInternetGateway+":"+aws.StringValue(o.EgressOnlyInternetGatewayId), o.Tags, clusterName),

--- a/pkg/resources/aws/natgateway.go
+++ b/pkg/resources/aws/natgateway.go
@@ -38,6 +38,7 @@ func buildNatGatewayResource(ngw *ec2.NatGateway, forceShared bool, clusterName 
 	r := &resources.Resource{
 		Name:    id,
 		ID:      id,
+		Obj:     ngw,
 		Type:    TypeNatGateway,
 		Dumper:  DumpNatGateway,
 		Deleter: DeleteNatGateway,


### PR DESCRIPTION
I had forgotten to populate the object itself, so it was not appearing
in the raw dump.
