### PR TITLE
skip file remapping if same host

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -250,14 +250,15 @@ func (a *AssetBuilder) RemapFileAndSHA(fileURL *url.URL) (*url.URL, *hashing.Has
 
 	if a.AssetsLocation != nil && a.AssetsLocation.FileRepository != nil {
 
-		normalizedFileURL, err := a.remapURL(fileURL)
+		normalizedFile, err := a.remapURL(fileURL)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		fileAsset.DownloadURL = normalizedFileURL
-
-		klog.V(4).Infof("adding remapped file: %+v", fileAsset)
+		if fileURL.Host != normalizedFile.Host {
+			fileAsset.DownloadURL = normalizedFile
+			klog.V(4).Infof("adding remapped file: %q", fileAsset.DownloadURL.String())
+		}
 	}
 
 	h, err := a.findHash(fileAsset)
@@ -289,9 +290,10 @@ func (a *AssetBuilder) RemapFileAndSHAValue(fileURL *url.URL, shaValue string) (
 		if err != nil {
 			return nil, err
 		}
-
-		fileAsset.DownloadURL = normalizedFile
-		klog.V(4).Infof("adding remapped file: %q", fileAsset.DownloadURL.String())
+		if fileURL.Host != normalizedFile.Host {
+			fileAsset.DownloadURL = normalizedFile
+			klog.V(4).Infof("adding remapped file: %q", fileAsset.DownloadURL.String())
+		}
 	}
 
 	klog.V(8).Infof("adding file: %+v", fileAsset)


### PR DESCRIPTION
what is the use-case for this? I do have KOPS_BASE_URL located in same object storage. It does not make sense to make 2 copies from same files basically.

blue: before
red: after

<img width="2066" alt="Screenshot 2023-11-20 at 9 21 36" src="https://github.com/kubernetes/kops/assets/22482503/853f9c8c-f63c-4879-b05c-2f8f46309939">
