### PR TITLE
aws: fix maxPods when cilium ipam=eni is used

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -634,7 +634,7 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 	c.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
 
 	// Respect any MaxPods value the user sets explicitly.
-	if b.NodeupConfig.Networking.AmazonVPC != nil && c.MaxPods == nil {
+	if (b.NodeupConfig.Networking.AmazonVPC != nil || (b.NodeupConfig.Networking.Cilium != nil && b.NodeupConfig.Networking.Cilium.IPAM == kops.CiliumIpamEni)) && c.MaxPods == nil {
 		sess := session.Must(session.NewSession())
 		metadata := ec2metadata.New(sess)
 


### PR DESCRIPTION
**What does this PR introduce?**
This PR addresses the issue where kubelet is configured with maxPods 100 in the AWS environment and when cilium with ipam=eni is used.

**Why is this change needed?**
The number of IP addresses is connected to the AWS instance type and is much less than 100 which is the default maxPods value. So, for small instance types we in most cases end up with the pod not being able to schedule because of 'No IP's left to assign on aws instances'

**How does it address the issue?**
We use the same code to determine maxPods per AWS instance type as for amazonvpc networking.

**Related Issue**
Fixes https://github.com/kubernetes/kops/issues/16064