### PR TITLE
gce: Set node IP Alias range to match NodeCIDRMaskSize

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -190,8 +190,12 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 			if gce.UsesIPAliases(b.Cluster) {
 				t.CanIPForward = fi.PtrTo(false)
 
+				nodeCIDRMaskSize := int32(24)
+				if b.Cluster.Spec.KubeControllerManager.NodeCIDRMaskSize != nil {
+					nodeCIDRMaskSize = *b.Cluster.Spec.KubeControllerManager.NodeCIDRMaskSize
+				}
 				t.AliasIPRanges = map[string]string{
-					b.NameForIPAliasRange("pods"): "/24",
+					b.NameForIPAliasRange("pods"): fmt.Sprintf("/%d", nodeCIDRMaskSize),
 				}
 			} else {
 				t.CanIPForward = fi.PtrTo(true)


### PR DESCRIPTION
Prior to this change, GCE Node IP Alias CIDR range was hardcoded to be a `/24` which can be a limiting factor for scaling out a cluster when using smaller instance types, and could cause IP pool exhaustion despite many unallocated IPs.

This also means it's possible to bring up a cluster where the actual node CIDR size disagrees with what is configured in `cluster.spec.kubeControllerManager.NodeCIDRMaskSize` - although I do not know how detrimental that would be.

This change updates the IP Alias range to match the value configured in `cluster.spec.kubeControllerManager.NodeCIDRMaskSize`.