### PR TITLE
aws: Use instance metadata to get warm pool state

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -1116,6 +1116,9 @@ func addASLifecyclePolicies(p *Policy, enableHookSupport bool) {
 			"autoscaling:DescribeLifecycleHooks",
 		)
 	}
+	// TODO: remove this after k8s 1.29 support is removed
+	// It is no longer needed as of kops 1.29 but to prevent node bootstrap issues
+	// during kops upgrades we keep the permission until it is guaranteed to not be needed.
 	p.unconditionalAction.Insert(
 		"autoscaling:DescribeAutoScalingInstances",
 	)

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -246,9 +246,12 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 		}
 		modelContext.InstanceID = string(instanceIDBytes)
 
-		modelContext.ConfigurationMode, err = getAWSConfigurationMode(ctx, modelContext)
-		if err != nil {
-			return err
+		// Check if WarmPool is enabled first, to avoid additional API calls
+		if len(modelContext.NodeupConfig.WarmPoolImages) > 0 {
+			modelContext.ConfigurationMode, err = getAWSConfigurationMode(ctx, modelContext)
+			if err != nil {
+				return err
+			}
 		}
 
 		modelContext.MachineType, err = getMachineType()
@@ -713,6 +716,11 @@ func getNodeConfigFromServers(ctx context.Context, bootConfig *nodeup.BootConfig
 }
 
 func getAWSConfigurationMode(ctx context.Context, c *model.NodeupModelContext) (string, error) {
+	// Check if WarmPool is enabled first, to avoid additional API calls
+	if len(c.NodeupConfig.WarmPoolImages) == 0 {
+		return "", nil
+	}
+
 	// Only worker nodes and apiservers can actually autoscale.
 	// We are not adding describe permissions to the other roles
 	role := c.BootConfig.InstanceGroupRole


### PR DESCRIPTION
This should eliminate some of the API throttling during scale tests and help with time for nodes to join the cluster

See the example userdata [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/tutorial-lifecycle-hook-instance-metadata.html#instance-metadata-create-hello-world-function) for usage of this instance metadata endpoint. I confirmed the 404 behavior works on non-ASG instances.