### PR TITLE
Automated cherry pick of #16085: Update Go to v1.21.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: '1.20.10'
+          go-version: '1.21.4'
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
@@ -36,7 +36,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: '1.20.10'
+        go-version: '1.21.4'
 
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       with:
@@ -53,7 +53,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: '1.20.10'
+        go-version: '1.21.4'
 
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       with:
@@ -70,7 +70,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: '1.20.10'
+          go-version: '1.21.4'
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: '1.20.10'
+          go-version: '1.21.4'
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Update Dependencies
         id: update_deps

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # Push the images
-- name: 'docker.io/library/golang:1.20.10-bullseye'
+- name: 'docker.io/library/golang:1.21.4-bookworm'
   id: images
   entrypoint: make
   env:
@@ -21,7 +21,7 @@ steps:
   - dns-controller-push
   - kube-apiserver-healthcheck-push
 # Push the artifacts
-- name: 'docker.io/library/golang:1.20.10-bullseye'
+- name: 'docker.io/library/golang:1.21.4-bookworm'
   id: artifacts
   entrypoint: make
   env:
@@ -36,7 +36,7 @@ steps:
   args:
   - gcs-upload-and-tag
 # Build cloudbuild artifacts (for attestation)
-- name: 'docker.io/library/golang:1.20.10-bullseye'
+- name: 'docker.io/library/golang:1.21.4-bookworm'
   id: cloudbuild-artifacts
   entrypoint: make
   env:


### PR DESCRIPTION
Cherry pick of #16085 on release-1.28.

#16085: Update Go to v1.21.4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```