### PR TITLE
Prefer external endpoints when building kubeconfig

### DIFF
--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -72,6 +72,9 @@ type SubnetInfo struct {
 // ApiIngressStatus represents the status of an ingress point:
 // traffic intended for the service should be sent to an ingress point.
 type ApiIngressStatus struct {
+	// InternalEndpoint is true when the endpoint is only reachable from the cloud.
+	InternalEndpoint bool
+
 	// IP is set for load-balancer ingress points that are IP based
 	// (typically GCE or OpenStack load-balancers)
 	// +optional


### PR DESCRIPTION
This means that if/when we have multiple load balancers, we will go
through the external one by default.
