### PR TITLE
aws: Use `domain` instead of `vpc` when rendering `aws_eip`

### DIFF
--- a/tests/integration/update_cluster/additionalobjects/kubernetes.tf
+++ b/tests/integration/update_cluster/additionalobjects/kubernetes.tf
@@ -980,7 +980,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/apiservernodes/kubernetes.tf
+++ b/tests/integration/update_cluster/apiservernodes/kubernetes.tf
@@ -1130,7 +1130,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -1130,7 +1130,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -406,12 +406,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-bastionuserdata-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-bastionuserdata-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                                 = "bastionuserdata.example.com"
     "Name"                                              = "us-test-1a.bastionuserdata.example.com"
     "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_elb" "api-bastionuserdata-example-com" {
@@ -1462,7 +1462,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/kubernetes.tf
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/kubernetes.tf
@@ -1223,7 +1223,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/kubernetes.tf
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/kubernetes.tf
@@ -1223,7 +1223,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -1391,7 +1391,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -925,7 +925,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/containerd-custom/kubernetes.tf
+++ b/tests/integration/update_cluster/containerd-custom/kubernetes.tf
@@ -937,7 +937,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/containerd/kubernetes.tf
+++ b/tests/integration/update_cluster/containerd/kubernetes.tf
@@ -937,7 +937,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/digit/kubernetes.tf
+++ b/tests/integration/update_cluster/digit/kubernetes.tf
@@ -1029,7 +1029,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -1351,7 +1351,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -1789,7 +1789,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/external_dns/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns/kubernetes.tf
@@ -937,7 +937,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
@@ -1086,7 +1086,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -941,7 +941,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -1174,7 +1174,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -1423,7 +1423,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -819,7 +819,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -1072,7 +1072,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/karpenter/kubernetes.tf
+++ b/tests/integration/update_cluster/karpenter/kubernetes.tf
@@ -1298,7 +1298,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -56,12 +56,12 @@ provider "aws" {
 }
 
 resource "aws_eip" "us-test-1a-lifecyclephases-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                                 = "lifecyclephases.example.com"
     "Name"                                              = "us-test-1a.lifecyclephases.example.com"
     "kubernetes.io/cluster/lifecyclephases.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_internet_gateway" "lifecyclephases-example-com" {
@@ -193,7 +193,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 4.0.0"
+      "version" = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
@@ -1199,7 +1199,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/kubernetes.tf
@@ -1207,7 +1207,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/kubernetes.tf
@@ -1207,7 +1207,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/kubernetes.tf
@@ -1207,7 +1207,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
@@ -1009,7 +1009,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -599,7 +599,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/many-addons/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons/kubernetes.tf
@@ -994,7 +994,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-1.24/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.24/kubernetes.tf
@@ -988,7 +988,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-1.25/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.25/kubernetes.tf
@@ -988,7 +988,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-1.26/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.26/kubernetes.tf
@@ -980,7 +980,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-1.27/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.27/kubernetes.tf
@@ -980,7 +980,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-1.28/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.28/kubernetes.tf
@@ -980,7 +980,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-1.29/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.29/kubernetes.tf
@@ -980,7 +980,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-aws/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-aws/kubernetes.tf
@@ -937,7 +937,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-dns-none/kubernetes.tf
@@ -1141,7 +1141,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-etcd/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-etcd/kubernetes.tf
@@ -937,7 +937,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -933,7 +933,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
@@ -366,21 +366,21 @@ resource "aws_egress_only_internet_gateway" "minimal-ipv6-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-minimal-ipv6-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1a.minimal-ipv6.example.com"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_eip" "us-test-1b-minimal-ipv6-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1b.minimal-ipv6.example.com"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_iam_instance_profile" "masters-minimal-ipv6-example-com" {
@@ -1389,7 +1389,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
@@ -366,21 +366,21 @@ resource "aws_egress_only_internet_gateway" "minimal-ipv6-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-minimal-ipv6-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1a.minimal-ipv6.example.com"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_eip" "us-test-1b-minimal-ipv6-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1b.minimal-ipv6.example.com"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_iam_instance_profile" "masters-minimal-ipv6-example-com" {
@@ -1380,7 +1380,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/kubernetes.tf
@@ -366,21 +366,21 @@ resource "aws_egress_only_internet_gateway" "minimal-ipv6-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-minimal-ipv6-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1a.minimal-ipv6.example.com"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_eip" "us-test-1b-minimal-ipv6-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1b.minimal-ipv6.example.com"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_iam_instance_profile" "masters-minimal-ipv6-example-com" {
@@ -1372,7 +1372,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
@@ -366,21 +366,21 @@ resource "aws_egress_only_internet_gateway" "minimal-ipv6-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-minimal-ipv6-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1a.minimal-ipv6.example.com"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_eip" "us-test-1b-minimal-ipv6-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1b.minimal-ipv6.example.com"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_iam_instance_profile" "masters-minimal-ipv6-example-com" {
@@ -1372,7 +1372,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-longclustername/kubernetes.tf
@@ -937,7 +937,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
@@ -957,7 +957,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -575,7 +575,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -669,7 +669,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -638,7 +638,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -638,7 +638,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -575,7 +575,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -628,7 +628,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -588,7 +588,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
@@ -937,7 +937,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gossip_irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/kubernetes.tf
@@ -1058,7 +1058,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_hetzner/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_hetzner/kubernetes.tf
@@ -311,7 +311,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
     hcloud = {
       "source"  = "hetznercloud/hcloud"

--- a/tests/integration/update_cluster/minimal_scaleway/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_scaleway/kubernetes.tf
@@ -275,7 +275,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
     scaleway = {
       "source"  = "scaleway/scaleway"

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -1441,7 +1441,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -1441,7 +1441,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/kubernetes.tf
@@ -983,7 +983,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/nth-imds-processor/kubernetes.tf
+++ b/tests/integration/update_cluster/nth-imds-processor/kubernetes.tf
@@ -834,7 +834,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/nvidia/kubernetes.tf
+++ b/tests/integration/update_cluster/nvidia/kubernetes.tf
@@ -953,7 +953,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -1412,7 +1412,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -1319,7 +1319,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -406,12 +406,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatecalico-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-privatecalico-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                               = "privatecalico.example.com"
     "Name"                                            = "us-test-1a.privatecalico.example.com"
     "kubernetes.io/cluster/privatecalico.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_elb" "api-privatecalico-example-com" {
@@ -1510,7 +1510,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -406,12 +406,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatecanal-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-privatecanal-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                              = "privatecanal.example.com"
     "Name"                                           = "us-test-1a.privatecanal.example.com"
     "kubernetes.io/cluster/privatecanal.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_elb" "api-privatecanal-example-com" {
@@ -1469,7 +1469,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium-eni/kubernetes.tf
@@ -406,12 +406,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatecilium-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-privatecilium-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"
     "Name"                                            = "us-test-1a.privatecilium.example.com"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_elb" "api-privatecilium-example-com" {
@@ -1461,7 +1461,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -406,12 +406,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatecilium-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-privatecilium-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"
     "Name"                                            = "us-test-1a.privatecilium.example.com"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_elb" "api-privatecilium-example-com" {
@@ -1461,7 +1461,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -406,12 +406,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatecilium-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-privatecilium-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"
     "Name"                                            = "us-test-1a.privatecilium.example.com"
     "kubernetes.io/cluster/privatecilium.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_elb" "api-privatecilium-example-com" {
@@ -1477,7 +1477,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -423,12 +423,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privateciliumadvanced-example-co
 }
 
 resource "aws_eip" "us-test-1a-privateciliumadvanced-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
     "Name"                                                    = "us-test-1a.privateciliumadvanced.example.com"
     "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_elb" "api-privateciliumadvanced-example-com" {
@@ -1494,7 +1494,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -448,6 +448,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatedns1-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-privatedns1-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "us-test-1a.privatedns1.example.com"
@@ -455,7 +456,6 @@ resource "aws_eip" "us-test-1a-privatedns1-example-com" {
     "foo/bar"                                       = "fib+baz"
     "kubernetes.io/cluster/privatedns1.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_elb" "api-privatedns1-example-com" {
@@ -1568,7 +1568,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -406,12 +406,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatedns2-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-privatedns2-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                             = "privatedns2.example.com"
     "Name"                                          = "us-test-1a.privatedns2.example.com"
     "kubernetes.io/cluster/privatedns2.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_elb" "api-privatedns2-example-com" {
@@ -1421,7 +1421,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -406,12 +406,12 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privateflannel-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-privateflannel-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                                = "privateflannel.example.com"
     "Name"                                             = "us-test-1a.privateflannel.example.com"
     "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_elb" "api-privateflannel-example-com" {
@@ -1469,7 +1469,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -1534,7 +1534,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -1094,7 +1094,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -862,7 +862,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -905,7 +905,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/kubernetes.tf
@@ -357,21 +357,21 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-ipv6-example-com" {
 }
 
 resource "aws_eip" "us-test-1a-minimal-ipv6-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1a.minimal-ipv6.example.com"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_eip" "us-test-1b-minimal-ipv6-example-com" {
+  domain = "vpc"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1b.minimal-ipv6.example.com"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
   }
-  vpc = true
 }
 
 resource "aws_iam_instance_profile" "masters-minimal-ipv6-example-com" {
@@ -1331,7 +1331,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -1405,7 +1405,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -974,7 +974,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 4.0.0"
+      "version"               = ">= 5.0.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -251,7 +251,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 4.0.0"
+      "version" = ">= 5.0.0"
     }
   }
 }
@@ -325,7 +325,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 4.0.0"
+      "version" = ">= 5.0.0"
     }
   }
 }
@@ -408,7 +408,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 4.0.0"
+      "version" = ">= 5.0.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -271,8 +271,8 @@ func (_ *ElasticIP) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *ElasticIP) e
 }
 
 type terraformElasticIP struct {
-	VPC  *bool             `cty:"vpc"`
-	Tags map[string]string `cty:"tags"`
+	Domain *string           `cty:"domain"`
+	Tags   map[string]string `cty:"tags"`
 }
 
 func (_ *ElasticIP) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ElasticIP) error {
@@ -285,8 +285,8 @@ func (_ *ElasticIP) RenderTerraform(t *terraform.TerraformTarget, a, e, changes 
 	}
 
 	tf := &terraformElasticIP{
-		VPC:  aws.Bool(true),
-		Tags: e.Tags,
+		Domain: aws.String("vpc"),
+		Tags:   e.Tags,
 	}
 
 	return t.RenderResource("aws_eip", *e.Name, tf)

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
@@ -98,7 +98,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 4.0.0"
+      "version" = ">= 5.0.0"
     }
   }
 }
@@ -184,7 +184,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 4.0.0"
+      "version" = ">= 5.0.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -241,7 +241,7 @@ func (t *TerraformTarget) writeTerraform(buf *bytes.Buffer) {
 		providerVersions := map[string]map[string]string{
 			"aws": {
 				"source":  "hashicorp/aws",
-				"version": ">= 4.0.0",
+				"version": ">= 5.0.0",
 			},
 			"google": {
 				"source":  "hashicorp/google",


### PR DESCRIPTION
```
/home/prow/go/src/k8s.io/kops/tests/integration/update_cluster/bastionadditional_user-data
╷
│ Warning: Argument is deprecated
│ 
│   with aws_eip.us-test-1a-bastionuserdata-example-com,
│   on kubernetes.tf line 414, in resource "aws_eip" "us-test-1a-bastionuserdata-example-com":
│  414:   vpc = true
│ 
│ use domain attribute instead
╵
Success! The configuration is valid, but there were some
validation warnings as shown above.
```
Ref: https://github.com/hashicorp/terraform-provider-aws/issues/26714