### PR TITLE
Dont list and terminate ASG-managed EC2 instances

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -63,7 +63,6 @@ func ListResourcesAWS(cloud awsup.AWSCloud, clusterInfo resources.ClusterInfo) (
 	listFunctions := []listFn{
 		// EC2
 		ListAutoScalingGroups,
-		ListInstances,
 		ListKeypairs,
 		ListSecurityGroups,
 		ListVolumes,
@@ -86,6 +85,12 @@ func ListResourcesAWS(cloud awsup.AWSCloud, clusterInfo resources.ClusterInfo) (
 		ListSQSQueues,
 		// EventBridge
 		ListEventBridgeRules,
+	}
+
+	if clusterInfo.UsesKarpenter {
+		// ASG deletion cascades to their instances
+		// Only karpenter-enabled clusters have instances not in ASGs
+		listFunctions = append(listFunctions, ListInstances)
 	}
 
 	if !dns.IsGossipClusterName(clusterName) && !clusterUsesNoneDNS {

--- a/pkg/resources/clusterinfo.go
+++ b/pkg/resources/clusterinfo.go
@@ -17,8 +17,9 @@ limitations under the License.
 package resources
 
 type ClusterInfo struct {
-	Name        string
-	UsesNoneDNS bool
+	Name          string
+	UsesNoneDNS   bool
+	UsesKarpenter bool
 	// Azure specific
 	AzureResourceGroupName   string
 	AzureResourceGroupShared bool

--- a/pkg/resources/ops/collector.go
+++ b/pkg/resources/ops/collector.go
@@ -41,8 +41,9 @@ import (
 // ListResources collects the resources from the specified cloud
 func ListResources(cloud fi.Cloud, cluster *kops.Cluster) (map[string]*resources.Resource, error) {
 	clusterInfo := resources.ClusterInfo{
-		Name:        cluster.Name,
-		UsesNoneDNS: cluster.UsesNoneDNS(),
+		Name:          cluster.Name,
+		UsesNoneDNS:   cluster.UsesNoneDNS(),
+		UsesKarpenter: cluster.Spec.Karpenter != nil && cluster.Spec.Karpenter.Enabled,
 	}
 
 	switch cloud.ProviderID() {


### PR DESCRIPTION
/hold for feedback

Looking at [scale tests](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/16204/presubmit-kops-aws-scale-amazonvpc-using-cl2/1742962895290896384/build-log.txt), kops delete cluster spends 6 minutes trying to terminate all of the ec2 instances. In reality this shouldn't be necessary because kops also deletes the ASGs (which appear to happen much faster) and the ASGs will terminate the instances.

I dont know how the timing compares but it should at least eliminate the throttled API calls.