### PR TITLE
aws: Set provider ID when starting kubelet

### DIFF
--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -195,7 +195,7 @@ func runKubeletBuilder(t *testing.T, context *fi.NodeupModelBuilderContext, node
 		return
 	}
 	{
-		fileTask, err := buildKubeletComponentConfig(kubeletConfig)
+		fileTask, err := buildKubeletComponentConfig(kubeletConfig, "")
 		if err != nil {
 			t.Fatalf("error from KubeletBuilder buildKubeletComponentConfig: %v", err)
 			return
@@ -406,7 +406,7 @@ func Test_BuildComponentConfigFile(t *testing.T) {
 		ShutdownGracePeriodCriticalPods: &metav1.Duration{Duration: 10 * time.Second},
 	}
 
-	_, err := buildKubeletComponentConfig(&componentConfig)
+	_, err := buildKubeletComponentConfig(&componentConfig, "")
 	if err != nil {
 		t.Errorf("Failed to build component config file: %v", err)
 	}


### PR DESCRIPTION
Seeing this in scale-test logs:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/16204/presubmit-kops-aws-scale-amazonvpc-using-cl2/1742962895290896384/artifacts/cluster-info/kube-system/kops-controller-6zn8r/kops-controller.log
```
E0104 17:49:08.753991       1 controller.go:329] "msg"="Reconciler error" "error"="error identifying node \"i-010f7ccf4cfd4f129\":
providerID was not set for node i-010f7ccf4cfd4f129" "Node"={"name":"i-010f7ccf4cfd4f129"} "controller"="node" "controllerGroup"="" "controllerKind"="Node" "name"="i-010f7ccf4cfd4f129" "namespace"="" "reconcileID"="c14b9e58-c70b-489e-9166-99d86a4ec093"
```

/cc @rifelpet 