### PR TITLE
Automated cherry pick of #16113: Replace * in IAM tags when IRSA namespace has wildcard

### DIFF
--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -200,7 +200,7 @@ func (b *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (ma
 func (b *KopsModelContext) CloudTagsForServiceAccount(name string, sa types.NamespacedName) map[string]string {
 	tags := b.CloudTags(name, false)
 	tags[awstasks.CloudTagServiceAccountName] = sa.Name
-	tags[awstasks.CloudTagServiceAccountNamespace] = sa.Namespace
+	tags[awstasks.CloudTagServiceAccountNamespace] = strings.ReplaceAll(sa.Namespace, "*", "wildcard")
 	return tags
 }
 

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -433,7 +433,7 @@ resource "aws_iam_role" "myserviceaccount-test-wildcard-sa-minimal-example-com" 
     "Name"                                      = "myserviceaccount.test-wildcard.sa.minimal.example.com"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
     "service-account.kops.k8s.io/name"          = "myserviceaccount"
-    "service-account.kops.k8s.io/namespace"     = "test-*"
+    "service-account.kops.k8s.io/namespace"     = "test-wildcard"
   }
 }
 


### PR DESCRIPTION
Cherry pick of #16113 on release-1.28.

#16113: Replace * in IAM tags when IRSA namespace has wildcard

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```