### PR TITLE
Don't get cluster --full when attempting leak cleanup

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/down.go
+++ b/tests/e2e/kubetest2-kops/deployer/down.go
@@ -33,7 +33,7 @@ func (d *deployer) Down() error {
 	}
 
 	// There is no point running the rest of this function if the cluster doesn't exist
-	cluster, _ := kops.GetCluster(d.KopsBinaryPath, d.ClusterName, nil)
+	cluster, _ := kops.GetCluster(d.KopsBinaryPath, d.ClusterName, nil, false)
 	if cluster == nil {
 		return nil
 	}

--- a/tests/e2e/pkg/kops/state.go
+++ b/tests/e2e/pkg/kops/state.go
@@ -29,9 +29,12 @@ import (
 )
 
 // GetCluster will retrieve the specified Cluster from the state store.
-func GetCluster(kopsBinary, clusterName string, env []string) (*api.Cluster, error) {
+func GetCluster(kopsBinary, clusterName string, env []string, full bool) (*api.Cluster, error) {
 	args := []string{
-		kopsBinary, "get", "cluster", clusterName, "-ojson", "--full",
+		kopsBinary, "get", "cluster", clusterName, "-ojson",
+	}
+	if full {
+		args = append(args, "--full")
 	}
 	c := exec.Command(args[0], args[1:]...)
 	c.SetEnv(env...)

--- a/tests/e2e/pkg/tester/tester.go
+++ b/tests/e2e/pkg/tester/tester.go
@@ -107,7 +107,7 @@ func (t *Tester) getKopsCluster() (*api.Cluster, error) {
 
 	kopsClusterName := currentContext
 
-	cluster, err := kops.GetCluster("kops", kopsClusterName, nil)
+	cluster, err := kops.GetCluster("kops", kopsClusterName, nil, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If a job's --down was interrupted, the state store can be in an inconsistent state. This can cause `kops get cluster --full` to fail if certain additional objects are missing, yet `kops get cluster` would succeed:

https://github.com/kubernetes/kops/blob/cef906f1a64594813a0598de53eb58402295c0f8/cmd/kops/get_cluster.go#L159-L167

https://github.com/kubernetes/kops/blob/b7befc1cb521001a21181188237c12430f5894ae/cmd/kops/get_cluster.go#L282-L293

We omit `--full` to ensure `kops get cluster` succeeds and leak cleanup is reattempted.

Fixes these jobs:
* https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-arm64-ci/1724140038914052096
* https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-metrics-server/1724256557673222144
* https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-scenario-terraform/1724050760506806272
* https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-scenario-ipv6-terraform/1724204967113265152

`W1113 19:05:00.508649   13785 state.go:43] failed to run /home/prow/go/src/k8s.io/kops/_rundir/8953c0d3-d447-49dc-8ca7-0931ee4ab080/kops get cluster e2e-e2e-kops-aws-arm64-ci.test-cncf-aws.k8s.io -ojson --full; stderr=Error: error loading Cluster "s3://k8s-kops-prow/e2e-e2e-kops-aws-arm64-ci.test-cncf-aws.k8s.io/cluster-completed.spec": file does not exist`