### PR TITLE
`kops validate cluster` improvements

### DIFF
--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -31,6 +31,7 @@ kops validate cluster [CLUSTER] [flags]
 ```
       --count int           Number of consecutive successful validations required
   -h, --help                help for cluster
+      --interval duration   Time in duration to wait between validation attempts (default 10s)
       --kubeconfig string   Path to the kubeconfig file
   -o, --output string       Output format. One of json|yaml|table. (default "table")
       --wait duration       Amount of time to wait for the cluster to become ready

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -65,7 +65,9 @@ type deployer struct {
 	ControlPlaneIGOverrides []string `flag:"control-plane-instance-group-overrides" desc:"overrides for the control plane instance groups"`
 	NodeIGOverrides         []string `flag:"node-instance-group-overrides" desc:"overrides for the node instance groups"`
 
-	ValidationWait time.Duration `flag:"validation-wait" desc:"time to wait for newly created cluster to pass validation"`
+	ValidationWait     time.Duration `flag:"validation-wait" desc:"time to wait for newly created cluster to pass validation"`
+	ValidationCount    int           `flag:"validation-count" desc:"how many times should a validation pass"`
+	ValidationInterval time.Duration `flag:"validation-interval" desc:"time in duration to wait between validation attempts"`
 
 	TemplatePath string `flag:"template-path" desc:"The path to the manifest template used for cluster creation"`
 
@@ -109,13 +111,15 @@ func (d *deployer) Provider() string {
 
 // New implements deployer.New for kops
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
-	// create a deployer object and set fields that are not flag controlled
+	// create a deployer object and set fields that are not flag controlled, and default values
 	d := &deployer{
 		commonOptions: opts,
 		BuildOptions: &builder.BuildOptions{
 			BuildKubernetes: false,
 		},
 		boskosHeartbeatClose: make(chan struct{}),
+		ValidationCount:      10,
+		ValidationInterval:   10 * time.Second,
 	}
 
 	dir, err := defaultArtifactsDir()

--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -163,7 +163,10 @@ func (d *deployer) dumpClusterInfo() error {
 		"leases",
 		"persistentvolumeclaims",
 		"poddisruptionbudgets",
+		"podmonitors",
+		"statefulsets",
 		"serviceaccounts",
+		"servicemonitors",
 		"rolebindings",
 		"roles",
 	}
@@ -198,6 +201,11 @@ func (d *deployer) dumpClusterInfo() error {
 				}
 			}
 		}
+	}
+	// cleanup zero byte files
+	cmd = exec.Command("find", d.ArtifactsDir, "-size", "0", "-print", "-delete", "-o")
+	if err := cmd.Run(); err != nil {
+		dumpErr = errors.Join(dumpErr, err)
 	}
 	return dumpErr
 }

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	osexec "os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -290,7 +291,8 @@ func (d *deployer) IsUp() (bool, error) {
 	args := []string{
 		d.KopsBinaryPath, "validate", "cluster",
 		"--name", d.ClusterName,
-		"--count", "10",
+		"--count", strconv.Itoa(d.ValidationCount),
+		"--interval", d.ValidationInterval.String(),
 		"--wait", wait.String(),
 	}
 	klog.Info(strings.Join(args, " "))


### PR DESCRIPTION
Required for #16181 

kops validate has a few critical problems:
- every 10 sec, it will try to fetch a complete list of every instance which eats in to the API quotas. A new flag allows you to adjust this duration, with the default set to 10s
- count is also adjustable via kubetest2 as well as the new flag