### PR TITLE
gce: Support additional StorageClasses and change default

### DIFF
--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 841d9adcf46c3c58b460d6a8eff1ef315288d5700f75007bb3944261c8405e17
+    manifestHash: b8815d8ac98d4fd8003d2429cfb23bb11160f3c1295b8266fda1900910061aab
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: b8815d8ac98d4fd8003d2429cfb23bb11160f3c1295b8266fda1900910061aab
+    manifestHash: a93442a083fa3a8031da7c683286343cf09e7e2822a75dba62e0305a32e5d454
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,8 +22,6 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -14,6 +14,46 @@ metadata:
 parameters:
   type: pd-standard
 provisioner: pd.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: balanced-csi
+parameters:
+  type: pd-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: ssd-csi
+parameters:
+  type: pd-ssd
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 
 ---

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 0309e99c6e3efbf154f0ca0d42dad2fcbad6269b4e57fef57f9e282c1c3a0f7c
+    manifestHash: 1d0c1cb84c6afaf155c710f4b045176036f330b337fba4528f9690eb43883e7d
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 43460694a38baf16384220585cca377c2f9387e4941a673ed75583747b628901
+    manifestHash: 0309e99c6e3efbf154f0ca0d42dad2fcbad6269b4e57fef57f9e282c1c3a0f7c
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,8 +22,6 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -14,6 +14,46 @@ metadata:
 parameters:
   type: pd-standard
 provisioner: pd.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: balanced-csi
+parameters:
+  type: pd-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: ssd-csi
+parameters:
+  type: pd-ssd
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 
 ---

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: c7693d3106fbc9586abfd4ce371ace3417bf36dc560f57cb5588c84f697c19f6
+    manifestHash: 78fb4e484de1c743e9d26780a0ecdc250edfe721c27445abc64695f0aa8eb4f6
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 94a9a11050edb370d194e27475930c1f3f500a1670860beac9ce855b9dd213f6
+    manifestHash: c7693d3106fbc9586abfd4ce371ace3417bf36dc560f57cb5588c84f697c19f6
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,8 +22,6 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -14,6 +14,46 @@ metadata:
 parameters:
   type: pd-standard
 provisioner: pd.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: balanced-csi
+parameters:
+  type: pd-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: ssd-csi
+parameters:
+  type: pd-ssd
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 
 ---

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 94a9a11050edb370d194e27475930c1f3f500a1670860beac9ce855b9dd213f6
+    manifestHash: c7693d3106fbc9586abfd4ce371ace3417bf36dc560f57cb5588c84f697c19f6
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: c7693d3106fbc9586abfd4ce371ace3417bf36dc560f57cb5588c84f697c19f6
+    manifestHash: 78fb4e484de1c743e9d26780a0ecdc250edfe721c27445abc64695f0aa8eb4f6
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,8 +22,6 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -14,6 +14,46 @@ metadata:
 parameters:
   type: pd-standard
 provisioner: pd.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: balanced-csi
+parameters:
+  type: pd-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: ssd-csi
+parameters:
+  type: pd-ssd
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 
 ---

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: d54cc7d3fb2a9b702b83a7efc0d97d5564e7ade46ccd86de907ac2c41e1a7e92
+    manifestHash: 7b774352cacf71865927549c4035801b025829a3a57be802eb2ff7cd56461473
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 12088934fb602e670e63e4f7e1489e87f65d05da281078f5bce139a9d16fa543
+    manifestHash: d54cc7d3fb2a9b702b83a7efc0d97d5564e7ade46ccd86de907ac2c41e1a7e92
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,8 +22,6 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -14,6 +14,46 @@ metadata:
 parameters:
   type: pd-standard
 provisioner: pd.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: balanced-csi
+parameters:
+  type: pd-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: ssd-csi
+parameters:
+  type: pd-ssd
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 
 ---

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 2e71d2b51a52edf8f6497177cde0fd2945b3e5533bd00d18ad5517aad4b132cf
+    manifestHash: 5a5444a9f8e7495481a69eb04b7c2f7a6f52b790b2dd937c53ceb06ca9420f81
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 984f168ba95c31d9b3f9b68d55a11d68df603702363ba7e056084904d72db0b5
+    manifestHash: 2e71d2b51a52edf8f6497177cde0fd2945b3e5533bd00d18ad5517aad4b132cf
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,8 +22,6 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -14,6 +14,46 @@ metadata:
 parameters:
   type: pd-standard
 provisioner: pd.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: balanced-csi
+parameters:
+  type: pd-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: ssd-csi
+parameters:
+  type: pd-ssd
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 
 ---

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 2e71d2b51a52edf8f6497177cde0fd2945b3e5533bd00d18ad5517aad4b132cf
+    manifestHash: 5a5444a9f8e7495481a69eb04b7c2f7a6f52b790b2dd937c53ceb06ca9420f81
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 984f168ba95c31d9b3f9b68d55a11d68df603702363ba7e056084904d72db0b5
+    manifestHash: 2e71d2b51a52edf8f6497177cde0fd2945b3e5533bd00d18ad5517aad4b132cf
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,8 +22,6 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -14,6 +14,46 @@ metadata:
 parameters:
   type: pd-standard
 provisioner: pd.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: balanced-csi
+parameters:
+  type: pd-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: ssd-csi
+parameters:
+  type: pd-ssd
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 
 ---

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 43d87627a8435bde820421e6ca7db78751f7a7dce1513a6a9047c93f5f290400
+    manifestHash: 8e1135e5e35ab819145872bfe5e29a18fcbb5e52b6b3d3d421ef92d13db33b9c
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 86facd78ba966b12172d01da4c42fb5ef5d2dd7529228d0697fb3bca007a227b
+    manifestHash: 43d87627a8435bde820421e6ca7db78751f7a7dce1513a6a9047c93f5f290400
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,8 +22,6 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -14,6 +14,46 @@ metadata:
 parameters:
   type: pd-standard
 provisioner: pd.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: balanced-csi
+parameters:
+  type: pd-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: ssd-csi
+parameters:
+  type: pd-ssd
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 
 ---

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 2fba7d4bf6c803e2b2851acc5c4f04e10724ab0f9c7336957713472e5b8f50fd
+    manifestHash: a0cbcb0974ef466ad126893d70a3aa1f571d901cb53538163c04d81898bb99d7
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: e275d32a8f9ac95a191bf52060982203a24d7d37851088f47f121aa232f41bd7
+    manifestHash: 2fba7d4bf6c803e2b2851acc5c4f04e10724ab0f9c7336957713472e5b8f50fd
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,8 +22,6 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -14,6 +14,46 @@ metadata:
 parameters:
   type: pd-standard
 provisioner: pd.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: balanced-csi
+parameters:
+  type: pd-balanced
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: ssd-csi
+parameters:
+  type: pd-ssd
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 
 ---

--- a/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
@@ -6,7 +6,7 @@ kind: StorageClass
 metadata:
   name: standard-csi
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   labels:
     kubernetes.io/cluster-service: "true"
     k8s-addon: gcp-pd-csi-driver.addons.k8s.io
@@ -15,6 +15,41 @@ parameters:
   type: pd-standard
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: balanced-csi
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+parameters:
+  type: pd-balanced
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  labels:
+    kubernetes.io/cluster-service: "true"
+    k8s-addon: gcp-pd-csi-driver.addons.k8s.io
+  name: ssd-csi
+parameters:
+  type: pd-ssd
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+
 {{ end }}
 
 ---

--- a/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
@@ -6,7 +6,7 @@ kind: StorageClass
 metadata:
   name: standard-csi
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
     k8s-addon: gcp-pd-csi-driver.addons.k8s.io
@@ -22,8 +22,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: balanced-csi
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
     k8s-addon: gcp-pd-csi-driver.addons.k8s.io


### PR DESCRIPTION
When the the GCE CSI driver is enabled, kOps installs a single StorageClass called `standard-csi`. This SC is backed by the Google Cloud `pd-standard` disk type, which is the slowest spinning disk variety.
https://cloud.google.com/compute/docs/disks#disk-types

On top of being slow, the `pd-standard` disks are not supported on some of the newer GCP Machine Types, such as the C3 family:
https://cloud.google.com/compute/docs/general-purpose-machines#c3_disks

For these reasons it would be great if kOps installed additional StorageClasses, for better performance and broader compatibility.

This change adds two additional StorageClasses named `balanced-csi` and `ssd-csi` to support the `pd-balanced` and `pd-ssd` GCP Persistent Disk types respectively. (I was trying to follow the pattern of the existing `standard-csi` when naming these, but I see over in the AWS side, kOps uses a SC names like `kops-ssd-1-17`, so let me know if that is required here also). 

~~This PR also updates the default StorageClass to be `balanced-csi`. Which is the default set on GKE clusters.
Looking at the AWS SC history, I see kOps has switched the default in the past, but let me know if this is something that needs better backwards compatibility.~~

