### PR TITLE
aws: Set AWS_REGION env var for ebs-csi-node and ebs-csi-driver

### DIFF
--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 31bef3817d0771e57f67144e47f01bdfdc1f957e89893a6e1b25db3ada20ce2b
+    manifestHash: 28306d9c7e7b654ba30426759bdf25bfb7f4976e87f87ce93710bfcbc1c4e54c
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -825,6 +827,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d62b713889f8066fb883e5e04870e03c17688e53d32199189d7578766e78bb2e
+    manifestHash: 74bb879436e2e5f1717af718e0e319feceb3ebec946e27572c8f03430434331a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 2e1cfdf07bfdf1bc57c8f0cd761953d64a133900d49503cded51b73f88d02417
+    manifestHash: b844e57f0861b0a84360e71af4cb0fffc621578b8940e82f75fa6dae2edfe9de
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 578b0ded488b0dd98343c977be5f5cdc29e81366098a3fbf0be1fd60caba0816
+    manifestHash: ad9538025983ef1b1e6076cd73e3f0097b7d4c44482edc524d34eeb83634be34
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a443fb995f99d385ec9f0c0917dd982e935e24adefde714723d4d4cd68508a04
+    manifestHash: 1eec2f2102794265a94fb5ba36cc437dd638862addae7ba243c5ed685533691d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -120,7 +120,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 861273b11061f46757527c47b505a8f40c2933fab73b661faf5a940f434c575d
+    manifestHash: cb937d69420abb71be1d67b12f1f4fc8f09e623004f1b8924cdef08007d9b125
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c26a07412f3928ff9ec97b5e4fe5fa0874ececb205dd8ee0b43410bd58e64c1
+    manifestHash: 93d0408db1854a36d54b528ca1ec3c65416149cd32a13b632c7772a0e7fa5d5d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 5252a97ecec46324a88de56fec57065d3703372c5a4f96bd9afe1d42c4adbb5c
+    manifestHash: b134b43a1995714a1b50d0fd738e11f12f3803e269d0f3c02ce9bcf93e98d451
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 5252a97ecec46324a88de56fec57065d3703372c5a4f96bd9afe1d42c4adbb5c
+    manifestHash: b134b43a1995714a1b50d0fd738e11f12f3803e269d0f3c02ce9bcf93e98d451
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a378c5fb27b77ec70f5a03a41ec28ecb1b71dec5c7ef185b360f554d1f662a4d
+    manifestHash: a198b7f8583d4de090f7a3ecfea955ad136dc44cf070724e77195a1d0d6c8d72
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 3ab16a9cefd6dbb84220c68dcc487fd71c3898b98af6087d9d971d3d71d3df76
+    manifestHash: 5313be36f31fdc3c3ba87b1a6da8712d568cd5a06f2ed4333a38db011baf0a6d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 2d1a2b9f44bb721601bdfc57298e34680936ce2aca90846a9178461cd1f931d4
+    manifestHash: 5354237939783054df50973b50a0ec1b95c58f62b2128e47ed28f1f178954ba5
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -825,6 +827,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d62b713889f8066fb883e5e04870e03c17688e53d32199189d7578766e78bb2e
+    manifestHash: 74bb879436e2e5f1717af718e0e319feceb3ebec946e27572c8f03430434331a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 54ecc8b136c4d24bd66833dbdc1d235c3bc824c70df73779864f3f206da1cf04
+    manifestHash: e89b1bba5f73eb8708262083f878e5916bfbf10c7e322f6982fe40ba5ded9d2b
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: febca8e1982b1e16bd967b4047c66f46088a6f59e62a9b93ffc9ea66d0af6e8f
+    manifestHash: 7a29809ef51bc0cb56ef0d1a5d0e37dff38edfba896183b77bae7117c76fdd9e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 61600996b4b0adf9e516d4aeffb7ec0ca00494981836b40f51b6ce3426fe082c
+    manifestHash: a39b5c6deb70bf88b581c24d2d3e752e59cec226e1e1cba13858750559025a91
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -825,6 +827,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d62b713889f8066fb883e5e04870e03c17688e53d32199189d7578766e78bb2e
+    manifestHash: 74bb879436e2e5f1717af718e0e319feceb3ebec946e27572c8f03430434331a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -825,6 +827,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -193,7 +193,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1d04946f48ae612c59f04d9a90afd45aa7810fd80dcc64a946d8b658baeace79
+    manifestHash: ac0511a9705d540841c47594fe8602c5973b330b663183746d569dd1a8f1c00f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -825,6 +827,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -200,7 +200,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1d04946f48ae612c59f04d9a90afd45aa7810fd80dcc64a946d8b658baeace79
+    manifestHash: ac0511a9705d540841c47594fe8602c5973b330b663183746d569dd1a8f1c00f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -825,6 +827,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -200,7 +200,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1d04946f48ae612c59f04d9a90afd45aa7810fd80dcc64a946d8b658baeace79
+    manifestHash: ac0511a9705d540841c47594fe8602c5973b330b663183746d569dd1a8f1c00f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -825,6 +827,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -201,7 +201,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1d04946f48ae612c59f04d9a90afd45aa7810fd80dcc64a946d8b658baeace79
+    manifestHash: ac0511a9705d540841c47594fe8602c5973b330b663183746d569dd1a8f1c00f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -193,7 +193,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 96eec4df3745eb85e9a7ba139d741745e279f42de54afaa223e69d1c183f05c3
+    manifestHash: 16db6197c0c8e0c130b26bd6ede539b6d863883ccac18ad6b51b588f39b68024
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -193,7 +193,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 97f8be0979ecf0a0b507be92e0631a661dd601131e1b7669b7efab4c0d4ce3c5
+    manifestHash: ed1b738cbfc6dd4fd91486578f1c59d127d68d99e4572e72f43b2bfe26412b69
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 2c7506ddc006eb098a21db10ea1b863083485de80458e55c0597b36404b25ec3
+    manifestHash: d06b2f3caef453378f19e3040249001ed8b612b837da2860cd303b8293d43602
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: dcbacd67dd0844e6d76ad13a0d7e8d39b7a216f1dec6de1cf9a1e0c184ebeeef
+    manifestHash: f38bc82dea9c1bc332603334b34a71535e080c7f7a1e436b24e734ad6fd0e5e8
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -610,6 +610,8 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -833,6 +835,8 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -168,7 +168,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 43158ad1257aa193e900986eff6da985bf7f083113af4f97c5e3d668c067ef0a
+    manifestHash: 0538f811cfa4b6d55f9e1c69a088f63845c48a957e5cdc5dd2fabb9fa18f4bb6
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -610,6 +610,8 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -833,6 +835,8 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -121,7 +121,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 43158ad1257aa193e900986eff6da985bf7f083113af4f97c5e3d668c067ef0a
+    manifestHash: 0538f811cfa4b6d55f9e1c69a088f63845c48a957e5cdc5dd2fabb9fa18f4bb6
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -610,6 +610,8 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -833,6 +835,8 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 43158ad1257aa193e900986eff6da985bf7f083113af4f97c5e3d668c067ef0a
+    manifestHash: 0538f811cfa4b6d55f9e1c69a088f63845c48a957e5cdc5dd2fabb9fa18f4bb6
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -610,6 +610,8 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -833,6 +835,8 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 43158ad1257aa193e900986eff6da985bf7f083113af4f97c5e3d668c067ef0a
+    manifestHash: 0538f811cfa4b6d55f9e1c69a088f63845c48a957e5cdc5dd2fabb9fa18f4bb6
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 109ba92bb06d627e7cc6b6694d6dfe30b91d7afd5bb06fa1385c4cfa641850b5
+    manifestHash: 8718ea9697e1ea69f26ac88a5ff5f634e93fc1b8ba6a0218926f2b336a124fb6
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6ca9d899055ace676b3236bc1e4ff64e04daeaaeb5d353be822424e18e29e6f3
+    manifestHash: c5def33d876bebb6f1f1e7f639e5ed6f21e5409bc5cb1e6ce2f5d2d2d62c1d0f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d07103082d66a59e37877f66c533d8c84d7640625bd0d18163dbce7703e46225
+    manifestHash: 78181aa58d1469369e1646201b3550fe240324a71134752a7a295562177d847f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -825,6 +827,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 03566539071dca3cf9770bd56612f3a6e35fd4ae0f6b5f4f77f61c3382ddf49b
+    manifestHash: 505a1828c1807a52166f8cf34bbf91c2a7caec363c7d87cef2bb4d0cc022e25f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7485b10c0b54bc670462384c285e7639ecbb4d1955b9c3891da31c86fae63184
+    manifestHash: bc10d57d4e7b2c5fb38e19436929cfa77e2f5e8a6fdffdea1c4d1c6dac1b2b0f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7485b10c0b54bc670462384c285e7639ecbb4d1955b9c3891da31c86fae63184
+    manifestHash: bc10d57d4e7b2c5fb38e19436929cfa77e2f5e8a6fdffdea1c4d1c6dac1b2b0f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -825,6 +827,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -104,7 +104,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 24a0f2b511f419c185e5f3cbc6e28738df09bbbb688e4a5b7acc20b3a9793ff9
+    manifestHash: 5d9236dec5102773dc5b8b3fed5ba024a01fbe612f01f4134d209d8741444b7a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -104,7 +104,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: ab5224290ceb448165f64e2b324ae3fb39a7fdf661b4b3fef6e727e55a7d227c
+    manifestHash: 88d52f9255800800b21ec02b311457dd8a2fe26f36db38a40b08b04371a89eb0
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 101b894f3f2e40c1819be9a5d53ae9de6dd8d65ab3da8d69c049eca84f667eb0
+    manifestHash: edb006b78b8f4e1b5a63d9f4b3d6563725542278092ce2b09929b9bb813a4afc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: fb98bde23d4bfdd5bad6f78b92ea1b915692f9797494d90371b9d1ea865148d6
+    manifestHash: 7228580af291624742d3f1651561b92ff8239946d5ce69491a2ec69d824061f0
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -168,7 +168,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 8a9b6aeb5c686d90932234b3c5e970f93ec7a5acfe187c9464d935501a804248
+    manifestHash: 4db108d99ac4b4c9ff40be8c2896c20c856cac77c08b847fa5500ec23b2bf29d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -168,7 +168,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 67369f8326905f1c0469df2adbfb37a87182c7e39b9938e127d57b5df13e0dd0
+    manifestHash: 5721c91e34b98ac38072f78782e4ccbabdd01475f456c36aebc19ce78085752f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d0ae0e112c6ef7415627c0962173faebc4fdb125e1b19815e2ef45e150c18ae9
+    manifestHash: b71a7d52f29bfc2850309c5a5066a4208572f15f631b897283dbeae4c6ed817a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d0ae0e112c6ef7415627c0962173faebc4fdb125e1b19815e2ef45e150c18ae9
+    manifestHash: b71a7d52f29bfc2850309c5a5066a4208572f15f631b897283dbeae4c6ed817a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d0ae0e112c6ef7415627c0962173faebc4fdb125e1b19815e2ef45e150c18ae9
+    manifestHash: b71a7d52f29bfc2850309c5a5066a4208572f15f631b897283dbeae4c6ed817a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 75e26c518920dc2c8a78b8d0ad334d7f8bd0bcd3be042e3de93918c222b4f91d
+    manifestHash: 30f273d539a0b4b4594a11cd469e3284f4d2ba44b171a8166ed0db11546a6ccd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 91976b1733bcc3bfc32f1d17c79d2f106efdad46145c7718cfcc0e948f39dce0
+    manifestHash: 519a85e27066bd22a91117895c5c3f562f589cbf17bc32e1e4508bbc0c23f500
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 305a17f31f59a70cd04721d00755e39bf7d5e0bab9f706bb22612f1a023d89dd
+    manifestHash: 43877c2bf22dfa8943611aa6dc474c06a1730b956a110b545f3582f418b058be
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -164,7 +164,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 48759f8020c5b1e82c29891f91e5bcd3b0a9d89f6be6ae9a7d8e8f0e928a9c4c
+    manifestHash: 49dc04dbd12a2c01b0db65312b88a0b1ac0017ee1e223ea9305f04f875f3ee35
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -155,7 +155,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a27064034623e13758ff501920edf3556473a3c6f7592c59809e0bdc5f1ca89f
+    manifestHash: f23f8651fe918c0e7a1139e4f4135765ba482fe303f4b33f8495a4a741846671
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -825,6 +827,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d62b713889f8066fb883e5e04870e03c17688e53d32199189d7578766e78bb2e
+    manifestHash: 74bb879436e2e5f1717af718e0e319feceb3ebec946e27572c8f03430434331a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a0b91204c6171bed5995a1d755f7c154ce0773d0c47a4672c66433d1cfb9b402
+    manifestHash: 4a0e7769f6956f12ef70231e394d5148b56842fa349d022bf15817922fa7dde2
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 600b287761f793797340ea6b00029d68a71491194081ceb4d12e2b67c9ad9815
+    manifestHash: 01b2455299f15b1202ddc5a93fe28310db4553a170c52a79cefa8d141668a9f2
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -610,6 +610,8 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -833,6 +835,8 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 43158ad1257aa193e900986eff6da985bf7f083113af4f97c5e3d668c067ef0a
+    manifestHash: 0538f811cfa4b6d55f9e1c69a088f63845c48a957e5cdc5dd2fabb9fa18f4bb6
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 87ec137e7e4d4a5e4ff30873f3333761905aafabb2d019e62626f3d870f2a396
+    manifestHash: 8bd9ce63049028c7526b3a37b4470370bdfa78c6b9152b920d582a0afbb6c7ac
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -608,6 +608,8 @@ spec:
         - --logging-format=text
         - --v=2
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         - name: CSI_NODE_NAME
@@ -829,6 +831,8 @@ spec:
         - --logging-format=text
         - --v=5
         env:
+        - name: AWS_REGION
+          value: us-test-1
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: e71cd82ccebd29d821334317bf9b6e571fb69ac87bfb4505e7bf96d8c3e429cd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -419,6 +419,8 @@ spec:
             - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
               value: IPv6
             {{- end }}
+            - name: AWS_REGION
+              value: {{ Region }}
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
             - name: CSI_NODE_NAME
@@ -682,6 +684,8 @@ spec:
             - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
               value: IPv6
             {{- end }}
+            - name: AWS_REGION
+              value: {{ Region }}
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: CSI_NODE_NAME

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: 95f0b30ef92c99f6e30309c9e9c3bf247c74e6139e870eddd57d9603d224adfc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: 95f0b30ef92c99f6e30309c9e9c3bf247c74e6139e870eddd57d9603d224adfc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: 95f0b30ef92c99f6e30309c9e9c3bf247c74e6139e870eddd57d9603d224adfc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: 95f0b30ef92c99f6e30309c9e9c3bf247c74e6139e870eddd57d9603d224adfc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: 95f0b30ef92c99f6e30309c9e9c3bf247c74e6139e870eddd57d9603d224adfc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: 95f0b30ef92c99f6e30309c9e9c3bf247c74e6139e870eddd57d9603d224adfc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: 95f0b30ef92c99f6e30309c9e9c3bf247c74e6139e870eddd57d9603d224adfc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -128,7 +128,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: 95f0b30ef92c99f6e30309c9e9c3bf247c74e6139e870eddd57d9603d224adfc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: 95f0b30ef92c99f6e30309c9e9c3bf247c74e6139e870eddd57d9603d224adfc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d62b713889f8066fb883e5e04870e03c17688e53d32199189d7578766e78bb2e
+    manifestHash: f76034a1c9e3adc0be8ec35ecfdd4a229268abe27dbf37f4f5b4e271726bd335
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d49c2cbbf7a84e880835314656860aa5ad5814e883fbdc1cde274df3cd3438bf
+    manifestHash: 95f0b30ef92c99f6e30309c9e9c3bf247c74e6139e870eddd57d9603d224adfc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io


### PR DESCRIPTION
Even if not mandatory, AWS_REGION is desired:
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/0c459169dd183c1b1fb27443d562cc0f6579a62b/pkg/driver/node.go#L92
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/0c459169dd183c1b1fb27443d562cc0f6579a62b/pkg/driver/controller.go#L81
```
==== START logs for CURRENT container ebs-plugin of pod kube-system/ebs-csi-node-225c7 ====
I0102 06:52:14.411180       1 driver.go:78] "Driver Information" Driver="ebs.csi.aws.com" Version="v1.25.0"
I0102 06:52:14.411305       1 node.go:84] "regionFromSession Node service" region=""
I0102 06:52:14.411325       1 metadata.go:85] "retrieving instance data from ec2 metadata"
I0102 06:52:17.594067       1 metadata.go:88] "ec2 metadata is not available"
I0102 06:52:17.594105       1 metadata.go:96] "retrieving instance data from kubernetes api"
I0102 06:52:17.594641       1 metadata.go:101] "kubernetes api is available"
==== END logs for CURRENT container ebs-plugin of pod kube-system/ebs-csi-node-225c7 ====
```