### PR TITLE
allow local file VFS in asset copy

### DIFF
--- a/pkg/assets/copyfile.go
+++ b/pkg/assets/copyfile.go
@@ -179,7 +179,7 @@ func writeFile(ctx context.Context, cluster *kops.Cluster, p vfs.Path, data []by
 // buildVFSPath task a recognizable https url and transforms that URL into the equivalent url with the object
 // store prefix.
 func buildVFSPath(target string) (string, error) {
-	if !strings.Contains(target, "://") || strings.HasPrefix(target, "memfs://") {
+	if !strings.Contains(target, "://") || strings.HasPrefix(target, "memfs://") || strings.HasPrefix(target, "file://") {
 		return target, nil
 	}
 


### PR DESCRIPTION
currently it is not possible to use local file:// vfs when copying assets. This makes it easier to generate files for asset `fileRepository`. It can be done like:

1)

```
spec:
  assets:
    fileRepository: file:///tmp/kops
```

2) `kops get assets --name mycluster.k8s.local --copy` (after this the assets are available in local disk)
3) copy assets from local disk to place that can serve static files. It can be for instance just nginx
4) edit spec again

```
spec:
  assets:
    fileRepository: https://path/to/my/nginx/foo
```

