### PR TITLE
bump k8s and ubuntu ami versions in alpha

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -58,19 +58,19 @@ spec:
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20231004
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20231121.1
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.18.0 <1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20231004
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20231121.1
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0 <1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230919
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231121
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20230919
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20231121
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.27.0"
@@ -104,16 +104,16 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.28.0"
-    recommendedVersion: 1.28.3
+    recommendedVersion: 1.28.4
     requiredVersion: 1.28.0
   - range: ">=1.27.0"
-    recommendedVersion: 1.27.7
+    recommendedVersion: 1.27.8
     requiredVersion: 1.27.0
   - range: ">=1.26.0"
-    recommendedVersion: 1.26.10
+    recommendedVersion: 1.26.11
     requiredVersion: 1.26.0
   - range: ">=1.25.0"
-    recommendedVersion: 1.25.15
+    recommendedVersion: 1.25.16
     requiredVersion: 1.25.0
   - range: ">=1.24.0"
     recommendedVersion: 1.24.17
@@ -164,19 +164,19 @@ spec:
   - range: ">=1.28.0-alpha.1"
     recommendedVersion: "1.28.0"
     #requiredVersion: 1.28.0
-    kubernetesVersion: 1.28.3
+    kubernetesVersion: 1.28.4
   - range: ">=1.27.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.27.0
-    kubernetesVersion: 1.27.7
+    kubernetesVersion: 1.27.8
   - range: ">=1.26.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.26.0
-    kubernetesVersion: 1.26.10
+    kubernetesVersion: 1.26.11
   - range: ">=1.25.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.25.0
-    kubernetesVersion: 1.25.15
+    kubernetesVersion: 1.25.16
   - range: ">=1.24.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.24.0


### PR DESCRIPTION
**What this PR does / why we need it**:
bumping versions for k8s and ubuntu ec2 ami (focal and jammy) to latest


**Special notes for your reviewer**:
k8s releases:
- https://github.com/kubernetes/kubernetes/releases/tag/v1.25.16
- https://github.com/kubernetes/kubernetes/releases/tag/v1.26.11
- https://github.com/kubernetes/kubernetes/releases/tag/v1.27.8
- https://github.com/kubernetes/kubernetes/releases/tag/v1.28.4

Ubuntu AMI page ec2 locator:
https://cloud-images.ubuntu.com/locator/ec2/

/cc @hakman
