### PR TITLE
test: Print the `create cluster` command

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -217,6 +217,7 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		args = appendIfUnset(args, "--kubernetes-feature-gates", d.KubernetesFeatureGates)
 	}
 
+	klog.Info(strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(d.env()...)
 


### PR DESCRIPTION
Should be useful to have this again:
```
I0102 08:51:38.744132   13973 up.go:220] /home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops create cluster
--name e2e-pr16202.pull-kops-e2e-k8s-aws-calico.test-cncf-aws.k8s.io
--cloud aws
--kubernetes-version https://dl.k8s.io/release/v1.29.0
--ssh-public-key /tmp/kops/e2e-pr16202.pull-kops-e2e-k8s-aws-calico.test-cncf-aws.k8s.io/id_ed25519.pub
--set cluster.spec.nodePortAccess=0.0.0.0/0
--set spec.containerd.configAdditions=plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.runtime_type=io.containerd.runc.v2
--channel=alpha
--networking=calico
--discovery-store=s3://k8s-kops-prow/discovery
--admin-access 35.222.3.8/32
--master-count 1 --master-size c5.large --master-volume-size 48 --node-count 4 --node-volume-size 48
--zones ap-southeast-2b
```

/cc @rifelpet @upodroid 