### PR TITLE
Ignore cert-manager in LBC's webhooks

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1063,6 +1063,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""
@@ -1094,6 +1095,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -148,7 +148,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 62e52a735ecf0a976a1ca912758a92ddb9ffbac09d4f7cd0e2331f1d3e702f89
+    manifestHash: 1c7618e2ac4639ab78b8cab895782fc62d521f4fd208b4bff4a0558fa771afc3
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1063,6 +1063,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""
@@ -1094,6 +1095,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -163,7 +163,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 62e52a735ecf0a976a1ca912758a92ddb9ffbac09d4f7cd0e2331f1d3e702f89
+    manifestHash: 1c7618e2ac4639ab78b8cab895782fc62d521f4fd208b4bff4a0558fa771afc3
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1063,6 +1063,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""
@@ -1094,6 +1095,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 62e52a735ecf0a976a1ca912758a92ddb9ffbac09d4f7cd0e2331f1d3e702f89
+    manifestHash: 1c7618e2ac4639ab78b8cab895782fc62d521f4fd208b4bff4a0558fa771afc3
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1063,6 +1063,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""
@@ -1094,6 +1095,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 62e52a735ecf0a976a1ca912758a92ddb9ffbac09d4f7cd0e2331f1d3e702f89
+    manifestHash: 1c7618e2ac4639ab78b8cab895782fc62d521f4fd208b4bff4a0558fa771afc3
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1063,6 +1063,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""
@@ -1094,6 +1095,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -171,7 +171,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 62e52a735ecf0a976a1ca912758a92ddb9ffbac09d4f7cd0e2331f1d3e702f89
+    manifestHash: 1c7618e2ac4639ab78b8cab895782fc62d521f4fd208b4bff4a0558fa771afc3
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1069,6 +1069,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""
@@ -1100,6 +1101,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -163,7 +163,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 35f62f8f1ce737681494453c1ca84ebebcdde1baeefd414edeedb1f396e5dc3c
+    manifestHash: 4b7e10379beabe347fe4d72ddfc00ae77daab278c65251f5a8a56a6e91c2a907
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -1069,6 +1069,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""
@@ -1100,6 +1101,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -163,7 +163,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: a2f8441f322c19711b1ea935c5eb21e9fa2a231e86c898f6eddf0279ad9c361c
+    manifestHash: ea17759bdf2e9ace58d6cd23a0f5f0697736eef8e52a25a30c3bbef8b77aaa48
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
@@ -1008,6 +1008,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""
@@ -1039,6 +1040,7 @@ webhooks:
       operator: NotIn
       values:
       - aws-load-balancer-controller
+      - cert-manager
   rules:
   - apiGroups:
     - ""


### PR DESCRIPTION
LBC depends on cert-manager but kops can get in a circular dependency loop when applying these manifests on a new cluster.
The cert-manager pods wont be created because the LBC webhook on "CREATE services" isn't working yet, but LBC pod cant be created because it depends on a secret volume mount created by cert-manager

Observe the errors in [these protokube logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-aws-load-balancer-controller/1736863382264352768/artifacts/i-0a6999e13be6fc486/protokube.log):

`W1218 22:01:20.531717   10658 results.go:63] error from apply on /v1, Kind=Service kube-system/cert-manager: error from apply: error patching object: Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": dial tcp 100.69.153.238:443: connect: connection refused`

`W1218 22:01:22.130490   10658 results.go:63] error from apply on cert-manager.io/v1, Kind=Certificate kube-system/aws-load-balancer-serving-cert: error from apply: error patching object: Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.kube-system.svc:443/mutate?timeout=10s": service "cert-manager-webhook" not found`

and kube-system event:

```yaml
- count: 15
  eventTime: null
  firstTimestamp: "2023-12-18T21:48:54Z"
  involvedObject:
    apiVersion: v1
    kind: Pod
    name: aws-load-balancer-controller-d7cfbcbd4-s42pv
    namespace: kube-system
    resourceVersion: "932"
    uid: ffa0fc59-ed11-42d8-8114-5fc65d33bda4
  lastTimestamp: "2023-12-18T22:03:13Z"
  message: 'MountVolume.SetUp failed for volume "cert" : secret "aws-load-balancer-webhook-tls"
    not found'
```

This should fix the flakiness in [this prow job](https://testgrid.k8s.io/kops-misc#kops-aws-aws-load-balancer-controller) that started after we upgraded LBC (https://github.com/kubernetes/kops/pull/16155) that added the "CREATE services" webhook configuration.