### PR TITLE
kube-router: skip 1.28 tests that fail consistently

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -99,6 +99,7 @@ func (t *Tester) setSkipRegexFlag() error {
 	} else if networking.KubeRouter != nil {
 		skipRegex += "|load-balancer|hairpin|affinity\\stimeout|service\\.kubernetes\\.io|CLOSE_WAIT"
 		skipRegex += "|EndpointSlice.should.support.a.Service.with.multiple"
+		skipRegex += "|internalTrafficPolicy|externallTrafficPolicy|only.terminating.endpoints"
 	} else if networking.Kubenet != nil {
 		skipRegex += "|Services.*affinity"
 	}


### PR DESCRIPTION
@hakman 

Since we un-pinned the kube-router tests from 1.27 in https://github.com/kubernetes/test-infra/pull/31278 kube-router now has a couple of new tests that fail consistently.

I'm still working through these, but since the project likes to avoid having consistently failing tests, I figure it would be better to exclude these ones for now.

See: https://testgrid.k8s.io/kops-network-plugins#kops-aws-cni-kuberouter