### PR TITLE
Don't set LimitNoFile for containerd systemd unit file

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -203,7 +203,6 @@ func (b *ContainerdBuilder) buildSystemdService(sv semver.Version) *nodetasks.Se
 
 	manifest.Set("Service", "LimitNPROC", "infinity")
 	manifest.Set("Service", "LimitCORE", "infinity")
-	manifest.Set("Service", "LimitNOFILE", "infinity")
 	manifest.Set("Service", "TasksMax", "infinity")
 
 	// make killing of processes of this unit under memory pressure very unlikely

--- a/nodeup/pkg/model/tests/containerdbuilder/complex/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/complex/tasks.yaml
@@ -362,7 +362,6 @@ definition: |
   RestartSec=5
   LimitNPROC=infinity
   LimitCORE=infinity
-  LimitNOFILE=infinity
   TasksMax=infinity
   OOMScoreAdjust=-999
 

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -355,7 +355,6 @@ definition: |
   RestartSec=5
   LimitNPROC=infinity
   LimitCORE=infinity
-  LimitNOFILE=infinity
   TasksMax=infinity
   OOMScoreAdjust=-999
 


### PR DESCRIPTION
@dims 

Slack Thread for context: https://kubernetes.slack.com/archives/C09QZ4DQB/p1701357762061459

This is an upstream change in containerd that should fix NFS test issues on al2023

https://github.com/containerd/containerd/pull/8924
