### PR TITLE
Remove duplicate m5.large from scalability test

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -120,7 +120,7 @@ create_args+=("--set spec.kubeProxy.metricsBindAddress=0.0.0.0:10249")
 create_args+=("--node-count=${KUBE_NODE_COUNT:-101}")
 # TODO: track failures of tests (HostPort & OIDC) when using `--dns=none`
 create_args+=("--dns none")
-create_args+=("--node-size=t3a.medium,t3.medium,t2.medium,t3a.large,c5a.large,t3.large,c5.large,m5a.large,m6a.large,m5.large,m5.large,c4.large,c7a.large,r5a.large,r6a.large,m7a.large")
+create_args+=("--node-size=t3a.medium,t3.medium,t2.medium,t3a.large,c5a.large,t3.large,c5.large,m5a.large,m6a.large,m5.large,c4.large,c7a.large,r5a.large,r6a.large,m7a.large")
 create_args+=("--node-volume-size=20")
 create_args+=("--control-plane-count=${CONTROL_PLANE_COUNT:-1}")
 create_args+=("--master-size=${CONTROL_PLANE_SIZE:-c5.2xlarge}")


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-scale-amazonvpc-using-cl2/1733004377897046016

`Error: error running tasks: deadline exceeded executing task AutoscalingGroup/nodes-us-east-2c.scale-1000.periodic.test-cncf-aws.k8s.io. Example error: error creating AutoScalingGroup: Cannot add same instance type override more than once. Remove these duplicates from the request and try again: [m5.large]`

Followup to https://github.com/kubernetes/kops/pull/16156