### PR TITLE
Upgrade Karpenter to 0.31.3

### DIFF
--- a/pkg/model/components/karpenter.go
+++ b/pkg/model/components/karpenter.go
@@ -36,7 +36,7 @@ func (b *KarpenterOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Image == "" {
-		c.Image = "public.ecr.aws/karpenter/controller:v0.30.0"
+		c.Image = "public.ecr.aws/karpenter/controller:v0.31.3"
 	}
 
 	if c.LogEncoding == "" {

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -57,7 +57,7 @@ spec:
   karpenter:
     cpuRequest: 100m
     enabled: true
-    image: public.ecr.aws/karpenter/controller:v0.30.0
+    image: public.ecr.aws/karpenter/controller:v0.31.3
     logEncoding: console
     logLevel: debug
     memoryLimit: 2Gi

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -120,7 +120,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: 4d98502de7554ba20b42fd19517a874e79df1db60336e72d9ecfefaa5e980c78
+    manifestHash: 09f06376ef7bfcb706ec648daadae641bf9650d7ab10b6b58d7cd33c0c224867
     name: karpenter.sh
     prune:
       kinds:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -1076,8 +1076,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
@@ -1099,8 +1099,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
@@ -1116,8 +1116,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-cert
   namespace: kube-system
@@ -1159,8 +1159,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: config-logging
   namespace: kube-system
@@ -1191,8 +1191,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-global-settings
   namespace: kube-system
@@ -1208,8 +1208,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: karpenter-admin
@@ -1251,8 +1251,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-core
 rules:
@@ -1376,8 +1376,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
 rules:
@@ -1425,8 +1425,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-core
 roleRef:
@@ -1449,8 +1449,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
 roleRef:
@@ -1473,8 +1473,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
@@ -1552,8 +1552,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-dns
   namespace: kube-system
@@ -1578,8 +1578,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-lease
   namespace: kube-node-lease
@@ -1610,8 +1610,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
@@ -1635,8 +1635,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-dns
   namespace: kube-system
@@ -1660,8 +1660,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-lease
   namespace: kube-node-lease
@@ -1685,8 +1685,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
@@ -1716,8 +1716,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
@@ -1796,7 +1796,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/karpenter.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/karpenter/controller:v0.30.0
+        image: public.ecr.aws/karpenter/controller:v0.31.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1833,6 +1833,11 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+          runAsGroup: 65536
+          runAsNonRoot: true
+          runAsUser: 65536
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /var/run/secrets/amazonaws.com/
           name: token-amazonaws-com
@@ -1840,12 +1845,7 @@ spec:
       dnsPolicy: Default
       priorityClassName: system-cluster-critical
       securityContext:
-        fsGroup: 65536
-        runAsGroup: 65536
-        runAsNonRoot: true
-        runAsUser: 65536
-        seccompProfile:
-          type: RuntimeDefault
+        fsGroup: 10001
       serviceAccountName: karpenter
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -1883,8 +1883,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: defaulting.webhook.karpenter.k8s.aws
 webhooks:
@@ -1932,8 +1932,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: validation.webhook.karpenter.sh
 webhooks:
@@ -1970,8 +1970,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: validation.webhook.config.karpenter.sh
 webhooks:
@@ -2000,8 +2000,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.30.0
-    helm.sh/chart: karpenter-v0.30.0
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: validation.webhook.karpenter.k8s.aws
 webhooks:

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -1,7 +1,7 @@
 # helm template karpenter oci://public.ecr.aws/karpenter/karpenter-crd \
-#  --version v0.30.0
+#  --version v0.31.3
 # helm template karpenter oci://public.ecr.aws/karpenter/karpenter \
-#  --version v0.30.0 \
+#  --version v0.31.3 \
 #  --namespace kube-system \
 #  --set controller.resources.requests.cpu=500m \
 #  --set controller.resources.requests.memory=1Gi \
@@ -1065,10 +1065,10 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   maxUnavailable: 1
@@ -1084,10 +1084,10 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: karpenter/templates/secret-webhook-cert.yaml
@@ -1097,10 +1097,10 @@ metadata:
   name: karpenter-cert
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 # data: {} # Injected by karpenter-webhook
 ---
@@ -1111,10 +1111,10 @@ metadata:
   name: config-logging
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 data:
   # https://github.com/uber-go/zap/blob/aa3e73ec0896f8b066ddf668597a02f89628ee50/config.go
@@ -1151,10 +1151,10 @@ metadata:
   name: karpenter-global-settings
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 data:
     "aws.assumeRoleARN": ""
@@ -1183,10 +1183,10 @@ metadata:
   name: karpenter-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["karpenter.sh"]
@@ -1202,10 +1202,10 @@ kind: ClusterRole
 metadata:
   name: karpenter-core
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Read
@@ -1254,10 +1254,10 @@ kind: ClusterRole
 metadata:
   name: karpenter
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Read
@@ -1283,10 +1283,10 @@ kind: ClusterRoleBinding
 metadata:
   name: karpenter-core
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1303,10 +1303,10 @@ kind: ClusterRoleBinding
 metadata:
   name: karpenter
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1324,10 +1324,10 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Read
@@ -1373,10 +1373,10 @@ metadata:
   name: karpenter-dns
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Read
@@ -1392,10 +1392,10 @@ metadata:
   name: karpenter-lease
   namespace: kube-node-lease
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Read
@@ -1414,10 +1414,10 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1435,10 +1435,10 @@ metadata:
   name: karpenter-dns
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1456,10 +1456,10 @@ metadata:
   name: karpenter-lease
   namespace: kube-node-lease
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1477,10 +1477,10 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1504,10 +1504,10 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: {{ ControlPlaneControllerReplicas false }}
@@ -1526,13 +1526,6 @@ spec:
         karpenter: webhook
     spec:
       serviceAccountName: karpenter
-      securityContext:
-        fsGroup: 65536
-        runAsUser: 65536
-        runAsGroup: 65536
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       priorityClassName: "system-cluster-critical"
       {{ if not IsIPv6Only }}
       dnsPolicy: Default
@@ -1543,10 +1536,15 @@ spec:
       containers:
         - name: controller
           securityContext:
+            runAsUser: 65536
+            runAsGroup: 65536
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-              - ALL
+                - ALL
             readOnlyRootFilesystem: true
           image: {{ .Karpenter.Image }}
           imagePullPolicy: IfNotPresent
@@ -1655,10 +1653,10 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.karpenter.k8s.aws
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: defaulting.webhook.karpenter.k8s.aws
@@ -1699,10 +1697,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.karpenter.sh
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: validation.webhook.karpenter.sh
@@ -1732,10 +1730,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.config.karpenter.sh
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: validation.webhook.config.karpenter.sh
@@ -1757,10 +1755,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.karpenter.k8s.aws
   labels:
-    helm.sh/chart: karpenter-v0.30.0
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.30.0"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: validation.webhook.karpenter.k8s.aws


### PR DESCRIPTION
According to the [beta migration guide](https://karpenter.sh/docs/upgrading/v1beta1-migration/) this is the most recent version that can be downgraded to before migrating to the beta APIs.

See the upgrade plan mentioned in https://github.com/kubernetes/kops/issues/16143