### PR TITLE
openstack: Include kube-apiserver controlplane ports in dns=none

### DIFF
--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -201,7 +201,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.CloudupModelBuilderContex
 		c.AddTask(portTask)
 
 		if b.Cluster.UsesNoneDNS() && ig.Spec.Role == kops.InstanceGroupRoleControlPlane {
-			portTask.ForAPIServer = true
+			portTask.WellKnownServices = append(portTask.WellKnownServices, wellknownservices.KubeAPIServer)
 		}
 
 		metaWithName := make(map[string]string)

--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -26,7 +26,6 @@ Port:
   AdditionalSecurityGroups:
   - additional-sg
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -56,6 +55,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -196,7 +196,6 @@ PublicACL: null
 AdditionalSecurityGroups:
 - additional-sg
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -226,6 +225,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -26,7 +26,6 @@ Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -56,6 +55,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -194,7 +194,6 @@ PublicACL: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -224,6 +223,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -26,7 +26,6 @@ Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -56,6 +55,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -194,7 +194,6 @@ PublicACL: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -224,6 +223,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/configures-allowed-address-pairs-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-allowed-address-pairs-with-annotations.yaml
@@ -28,7 +28,6 @@ Port:
   - ip_address: 10.123.0.1
     mac_address: 12:34:56:78:90:AB
   - ip_address: 192.168.0.0/16
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -58,6 +57,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -199,7 +199,6 @@ AllowedAddressPairs:
 - ip_address: 10.123.0.1
   mac_address: 12:34:56:78:90:AB
 - ip_address: 192.168.0.0/16
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -229,6 +228,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
@@ -25,7 +25,6 @@ Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -55,6 +54,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -193,7 +193,6 @@ PublicACL: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -223,6 +222,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -87,7 +87,6 @@ Name: master-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -123,6 +122,7 @@ Port:
   - KopsInstanceGroup=master
   - KopsName=port-master-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -178,7 +178,6 @@ Name: master-2-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -214,6 +213,7 @@ Port:
   - KopsInstanceGroup=master
   - KopsName=port-master-2
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -269,7 +269,6 @@ Name: master-3-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -305,6 +304,7 @@ Port:
   - KopsInstanceGroup=master
   - KopsName=port-master-3
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -355,7 +355,6 @@ Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -385,6 +384,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -435,7 +435,6 @@ Name: node-2-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -465,6 +464,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-2
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -515,7 +515,6 @@ Name: node-3-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -545,6 +544,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-3
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -693,7 +693,6 @@ PublicACL: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -729,10 +728,10 @@ Tags:
 - KopsInstanceGroup=master
 - KopsName=port-master-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -768,10 +767,10 @@ Tags:
 - KopsInstanceGroup=master
 - KopsName=port-master-2
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -807,10 +806,10 @@ Tags:
 - KopsInstanceGroup=master
 - KopsName=port-master-3
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -840,10 +839,10 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -873,10 +872,10 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-2
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -906,6 +905,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-3
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -66,7 +66,6 @@ Name: master-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: true
   ID: null
   InstanceGroupName: master-a
   Lifecycle: Sync
@@ -96,6 +95,8 @@ Port:
   - KopsInstanceGroup=master-a
   - KopsName=port-master-a-1
   - KubernetesCluster=cluster
+  WellKnownServices:
+  - kube-apiserver
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -143,7 +144,6 @@ Name: master-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: true
   ID: null
   InstanceGroupName: master-b
   Lifecycle: Sync
@@ -173,6 +173,8 @@ Port:
   - KopsInstanceGroup=master-b
   - KopsName=port-master-b-1
   - KubernetesCluster=cluster
+  WellKnownServices:
+  - kube-apiserver
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -220,7 +222,6 @@ Name: master-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: true
   ID: null
   InstanceGroupName: master-c
   Lifecycle: Sync
@@ -250,6 +251,8 @@ Port:
   - KopsInstanceGroup=master-c
   - KopsName=port-master-c-1
   - KubernetesCluster=cluster
+  WellKnownServices:
+  - kube-apiserver
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -294,7 +297,6 @@ Name: node-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-a
   Lifecycle: Sync
@@ -324,6 +326,7 @@ Port:
   - KopsInstanceGroup=node-a
   - KopsName=port-node-a-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: ""
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -368,7 +371,6 @@ Name: node-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-b
   Lifecycle: Sync
@@ -398,6 +400,7 @@ Port:
   - KopsInstanceGroup=node-b
   - KopsName=port-node-b-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: ""
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -442,7 +445,6 @@ Name: node-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-c
   Lifecycle: Sync
@@ -472,6 +474,7 @@ Port:
   - KopsInstanceGroup=node-c
   - KopsName=port-node-c-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: ""
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -833,7 +836,6 @@ Pool:
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: true
 ID: null
 InstanceGroupName: master-a
 Lifecycle: Sync
@@ -863,10 +865,11 @@ Tags:
 - KopsInstanceGroup=master-a
 - KopsName=port-master-a-1
 - KubernetesCluster=cluster
+WellKnownServices:
+- kube-apiserver
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: true
 ID: null
 InstanceGroupName: master-b
 Lifecycle: Sync
@@ -896,10 +899,11 @@ Tags:
 - KopsInstanceGroup=master-b
 - KopsName=port-master-b-1
 - KubernetesCluster=cluster
+WellKnownServices:
+- kube-apiserver
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: true
 ID: null
 InstanceGroupName: master-c
 Lifecycle: Sync
@@ -929,10 +933,11 @@ Tags:
 - KopsInstanceGroup=master-c
 - KopsName=port-master-c-1
 - KubernetesCluster=cluster
+WellKnownServices:
+- kube-apiserver
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-a
 Lifecycle: Sync
@@ -962,10 +967,10 @@ Tags:
 - KopsInstanceGroup=node-a
 - KopsName=port-node-a-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-b
 Lifecycle: Sync
@@ -995,10 +1000,10 @@ Tags:
 - KopsInstanceGroup=node-b
 - KopsName=port-node-b-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-c
 Lifecycle: Sync
@@ -1028,6 +1033,7 @@ Tags:
 - KopsInstanceGroup=node-c
 - KopsName=port-node-c-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -66,7 +66,6 @@ Name: master-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master-a
   Lifecycle: Sync
@@ -96,6 +95,7 @@ Port:
   - KopsInstanceGroup=master-a
   - KopsName=port-master-a-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -143,7 +143,6 @@ Name: master-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master-b
   Lifecycle: Sync
@@ -173,6 +172,7 @@ Port:
   - KopsInstanceGroup=master-b
   - KopsName=port-master-b-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -220,7 +220,6 @@ Name: master-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master-c
   Lifecycle: Sync
@@ -250,6 +249,7 @@ Port:
   - KopsInstanceGroup=master-c
   - KopsName=port-master-c-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -294,7 +294,6 @@ Name: node-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-a
   Lifecycle: Sync
@@ -324,6 +323,7 @@ Port:
   - KopsInstanceGroup=node-a
   - KopsName=port-node-a-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -368,7 +368,6 @@ Name: node-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-b
   Lifecycle: Sync
@@ -398,6 +397,7 @@ Port:
   - KopsInstanceGroup=node-b
   - KopsName=port-node-b-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -442,7 +442,6 @@ Name: node-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-c
   Lifecycle: Sync
@@ -472,6 +471,7 @@ Port:
   - KopsInstanceGroup=node-c
   - KopsName=port-node-c-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -833,7 +833,6 @@ Pool:
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master-a
 Lifecycle: Sync
@@ -863,10 +862,10 @@ Tags:
 - KopsInstanceGroup=master-a
 - KopsName=port-master-a-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master-b
 Lifecycle: Sync
@@ -896,10 +895,10 @@ Tags:
 - KopsInstanceGroup=master-b
 - KopsName=port-master-b-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master-c
 Lifecycle: Sync
@@ -929,10 +928,10 @@ Tags:
 - KopsInstanceGroup=master-c
 - KopsName=port-master-c-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-a
 Lifecycle: Sync
@@ -962,10 +961,10 @@ Tags:
 - KopsInstanceGroup=node-a
 - KopsName=port-node-a-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-b
 Lifecycle: Sync
@@ -995,10 +994,10 @@ Tags:
 - KopsInstanceGroup=node-b
 - KopsName=port-node-b-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-c
 Lifecycle: Sync
@@ -1028,6 +1027,7 @@ Tags:
 - KopsInstanceGroup=node-c
 - KopsName=port-node-c-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -99,7 +99,6 @@ Name: master-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master-a
   Lifecycle: Sync
@@ -135,6 +134,7 @@ Port:
   - KopsInstanceGroup=master-a
   - KopsName=port-master-a-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -190,7 +190,6 @@ Name: master-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master-b
   Lifecycle: Sync
@@ -226,6 +225,7 @@ Port:
   - KopsInstanceGroup=master-b
   - KopsName=port-master-b-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -281,7 +281,6 @@ Name: master-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master-c
   Lifecycle: Sync
@@ -317,6 +316,7 @@ Port:
   - KopsInstanceGroup=master-c
   - KopsName=port-master-c-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -367,7 +367,6 @@ Name: node-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-a
   Lifecycle: Sync
@@ -397,6 +396,7 @@ Port:
   - KopsInstanceGroup=node-a
   - KopsName=port-node-a-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -447,7 +447,6 @@ Name: node-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-b
   Lifecycle: Sync
@@ -477,6 +476,7 @@ Port:
   - KopsInstanceGroup=node-b
   - KopsName=port-node-b-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -527,7 +527,6 @@ Name: node-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-c
   Lifecycle: Sync
@@ -557,6 +556,7 @@ Port:
   - KopsInstanceGroup=node-c
   - KopsName=port-node-c-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -745,7 +745,6 @@ PublicACL: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master-a
 Lifecycle: Sync
@@ -781,10 +780,10 @@ Tags:
 - KopsInstanceGroup=master-a
 - KopsName=port-master-a-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master-b
 Lifecycle: Sync
@@ -820,10 +819,10 @@ Tags:
 - KopsInstanceGroup=master-b
 - KopsName=port-master-b-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master-c
 Lifecycle: Sync
@@ -859,10 +858,10 @@ Tags:
 - KopsInstanceGroup=master-c
 - KopsName=port-master-c-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-a
 Lifecycle: Sync
@@ -892,10 +891,10 @@ Tags:
 - KopsInstanceGroup=node-a
 - KopsName=port-node-a-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-b
 Lifecycle: Sync
@@ -925,10 +924,10 @@ Tags:
 - KopsInstanceGroup=node-b
 - KopsName=port-node-b-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-c
 Lifecycle: Sync
@@ -958,6 +957,7 @@ Tags:
 - KopsInstanceGroup=node-c
 - KopsName=port-node-c-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -43,7 +43,6 @@ Name: master-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master-a
   Lifecycle: Sync
@@ -79,6 +78,7 @@ Port:
   - KopsInstanceGroup=master-a
   - KopsName=port-master-a-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -126,7 +126,6 @@ Name: master-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master-b
   Lifecycle: Sync
@@ -162,6 +161,7 @@ Port:
   - KopsInstanceGroup=master-b
   - KopsName=port-master-b-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -209,7 +209,6 @@ Name: master-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master-c
   Lifecycle: Sync
@@ -245,6 +244,7 @@ Port:
   - KopsInstanceGroup=master-c
   - KopsName=port-master-c-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -289,7 +289,6 @@ Name: node-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-a
   Lifecycle: Sync
@@ -319,6 +318,7 @@ Port:
   - KopsInstanceGroup=node-a
   - KopsName=port-node-a-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -363,7 +363,6 @@ Name: node-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-b
   Lifecycle: Sync
@@ -393,6 +392,7 @@ Port:
   - KopsInstanceGroup=node-b
   - KopsName=port-node-b-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -437,7 +437,6 @@ Name: node-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-c
   Lifecycle: Sync
@@ -467,6 +466,7 @@ Port:
   - KopsInstanceGroup=node-c
   - KopsName=port-node-c-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -655,7 +655,6 @@ PublicACL: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master-a
 Lifecycle: Sync
@@ -691,10 +690,10 @@ Tags:
 - KopsInstanceGroup=master-a
 - KopsName=port-master-a-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master-b
 Lifecycle: Sync
@@ -730,10 +729,10 @@ Tags:
 - KopsInstanceGroup=master-b
 - KopsName=port-master-b-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master-c
 Lifecycle: Sync
@@ -769,10 +768,10 @@ Tags:
 - KopsInstanceGroup=master-c
 - KopsName=port-master-c-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-a
 Lifecycle: Sync
@@ -802,10 +801,10 @@ Tags:
 - KopsInstanceGroup=node-a
 - KopsName=port-node-a-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-b
 Lifecycle: Sync
@@ -835,10 +834,10 @@ Tags:
 - KopsInstanceGroup=node-b
 - KopsName=port-node-b-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-c
 Lifecycle: Sync
@@ -868,6 +867,7 @@ Tags:
 - KopsInstanceGroup=node-c
 - KopsName=port-node-c-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -29,7 +29,6 @@ Name: bastion-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: bastion
   Lifecycle: Sync
@@ -59,6 +58,7 @@ Port:
   - KopsInstanceGroup=bastion
   - KopsName=port-bastion-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Bastion
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -106,7 +106,6 @@ Name: master-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -142,6 +141,7 @@ Port:
   - KopsInstanceGroup=master
   - KopsName=port-master-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -186,7 +186,6 @@ Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -216,6 +215,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -374,7 +374,6 @@ PublicACL: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: bastion
 Lifecycle: Sync
@@ -404,10 +403,10 @@ Tags:
 - KopsInstanceGroup=bastion
 - KopsName=port-bastion-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -443,10 +442,10 @@ Tags:
 - KopsInstanceGroup=master
 - KopsName=port-master-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -476,6 +475,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -42,7 +42,6 @@ Name: bastion-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: bastion
   Lifecycle: Sync
@@ -72,6 +71,7 @@ Port:
   - KopsInstanceGroup=bastion
   - KopsName=port-bastion-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Bastion
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -119,7 +119,6 @@ Name: master-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -155,6 +154,7 @@ Port:
   - KopsInstanceGroup=master
   - KopsName=port-master-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -199,7 +199,6 @@ Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -229,6 +228,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -387,7 +387,6 @@ PublicACL: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: bastion
 Lifecycle: Sync
@@ -417,10 +416,10 @@ Tags:
 - KopsInstanceGroup=bastion
 - KopsName=port-bastion-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -456,10 +455,10 @@ Tags:
 - KopsInstanceGroup=master
 - KopsName=port-master-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -489,6 +488,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -31,7 +31,6 @@ Name: master-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -67,6 +66,7 @@ Port:
   - KopsInstanceGroup=master
   - KopsName=port-master-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -111,7 +111,6 @@ Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -141,6 +140,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -289,7 +289,6 @@ PublicACL: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -325,10 +324,10 @@ Tags:
 - KopsInstanceGroup=master
 - KopsName=port-master-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -358,6 +357,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -55,7 +55,6 @@ Name: master-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -91,6 +90,7 @@ Port:
   - KopsInstanceGroup=master
   - KopsName=port-master-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -141,7 +141,6 @@ Name: node-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -171,6 +170,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -319,7 +319,6 @@ PublicACL: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -355,10 +354,10 @@ Tags:
 - KopsInstanceGroup=master
 - KopsName=port-master-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -388,6 +387,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/single-zone-setup-3-masters-1-node-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/single-zone-setup-3-masters-1-node-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -60,7 +60,6 @@ Name: master-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: true
   ID: null
   InstanceGroupName: master-a
   Lifecycle: Sync
@@ -90,6 +89,8 @@ Port:
   - KopsInstanceGroup=master-a
   - KopsName=port-master-a-1
   - KubernetesCluster=cluster
+  WellKnownServices:
+  - kube-apiserver
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -139,7 +140,6 @@ Name: master-b-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: true
   ID: null
   InstanceGroupName: master-b
   Lifecycle: Sync
@@ -169,6 +169,8 @@ Port:
   - KopsInstanceGroup=master-b
   - KopsName=port-master-b-1
   - KubernetesCluster=cluster
+  WellKnownServices:
+  - kube-apiserver
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -218,7 +220,6 @@ Name: master-c-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: true
   ID: null
   InstanceGroupName: master-c
   Lifecycle: Sync
@@ -248,6 +249,8 @@ Port:
   - KopsInstanceGroup=master-c
   - KopsName=port-master-c-1
   - KubernetesCluster=cluster
+  WellKnownServices:
+  - kube-apiserver
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -294,7 +297,6 @@ Name: node-a-1-cluster
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node-a
   Lifecycle: Sync
@@ -324,6 +326,7 @@ Port:
   - KopsInstanceGroup=node-a
   - KopsName=port-node-a-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: ""
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -665,7 +668,6 @@ Pool:
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: true
 ID: null
 InstanceGroupName: master-a
 Lifecycle: Sync
@@ -695,10 +697,11 @@ Tags:
 - KopsInstanceGroup=master-a
 - KopsName=port-master-a-1
 - KubernetesCluster=cluster
+WellKnownServices:
+- kube-apiserver
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: true
 ID: null
 InstanceGroupName: master-b
 Lifecycle: Sync
@@ -728,10 +731,11 @@ Tags:
 - KopsInstanceGroup=master-b
 - KopsName=port-master-b-1
 - KubernetesCluster=cluster
+WellKnownServices:
+- kube-apiserver
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: true
 ID: null
 InstanceGroupName: master-c
 Lifecycle: Sync
@@ -761,10 +765,11 @@ Tags:
 - KopsInstanceGroup=master-c
 - KopsName=port-master-c-1
 - KubernetesCluster=cluster
+WellKnownServices:
+- kube-apiserver
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node-a
 Lifecycle: Sync
@@ -794,6 +799,7 @@ Tags:
 - KopsInstanceGroup=node-a
 - KopsName=port-node-a-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
@@ -55,7 +55,6 @@ Name: master-1-tom-software-dev-playground-real33-k8s-local
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: master
   Lifecycle: Sync
@@ -91,6 +90,7 @@ Port:
   - KopsInstanceGroup=master
   - KopsName=port-master-1
   - KubernetesCluster=tom-software-dev-playground-real33--kngu8l
+  WellKnownServices: null
 Region: region
 Role: ControlPlane
 SSHKey: kubernetes.tom-software-dev-playground-real33-k8s-local-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -141,7 +141,6 @@ Name: node-1-tom-software-dev-playground-real33-k8s-local
 Port:
   AdditionalSecurityGroups: null
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -171,6 +170,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=tom-software-dev-playground-real33--kngu8l
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.tom-software-dev-playground-real33-k8s-local-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -319,7 +319,6 @@ PublicACL: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: master
 Lifecycle: Sync
@@ -355,10 +354,10 @@ Tags:
 - KopsInstanceGroup=master
 - KopsName=port-master-1
 - KubernetesCluster=tom-software-dev-playground-real33--kngu8l
+WellKnownServices: null
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -388,6 +387,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=tom-software-dev-playground-real33--kngu8l
+WellKnownServices: null
 ---
 ClusterName: tom-software-dev-playground-real33-k8s-local
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -26,7 +26,6 @@ Port:
   AdditionalSecurityGroups:
   - additional-sg
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -56,6 +55,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -196,7 +196,6 @@ PublicACL: null
 AdditionalSecurityGroups:
 - additional-sg
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -226,6 +225,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -26,7 +26,6 @@ Port:
   AdditionalSecurityGroups:
   - additional-sg
   AllowedAddressPairs: null
-  ForAPIServer: false
   ID: null
   InstanceGroupName: node
   Lifecycle: Sync
@@ -56,6 +55,7 @@ Port:
   - KopsInstanceGroup=node
   - KopsName=port-node-1
   - KubernetesCluster=cluster
+  WellKnownServices: null
 Region: region
 Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -196,7 +196,6 @@ PublicACL: null
 AdditionalSecurityGroups:
 - additional-sg
 AllowedAddressPairs: null
-ForAPIServer: false
 ID: null
 InstanceGroupName: node
 Lifecycle: Sync
@@ -226,6 +225,7 @@ Tags:
 - KopsInstanceGroup=node
 - KopsName=port-node-1
 - KubernetesCluster=cluster
+WellKnownServices: null
 ---
 ClusterName: cluster
 ID: null

--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -24,6 +24,7 @@ import (
 	secgroup "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/wellknownservices"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 )
@@ -39,8 +40,11 @@ type Port struct {
 	AdditionalSecurityGroups []string
 	Lifecycle                fi.Lifecycle
 	Tags                     []string
-	ForAPIServer             bool
 	AllowedAddressPairs      []ports.AddressPair
+
+	// WellKnownServices indicates which services are supported by this resource.
+	// This field is internal and is not rendered to the cloud.
+	WellKnownServices []wellknownservices.WellKnownService
 }
 
 // GetDependencies returns the dependencies of the Port task
@@ -84,8 +88,8 @@ func (s *Port) FindAddresses(context *fi.CloudupContext) ([]string, error) {
 
 // GetWellKnownServices implements fi.HasAddress::GetWellKnownServices.
 // It indicates which services we support with this load balancer.
-func (s *Port) GetWellKnownServices() bool {
-	return s.ForAPIServer
+func (s *Port) GetWellKnownServices() []wellknownservices.WellKnownService {
+	return s.WellKnownServices
 }
 
 // getActualAllowedAddressPairs returns the actual allowed address pairs which kOps currently manages.
@@ -190,7 +194,7 @@ func newPortTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle fi.Lifecycle
 		find.ID = actual.ID
 		actual.InstanceGroupName = find.InstanceGroupName
 		actual.AdditionalSecurityGroups = find.AdditionalSecurityGroups
-		actual.ForAPIServer = find.ForAPIServer
+		actual.WellKnownServices = find.WellKnownServices
 	}
 	return actual, nil
 }


### PR DESCRIPTION
fixes #16270

see discussion (or actually my wall of text) in issue

cc @justinsb @hakman 

with this change I can get working kube_env.yaml like following in normal node:

```
root@nodes-xx-kybe4u:/home/ubuntu# cat /opt/kops/conf/kube_env.yaml 
APIServerIPs:
- 10.2.131.13
- 10.2.192.39
- 10.2.65.84
CloudProvider: openstack
ClusterName: jessetesti.k8s.local
ConfigServer:
  CACertificates: |
    -----BEGIN CERTIFICATE-----
    snip
    TdTyytTpZ/HeOvfbyt6p2qd3I5iaJb2W9Ydo3RROsYAi6p2fMDa/IATzSAQ=
    -----END CERTIFICATE-----
  servers:
  - https://10.2.131.13:3988/
  - https://10.2.192.39:3988/
  - https://10.2.65.84:3988/
InstanceGroupName: nodes-xx
InstanceGroupRole: Node
NodeupConfigHash: HT1Osvmi/hpjF1M1oH8RuCaqyhiO2/D41/wdkQACILE=
```

```
% kubectl get nodes
NAME                          STATUS   ROLES           AGE    VERSION
control-plane-xx-t70fjk   Ready    control-plane   106s   v1.29.1
control-plane-yy-1xqslp   Ready    control-plane   116s   v1.29.1
control-plane-zz-mwzfde    Ready    control-plane   112s   v1.29.1
nodes-xx-9e0jht           Ready    node            43s    v1.29.1
nodes-yy-wflops           Ready    node            45s    v1.29.1
nodes-zz-kybe4u            Ready    node            46s    v1.29.1
```
