### PR TITLE
Only set containerd plugins on kops versions that include quote fixes

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -130,8 +130,17 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		"--kubernetes-version", d.KubernetesVersion,
 		"--ssh-public-key", d.SSHPublicKeyPath,
 		"--set", "cluster.spec.nodePortAccess=0.0.0.0/0",
-		"--set", `spec.containerd.configAdditions=plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.runtime_type=io.containerd.runc.v2`,
 	}
+
+	version, err := kops.GetVersion(d.KopsBinaryPath)
+	if err != nil {
+		return err
+	}
+	if version > "1.29" {
+		// Requires https://github.com/kubernetes/kops/pull/16128
+		args = append(args, "--set", `spec.containerd.configAdditions=plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.runtime_type=io.containerd.runc.v2`)
+	}
+
 	if yes {
 		args = append(args, "--yes")
 	}
@@ -211,7 +220,7 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 	cmd.SetEnv(d.env()...)
 
 	exec.InheritOutput(cmd)
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://github.com/kubernetes/kops/pull/16056 broke jobs that use any kops build that doesn't include https://github.com/kubernetes/kops/pull/16128 ([example](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-addon-resource-tracking/1729964344453632000)). Until we can implement https://github.com/kubernetes/kops/issues/16084 we can guard the new --set assignment behind a kops version check.

This will eval to true for all 1.29 builds. We dont have any jobs that test 1.29 prereleases (which dont include #16128) we only have jobs that test CI builds of the kops master branch, so any kops 1.29 job _will_ include the quote fix.