### PR TITLE
kops: Support quotes in --set flags

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -408,9 +408,9 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		return []string{"json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
-	cmd.Flags().StringSliceVar(&options.Sets, "override", options.Sets, "Directly set values in the spec")
+	LazyQuoteStringSliceVar(cmd.Flags(), &options.Sets, "override", options.Sets, "Directly set values in the spec")
 	cmd.Flags().MarkDeprecated("override", "use --set instead")
-	cmd.Flags().StringSliceVar(&options.Sets, "set", options.Sets, "Directly set values in the spec")
+	LazyQuoteStringSliceVar(cmd.Flags(), &options.Sets, "set", options.Sets, "Directly set values in the spec")
 	cmd.RegisterFlagCompletionFunc("set", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	})

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -84,7 +84,7 @@ func NewCmdEditCluster(f *util.Factory, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&options.Sets, "set", options.Sets, "Directly set values in the spec")
+	LazyQuoteStringSliceVar(cmd.Flags(), &options.Sets, "set", options.Sets, "Directly set values in the spec")
 	cmd.RegisterFlagCompletionFunc("set", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	})

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -107,7 +107,7 @@ func NewCmdEditInstanceGroup(f *util.Factory, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&options.Sets, "set", options.Sets, "Directly set values in the spec")
+	LazyQuoteStringSliceVar(cmd.Flags(), &options.Sets, "set", options.Sets, "Directly set values in the spec")
 	cmd.RegisterFlagCompletionFunc("set", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	})

--- a/cmd/kops/flags_stringslice_lazyquotes.go
+++ b/cmd/kops/flags_stringslice_lazyquotes.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// LazyQuoteStringSliceVar is like flagset.StringSliceVar, but supports quotes in values.
+func LazyQuoteStringSliceVar(f *pflag.FlagSet, p *[]string, name string, value []string, usage string) {
+	f.VarP(newLazyQuoteStringSliceValue(value, p), name, "", usage)
+}
+
+// lazyQuoteStringSliceValue implements stringSlice, but allows quotes in the values.
+// Inspired by https://github.com/spf13/pflag/pull/371
+type lazyQuoteStringSliceValue struct {
+	value      *[]string
+	changed    bool
+	lazyQuotes bool
+}
+
+func newLazyQuoteStringSliceValue(val []string, p *[]string) *lazyQuoteStringSliceValue {
+	ssv := new(lazyQuoteStringSliceValue)
+	ssv.value = p
+	*ssv.value = val
+	ssv.lazyQuotes = true
+	return ssv
+}
+
+func readAsCSV(val string, lazyQuotes bool) ([]string, error) {
+	if val == "" {
+		return []string{}, nil
+	}
+	stringReader := strings.NewReader(val)
+	csvReader := csv.NewReader(stringReader)
+	csvReader.LazyQuotes = lazyQuotes
+	return csvReader.Read()
+}
+
+func writeAsCSV(vals []string) (string, error) {
+	b := &bytes.Buffer{}
+	w := csv.NewWriter(b)
+	err := w.Write(vals)
+	if err != nil {
+		return "", err
+	}
+	w.Flush()
+	return strings.TrimSuffix(b.String(), "\n"), nil
+}
+
+func (s *lazyQuoteStringSliceValue) Set(val string) error {
+	v, err := readAsCSV(val, s.lazyQuotes)
+	if err != nil {
+		return fmt.Errorf("stringSliceValue %q: %w", val, err)
+	}
+	if !s.changed {
+		*s.value = v
+	} else {
+		*s.value = append(*s.value, v...)
+	}
+	s.changed = true
+	return nil
+}
+
+func (s *lazyQuoteStringSliceValue) Type() string {
+	return "stringSlice"
+}
+
+func (s *lazyQuoteStringSliceValue) String() string {
+	str, _ := writeAsCSV(*s.value)
+	return "[" + str + "]"
+}
+
+func (s *lazyQuoteStringSliceValue) Append(val string) error {
+	*s.value = append(*s.value, val)
+	return nil
+}
+
+func (s *lazyQuoteStringSliceValue) Replace(val []string) error {
+	*s.value = val
+	return nil
+}
+
+func (s *lazyQuoteStringSliceValue) GetSlice() []string {
+	return *s.value
+}

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -118,7 +118,7 @@ kops create cluster [CLUSTER] [flags]
       --out string                              Path to write any local output
   -o, --output string                           Output format. One of json or yaml. Used with the --dry-run flag.
       --project string                          Project to use (must be set on GCE)
-      --set strings                             Directly set values in the spec
+      --set strings                             Directly set values in the spec (default [])
       --ssh-access strings                      Restrict SSH access to this CIDR.  If not set, uses the value of the admin-access flag.
       --ssh-public-key string                   SSH public key to use
       --subnets strings                         Shared subnets to use

--- a/docs/cli/kops_edit_cluster.md
+++ b/docs/cli/kops_edit_cluster.md
@@ -31,7 +31,7 @@ kops edit cluster [CLUSTER] [flags]
 
 ```
   -h, --help            help for cluster
-      --set strings     Directly set values in the spec
+      --set strings     Directly set values in the spec (default [])
       --unset strings   Directly unset values in the spec
 ```
 

--- a/docs/cli/kops_edit_instancegroup.md
+++ b/docs/cli/kops_edit_instancegroup.md
@@ -31,7 +31,7 @@ kops edit instancegroup INSTANCE_GROUP [flags]
 
 ```
   -h, --help            help for instancegroup
-      --set strings     Directly set values in the spec
+      --set strings     Directly set values in the spec (default [])
       --unset strings   Directly unset values in the spec
 ```
 


### PR DESCRIPTION
The pflag library tries to split comma separated values using strict
CSV semantics, which requires quoting of the full value if the value
contains a quote.  We switch to LazyQuotes which is much more
tolerant.
