### PR TITLE
gce: Switch from using targetpools to backend services

### DIFF
--- a/cloudmock/gce/mockcompute/api.go
+++ b/cloudmock/gce/mockcompute/api.go
@@ -137,11 +137,11 @@ func (c *MockClient) HTTPHealthChecks() gce.HttpHealthChecksClient {
 	return c.httpHealthChecksClient
 }
 
-func (c *MockClient) RegionHealthChecks() gce.RegionHealthChecksClient {
+func (c *MockClient) HealthChecks() gce.HealthChecksClient {
 	return c.healthCheckClient
 }
 
-func (c *MockClient) RegionBackendServices() gce.RegionBackendServiceClient {
+func (c *MockClient) BackendServices() gce.BackendServiceClient {
 	return c.backendServiceClient
 }
 

--- a/cloudmock/gce/mockcompute/backend_services.go
+++ b/cloudmock/gce/mockcompute/backend_services.go
@@ -31,7 +31,7 @@ type backendServiceClient struct {
 	sync.Mutex
 }
 
-var _ gce.RegionBackendServiceClient = &backendServiceClient{}
+var _ gce.BackendServiceClient = &backendServiceClient{}
 
 func newBackendServiceClient() *backendServiceClient {
 	return &backendServiceClient{

--- a/cloudmock/gce/mockcompute/health_checks.go
+++ b/cloudmock/gce/mockcompute/health_checks.go
@@ -31,7 +31,7 @@ type healthCheckClient struct {
 	sync.Mutex
 }
 
-var _ gce.RegionHealthChecksClient = &healthCheckClient{}
+var _ gce.HealthChecksClient = &healthCheckClient{}
 
 func newHealthCheckClient() *healthCheckClient {
 	return &healthCheckClient{

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -384,7 +384,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.APILoadBalancerClass, "api-loadbalancer-class", options.APILoadBalancerClass, "Class of load balancer for the Kubernetes API (AWS only): classic or network")
 	cmd.Flags().MarkDeprecated("api-loadbalancer-class", "network load balancer should be used for all newly created clusters")
 	cmd.RegisterFlagCompletionFunc("api-loadbalancer-class", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"classic", "network"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{"classic", "network", "regional", "global"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	cmd.Flags().StringVar(&options.APILoadBalancerType, "api-loadbalancer-type", options.APILoadBalancerType, "Type of load balancer for the Kubernetes API: public or internal")
 	cmd.RegisterFlagCompletionFunc("api-loadbalancer-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -505,8 +505,10 @@ const (
 type LoadBalancerClass string
 
 const (
-	LoadBalancerClassClassic LoadBalancerClass = "Classic"
-	LoadBalancerClassNetwork LoadBalancerClass = "Network"
+	LoadBalancerClassClassic  LoadBalancerClass = "Classic"
+	LoadBalancerClassNetwork  LoadBalancerClass = "Network"
+	LoadBalancerClassRegional LoadBalancerClass = "Regional"
+	LoadBalancerClassGlobal   LoadBalancerClass = "Global"
 )
 
 type AccessLogSpec struct {

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -224,9 +224,6 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 		lbSpec := spec.API.LoadBalancer
 		lbPath := fieldPath.Child("api", "loadBalancer")
 		if spec.GetCloudProvider() != kops.CloudProviderAWS {
-			if lbSpec.Class != "" {
-				allErrs = append(allErrs, field.Forbidden(lbPath.Child("class"), "class is only supported on AWS"))
-			}
 			if lbSpec.IdleTimeoutSeconds != nil {
 				allErrs = append(allErrs, field.Forbidden(lbPath.Child("idleTimeoutSeconds"), "idleTimeoutSeconds is only supported on AWS"))
 			}

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -301,6 +301,11 @@ func (b *KopsModelContext) UseNetworkLoadBalancer() bool {
 	return b.Cluster.Spec.API.LoadBalancer.Class == kops.LoadBalancerClassNetwork
 }
 
+// UseRegionalLoadBalancer checks if we are using Regional LoadBalancer
+func (b *KopsModelContext) UseRegionalLoadBalancer() bool {
+	return b.Cluster.Spec.API.LoadBalancer.Class == kops.LoadBalancerClassRegional
+}
+
 // UseSSHKey returns true if SSHKeyName from the cluster spec is set to a nonempty string
 // or there is an SSH public key provisioned in the key store.
 func (b *KopsModelContext) UseSSHKey() bool {

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -309,23 +309,6 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 				InstanceTemplate:            instanceTemplate,
 				ListManagedInstancesResults: "PAGINATED",
 			}
-
-			// Attach masters to load balancer if we're using one
-			switch ig.Spec.Role {
-			case kops.InstanceGroupRoleControlPlane:
-				if b.UseLoadBalancerForAPI() {
-					lbSpec := b.Cluster.Spec.API.LoadBalancer
-					if lbSpec != nil {
-						switch lbSpec.Type {
-						case kops.LoadBalancerTypePublic:
-							t.TargetPools = append(t.TargetPools, b.LinkToTargetPool("api"))
-						case kops.LoadBalancerTypeInternal:
-							klog.Warningf("Not hooking the instance group manager up to anything.")
-						}
-					}
-				}
-			}
-
 			c.AddTask(t)
 		}
 	}

--- a/pkg/model/gcemodel/context.go
+++ b/pkg/model/gcemodel/context.go
@@ -96,6 +96,10 @@ func (c *GCEModelContext) LinkToTargetPool(id string) *gcetasks.TargetPool {
 	return &gcetasks.TargetPool{Name: s(c.NameForTargetPool(id))}
 }
 
+func (c *GCEModelContext) LinkToBackendService(id string) *gcetasks.BackendService {
+	return &gcetasks.BackendService{Name: s(c.NameForBackendService(id))}
+}
+
 func (c *GCEModelContext) NameForTargetPool(id string) string {
 	return c.SafeSuffixedObjectName(id)
 }

--- a/tests/integration/create_cluster/minimal-1.26-gce-dns-none/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26-gce-dns-none/expected-v1alpha2.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   api:
     loadBalancer:
+      class: Regional
       type: Public
   authorization:
     rbac: {}

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   api:
     loadBalancer:
+      class: Regional
       type: Public
   authorization:
     rbac: {}

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -478,13 +478,6 @@ resource "google_compute_forwarding_rule" "kops-controller-us-test1-minimal-gce-
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-example-com.name
 }
 
-resource "google_compute_health_check" "api-minimal-gce-example-com" {
-  name = "api-minimal-gce-example-com"
-  tcp_health_check {
-    port = 443
-  }
-}
-
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-example-com" {
   base_instance_name             = "master-us-test1-a"
   list_managed_instances_results = "PAGINATED"
@@ -610,6 +603,18 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
 resource "google_compute_network" "minimal-gce-example-com" {
   auto_create_subnetworks = false
   name                    = "minimal-gce-example-com"
+}
+
+resource "google_compute_region_health_check" "api-minimal-gce-example-com" {
+  http_health_check {
+    port         = 443
+    request_path = "/healthz"
+  }
+  name   = "api-minimal-gce-example-com"
+  region = "us-test1"
+  tcp_health_check {
+    port = 0
+  }
 }
 
 resource "google_compute_router" "nat-minimal-gce-example-com" {

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -447,13 +447,6 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-ilb-example-
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-ilb-example-com.name
 }
 
-resource "google_compute_health_check" "api-minimal-gce-ilb-example-com" {
-  name = "api-minimal-gce-ilb-example-com"
-  tcp_health_check {
-    port = 443
-  }
-}
-
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-ilb-example-com" {
   base_instance_name             = "master-us-test1-a"
   list_managed_instances_results = "PAGINATED"
@@ -579,6 +572,18 @@ resource "google_compute_instance_template" "nodes-minimal-gce-ilb-example-com" 
 resource "google_compute_network" "minimal-gce-ilb-example-com" {
   auto_create_subnetworks = false
   name                    = "minimal-gce-ilb-example-com"
+}
+
+resource "google_compute_region_health_check" "api-minimal-gce-ilb-example-com" {
+  http_health_check {
+    port         = 443
+    request_path = "/healthz"
+  }
+  name   = "api-minimal-gce-ilb-example-com"
+  region = "us-test1"
+  tcp_health_check {
+    port = 0
+  }
 }
 
 resource "google_compute_router" "nat-minimal-gce-ilb-example-com" {

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -447,13 +447,6 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-with-a-very-
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi.name
 }
 
-resource "google_compute_health_check" "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com" {
-  name = "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
-  tcp_health_check {
-    port = 443
-  }
-}
-
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f" {
   base_instance_name             = "master-us-test1-a"
   list_managed_instances_results = "PAGINATED"
@@ -579,6 +572,18 @@ resource "google_compute_instance_template" "nodes-minimal-gce-with-a-very-very-
 resource "google_compute_network" "minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi" {
   auto_create_subnetworks = false
   name                    = "minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi"
+}
+
+resource "google_compute_region_health_check" "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com" {
+  http_health_check {
+    port         = 443
+    request_path = "/healthz"
+  }
+  name   = "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
+  region = "us-test1"
+  tcp_health_check {
+    port = 0
+  }
 }
 
 resource "google_compute_router" "nat-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi" {

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -318,6 +318,11 @@ func (c *gceCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]f
 	var ingresses []fi.ApiIngressStatus
 
 	klog.V(2).Infof("Querying GCE to find forwardingRules for API")
+	region := ""
+	if cluster.Spec.API.LoadBalancer.Class == kops.LoadBalancerClassRegional {
+		region = c.region
+	}
+	klog.V(2).Infof("Querying GCE to find ForwardingRules for API")
 	// These are the ingress rules, so we search for them in the network project.
 	_, project, err := ParseNameAndProjectFromNetworkID(cluster.Spec.Networking.NetworkID)
 	if err != nil {
@@ -326,7 +331,7 @@ func (c *gceCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]f
 		project = c.Project()
 	}
 
-	forwardingRules, err := c.compute.ForwardingRules().List(context.Background(), project, c.region)
+	forwardingRules, err := c.compute.ForwardingRules().List(context.Background(), project, region)
 	if err != nil {
 		if !IsNotFound(err) {
 			forwardingRules = nil

--- a/upup/pkg/fi/cloudup/gcetasks/address.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address.go
@@ -36,6 +36,7 @@ type Address struct {
 	IPAddress     *string
 	IPAddressType *string
 	Purpose       *string
+	Region        string
 
 	Subnetwork *Subnet
 
@@ -51,7 +52,7 @@ func (e *Address) CompareWithID() *string {
 }
 
 func (e *Address) Find(c *fi.CloudupContext) (*Address, error) {
-	actual, err := e.find(c.T.Cloud.(gce.GCECloud))
+	actual, err := e.find(c.T.Cloud.(gce.GCECloud), e.Region)
 	if actual != nil && err == nil {
 		if e.IPAddress == nil {
 			e.IPAddress = actual.IPAddress
@@ -64,9 +65,9 @@ func (e *Address) Find(c *fi.CloudupContext) (*Address, error) {
 	return actual, err
 }
 
-func findAddressByIP(cloud gce.GCECloud, ip string) (*Address, error) {
+func findAddressByIP(cloud gce.GCECloud, ip, region string) (*Address, error) {
 	// Technically this is a regex, but it doesn't matter...
-	addrs, err := cloud.Compute().Addresses().ListWithFilter(cloud.Project(), cloud.Region(), "address eq "+ip)
+	addrs, err := cloud.Compute().Addresses().ListWithFilter(cloud.Project(), region, "address eq "+ip)
 	if err != nil {
 		return nil, fmt.Errorf("error listing IP Addresses: %v", err)
 	}
@@ -87,8 +88,8 @@ func findAddressByIP(cloud gce.GCECloud, ip string) (*Address, error) {
 	return actual, nil
 }
 
-func (e *Address) find(cloud gce.GCECloud) (*Address, error) {
-	r, err := cloud.Compute().Addresses().Get(cloud.Project(), cloud.Region(), *e.Name)
+func (e *Address) find(cloud gce.GCECloud, region string) (*Address, error) {
+	r, err := cloud.Compute().Addresses().Get(cloud.Project(), region, *e.Name)
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -120,7 +121,7 @@ func (e *Address) GetWellKnownServices() []wellknownservices.WellKnownService {
 }
 
 func (e *Address) FindAddresses(context *fi.CloudupContext) ([]string, error) {
-	actual, err := e.find(context.T.Cloud.(gce.GCECloud))
+	actual, err := e.find(context.T.Cloud.(gce.GCECloud), e.Region)
 	if err != nil {
 		return nil, fmt.Errorf("error querying for IP Address: %v", err)
 	}
@@ -153,7 +154,7 @@ func (_ *Address) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Address) error {
 		Address:     fi.ValueOf(e.IPAddress),
 		AddressType: fi.ValueOf(e.IPAddressType),
 		Purpose:     fi.ValueOf(e.Purpose),
-		Region:      cloud.Region(),
+		Region:      e.Region,
 	}
 
 	if e.Subnetwork != nil {
@@ -163,7 +164,7 @@ func (_ *Address) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Address) error {
 	if a == nil {
 		klog.V(2).Infof("Creating Address: %q", addr.Name)
 
-		op, err := cloud.Compute().Addresses().Insert(cloud.Project(), cloud.Region(), addr)
+		op, err := cloud.Compute().Addresses().Insert(cloud.Project(), e.Region, addr)
 		if err != nil {
 			return fmt.Errorf("error creating IP Address: %v", err)
 		}

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1490,6 +1490,17 @@ func setupAPI(opt *NewClusterOptions, cluster *api.Cluster) error {
 		}
 	}
 
+	if cluster.Spec.API.LoadBalancer != nil && cluster.Spec.API.LoadBalancer.Class == "" && cluster.Spec.GetCloudProvider() == api.CloudProviderGCE {
+		switch opt.APILoadBalancerClass {
+		case "global":
+			cluster.Spec.API.LoadBalancer.Class = api.LoadBalancerClassGlobal
+		case "", "regional":
+			cluster.Spec.API.LoadBalancer.Class = api.LoadBalancerClassRegional
+		default:
+			return fmt.Errorf("unknown api-loadbalancer-class: %q", opt.APILoadBalancerClass)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Google recommends creating NLBs using Backend Services instead of TargetPools to take advantage of newer features

https://cloud.google.com/load-balancing/docs/network/networklb-target-pools

Also, this change "almost" supports global LBs(missing TCP target proxy resource)
Google splits some services in to regional vs global with identical object types. I fixed the methods to detect if a region is being supplied.

Why:
1. I want to try and see if global TCP Proxy LBs don't trigger ddos protection when running scale tests.
2. If Ddos protection kicks in, we can write a cloud-armor policy that allows 1k rps(10k reqs per 10s) from any IP.