### PR TITLE
Automated cherry pick of #16110: Update kube-router to v1.6.0

### DIFF
--- a/docs/networking/kube-router.md
+++ b/docs/networking/kube-router.md
@@ -1,7 +1,5 @@
 # Kube-router
 
-&#9888; The Kube-router CNI is not supported for Kubernetes 1.28 or later.
-
 [Kube-router](https://github.com/cloudnativelabs/kube-router) is project that provides one cohesive solution that provides CNI networking for pods, an IPVS based network service proxy and iptables based network policy enforcement.
 
 Kube-router also provides a service proxy, so kube-proxy will not be deployed in to the cluster.

--- a/docs/releases/1.27-NOTES.md
+++ b/docs/releases/1.27-NOTES.md
@@ -45,7 +45,7 @@ they would do so when the respective `topology` was set to `public`.
 
 * Support for Ubuntu 18.04 is deprecated and will be removed in kOps 1.28.
 
-* Canal, Flannel, and Kube-Router are deprecated and support will be removed for Kubernetes 1.28 and later.
+* Canal, and Flannel are deprecated and support will be removed for Kubernetes 1.28 and later.
 
 * Support for AWS Classic Load Balancer for API is deprecated and should not be used for newly created clusters.
 

--- a/docs/releases/1.28-NOTES.md
+++ b/docs/releases/1.28-NOTES.md
@@ -26,7 +26,7 @@ This is a document to gather the release notes prior to the release.
 
 * Support for Ubuntu 18.04 is has been removed.
 
-* Support for Canal, Flannel, and Kube-Router has been removed for Kubernetes 1.28 and later.
+* Support for Canal and Flannel have been removed for Kubernetes 1.28 and later.
 
 * RHEL-based distros will no longer have `wget`, `curl`, `python2`, and `git` packages installed. Install them with [hooks](/cluster_spec/#hooks) if needed.
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1144,9 +1144,7 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 		}
 		optionTaken = true
 
-		if cluster.IsKubernetesGTE("1.28") {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kubeRouter"), "kube-router is not supported for Kubernetes >= 1.28"))
-		} else if cluster.Spec.IsIPv6Only() {
+		if cluster.Spec.IsIPv6Only() {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kubeRouter"), "kube-router does not support IPv6"))
 		}
 	}

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -1,4 +1,4 @@
-# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.5.3/daemonset/kubeadm-kuberouter.yaml
+# Pulled and modified from https://raw.githubusercontent.com/cloudnativelabs/kube-router/v1.6.0/daemonset/kubeadm-kuberouter.yaml
 
 apiVersion: v1
 kind: ConfigMap
@@ -62,7 +62,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v1.5.3
+        image: docker.io/cloudnativelabs/kube-router:v1.6.0
         args:
         - --run-router=true
         - --run-firewall=true
@@ -103,7 +103,7 @@ spec:
           readOnly: false
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v1.5.3
+        image: docker.io/cloudnativelabs/kube-router:v1.6.0
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
Cherry pick of #16110 on release-1.28.

#16110: Update kube-router to v1.6.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```