### PR TITLE
gce: fix nlb firewall rules, operations and alias network subnets

### DIFF
--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -62,6 +62,8 @@ func (b *FirewallModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				// https://cloud.google.com/load-balancing/docs/health-checks
 				"35.191.0.0/16",
 				"130.211.0.0/22",
+				"209.85.204.0/22",
+				"209.85.152.0/22",
 			},
 			TargetTags: []string{b.GCETagForRole(kops.InstanceGroupRoleControlPlane)},
 			Allowed:    []string{"tcp"},

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -266,7 +266,7 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-example-com" {
   disabled      = false
   name          = "lb-health-checks-minimal-gce-example-com"
   network       = google_compute_network.minimal-gce-example-com.name
-  source_ranges = ["35.191.0.0/16", "130.211.0.0/22"]
+  source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
   target_tags   = ["minimal-gce-example-com-k8s-io-role-control-plane"]
 }
 

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -250,7 +250,7 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-ilb-example-com
   disabled      = false
   name          = "lb-health-checks-minimal-gce-ilb-example-com"
   network       = google_compute_network.minimal-gce-ilb-example-com.name
-  source_ranges = ["35.191.0.0/16", "130.211.0.0/22"]
+  source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
   target_tags   = ["minimal-gce-ilb-example-com-k8s-io-role-control-plane"]
 }
 

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -250,7 +250,7 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-with-a-very-ver
   disabled      = false
   name          = "lb-health-checks-minimal-gce-with-a-very-very-very-very--96dqvi"
   network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
-  source_ranges = ["35.191.0.0/16", "130.211.0.0/22"]
+  source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
   target_tags   = ["minimal-gce-with-a-very-very-v-96dqvi-k8s-io-role-control-plane"]
 }
 

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -237,7 +237,7 @@ resource "google_compute_firewall" "lb-health-checks-minimal-gce-plb-example-com
   disabled      = false
   name          = "lb-health-checks-minimal-gce-plb-example-com"
   network       = google_compute_network.minimal-gce-plb-example-com.name
-  source_ranges = ["35.191.0.0/16", "130.211.0.0/22"]
+  source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.204.0/22", "209.85.152.0/22"]
   target_tags   = ["minimal-gce-plb-example-com-k8s-io-role-control-plane"]
 }
 

--- a/upup/pkg/fi/cloudup/gce/network.go
+++ b/upup/pkg/fi/cloudup/gce/network.go
@@ -167,12 +167,12 @@ func performNetworkAssignmentsIPAliases(ctx context.Context, c *kops.Cluster, cl
 		return err
 	}
 
-	serviceCIDR, err := used.Allocate(networkCIDR, net.CIDRMask(20, 32))
+	serviceCIDR, err := used.Allocate(networkCIDR, net.CIDRMask(16, 32))
 	if err != nil {
 		return err
 	}
 
-	nodeCIDR, err := used.Allocate(networkCIDR, net.CIDRMask(20, 32))
+	nodeCIDR, err := used.Allocate(networkCIDR, net.CIDRMask(19, 32))
 	if err != nil {
 		return err
 	}

--- a/upup/pkg/fi/cloudup/gce/op.go
+++ b/upup/pkg/fi/cloudup/gce/op.go
@@ -58,7 +58,7 @@ func waitForZoneOp(client *compute.Service, op *compute.Operation) error {
 	}
 
 	return waitForOp(op, func(operationName string) (*compute.Operation, error) {
-		return client.ZoneOperations.Get(u.Project, u.Zone, operationName).Do()
+		return client.ZoneOperations.Wait(u.Project, u.Zone, operationName).Do()
 	})
 }
 
@@ -69,7 +69,7 @@ func waitForRegionOp(client *compute.Service, op *compute.Operation) error {
 	}
 
 	return waitForOp(op, func(operationName string) (*compute.Operation, error) {
-		return client.RegionOperations.Get(u.Project, u.Region, operationName).Do()
+		return client.RegionOperations.Wait(u.Project, u.Region, operationName).Do()
 	})
 }
 
@@ -80,7 +80,7 @@ func waitForGlobalOp(client *compute.Service, op *compute.Operation) error {
 	}
 
 	return waitForOp(op, func(operationName string) (*compute.Operation, error) {
-		return client.GlobalOperations.Get(u.Project, operationName).Do()
+		return client.GlobalOperations.Wait(u.Project, operationName).Do()
 	})
 }
 
@@ -108,7 +108,8 @@ func waitForOp(op *compute.Operation, getOperation func(operationName string) (*
 		}
 		pollOp, err := getOperation(opName)
 		if err != nil {
-			klog.Warningf("GCE poll operation %s failed: pollOp: [%v] err: [%v] getErrorFromOp: [%v]", opName, pollOp, err, getErrorFromOp(pollOp))
+			klog.Warningf("GCE poll operation %s failed: pollOp: [%v] err: [%v]", opName, pollOp, err)
+			klog.Infof("getErrorFromOp: [%v]", getErrorFromOp(pollOp))
 		}
 		done := opIsDone(pollOp)
 		if done {


### PR DESCRIPTION
Splitting #16181 to separate PRs

This one fixes bugs in GCE infra creation.
- Uses WAIT instead of GET polling for operations. This uses [fewer](https://cloud.google.com/compute/docs/reference/rest/v1/globalOperations/wait) API calls to track operations.
- Increases the GCE alias mode subnet sizes to support 5k nodes
- Fixes a [missing](https://cloud.google.com/load-balancing/docs/health-checks#fw-netlb) firewall rule for NLBs