### PR TITLE
Automated cherry pick of #16245: Update Go to v1.21.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: '1.21.5'
+          go-version: '1.21.6'
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
@@ -36,7 +36,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: '1.21.5'
+        go-version: '1.21.6'
 
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       with:
@@ -53,7 +53,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: '1.21.5'
+        go-version: '1.21.6'
 
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       with:
@@ -70,7 +70,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: '1.21.5'
+          go-version: '1.21.6'
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -17,10 +17,10 @@ jobs:
     if: ${{ github.repository == 'kubernetes/kops' }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: '1.21.5'
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+          go-version: '1.21.6'
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Update Dependencies
         id: update_deps
         run: |

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # Push the images
-- name: 'docker.io/library/golang:1.21.5-bookworm'
+- name: 'docker.io/library/golang:1.21.6-bookworm'
   id: images
   entrypoint: make
   env:
@@ -21,7 +21,7 @@ steps:
   - dns-controller-push
   - kube-apiserver-healthcheck-push
 # Push the artifacts
-- name: 'docker.io/library/golang:1.21.5-bookworm'
+- name: 'docker.io/library/golang:1.21.6-bookworm'
   id: artifacts
   entrypoint: make
   env:
@@ -36,7 +36,7 @@ steps:
   args:
   - gcs-upload-and-tag
 # Build cloudbuild artifacts (for attestation)
-- name: 'docker.io/library/golang:1.21.5-bookworm'
+- name: 'docker.io/library/golang:1.21.6-bookworm'
   id: cloudbuild-artifacts
   entrypoint: make
   env:


### PR DESCRIPTION
Cherry pick of #16245 on release-1.28.

#16245: Update Go to v1.21.6

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```