### PR TITLE
kops: Don't try to split --set flags on commas

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -408,9 +408,9 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		return []string{"json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
-	cmd.Flags().StringSliceVar(&options.Sets, "override", options.Sets, "Directly set values in the spec")
+	cmd.Flags().StringArrayVar(&options.Sets, "override", options.Sets, "Directly set values in the spec")
 	cmd.Flags().MarkDeprecated("override", "use --set instead")
-	cmd.Flags().StringSliceVar(&options.Sets, "set", options.Sets, "Directly set values in the spec")
+	cmd.Flags().StringArrayVar(&options.Sets, "set", options.Sets, "Directly set values in the spec")
 	cmd.RegisterFlagCompletionFunc("set", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	})

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -84,7 +84,7 @@ func NewCmdEditCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&options.Sets, "set", options.Sets, "Directly set values in the spec")
+	cmd.Flags().StringArrayVar(&options.Sets, "set", options.Sets, "Directly set values in the spec")
 	cmd.RegisterFlagCompletionFunc("set", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	})

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -107,7 +107,7 @@ func NewCmdEditInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&options.Sets, "set", options.Sets, "Directly set values in the spec")
+	cmd.Flags().StringArrayVar(&options.Sets, "set", options.Sets, "Directly set values in the spec")
 	cmd.RegisterFlagCompletionFunc("set", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	})

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -118,7 +118,7 @@ kops create cluster [CLUSTER] [flags]
       --out string                              Path to write any local output
   -o, --output string                           Output format. One of json or yaml. Used with the --dry-run flag.
       --project string                          Project to use (must be set on GCE)
-      --set strings                             Directly set values in the spec
+      --set stringArray                         Directly set values in the spec
       --ssh-access strings                      Restrict SSH access to this CIDR.  If not set, uses the value of the admin-access flag.
       --ssh-public-key string                   SSH public key to use
       --subnets strings                         Shared subnets to use

--- a/docs/cli/kops_edit_cluster.md
+++ b/docs/cli/kops_edit_cluster.md
@@ -30,9 +30,9 @@ kops edit cluster [CLUSTER] [flags]
 ### Options
 
 ```
-  -h, --help            help for cluster
-      --set strings     Directly set values in the spec
-      --unset strings   Directly unset values in the spec
+  -h, --help              help for cluster
+      --set stringArray   Directly set values in the spec
+      --unset strings     Directly unset values in the spec
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kops_edit_instancegroup.md
+++ b/docs/cli/kops_edit_instancegroup.md
@@ -30,9 +30,9 @@ kops edit instancegroup INSTANCE_GROUP [flags]
 ### Options
 
 ```
-  -h, --help            help for instancegroup
-      --set strings     Directly set values in the spec
-      --unset strings   Directly unset values in the spec
+  -h, --help              help for instancegroup
+      --set stringArray   Directly set values in the spec
+      --unset strings     Directly unset values in the spec
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Passing quotes in very difficult with the --set flag, because the
pflag library tries to parse it using strict CSV semantics.  We switch
to using the StringArrayVar, which does not attempt splitting.

This is a breaking change; compound flags must now be written as two flags, but I think that is clearer.

Example: `--set=a,b` must now be `--set=a --set=b`
