### PR TITLE
Allow EKS Pod identity env variables

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -187,7 +187,7 @@ func (d *deployer) env() []string {
 
 	if d.CloudProvider == "aws" {
 		// Pass through some env vars if set
-		for _, k := range []string{"AWS_PROFILE", "AWS_SHARED_CREDENTIALS_FILE"} {
+		for _, k := range []string{"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", "AWS_CONTAINER_CREDENTIALS_FULL_URI", "AWS_PROFILE", "AWS_SHARED_CREDENTIALS_FILE"} {
 			v := os.Getenv(k)
 			if v != "" {
 				vars = append(vars, k+"="+v)


### PR DESCRIPTION
Allow env variables required by EKS Pod identity for authentification are passed to the kops binary.

See https://docs.aws.amazon.com/eks/latest/userguide/pod-id-how-it-works.html