### PR TITLE
Automated cherry pick of #16167: Ignore HPA status when applying addons

### DIFF
--- a/pkg/applylib/applyset/health.go
+++ b/pkg/applylib/applyset/health.go
@@ -38,7 +38,9 @@ func isHealthy(u *unstructured.Unstructured) bool {
 	gvk := u.GroupVersionKind()
 	switch gvk {
 	case schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
-		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"}:
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"},
+		schema.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "HorizontalPodAutoscaler"},
+		schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"}:
 		// No ready signal; assume ready
 		return true
 	case schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},


### PR DESCRIPTION
Cherry pick of #16167 on release-1.28.

#16167: Ignore HPA status when applying addons

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```