### PR TITLE
Add cert-manager resource types to kubetest2-kops artifacts

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -157,9 +157,12 @@ func (d *deployer) dumpClusterInfo() error {
 	}
 
 	namespacedResourceTypes := []string{
+		"certificaterequests",
+		"certificates",
 		"configmaps",
 		"endpoints",
 		"endpointslices",
+		"issuers",
 		"leases",
 		"persistentvolumeclaims",
 		"poddisruptionbudgets",


### PR DESCRIPTION
The LBC prow job is flaking. I believe its due to a race condition that still exists. I'm adding the cert-manager resources that the LBC addon includes to help with troubleshooting

https://testgrid.k8s.io/kops-misc#kops-aws-aws-load-balancer-controller