### PR TITLE
skip_regex.go: kube-router add back in service afinity test

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -97,7 +97,7 @@ func (t *Tester) setSkipRegexFlag() error {
 			skipRegex += "|should.create.a.Pod.with.SCTP.HostPort"
 		}
 	} else if networking.KubeRouter != nil {
-		skipRegex += "|load-balancer|hairpin|affinity\\stimeout|service\\.kubernetes\\.io|CLOSE_WAIT"
+		skipRegex += "|load-balancer|hairpin|service\\.kubernetes\\.io|CLOSE_WAIT"
 		skipRegex += "|EndpointSlice.should.support.a.Service.with.multiple"
 		skipRegex += "|internalTrafficPolicy|externallTrafficPolicy|only.terminating.endpoints"
 	} else if networking.Kubenet != nil {


### PR DESCRIPTION
@hakman 

Requires https://github.com/kubernetes/kubernetes/pull/122440 to be merged first.

Once those two are merged, kube-router should be passing both of the service affinity tests in the e2e suite, so we can allow those to run and no longer worry about failures.

