### PR TITLE
aws: support custom naming with external ccm

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5801,6 +5801,10 @@ spec:
                       description: Region is the region the subnet is in, set for
                         subnets that are regionally scoped
                       type: string
+                    resourceBasedNaming:
+                      description: ResourceBasedNaming is used to enable/disable resource
+                        based naming for this subnet
+                      type: boolean
                     type:
                       description: SubnetType string describes subnet types (public,
                         private, utility)

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -777,6 +777,8 @@ type ClusterSubnetSpec struct {
 	PublicIP string `json:"publicIP,omitempty"`
 	// AdditionalRoutes to attach to the subnet's route table
 	AdditionalRoutes []RouteSpec `json:"additionalRoutes,omitempty"`
+	// ResourceBasedNaming is used to enable/disable resource based naming for this subnet
+	ResourceBasedNaming *bool `json:"resourceBasedNaming,omitempty"`
 }
 
 type RouteSpec struct {

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -752,6 +752,9 @@ type ClusterSubnetSpec struct {
 
 	// AdditionalRoutes to attach to the subnet's route table
 	AdditionalRoutes []RouteSpec `json:"additionalRoutes,omitempty"`
+
+	// ResourceBasedNaming is used to enable/disable resource based naming for this subnet
+	ResourceBasedNaming *bool `json:"resourceBasedNaming,omitempty"`
 }
 
 type RouteSpec struct {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3117,6 +3117,7 @@ func autoConvert_v1alpha2_ClusterSubnetSpec_To_kops_ClusterSubnetSpec(in *Cluste
 	} else {
 		out.AdditionalRoutes = nil
 	}
+	out.ResourceBasedNaming = in.ResourceBasedNaming
 	return nil
 }
 
@@ -3146,6 +3147,7 @@ func autoConvert_kops_ClusterSubnetSpec_To_v1alpha2_ClusterSubnetSpec(in *kops.C
 	} else {
 		out.AdditionalRoutes = nil
 	}
+	out.ResourceBasedNaming = in.ResourceBasedNaming
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1406,6 +1406,11 @@ func (in *ClusterSubnetSpec) DeepCopyInto(out *ClusterSubnetSpec) {
 		*out = make([]RouteSpec, len(*in))
 		copy(*out, *in)
 	}
+	if in.ResourceBasedNaming != nil {
+		in, out := &in.ResourceBasedNaming, &out.ResourceBasedNaming
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -714,6 +714,9 @@ type ClusterSubnetSpec struct {
 
 	// AdditionalRoutes to attach to the subnet's route table
 	AdditionalRoutes []RouteSpec `json:"additionalRoutes,omitempty"`
+
+	// ResourceBasedNaming is used to enable/disable resource based naming for this subnet
+	ResourceBasedNaming *bool `json:"resourceBasedNaming,omitempty"`
 }
 
 type RouteSpec struct {

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -3338,6 +3338,7 @@ func autoConvert_v1alpha3_ClusterSubnetSpec_To_kops_ClusterSubnetSpec(in *Cluste
 	} else {
 		out.AdditionalRoutes = nil
 	}
+	out.ResourceBasedNaming = in.ResourceBasedNaming
 	return nil
 }
 
@@ -3367,6 +3368,7 @@ func autoConvert_kops_ClusterSubnetSpec_To_v1alpha3_ClusterSubnetSpec(in *kops.C
 	} else {
 		out.AdditionalRoutes = nil
 	}
+	out.ResourceBasedNaming = in.ResourceBasedNaming
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -1296,6 +1296,11 @@ func (in *ClusterSubnetSpec) DeepCopyInto(out *ClusterSubnetSpec) {
 		*out = make([]RouteSpec, len(*in))
 		copy(*out, *in)
 	}
+	if in.ResourceBasedNaming != nil {
+		in, out := &in.ResourceBasedNaming, &out.ResourceBasedNaming
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1416,6 +1416,11 @@ func (in *ClusterSubnetSpec) DeepCopyInto(out *ClusterSubnetSpec) {
 		*out = make([]RouteSpec, len(*in))
 		copy(*out, *in)
 	}
+	if in.ResourceBasedNaming != nil {
+		in, out := &in.ResourceBasedNaming, &out.ResourceBasedNaming
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -290,7 +290,7 @@ func (b *NetworkModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 		}
 
 		if b.Cluster.Spec.ExternalCloudControllerManager != nil {
-			subnet.ResourceBasedNaming = fi.PtrTo(true)
+			subnet.ResourceBasedNaming = subnetSpec.ResourceBasedNaming
 		}
 
 		if subnetSpec.CIDR != "" {


### PR DESCRIPTION
Allow to customize ResourceBasedNaming subnet configuration