### PR TITLE
Fix parsing of newer kubernetes version URLs

### DIFF
--- a/pkg/apis/kops/util/versions.go
+++ b/pkg/apis/kops/util/versions.go
@@ -18,80 +18,24 @@ package util
 
 import (
 	"fmt"
-	"strings"
+	"regexp"
+	"strconv"
 
 	"github.com/blang/semver/v4"
 	"k8s.io/klog/v2"
 )
 
+var versionURLPattern = regexp.MustCompile(`/v1\.([\d]+)\.`)
+
 func ParseKubernetesVersion(version string) (*semver.Version, error) {
 	sv, err := semver.ParseTolerant(version)
 	if err != nil {
-		v := strings.Trim(version, "v")
-		if strings.HasPrefix(v, "1.3.") {
-			sv = semver.Version{Major: 1, Minor: 3}
-		} else if strings.HasPrefix(v, "1.4.") {
-			sv = semver.Version{Major: 1, Minor: 4}
-		} else if strings.HasPrefix(v, "1.5.") {
-			sv = semver.Version{Major: 1, Minor: 5}
-		} else if strings.HasPrefix(v, "1.6.") {
-			sv = semver.Version{Major: 1, Minor: 6}
-		} else if strings.HasPrefix(v, "1.7.") {
-			sv = semver.Version{Major: 1, Minor: 7}
-		} else if strings.Contains(v, "/v1.3.") {
-			sv = semver.Version{Major: 1, Minor: 3}
-		} else if strings.Contains(v, "/v1.4.") {
-			sv = semver.Version{Major: 1, Minor: 4}
-		} else if strings.Contains(v, "/v1.5.") {
-			sv = semver.Version{Major: 1, Minor: 5}
-		} else if strings.Contains(v, "/v1.6.") {
-			sv = semver.Version{Major: 1, Minor: 6}
-		} else if strings.Contains(v, "/v1.7.") {
-			sv = semver.Version{Major: 1, Minor: 7}
-		} else if strings.Contains(v, "/v1.8.") {
-			sv = semver.Version{Major: 1, Minor: 8}
-		} else if strings.Contains(v, "/v1.9.") {
-			sv = semver.Version{Major: 1, Minor: 9}
-		} else if strings.Contains(v, "/v1.10.") {
-			sv = semver.Version{Major: 1, Minor: 10}
-		} else if strings.Contains(v, "/v1.11.") {
-			sv = semver.Version{Major: 1, Minor: 11}
-		} else if strings.Contains(v, "/v1.12.") {
-			sv = semver.Version{Major: 1, Minor: 12}
-		} else if strings.Contains(v, "/v1.13.") {
-			sv = semver.Version{Major: 1, Minor: 13}
-		} else if strings.Contains(v, "/v1.14.") {
-			sv = semver.Version{Major: 1, Minor: 14}
-		} else if strings.Contains(v, "/v1.15.") {
-			sv = semver.Version{Major: 1, Minor: 15}
-		} else if strings.Contains(v, "/v1.16.") {
-			sv = semver.Version{Major: 1, Minor: 16}
-		} else if strings.Contains(v, "/v1.17.") {
-			sv = semver.Version{Major: 1, Minor: 17}
-		} else if strings.Contains(v, "/v1.18.") {
-			sv = semver.Version{Major: 1, Minor: 18}
-		} else if strings.Contains(v, "/v1.19.") {
-			sv = semver.Version{Major: 1, Minor: 19}
-		} else if strings.Contains(v, "/v1.20.") {
-			sv = semver.Version{Major: 1, Minor: 20}
-		} else if strings.Contains(v, "/v1.21.") {
-			sv = semver.Version{Major: 1, Minor: 21}
-		} else if strings.Contains(v, "/v1.22.") {
-			sv = semver.Version{Major: 1, Minor: 22}
-		} else if strings.Contains(v, "/v1.23.") {
-			sv = semver.Version{Major: 1, Minor: 23}
-		} else if strings.Contains(v, "/v1.24.") {
-			sv = semver.Version{Major: 1, Minor: 24}
-		} else if strings.Contains(v, "/v1.25.") {
-			sv = semver.Version{Major: 1, Minor: 25}
-		} else if strings.Contains(v, "/v1.26.") {
-			sv = semver.Version{Major: 1, Minor: 26}
-		} else if strings.Contains(v, "/v1.27.") {
-			sv = semver.Version{Major: 1, Minor: 27}
-		} else if strings.Contains(v, "/v1.28.") {
-			sv = semver.Version{Major: 1, Minor: 28}
-		} else if strings.Contains(v, "/v1.29.") {
-			sv = semver.Version{Major: 1, Minor: 29}
+		if submatch := versionURLPattern.FindStringSubmatch(version); len(submatch) >= 2 {
+			minor, err := strconv.Atoi(submatch[1])
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse kubernetes version (%s): %w", version, err)
+			}
+			sv = semver.Version{Major: 1, Minor: uint64(minor)}
 		} else {
 			klog.Errorf("unable to parse Kubernetes version %q", version)
 			return nil, fmt.Errorf("unable to parse kubernetes version %q", version)

--- a/pkg/apis/kops/util/versions_test.go
+++ b/pkg/apis/kops/util/versions_test.go
@@ -72,6 +72,14 @@ func Test_ParseKubernetesVersion(t *testing.T) {
 			},
 		},
 		{
+			version: "https://storage.googleapis.com/k8s-release-dev/ci/v1.30.0-alpha.0.5+d61cbac69aae97",
+			expected: &semver.Version{
+				Major: 1,
+				Minor: 30,
+				Patch: 0,
+			},
+		},
+		{
 			version:       "",
 			expectedError: fmt.Errorf("unable to parse kubernetes version \"\""),
 		},


### PR DESCRIPTION
Now that k/k's CI version markers point to 1.30 builds, kops' e2e jobs have started failing:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-amd64-conformance/1727421344523489280