### PR TITLE
gce: Change default storage class to balanced-csi

### DIFF
--- a/docs/releases/1.29-NOTES.md
+++ b/docs/releases/1.29-NOTES.md
@@ -35,6 +35,8 @@ instances.
 ## GCP
 
 * As of Kubernetes version 1.29, credentials for private GCR/AR repositories will be handled by the out-of-tree credential provider. This is an additional binary that each instance downloads from the assets repository.
+* Two additional `StorageClasses` are created on GCP clusters. These are called `balanced-csi` and `ssd-csi` and utilize the GCP Balanced and SSD Persistent Disk volume types respectively.
+* **Breaking Change** - the default `StorageClass` has been changed from `standard-csi` to `balanced-csi`.
 
 ## Openstack
 

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: a93442a083fa3a8031da7c683286343cf09e7e2822a75dba62e0305a32e5d454
+    manifestHash: b8815d8ac98d4fd8003d2429cfb23bb11160f3c1295b8266fda1900910061aab
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,6 +22,8 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -119,7 +119,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 1d0c1cb84c6afaf155c710f4b045176036f330b337fba4528f9690eb43883e7d
+    manifestHash: 0309e99c6e3efbf154f0ca0d42dad2fcbad6269b4e57fef57f9e282c1c3a0f7c
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,6 +22,8 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 78fb4e484de1c743e9d26780a0ecdc250edfe721c27445abc64695f0aa8eb4f6
+    manifestHash: c7693d3106fbc9586abfd4ce371ace3417bf36dc560f57cb5588c84f697c19f6
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,6 +22,8 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 78fb4e484de1c743e9d26780a0ecdc250edfe721c27445abc64695f0aa8eb4f6
+    manifestHash: c7693d3106fbc9586abfd4ce371ace3417bf36dc560f57cb5588c84f697c19f6
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,6 +22,8 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 7b774352cacf71865927549c4035801b025829a3a57be802eb2ff7cd56461473
+    manifestHash: d54cc7d3fb2a9b702b83a7efc0d97d5564e7ade46ccd86de907ac2c41e1a7e92
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,6 +22,8 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 5a5444a9f8e7495481a69eb04b7c2f7a6f52b790b2dd937c53ceb06ca9420f81
+    manifestHash: 2e71d2b51a52edf8f6497177cde0fd2945b3e5533bd00d18ad5517aad4b132cf
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,6 +22,8 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 5a5444a9f8e7495481a69eb04b7c2f7a6f52b790b2dd937c53ceb06ca9420f81
+    manifestHash: 2e71d2b51a52edf8f6497177cde0fd2945b3e5533bd00d18ad5517aad4b132cf
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,6 +22,8 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 8e1135e5e35ab819145872bfe5e29a18fcbb5e52b6b3d3d421ef92d13db33b9c
+    manifestHash: 43d87627a8435bde820421e6ca7db78751f7a7dce1513a6a9047c93f5f290400
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,6 +22,8 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: a0cbcb0974ef466ad126893d70a3aa1f571d901cb53538163c04d81898bb99d7
+    manifestHash: 2fba7d4bf6c803e2b2851acc5c4f04e10724ab0f9c7336957713472e5b8f50fd
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io
@@ -22,6 +22,8 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: gcp-pd-csi-driver.addons.k8s.io

--- a/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
@@ -6,7 +6,7 @@ kind: StorageClass
 metadata:
   name: standard-csi
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "false"
   labels:
     kubernetes.io/cluster-service: "true"
     k8s-addon: gcp-pd-csi-driver.addons.k8s.io
@@ -22,6 +22,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: balanced-csi
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
     k8s-addon: gcp-pd-csi-driver.addons.k8s.io


### PR DESCRIPTION
This change updates the default `StorageClass` to be `balanced-csi` on GCP clusters. 

Balanced persistent disk type is the default set on GKE clusters.

I've updated the release notes with the breaking change, as discussed in the office hours call last year. LMK if there is anywhere else that needs updating. 