### PR TITLE
chore(channels): bump k8s and ubuntu ami versions in alpha channel

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -58,19 +58,19 @@ spec:
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20231121.1
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20231208
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.18.0 <1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20231121.1
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20231208
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0 <1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231121
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20231207
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20231121
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20231207
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.27.0"
@@ -104,13 +104,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.28.0"
-    recommendedVersion: 1.28.4
+    recommendedVersion: 1.28.5
     requiredVersion: 1.28.0
   - range: ">=1.27.0"
-    recommendedVersion: 1.27.8
+    recommendedVersion: 1.27.9
     requiredVersion: 1.27.0
   - range: ">=1.26.0"
-    recommendedVersion: 1.26.11
+    recommendedVersion: 1.26.12
     requiredVersion: 1.26.0
   - range: ">=1.25.0"
     recommendedVersion: 1.25.16
@@ -164,15 +164,15 @@ spec:
   - range: ">=1.28.0-alpha.1"
     recommendedVersion: "1.28.0"
     #requiredVersion: 1.28.0
-    kubernetesVersion: 1.28.4
+    kubernetesVersion: 1.28.5
   - range: ">=1.27.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.27.0
-    kubernetesVersion: 1.27.8
+    kubernetesVersion: 1.27.9
   - range: ">=1.26.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.26.0
-    kubernetesVersion: 1.26.11
+    kubernetesVersion: 1.26.12
   - range: ">=1.25.0-alpha.1"
     recommendedVersion: "1.27.0"
     #requiredVersion: 1.25.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Update k8s versions and Ubuntu AMI versions (focal/jammy) to latest

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

- https://github.com/kubernetes/kubernetes/releases/tag/v1.28.5
- https://github.com/kubernetes/kubernetes/releases/tag/v1.27.9
- https://github.com/kubernetes/kubernetes/releases/tag/v1.26.12
- https://cloud-images.ubuntu.com/locator/ec2/ (use search bar to lookup `focal` and `jammy`)

/cc @hakman