### PR TITLE
Add --max-nodes flag to toolbox dump, default to 500

### DIFF
--- a/cmd/kops/toolbox_dump_test.go
+++ b/cmd/kops/toolbox_dump_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTruncateNodeList(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    []corev1.Node
+		max      int
+		expected []corev1.Node
+		err      bool
+	}{
+		{
+			name: "less than max",
+			input: []corev1.Node{
+				makeNode(),
+				makeNode(),
+				makeControlPlaneNode(),
+			},
+			max: 5,
+			expected: []corev1.Node{
+				makeControlPlaneNode(),
+				makeNode(),
+				makeNode(),
+			},
+		},
+		{
+			name: "truncate",
+			input: []corev1.Node{
+				makeNode(),
+				makeNode(),
+				makeNode(),
+				makeControlPlaneNode(),
+				makeNode(),
+			},
+			max: 4,
+			expected: []corev1.Node{
+				makeControlPlaneNode(),
+				makeNode(),
+				makeNode(),
+				makeNode(),
+			},
+		},
+		{
+			name: "less than zero",
+			input: []corev1.Node{
+				makeNode(),
+				makeNode(),
+				makeNode(),
+				makeControlPlaneNode(),
+				makeNode(),
+			},
+			max: -1,
+			err: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nodeList := corev1.NodeList{Items: tc.input}
+			err := truncateNodeList(&nodeList, tc.max)
+			if tc.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, nodeList.Items)
+			}
+		})
+	}
+}
+
+func makeControlPlaneNode() corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"node-role.kubernetes.io/control-plane": "",
+			},
+		},
+	}
+}
+
+func makeNode() corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"node-role.kubernetes.io/node": "",
+			},
+		},
+	}
+}

--- a/docs/cli/kops_toolbox_dump.md
+++ b/docs/cli/kops_toolbox_dump.md
@@ -25,6 +25,7 @@ kops toolbox dump [CLUSTER] [flags]
 ```
       --dir string           Target directory; if specified will collect logs and other information.
   -h, --help                 help for dump
+      --max-nodes int        The maximum number of nodes from which to dump logs (default 500)
   -o, --output string        Output format.  One of json or yaml (default "yaml")
       --private-key string   File containing private key to use for SSH access to instances (default "~/.ssh/id_rsa")
       --ssh-user string      The remote user for SSH access to instances (default "ubuntu")

--- a/docs/releases/1.29-NOTES.md
+++ b/docs/releases/1.29-NOTES.md
@@ -42,6 +42,8 @@ instances.
 
 ## Other breaking changes
 
+* `kops toolbox dump` limits the number of nodes dumped to 500 by default. Use `--max-nodes` to override.
+ 
 * Support for Kubernetes version 1.23 has been removed.
 
 # Known Issues


### PR DESCRIPTION
ref: https://github.com/kubernetes/k8s.io/issues/6165#issuecomment-1844422503

/cc @dims @hakman

I default this to 500 so we don't have to worry about setting this flag in kubetest2-kops and ensuring we only set it for kops versions that include this addition, as opposed to older kops releases. We (kops maintainers) don't have any need to set this to a higher value in any of our e2e testing, so anyone that does can choose to override it themselves.

I'm also fine with using a lower limit like 100