### PR TITLE
Automated cherry pick of #16163: Upgrade Karpenter to v0.31.3

### DIFF
--- a/pkg/model/components/karpenter.go
+++ b/pkg/model/components/karpenter.go
@@ -36,7 +36,7 @@ func (b *KarpenterOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Image == "" {
-		c.Image = "public.ecr.aws/karpenter/controller:v0.28.1"
+		c.Image = "public.ecr.aws/karpenter/controller:v0.31.3"
 	}
 
 	if c.LogEncoding == "" {

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
@@ -61,7 +61,7 @@ spec:
   karpenter:
     cpuRequest: 100m
     enabled: true
-    image: public.ecr.aws/karpenter/controller:v0.28.1
+    image: public.ecr.aws/karpenter/controller:v0.31.3
     logEncoding: console
     logLevel: debug
     memoryLimit: 2Gi

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -120,7 +120,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: 83732936b11b5830020d8af7bf0955c4b6334c7a1ba93bf051b40bb79294075d
+    manifestHash: 09f06376ef7bfcb706ec648daadae641bf9650d7ab10b6b58d7cd33c0c224867
     name: karpenter.sh
     prune:
       kinds:
@@ -168,11 +168,13 @@ spec:
         kind: Role
         labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
         namespaces:
+        - kube-node-lease
         - kube-system
       - group: rbac.authorization.k8s.io
         kind: RoleBinding
         labelSelector: addon.kops.k8s.io/name=karpenter.sh,app.kubernetes.io/managed-by=kops
         namespaces:
+        - kube-node-lease
         - kube-system
     selector:
       k8s-addon: karpenter.sh

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
@@ -20,7 +20,15 @@ spec:
     singular: provisioner
   scope: Cluster
   versions:
-  - name: v1alpha5
+  - additionalPrinterColumns:
+    - jsonPath: .spec.providerRef.name
+      name: Template
+      type: string
+    - jsonPath: .spec.weight
+      name: Weight
+      priority: 1
+      type: string
+    name: v1alpha5
     schema:
       openAPIV3Schema:
         description: Provisioner is the Schema for the Provisioners API
@@ -382,7 +390,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
@@ -702,7 +710,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: karpenter.sh
@@ -1068,8 +1076,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
@@ -1091,8 +1099,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
@@ -1108,8 +1116,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-cert
   namespace: kube-system
@@ -1151,8 +1159,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: config-logging
   namespace: kube-system
@@ -1161,6 +1169,9 @@ metadata:
 
 apiVersion: v1
 data:
+  aws.assumeRoleARN: ""
+  aws.assumeRoleDuration: 15m
+  aws.clusterCABundle: ""
   aws.clusterEndpoint: https://api.internal.minimal.example.com
   aws.clusterName: minimal.example.com
   aws.defaultInstanceProfile: ""
@@ -1171,6 +1182,7 @@ data:
   aws.vmMemoryOverheadPercent: "0.075"
   batchIdleDuration: 1s
   batchMaxDuration: 10s
+  featureGates.driftEnabled: "false"
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -1179,8 +1191,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-global-settings
   namespace: kube-system
@@ -1196,8 +1208,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: karpenter-admin
@@ -1239,8 +1251,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-core
 rules:
@@ -1307,12 +1319,20 @@ rules:
 - apiGroups:
   - karpenter.sh
   resources:
-  - provisioners/status
   - machines
   - machines/status
   verbs:
   - create
   - delete
+  - update
+  - patch
+- apiGroups:
+  - karpenter.sh
+  resources:
+  - provisioners
+  - provisioners/status
+  verbs:
+  - update
   - patch
 - apiGroups:
   - ""
@@ -1356,8 +1376,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
 rules:
@@ -1388,6 +1408,7 @@ rules:
 - apiGroups:
   - karpenter.k8s.aws
   resources:
+  - awsnodetemplates
   - awsnodetemplates/status
   verbs:
   - patch
@@ -1404,8 +1425,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-core
 roleRef:
@@ -1428,8 +1449,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
 roleRef:
@@ -1452,8 +1473,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
@@ -1531,8 +1552,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-dns
   namespace: kube-system
@@ -1549,6 +1570,38 @@ rules:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
+    k8s-addon: karpenter.sh
+  name: karpenter-lease
+  namespace: kube-node-lease
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - delete
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
@@ -1557,8 +1610,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
@@ -1582,8 +1635,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter-dns
   namespace: kube-system
@@ -1591,6 +1644,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: karpenter-dns
+subjects:
+- kind: ServiceAccount
+  name: karpenter
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
+    k8s-addon: karpenter.sh
+  name: karpenter-lease
+  namespace: kube-node-lease
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: karpenter-lease
 subjects:
 - kind: ServiceAccount
   name: karpenter
@@ -1607,19 +1685,19 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
 spec:
   ports:
   - name: http-metrics
-    port: 8080
+    port: 8000
     protocol: TCP
     targetPort: http-metrics
   - name: https-webhook
-    port: 443
+    port: 8443
     protocol: TCP
     targetPort: https-webhook
   selector:
@@ -1638,8 +1716,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: karpenter
   namespace: kube-system
@@ -1718,7 +1796,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/karpenter.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: public.ecr.aws/karpenter/controller:v0.28.1
+        image: public.ecr.aws/karpenter/controller:v0.31.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1741,6 +1819,7 @@ spec:
           httpGet:
             path: /readyz
             port: http
+          initialDelaySeconds: 5
           timeoutSeconds: 30
         resources:
           limits:
@@ -1748,14 +1827,25 @@ spec:
           requests:
             cpu: 100m
             memory: 500Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65536
+          runAsNonRoot: true
+          runAsUser: 65536
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /var/run/secrets/amazonaws.com/
           name: token-amazonaws-com
           readOnly: true
-      dnsPolicy: ClusterFirst
+      dnsPolicy: Default
       priorityClassName: system-cluster-critical
       securityContext:
-        fsGroup: 1000
+        fsGroup: 10001
       serviceAccountName: karpenter
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -1772,13 +1862,6 @@ spec:
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
         whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: karpenter
-            app.kubernetes.io/name: karpenter
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: DoNotSchedule
       volumes:
       - name: token-amazonaws-com
         projected:
@@ -1800,8 +1883,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: defaulting.webhook.karpenter.k8s.aws
 webhooks:
@@ -1811,6 +1894,7 @@ webhooks:
     service:
       name: karpenter
       namespace: kube-system
+      port: 8443
   failurePolicy: Fail
   name: defaulting.webhook.karpenter.k8s.aws
   rules:
@@ -1848,8 +1932,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: validation.webhook.karpenter.sh
 webhooks:
@@ -1859,6 +1943,7 @@ webhooks:
     service:
       name: karpenter
       namespace: kube-system
+      port: 8443
   failurePolicy: Fail
   name: validation.webhook.karpenter.sh
   rules:
@@ -1885,8 +1970,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: validation.webhook.config.karpenter.sh
 webhooks:
@@ -1896,12 +1981,12 @@ webhooks:
     service:
       name: karpenter
       namespace: kube-system
+      port: 8443
   failurePolicy: Fail
   name: validation.webhook.config.karpenter.sh
   objectSelector:
     matchLabels:
-      app.kubernetes.io/instance: karpenter
-      app.kubernetes.io/name: karpenter
+      app.kubernetes.io/part-of: karpenter
   sideEffects: None
 
 ---
@@ -1915,8 +2000,8 @@ metadata:
     app.kubernetes.io/instance: karpenter
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: karpenter
-    app.kubernetes.io/version: 0.28.1
-    helm.sh/chart: karpenter-v0.28.1
+    app.kubernetes.io/version: 0.31.3
+    helm.sh/chart: karpenter-v0.31.3
     k8s-addon: karpenter.sh
   name: validation.webhook.karpenter.k8s.aws
 webhooks:
@@ -1926,6 +2011,7 @@ webhooks:
     service:
       name: karpenter
       namespace: kube-system
+      port: 8443
   failurePolicy: Fail
   name: validation.webhook.karpenter.k8s.aws
   rules:

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -1,7 +1,7 @@
 # helm template karpenter oci://public.ecr.aws/karpenter/karpenter-crd \
-#  --version v0.28.1
+#  --version v0.31.3
 # helm template karpenter oci://public.ecr.aws/karpenter/karpenter \
-#  --version v0.28.1 \
+#  --version v0.31.3 \
 #  --namespace kube-system \
 #  --set controller.resources.requests.cpu=500m \
 #  --set controller.resources.requests.memory=1Gi \
@@ -12,8 +12,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: provisioners.karpenter.sh
 spec:
   group: karpenter.sh
@@ -26,7 +25,15 @@ spec:
     singular: provisioner
   scope: Cluster
   versions:
-  - name: v1alpha5
+  - additionalPrinterColumns:
+    - jsonPath: .spec.providerRef.name
+      name: Template
+      type: string
+    - jsonPath: .spec.weight
+      name: Weight
+      priority: 1
+      type: string
+    name: v1alpha5
     schema:
       openAPIV3Schema:
         description: Provisioner is the Schema for the Provisioners API
@@ -387,8 +394,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: awsnodetemplates.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws
@@ -702,8 +708,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: machines.karpenter.sh
 spec:
   group: karpenter.sh
@@ -1064,10 +1069,10 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   maxUnavailable: 1
@@ -1083,10 +1088,10 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: karpenter/templates/secret-webhook-cert.yaml
@@ -1096,10 +1101,10 @@ metadata:
   name: karpenter-cert
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 # data: {} # Injected by karpenter-webhook
 ---
@@ -1110,10 +1115,10 @@ metadata:
   name: config-logging
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 data:
   # https://github.com/uber-go/zap/blob/aa3e73ec0896f8b066ddf668597a02f89628ee50/config.go
@@ -1150,12 +1155,15 @@ metadata:
   name: karpenter-global-settings
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 data:
+    "aws.assumeRoleARN": ""
+    "aws.assumeRoleDuration": "15m"
+    "aws.clusterCABundle": ""
     "aws.clusterEndpoint": "https://{{ APIInternalName }}"
     "aws.clusterName": "{{ ClusterName }}"
     "aws.defaultInstanceProfile": ""
@@ -1170,6 +1178,7 @@ data:
     "aws.vmMemoryOverheadPercent": "0.075"
     "batchIdleDuration": "1s"
     "batchMaxDuration": "10s"
+    "featureGates.driftEnabled": "false"
 ---
 # Source: karpenter/templates/aggregate-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1178,10 +1187,10 @@ metadata:
   name: karpenter-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["karpenter.sh"]
@@ -1197,10 +1206,10 @@ kind: ClusterRole
 metadata:
   name: karpenter-core
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Read
@@ -1224,8 +1233,11 @@ rules:
     verbs: [ "get", "list", "watch" ]
   # Write
   - apiGroups: ["karpenter.sh"]
-    resources: ["provisioners/status", "machines", "machines/status"]
-    verbs: ["create", "delete", "patch"]
+    resources: ["machines", "machines/status"]
+    verbs: ["create", "delete", "update", "patch"]
+  - apiGroups: ["karpenter.sh"]
+    resources: ["provisioners", "provisioners/status"]
+    verbs: ["update", "patch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
@@ -1246,10 +1258,10 @@ kind: ClusterRole
 metadata:
   name: karpenter
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Read
@@ -1266,7 +1278,7 @@ rules:
     resourceNames: ["defaulting.webhook.karpenter.k8s.aws"]
   # Write
   - apiGroups: ["karpenter.k8s.aws"]
-    resources: ["awsnodetemplates/status"]
+    resources: ["awsnodetemplates", "awsnodetemplates/status"]
     verbs: ["patch", "update"]
 ---
 # Source: karpenter/templates/clusterrole-core.yaml
@@ -1275,10 +1287,10 @@ kind: ClusterRoleBinding
 metadata:
   name: karpenter-core
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1295,10 +1307,10 @@ kind: ClusterRoleBinding
 metadata:
   name: karpenter
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1316,10 +1328,10 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Read
@@ -1365,10 +1377,10 @@ metadata:
   name: karpenter-dns
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   # Read
@@ -1377,6 +1389,28 @@ rules:
     resourceNames: ["kube-dns"]
     verbs: ["get"]
 ---
+# Source: karpenter/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: karpenter-lease
+  namespace: kube-node-lease
+  labels:
+    helm.sh/chart: karpenter-v0.31.3
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.31.3"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Read
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch"]
+  # Write
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["delete"]
+---
 # Source: karpenter/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -1384,10 +1418,10 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1405,15 +1439,36 @@ metadata:
   name: karpenter-dns
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: karpenter-dns
+subjects:
+  - kind: ServiceAccount
+    name: karpenter
+    namespace: kube-system
+---
+# Source: karpenter/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: karpenter-lease
+  namespace: kube-node-lease
+  labels:
+    helm.sh/chart: karpenter-v0.31.3
+    app.kubernetes.io/name: karpenter
+    app.kubernetes.io/instance: karpenter
+    app.kubernetes.io/version: "0.31.3"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: karpenter-lease
 subjects:
   - kind: ServiceAccount
     name: karpenter
@@ -1426,20 +1481,20 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
   ports:
     - name: http-metrics
-      port: 8080
+      port: 8000
       targetPort: http-metrics
       protocol: TCP
     - name: https-webhook
-      port: 443
+      port: 8443
       targetPort: https-webhook
       protocol: TCP
   selector:
@@ -1453,10 +1508,10 @@ metadata:
   name: karpenter
   namespace: kube-system
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: {{ ControlPlaneControllerReplicas false }}
@@ -1475,13 +1530,26 @@ spec:
         karpenter: webhook
     spec:
       serviceAccountName: karpenter
-      securityContext:
-        fsGroup: 1000
       priorityClassName: "system-cluster-critical"
+      {{ if not IsIPv6Only }}
+      dnsPolicy: Default
+      {{ else }}
       # Must use ClusterFirst on IPv6 clusters in order to get DNS64
       dnsPolicy: ClusterFirst
+      {{ end }}
       containers:
         - name: controller
+          securityContext:
+            runAsUser: 65536
+            runAsGroup: 65536
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           image: {{ .Karpenter.Image }}
           imagePullPolicy: IfNotPresent
           env:
@@ -1524,6 +1592,7 @@ spec:
               path: /healthz
               port: http
           readinessProbe:
+            initialDelaySeconds: 5
             timeoutSeconds: 30
             httpGet:
               path: /readyz
@@ -1574,13 +1643,6 @@ spec:
           maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: ScheduleAnyway
-        - labelSelector:
-            matchLabels:
-              app.kubernetes.io/instance: karpenter
-              app.kubernetes.io/name: karpenter
-          maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Exists
@@ -1595,10 +1657,10 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.karpenter.k8s.aws
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: defaulting.webhook.karpenter.k8s.aws
@@ -1607,6 +1669,7 @@ webhooks:
       service:
         name: karpenter
         namespace: kube-system
+        port: 8443
     failurePolicy: Fail
     sideEffects: None
     rules:
@@ -1638,10 +1701,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.karpenter.sh
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: validation.webhook.karpenter.sh
@@ -1650,6 +1713,7 @@ webhooks:
       service:
         name: karpenter
         namespace: kube-system
+        port: 8443
     failurePolicy: Fail
     sideEffects: None
     rules:
@@ -1670,10 +1734,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.config.karpenter.sh
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: validation.webhook.config.karpenter.sh
@@ -1682,12 +1746,12 @@ webhooks:
       service:
         name: karpenter
         namespace: kube-system
+        port: 8443
     failurePolicy: Fail
     sideEffects: None
     objectSelector:
       matchLabels:
-        app.kubernetes.io/name: karpenter
-        app.kubernetes.io/instance: karpenter
+        app.kubernetes.io/part-of: karpenter
 ---
 # Source: karpenter/templates/webhooks.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -1695,10 +1759,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.karpenter.k8s.aws
   labels:
-    helm.sh/chart: karpenter-v0.28.1
+    helm.sh/chart: karpenter-v0.31.3
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: karpenter
-    app.kubernetes.io/version: "0.28.1"
+    app.kubernetes.io/version: "0.31.3"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: validation.webhook.karpenter.k8s.aws
@@ -1707,6 +1771,7 @@ webhooks:
       service:
         name: karpenter
         namespace: kube-system
+        port: 8443
     failurePolicy: Fail
     sideEffects: None
     rules:


### PR DESCRIPTION
Cherry pick of #16163 on release-1.28.

#16163: Upgrade Karpenter to v0.31.3

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```