### PR TITLE
limit jobname value to 80

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -274,6 +274,9 @@ func defaultClusterName(cloudProvider string) (string, error) {
 		suffix = "k8s.local"
 	}
 
+	if len(jobName) > 79 { // SNS has char limit of 80
+		jobName = jobName[:79]
+	}
 	if jobType == "presubmit" {
 		return fmt.Sprintf("e2e-pr%s.%s.%s", pullNumber, jobName, suffix), nil
 	}


### PR DESCRIPTION
Limit jobName length 80 to avoid long job names from failing.

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-ci-kubernetes-e2e-al2023-aws-conformance-aws-cni-canary/1730167438948962304

```
Error: error running tasks: deadline exceeded executing task SQS/e2e-e2e-ci-kubernetes-e2e-al2023-aws-conformance-aws-cni-canary-test-cncf-aws-k8s-io-nth. Example error: error creating SQS queue: InvalidParameterValue: Can only include alphanumeric characters, hyphens, or underscores. 1 to 80 in length
```

/cc @hakman @dims 