### PR TITLE
Check if kubeconfig exists before dumping resources

### DIFF
--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -167,11 +167,11 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 
 		var nodes corev1.NodeList
 
-		config, err := clientGetter.ToRESTConfig()
+		kubeConfig, err := clientGetter.ToRESTConfig()
 		if err != nil {
 			klog.Warningf("cannot load kubeconfig settings for %q: %v", contextName, err)
 		} else {
-			k8sClient, err := kubernetes.NewForConfig(config)
+			k8sClient, err := kubernetes.NewForConfig(kubeConfig)
 			if err != nil {
 				klog.Warningf("cannot build kube client for %q: %v", contextName, err)
 			} else {
@@ -227,8 +227,9 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 		if err := dumper.DumpAllNodes(ctx, nodes, additionalIPs, additionalPrivateIPs); err != nil {
 			return fmt.Errorf("error dumping nodes: %v", err)
 		}
-		if options.K8sResources {
-			dumper, err := dump.NewResourceDumper(config, options.Output, options.Dir)
+
+		if kubeConfig != nil && options.K8sResources {
+			dumper, err := dump.NewResourceDumper(kubeConfig, options.Output, options.Dir)
 			if err != nil {
 				return fmt.Errorf("error creating resource dumper: %w", err)
 			}
@@ -236,7 +237,7 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 				return fmt.Errorf("error dumping resources: %w", err)
 			}
 
-			logDumper, err := dump.NewPodLogDumper(config, options.Dir)
+			logDumper, err := dump.NewPodLogDumper(kubeConfig, options.Dir)
 			if err != nil {
 				return fmt.Errorf("error creating pod log dumper: %w", err)
 			}


### PR DESCRIPTION
/cc @rifelpet

```
I0103 05:06:02.213472   14553 up.go:58] Cleaning up any leaked resources from previous cluster
I0103 05:06:02.424454   14553 dumplogs.go:47] /home/prow/go/src/k8s.io/bin/kops toolbox dump --name e2e-ff02749ef8-a423a.test-cncf-aws.k8s.io --dir /logs/artifacts --private-key /tmp/kops/e2e-ff02749ef8-a423a.test-cncf-aws.k8s.io/id_ed25519 --ssh-user ubuntu
I0103 05:06:02.431913   14592 featureflag.go:168] FeatureFlag "AWSSingleNodesInstanceGroup"=true
W0103 05:06:04.850989   14592 toolbox_dump.go:172] cannot load kubeconfig settings for "e2e-ff02749ef8-a423a.test-cncf-aws.k8s.io": context "e2e-ff02749ef8-a423a.test-cncf-aws.k8s.io" does not exist
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1d0 pc=0x3f0d853]

goroutine 1 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.func1()
	go.opentelemetry.io/otel/sdk@v1.21.0/trace/span.go:388 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc000281500, {0x0, 0x0, 0x0?})
	go.opentelemetry.io/otel/sdk@v1.21.0/trace/span.go:426 +0xa3b
panic({0x48dc800?, 0x8945740?})
	runtime/panic.go:914 +0x21f
k8s.io/kops/pkg/dump.NewResourceDumper(0x0, {0x5413e0c, 0x4}, {0x7ffc7debcce8, 0xf})
	k8s.io/kops/pkg/dump/resourcedumper.go:76 +0x33
main.RunToolboxDump({0x60f72f8, 0xc00088de00}, {0x60ce208?, 0xc000281080?}, {0x60bf580, 0xc000126020}, 0xc00078cf00)
	k8s.io/kops/cmd/kops/toolbox_dump.go:231 +0x1838
main.NewCmdToolboxDump.func1(0xc00050c900?, {0xc000063300?, 0x4?, 0x5413e98?})
	k8s.io/kops/cmd/kops/toolbox_dump.go:95 +0x38
github.com/spf13/cobra.(*Command).execute(0xc0008a8300, {0xc000063280, 0x8, 0x8})
	github.com/spf13/cobra@v1.8.0/command.go:983 +0xabc
github.com/spf13/cobra.(*Command).ExecuteC(0x8970660)
	github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	github.com/spf13/cobra@v1.8.0/command.go:1032
main.Execute({0x60f7250, 0x89c6620})
	k8s.io/kops/cmd/kops/root.go:100 +0x331
main.run({0x60f7250, 0x89c6620})
	k8s.io/kops/cmd/kops/main.go:55 +0x165
main.main()
	k8s.io/kops/cmd/kops/main.go:29 +0x25
W0103 05:06:04.864055   14553 dumplogs.go:55] kops toolbox dump failed: exit status 2
```