### PR TITLE
Enable pagination on GCE Instance Groups

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -301,12 +301,13 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 			name := gce.NameForInstanceGroupManager(b.Cluster.ObjectMeta.Name, ig.ObjectMeta.Name, zone)
 
 			t := &gcetasks.InstanceGroupManager{
-				Name:             s(name),
-				Lifecycle:        b.Lifecycle,
-				Zone:             s(zone),
-				TargetSize:       fi.PtrTo(int64(targetSize)),
-				BaseInstanceName: s(ig.ObjectMeta.Name),
-				InstanceTemplate: instanceTemplate,
+				Name:                        s(name),
+				Lifecycle:                   b.Lifecycle,
+				Zone:                        s(zone),
+				TargetSize:                  fi.PtrTo(int64(targetSize)),
+				BaseInstanceName:            s(ig.ObjectMeta.Name),
+				InstanceTemplate:            instanceTemplate,
+				ListManagedInstancesResults: "PAGINATED",
 			}
 
 			// Attach masters to load balancer if we're using one

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -501,9 +501,10 @@ resource "google_compute_firewall" "ssh-external-to-node-ipv6-ha-gce-example-com
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-ha-gce-example-com" {
-  base_instance_name = "master-us-test1-a"
-  name               = "a-master-us-test1-a-ha-gce-example-com"
-  target_size        = 1
+  base_instance_name             = "master-us-test1-a"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-master-us-test1-a-ha-gce-example-com"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.master-us-test1-a-ha-gce-example-com.self_link
   }
@@ -511,9 +512,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-ha-gce-exa
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-ha-gce-example-com" {
-  base_instance_name = "nodes"
-  name               = "a-nodes-ha-gce-example-com"
-  target_size        = 1
+  base_instance_name             = "nodes"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-nodes-ha-gce-example-com"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.nodes-ha-gce-example-com.self_link
   }
@@ -521,9 +523,10 @@ resource "google_compute_instance_group_manager" "a-nodes-ha-gce-example-com" {
 }
 
 resource "google_compute_instance_group_manager" "b-master-us-test1-b-ha-gce-example-com" {
-  base_instance_name = "master-us-test1-b"
-  name               = "b-master-us-test1-b-ha-gce-example-com"
-  target_size        = 1
+  base_instance_name             = "master-us-test1-b"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "b-master-us-test1-b-ha-gce-example-com"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.master-us-test1-b-ha-gce-example-com.self_link
   }
@@ -531,9 +534,10 @@ resource "google_compute_instance_group_manager" "b-master-us-test1-b-ha-gce-exa
 }
 
 resource "google_compute_instance_group_manager" "b-nodes-ha-gce-example-com" {
-  base_instance_name = "nodes"
-  name               = "b-nodes-ha-gce-example-com"
-  target_size        = 1
+  base_instance_name             = "nodes"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "b-nodes-ha-gce-example-com"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.nodes-ha-gce-example-com.self_link
   }
@@ -541,9 +545,10 @@ resource "google_compute_instance_group_manager" "b-nodes-ha-gce-example-com" {
 }
 
 resource "google_compute_instance_group_manager" "c-master-us-test1-c-ha-gce-example-com" {
-  base_instance_name = "master-us-test1-c"
-  name               = "c-master-us-test1-c-ha-gce-example-com"
-  target_size        = 1
+  base_instance_name             = "master-us-test1-c"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "c-master-us-test1-c-ha-gce-example-com"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.master-us-test1-c-ha-gce-example-com.self_link
   }
@@ -551,9 +556,10 @@ resource "google_compute_instance_group_manager" "c-master-us-test1-c-ha-gce-exa
 }
 
 resource "google_compute_instance_group_manager" "c-nodes-ha-gce-example-com" {
-  base_instance_name = "nodes"
-  name               = "c-nodes-ha-gce-example-com"
-  target_size        = 0
+  base_instance_name             = "nodes"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "c-nodes-ha-gce-example-com"
+  target_size                    = 0
   version {
     instance_template = google_compute_instance_template.nodes-ha-gce-example-com.self_link
   }

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -429,9 +429,10 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-example-com" {
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-example-com" {
-  base_instance_name = "master-us-test1-a"
-  name               = "a-master-us-test1-a-minimal-example-com"
-  target_size        = 1
+  base_instance_name             = "master-us-test1-a"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-master-us-test1-a-minimal-example-com"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.master-us-test1-a-minimal-example-com.self_link
   }
@@ -439,9 +440,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-ex
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-example-com" {
-  base_instance_name = "nodes"
-  name               = "a-nodes-minimal-example-com"
-  target_size        = 1
+  base_instance_name             = "nodes"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-nodes-minimal-example-com"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.nodes-minimal-example-com.self_link
   }

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -405,9 +405,10 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-example-com
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-example-com" {
-  base_instance_name = "master-us-test1-a"
-  name               = "a-master-us-test1-a-minimal-gce-example-com"
-  target_size        = 1
+  base_instance_name             = "master-us-test1-a"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-master-us-test1-a-minimal-gce-example-com"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.master-us-test1-a-minimal-gce-example-com.self_link
   }
@@ -415,9 +416,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-example-com" {
-  base_instance_name = "nodes"
-  name               = "a-nodes-minimal-gce-example-com"
-  target_size        = 2
+  base_instance_name             = "nodes"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-nodes-minimal-gce-example-com"
+  target_size                    = 2
   version {
     instance_template = google_compute_instance_template.nodes-minimal-gce-example-com.self_link
   }

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -486,9 +486,10 @@ resource "google_compute_health_check" "api-minimal-gce-example-com" {
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-example-com" {
-  base_instance_name = "master-us-test1-a"
-  name               = "a-master-us-test1-a-minimal-gce-example-com"
-  target_size        = 1
+  base_instance_name             = "master-us-test1-a"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-master-us-test1-a-minimal-gce-example-com"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.master-us-test1-a-minimal-gce-example-com.self_link
   }
@@ -496,9 +497,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-example-com" {
-  base_instance_name = "nodes"
-  name               = "a-nodes-minimal-gce-example-com"
-  target_size        = 2
+  base_instance_name             = "nodes"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-nodes-minimal-gce-example-com"
+  target_size                    = 2
   version {
     instance_template = google_compute_instance_template.nodes-minimal-gce-example-com.self_link
   }

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -455,9 +455,10 @@ resource "google_compute_health_check" "api-minimal-gce-ilb-example-com" {
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-ilb-example-com" {
-  base_instance_name = "master-us-test1-a"
-  name               = "a-master-us-test1-a-minimal-gce-ilb-example-com"
-  target_size        = 1
+  base_instance_name             = "master-us-test1-a"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-master-us-test1-a-minimal-gce-ilb-example-com"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.master-us-test1-a-minimal-gce-ilb-example-com.self_link
   }
@@ -465,9 +466,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-ilb-example-com" {
-  base_instance_name = "nodes"
-  name               = "a-nodes-minimal-gce-ilb-example-com"
-  target_size        = 2
+  base_instance_name             = "nodes"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-nodes-minimal-gce-ilb-example-com"
+  target_size                    = 2
   version {
     instance_template = google_compute_instance_template.nodes-minimal-gce-ilb-example-com.self_link
   }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -455,9 +455,10 @@ resource "google_compute_health_check" "api-minimal-gce-with-a-very-very-very-ve
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f" {
-  base_instance_name = "master-us-test1-a"
-  name               = "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f"
-  target_size        = 1
+  base_instance_name             = "master-us-test1-a"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.self_link
   }
@@ -465,9 +466,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-with-a-very-very-very-very-very-long-qk78uj" {
-  base_instance_name = "nodes"
-  name               = "a-nodes-minimal-gce-with-a-very-very-very-very-very-long-qk78uj"
-  target_size        = 2
+  base_instance_name             = "nodes"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-nodes-minimal-gce-with-a-very-very-very-very-very-long-qk78uj"
+  target_size                    = 2
   version {
     instance_template = google_compute_instance_template.nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.self_link
   }

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -405,9 +405,10 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-with-a-very
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f" {
-  base_instance_name = "master-us-test1-a"
-  name               = "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f"
-  target_size        = 1
+  base_instance_name             = "master-us-test1-a"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.self_link
   }
@@ -415,9 +416,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-with-a-very-very-very-very-very-long-qk78uj" {
-  base_instance_name = "nodes"
-  name               = "a-nodes-minimal-gce-with-a-very-very-very-very-very-long-qk78uj"
-  target_size        = 2
+  base_instance_name             = "nodes"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-nodes-minimal-gce-with-a-very-very-very-very-very-long-qk78uj"
+  target_size                    = 2
   version {
     instance_template = google_compute_instance_template.nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.self_link
   }

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -439,10 +439,11 @@ resource "google_compute_http_health_check" "api-minimal-gce-plb-example-com" {
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-plb-example-com" {
-  base_instance_name = "master-us-test1-a"
-  name               = "a-master-us-test1-a-minimal-gce-plb-example-com"
-  target_pools       = [google_compute_target_pool.api-minimal-gce-plb-example-com.self_link]
-  target_size        = 1
+  base_instance_name             = "master-us-test1-a"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-master-us-test1-a-minimal-gce-plb-example-com"
+  target_pools                   = [google_compute_target_pool.api-minimal-gce-plb-example-com.self_link]
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.master-us-test1-a-minimal-gce-plb-example-com.self_link
   }
@@ -450,9 +451,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-plb-example-com" {
-  base_instance_name = "nodes"
-  name               = "a-nodes-minimal-gce-plb-example-com"
-  target_size        = 2
+  base_instance_name             = "nodes"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-nodes-minimal-gce-plb-example-com"
+  target_size                    = 2
   version {
     instance_template = google_compute_instance_template.nodes-minimal-gce-plb-example-com.self_link
   }

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -405,9 +405,10 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-private-exa
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-private-example-com" {
-  base_instance_name = "master-us-test1-a"
-  name               = "a-master-us-test1-a-minimal-gce-private-example-com"
-  target_size        = 1
+  base_instance_name             = "master-us-test1-a"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-master-us-test1-a-minimal-gce-private-example-com"
+  target_size                    = 1
   version {
     instance_template = google_compute_instance_template.master-us-test1-a-minimal-gce-private-example-com.self_link
   }
@@ -415,9 +416,10 @@ resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gc
 }
 
 resource "google_compute_instance_group_manager" "a-nodes-minimal-gce-private-example-com" {
-  base_instance_name = "nodes"
-  name               = "a-nodes-minimal-gce-private-example-com"
-  target_size        = 2
+  base_instance_name             = "nodes"
+  list_managed_instances_results = "PAGINATED"
+  name                           = "a-nodes-minimal-gce-private-example-com"
+  target_size                    = 2
   version {
     instance_template = google_compute_instance_template.nodes-minimal-gce-private-example-com.self_link
   }


### PR DESCRIPTION
This is required to support MIGs with >1000 instances.

See https://cloud.google.com/compute/docs/instance-groups/add-remove-vms-in-mig#increase_the_groups_size_limit

Kops already uses pagination to get instances from instance groups so no other changes are necessary https://github.com/kubernetes/kops/blob/62fcb00f8c6ff3f86adbbaddf9cfe0dbf79c4498/upup/pkg/fi/cloudup/gce/compute.go#L712-L721