### PR TITLE
Skip hostname test in DigitalOcean

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -103,6 +103,11 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|Services.*affinity"
 	}
 
+	if cluster.Spec.LegacyCloudProvider == "digitalocean" {
+		// https://github.com/kubernetes/kubernetes/issues/121018
+		skipRegex += "|Services.should.respect.internalTrafficPolicy=Local.Pod.and.Node,.to.Pod"
+	}
+
 	if cluster.Spec.LegacyCloudProvider == "gce" {
 		// Firewall tests expect a specific format for cluster and control plane host names
 		// which kOps does not match


### PR DESCRIPTION
Fixes https://testgrid.k8s.io/kops-misc#e2e-kops-do-calico-gossip and https://testgrid.k8s.io/kops-misc#e2e-kops-do-calico-dns-none

See the linked issue for more context