### PR TITLE
fix: concurrent map write panic

### DIFF
--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/cloudresourcemanager/v1"
@@ -86,6 +87,7 @@ func (c *gceCloudImplementation) ProviderID() kops.CloudProviderID {
 }
 
 var gceCloudInstances map[string]GCECloud = make(map[string]GCECloud)
+var gceCloudInstancesMapMutex = sync.RWMutex{}
 
 // DefaultProject returns the current project configured in the gcloud SDK, ("", nil) if no project was set
 func DefaultProject() (string, error) {
@@ -179,6 +181,8 @@ func NewGCECloud(region string, project string, labels map[string]string) (GCECl
 }
 
 func CacheGCECloudInstance(region string, project string, c GCECloud) {
+	gceCloudInstancesMapMutex.Lock()
+	defer gceCloudInstancesMapMutex.Unlock()
 	gceCloudInstances[region+"::"+project] = c
 }
 

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -121,7 +121,9 @@ func DefaultProject() (string, error) {
 }
 
 func NewGCECloud(region string, project string, labels map[string]string) (GCECloud, error) {
+	gceCloudInstancesMapMutex.RLock()
 	i := gceCloudInstances[region+"::"+project]
+	gceCloudInstancesMapMutex.RUnlock()
 	if i != nil {
 		return i.(gceCloudInternal).WithLabels(labels), nil
 	}


### PR DESCRIPTION
@justinsb this is the fix for the concurrent map write panic that we discussed.

It only occurs when kops is invoked by Terraform, which is parallelising updates to multiple instance groups at the same time.

The stack trace looked liked:

```
fatal error: concurrent map writes
fatal error: concurrent map writes

goroutine 102 [running]:
k8s.io/kops/upup/pkg/fi/cloudup/gce.CacheGCECloudInstance(...)
	/Users/matt/git/kops/upup/pkg/fi/cloudup/gce/gce_cloud.go:182
k8s.io/kops/upup/pkg/fi/cloudup/gce.NewGCECloud({0x14001c8a010, 0xb}, {0x14001ff1f96, 0xa}, 0x140007be720)
	/Users/matt/git/kops/upup/pkg/fi/cloudup/gce/gce_cloud.go:165 +0x4d0
k8s.io/kops/upup/pkg/fi/cloudup.BuildCloud(0x140006cd400)
	/Users/matt/git/kops/upup/pkg/fi/cloudup/utils.go:63 +0xd20
github.com/eddycharly/terraform-provider-kops/pkg/api/resources.UpdateInstanceGroup({_, _}, {_, _}, _, _, {{0x14001f063d0, 0xa}, {0x14001f06430, 0xc}, ...}, ...)
	/Users/matt/git/terraform-provider-kops/pkg/api/resources/InstanceGroup.go:104 +0x168
github.com/eddycharly/terraform-provider-kops/pkg/resources.InstanceGroupUpdate({0x105bda908, 0x140019c4e00}, 0x0?, {0x104aadf00?, 0x14000f59120?})
	/Users/matt/git/terraform-provider-kops/pkg/resources/InstanceGroup.go:44 +0xe0
...
```