### PR TITLE
Make cluster deletion configurable

### DIFF
--- a/docs/cli/kops_delete_cluster.md
+++ b/docs/cli/kops_delete_cluster.md
@@ -24,11 +24,14 @@ kops delete cluster [CLUSTER] [flags]
 ### Options
 
 ```
-      --external        Delete an external cluster
-  -h, --help            help for cluster
-      --region string   External cluster's cloud region
-      --unregister      Don't delete cloud resources, just unregister the cluster
-  -y, --yes             Specify --yes to delete the cluster
+      --count int           Number of consecutive failures to make progress deleting the cluster resources (default 42)
+      --external            Delete an external cluster
+  -h, --help                help for cluster
+      --interval duration   Time in duration to wait between deletion attempts (default 10s)
+      --region string       External cluster's cloud region
+      --unregister          Don't delete cloud resources, just unregister the cluster
+      --wait duration       Amount of time to wait for the cluster resources to de deleted
+  -y, --yes                 Specify --yes to delete the cluster
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Cluster deletion fails on large clusters (5k node) due to no progress being made while waiting for the ASG to be deleted in the background.
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/16204/presubmit-kops-aws-scale-amazonvpc-using-cl2/1743704473194205184

Making cluster deleting configurable, similar to validation options should help with that.

/cc @rifelpet @upodroid @hakuna-matatah @dims 