### PR TITLE
Fix dumping logs for GCE scale tests

### DIFF
--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -210,7 +210,14 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 			return fmt.Errorf("adding key to SSH agent: %w", err)
 		}
 
-		dumper := dump.NewLogDumper(cluster.ObjectMeta.Name, sshConfig, keyRing, options.Dir)
+		// look for a bastion instance and use it if exists
+		bastionAddress := ""
+		for _, instance := range d.Instances {
+			if strings.Contains(instance.Name, "bastion") {
+				bastionAddress = instance.PublicAddresses[0]
+			}
+		}
+		dumper := dump.NewLogDumper(bastionAddress, sshConfig, keyRing, options.Dir)
 
 		var additionalIPs []string
 		var additionalPrivateIPs []string
@@ -224,7 +231,7 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 			}
 		}
 
-		if err := dumper.DumpAllNodes(ctx, nodes, additionalIPs, additionalPrivateIPs); err != nil {
+		if err := dumper.DumpAllNodes(ctx, nodes, options.MaxNodes, additionalIPs, additionalPrivateIPs); err != nil {
 			return fmt.Errorf("error dumping nodes: %v", err)
 		}
 

--- a/pkg/resources/gce/dump.go
+++ b/pkg/resources/gce/dump.go
@@ -63,6 +63,12 @@ func DumpManagedInstance(op *resources.DumpOperation, r *resources.Resource) err
 		klog.Warningf("instance %q not found", instance.Instance)
 	} else {
 		for _, ni := range instanceDetails.NetworkInterfaces {
+			if ni.NetworkIP != "" {
+				i.PrivateAddresses = append(i.PrivateAddresses, ni.NetworkIP)
+			}
+			if ni.Ipv6Address != "" {
+				i.PrivateAddresses = append(i.PrivateAddresses, ni.Ipv6Address)
+			}
 			for _, ac := range ni.AccessConfigs {
 				if ac.NatIP != "" {
 					i.PublicAddresses = append(i.PublicAddresses, ac.NatIP)

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -100,6 +100,8 @@ func (d *deployer) initialize() error {
 				d.SSHPublicKeyPath = publicKey
 			}
 			d.createBucket = true
+		} else if d.SSHPrivateKeyPath == "" && os.Getenv("KUBE_SSH_KEY_PATH") != "" {
+			d.SSHPrivateKeyPath = os.Getenv("KUBE_SSH_KEY_PATH")
 		}
 	}
 

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -68,6 +68,7 @@ type deployer struct {
 	ValidationWait     time.Duration `flag:"validation-wait" desc:"time to wait for newly created cluster to pass validation"`
 	ValidationCount    int           `flag:"validation-count" desc:"how many times should a validation pass"`
 	ValidationInterval time.Duration `flag:"validation-interval" desc:"time in duration to wait between validation attempts"`
+	MaxNodesToDump     string        `flag:"max-nodes-to-dump" desc:"max number of nodes to dump logs from, helpful to set when running scale tests"`
 
 	TemplatePath string `flag:"template-path" desc:"The path to the manifest template used for cluster creation"`
 

--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -44,6 +44,10 @@ func (d *deployer) DumpClusterLogs() error {
 		"--private-key", d.SSHPrivateKeyPath,
 		"--ssh-user", d.SSHUser,
 	}
+
+	if d.MaxNodesToDump != "" {
+		args = append(args, "--max-nodes", d.MaxNodesToDump)
+	}
 	klog.Info(strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(append(d.env(), "KOPS_TOOLBOX_DUMP_K8S_RESOURCES=1")...)


### PR DESCRIPTION
Splitting https://github.com/kubernetes/kops/pull/16181 to separate PRs

1. When a bastion is being used, kops tries to use it by its hostname which doesn't work with `--dns=none`. Using the IP address is much easier
2. we also dump the bastion IP in the logs
3. `--max-nodes` flag is now respected by the DumpAllNodes function.
4. kubetest2 now sets the `--ssh-private-key` automatically when running kops gce clusters, this flag must be set for the `kops toolbox dump` cmd to work
5. We calculate the correct internal IP addresses of GCE instances to use with bastions.
