### PR TITLE
Add permission needed for service-linked role creation

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -831,6 +831,7 @@ func AddCCMPermissions(p *Policy, cloudRoutes bool) {
 		"elasticloadbalancing:DescribeLoadBalancerPolicies",
 		"elasticloadbalancing:DescribeTargetGroups",
 		"elasticloadbalancing:DescribeTargetHealth",
+		"iam:CreateServiceLinkedRole",
 		"kms:DescribeKey",
 	)
 
@@ -884,7 +885,7 @@ func AddCCMPermissions(p *Policy, cloudRoutes bool) {
 	}
 }
 
-// AddAWSLoadbalancerControllerPermissions adds the permissions needed for the AWS Load Balancer Controller to the givnen policy
+// AddAWSLoadbalancerControllerPermissions adds the permissions needed for the AWS Load Balancer Controller to the given policy
 func AddAWSLoadbalancerControllerPermissions(p *Policy, enableWAF, enableWAFv2, enableShield bool) {
 	p.unconditionalAction.Insert(
 		"cognito-idp:DescribeUserPoolClient",

--- a/pkg/model/iam/tests/iam_builder_master_gossip.json
+++ b/pkg/model/iam/tests/iam_builder_master_gossip.json
@@ -127,6 +127,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/pkg/model/iam/tests/iam_builder_master_gossip_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_gossip_ecr.json
@@ -134,6 +134,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -127,6 +127,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -134,6 +134,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
@@ -196,6 +196,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -50,6 +50,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "kms:DescribeKey"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_masters.cas-priority-expander-custom.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_masters.cas-priority-expander-custom.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_masters.cas-priority-expander.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_masters.cas-priority-expander.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -50,6 +50,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "kms:DescribeKey"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -50,6 +50,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "kms:DescribeKey"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -50,6 +50,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "kms:DescribeKey"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -50,6 +50,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "kms:DescribeKey"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -50,6 +50,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "kms:DescribeKey"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -50,6 +50,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "kms:DescribeKey"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -250,6 +250,7 @@
         "elasticloadbalancing:DescribeTargetGroupAttributes",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
@@ -250,6 +250,7 @@
         "elasticloadbalancing:DescribeTargetGroupAttributes",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -196,6 +196,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -196,6 +196,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -196,6 +196,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -196,6 +196,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -196,6 +196,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -196,6 +196,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_masters.minimal-aws.example.com_policy
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_masters.minimal-aws.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -166,6 +166,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -191,6 +191,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -191,6 +191,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -191,6 +191,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -191,6 +191,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.long.cluster-name.m-kaamp9_policy
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.long.cluster-name.m-kaamp9_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -159,6 +159,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.k8s.local_policy
@@ -50,6 +50,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "kms:DescribeKey"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.nthimdsproces-25s838_policy
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.nthimdsproces-25s838_policy
@@ -50,6 +50,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "kms:DescribeKey"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
@@ -197,6 +197,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -199,6 +199,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
@@ -209,6 +209,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -50,6 +50,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "kms:DescribeKey"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -191,6 +191,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -189,6 +189,7 @@
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetHealth",
+        "iam:CreateServiceLinkedRole",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:CreateGrant",


### PR DESCRIPTION
Attempting to fix:
  - https://github.com/kubernetes/kops/issues/16218

by adding the permission needed for the AWS CCM to create a service-linked role for the elastic lb service.