### PR TITLE
Bump GCP terraform provider to latest

### DIFF
--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -823,7 +823,7 @@ terraform {
     }
     google = {
       "source"  = "hashicorp/google"
-      "version" = ">= 2.19.0"
+      "version" = ">= 5.11.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-gce/kubernetes.tf
@@ -603,7 +603,7 @@ terraform {
     }
     google = {
       "source"  = "hashicorp/google"
-      "version" = ">= 2.19.0"
+      "version" = ">= 5.11.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -579,7 +579,7 @@ terraform {
     }
     google = {
       "source"  = "hashicorp/google"
-      "version" = ">= 2.19.0"
+      "version" = ">= 5.11.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -673,7 +673,7 @@ terraform {
     }
     google = {
       "source"  = "hashicorp/google"
-      "version" = ">= 2.19.0"
+      "version" = ">= 5.11.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -642,7 +642,7 @@ terraform {
     }
     google = {
       "source"  = "hashicorp/google"
-      "version" = ">= 2.19.0"
+      "version" = ">= 5.11.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -642,7 +642,7 @@ terraform {
     }
     google = {
       "source"  = "hashicorp/google"
-      "version" = ">= 2.19.0"
+      "version" = ">= 5.11.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -579,7 +579,7 @@ terraform {
     }
     google = {
       "source"  = "hashicorp/google"
-      "version" = ">= 2.19.0"
+      "version" = ">= 5.11.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -632,7 +632,7 @@ terraform {
     }
     google = {
       "source"  = "hashicorp/google"
-      "version" = ">= 2.19.0"
+      "version" = ">= 5.11.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -592,7 +592,7 @@ terraform {
     }
     google = {
       "source"  = "hashicorp/google"
-      "version" = ">= 2.19.0"
+      "version" = ">= 5.11.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -245,7 +245,7 @@ func (t *TerraformTarget) writeTerraform(buf *bytes.Buffer) {
 			},
 			"google": {
 				"source":  "hashicorp/google",
-				"version": ">= 2.19.0",
+				"version": ">= 5.11.0",
 			},
 			"hcloud": {
 				"source":  "hetznercloud/hcloud",


### PR DESCRIPTION
From skimming all the [major version upgrade guides](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_5_upgrade), it doesn't appear there are any changes needed