### PR TITLE
Remove kube-system cert-manager webhook exclusion

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 81498170aca814f74ac23c3b323e3c866dc4bbd4bbebacec51a4e73ec798a287
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10080,10 +10080,6 @@ webhooks:
       operator: NotIn
       values:
       - "true"
-    - key: name
-      operator: NotIn
-      values:
-      - kube-system
   rules:
   - apiGroups:
     - cert-manager.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 81498170aca814f74ac23c3b323e3c866dc4bbd4bbebacec51a4e73ec798a287
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10080,10 +10080,6 @@ webhooks:
       operator: NotIn
       values:
       - "true"
-    - key: name
-      operator: NotIn
-      values:
-      - kube-system
   rules:
   - apiGroups:
     - cert-manager.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 81498170aca814f74ac23c3b323e3c866dc4bbd4bbebacec51a4e73ec798a287
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10080,10 +10080,6 @@ webhooks:
       operator: NotIn
       values:
       - "true"
-    - key: name
-      operator: NotIn
-      values:
-      - kube-system
   rules:
   - apiGroups:
     - cert-manager.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -63,7 +63,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 81498170aca814f74ac23c3b323e3c866dc4bbd4bbebacec51a4e73ec798a287
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10080,10 +10080,6 @@ webhooks:
       operator: NotIn
       values:
       - "true"
-    - key: name
-      operator: NotIn
-      values:
-      - kube-system
   rules:
   - apiGroups:
     - cert-manager.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -63,7 +63,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 81498170aca814f74ac23c3b323e3c866dc4bbd4bbebacec51a4e73ec798a287
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10080,10 +10080,6 @@ webhooks:
       operator: NotIn
       values:
       - "true"
-    - key: name
-      operator: NotIn
-      values:
-      - kube-system
   rules:
   - apiGroups:
     - cert-manager.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -64,7 +64,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 81498170aca814f74ac23c3b323e3c866dc4bbd4bbebacec51a4e73ec798a287
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10080,10 +10080,6 @@ webhooks:
       operator: NotIn
       values:
       - "true"
-    - key: name
-      operator: NotIn
-      values:
-      - kube-system
   rules:
   - apiGroups:
     - cert-manager.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 81498170aca814f74ac23c3b323e3c866dc4bbd4bbebacec51a4e73ec798a287
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10080,10 +10080,6 @@ webhooks:
       operator: NotIn
       values:
       - "true"
-    - key: name
-      operator: NotIn
-      values:
-      - kube-system
   rules:
   - apiGroups:
     - cert-manager.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 81498170aca814f74ac23c3b323e3c866dc4bbd4bbebacec51a4e73ec798a287
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10080,10 +10080,6 @@ webhooks:
       operator: NotIn
       values:
       - "true"
-    - key: name
-      operator: NotIn
-      values:
-      - kube-system
   rules:
   - apiGroups:
     - cert-manager.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 81498170aca814f74ac23c3b323e3c866dc4bbd4bbebacec51a4e73ec798a287
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10080,10 +10080,6 @@ webhooks:
       operator: NotIn
       values:
       - "true"
-    - key: name
-      operator: NotIn
-      values:
-      - kube-system
   rules:
   - apiGroups:
     - cert-manager.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 81498170aca814f74ac23c3b323e3c866dc4bbd4bbebacec51a4e73ec798a287
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10080,10 +10080,6 @@ webhooks:
       operator: NotIn
       values:
       - "true"
-    - key: name
-      operator: NotIn
-      values:
-      - kube-system
   rules:
   - apiGroups:
     - cert-manager.io

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -5621,10 +5621,6 @@ webhooks:
         operator: "NotIn"
         values:
         - "true"
-      - key: "name"
-        operator: "NotIn"
-        values:
-        - kube-system
     rules:
       - apiGroups:
           - "cert-manager.io"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 81498170aca814f74ac23c3b323e3c866dc4bbd4bbebacec51a4e73ec798a287
     name: certmanager.io
     prune:
       kinds:


### PR DESCRIPTION
Continuing to troubleshoot the cluster validation flakes in https://testgrid.k8s.io/kops-misc#kops-aws-aws-load-balancer-controller 

This matchExpression was removed upstream in https://github.com/cert-manager/cert-manager/pull/6129 