### PR TITLE
Add `boskos-resource-type` flag to use different GCE projects for scale/gpu testing

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/gce"
@@ -72,7 +71,7 @@ func (d *deployer) initialize() error {
 		if d.GCPProject == "" {
 			klog.V(1).Info("No GCP project provided, acquiring from Boskos")
 
-			boskosClient, err := boskos.NewClient("http://boskos.test-pods.svc.cluster.local.")
+			boskosClient, err := boskos.NewClient(d.BoskosLocation)
 			if err != nil {
 				return fmt.Errorf("failed to make boskos client: %s", err)
 			}
@@ -80,9 +79,9 @@ func (d *deployer) initialize() error {
 
 			resource, err := boskos.Acquire(
 				d.boskos,
-				"gce-project",
-				5*time.Minute,
-				5*time.Minute,
+				d.BoskosResourceType,
+				d.BoskosAcquireTimeout,
+				d.BoskosHeartbeatInterval,
 				d.boskosHeartbeatClose,
 			)
 			if err != nil {

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -91,8 +91,11 @@ type deployer struct {
 
 	// boskos struct field will be non-nil when the deployer is
 	// using boskos to acquire a GCP project
-	boskos *client.Client
-
+	boskos                  *client.Client
+	BoskosLocation          string        `flag:"boskos-location" desc:"If set, manually specifies the location of the Boskos server."`
+	BoskosAcquireTimeout    time.Duration `flag:"boskos-acquire-timeout" desc:"How long should boskos wait to acquire a resource before timing out"`
+	BoskosHeartbeatInterval time.Duration `flag:"boskos-heartbeat-interval" desc:"How often should boskos send a heartbeat to Boskos to hold the acquired resource. 0 means no heartbeat."`
+	BoskosResourceType      string        `flag:"boskos-resource-type" desc:"If set, manually specifies the resource type of GCP projects to acquire from Boskos."`
 	// this channel serves as a signal channel for the hearbeat goroutine
 	// so that it can be explicitly closed
 	boskosHeartbeatClose chan struct{}
@@ -117,11 +120,14 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 		BuildOptions: &builder.BuildOptions{
 			BuildKubernetes: false,
 		},
-		boskosHeartbeatClose: make(chan struct{}),
-		ValidationCount:      10,
-		ValidationInterval:   10 * time.Second,
+		boskosHeartbeatClose:    make(chan struct{}),
+		ValidationCount:         10,
+		ValidationInterval:      10 * time.Second,
+		BoskosLocation:          "http://boskos.test-pods.svc.cluster.local.",
+		BoskosResourceType:      "gce-project",
+		BoskosAcquireTimeout:    5 * time.Minute,
+		BoskosHeartbeatInterval: 5 * time.Minute,
 	}
-
 	dir, err := defaultArtifactsDir()
 	if err != nil {
 		klog.Fatalf("unable to determine artifacts directory: %v", err)

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -193,7 +193,6 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 			args = appendIfUnset(args, "--project", d.GCPProject)
 		}
 		// set some sane default e2e testing behaviour on gce
-		args = appendIfUnset(args, "--gce-service-account", "default")
 		args = appendIfUnset(args, "--networking", "kubenet")
 		args = appendIfUnset(args, "--node-volume-size", "100")
 

--- a/tests/e2e/scenarios/build/run-test.sh
+++ b/tests/e2e/scenarios/build/run-test.sh
@@ -27,7 +27,7 @@ kubetest2 kops -v=6 \
     --up --down --build --build-kubernetes=true --target-build-arch=linux/amd64 \
     --cloud-provider=gce --admin-access=0.0.0.0/0 \
     --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt \
-    --create-args "--networking=kubenet --set=spec.nodeProblemDetector.enabled=true" \
+    --create-args "--gce-service-account=default --networking=kubenet --set=spec.nodeProblemDetector.enabled=true" \
     --test=kops \
     -- \
     --ginkgo-args="--debug" \


### PR DESCRIPTION
Required for https://github.com/kubernetes/kops/pull/16181

When we are running scale/gpu tests, we need to use a dedicated pool of GCE projects called `scalability-project`, `scalability-scale-project` and `gpu-project`. This PR adds support for that feature.

Defined here https://github.com/kubernetes/k8s.io/blob/main/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/boskos-resources-configmap.yaml#L174

