### PR TITLE
Release 1.28.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,16 +66,16 @@ GITSHA := $(shell cd ${KOPS_ROOT}; git describe --always)
 # We lock the versions of our controllers also
 # We need to keep in sync with:
 #   pkg/model/components/etcdmanager/model.go
-KOPS_UTILS_CP_TAG=1.28.2
+KOPS_UTILS_CP_TAG=1.28.3
 KOPS_UTILS_CP_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KOPS_UTILS_CP_TAG | awk '{print $$2}')
 #   upup/models/cloudup/resources/addons/dns-controller/
-DNS_CONTROLLER_TAG=1.28.2
+DNS_CONTROLLER_TAG=1.28.3
 DNS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_DNS_CONTROLLER_TAG | awk '{print $$2}')
 #   upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/
-KOPS_CONTROLLER_TAG=1.28.2
+KOPS_CONTROLLER_TAG=1.28.3
 KOPS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KOPS_CONTROLLER_TAG | awk '{print $$2}')
 #   pkg/model/components/kubeapiserver/model.go
-KUBE_APISERVER_HEALTHCHECK_TAG=1.28.2
+KUBE_APISERVER_HEALTHCHECK_TAG=1.28.3
 KUBE_APISERVER_HEALTHCHECK_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KUBE_APISERVER_HEALTHCHECK_TAG | awk '{print $$2}')
 
 CGO_ENABLED=0

--- a/kops-version.go
+++ b/kops-version.go
@@ -21,8 +21,8 @@ var Version = KOPS_RELEASE_VERSION
 
 // These constants are parsed by build tooling - be careful about changing the formats
 const (
-	KOPS_RELEASE_VERSION = "1.28.2"
-	KOPS_CI_VERSION      = "1.28.3"
+	KOPS_RELEASE_VERSION = "1.28.3"
+	KOPS_CI_VERSION      = "1.28.4"
 )
 
 // GitVersion should be replaced by the makefile

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -208,7 +208,7 @@ spec:
     emptyDir: {}
 `
 
-const kopsUtilsImage = "registry.k8s.io/kops/kops-utils-cp:1.28.2"
+const kopsUtilsImage = "registry.k8s.io/kops/kops-utils-cp:1.28.3"
 
 // buildPod creates the pod spec, based on the EtcdClusterSpec
 func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instanceGroupName string) (*v1.Pod, error) {

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -113,7 +113,7 @@ Contents: |
       - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: kops-utils-cp
       resources: {}
       volumeMounts:
@@ -150,7 +150,7 @@ Contents: |
       - --src=/opt/etcd-v3.4.13/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-4-13
       resources: {}
       volumeMounts:
@@ -168,7 +168,7 @@ Contents: |
       - --src=/opt/etcd-v3.5.9/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-5-9
       resources: {}
       volumeMounts:
@@ -253,7 +253,7 @@ Contents: |
       - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: kops-utils-cp
       resources: {}
       volumeMounts:
@@ -290,7 +290,7 @@ Contents: |
       - --src=/opt/etcd-v3.4.13/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-4-13
       resources: {}
       volumeMounts:
@@ -308,7 +308,7 @@ Contents: |
       - --src=/opt/etcd-v3.5.9/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-5-9
       resources: {}
       volumeMounts:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -112,7 +112,7 @@ Contents: |
       - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: kops-utils-cp
       resources: {}
       volumeMounts:
@@ -149,7 +149,7 @@ Contents: |
       - --src=/opt/etcd-v3.4.13/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-4-13
       resources: {}
       volumeMounts:
@@ -167,7 +167,7 @@ Contents: |
       - --src=/opt/etcd-v3.5.9/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-5-9
       resources: {}
       volumeMounts:
@@ -251,7 +251,7 @@ Contents: |
       - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: kops-utils-cp
       resources: {}
       volumeMounts:
@@ -288,7 +288,7 @@ Contents: |
       - --src=/opt/etcd-v3.4.13/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-4-13
       resources: {}
       volumeMounts:
@@ -306,7 +306,7 @@ Contents: |
       - --src=/opt/etcd-v3.5.9/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-5-9
       resources: {}
       volumeMounts:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -115,7 +115,7 @@ Contents: |
       - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: kops-utils-cp
       resources: {}
       volumeMounts:
@@ -152,7 +152,7 @@ Contents: |
       - --src=/opt/etcd-v3.4.13/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-4-13
       resources: {}
       volumeMounts:
@@ -170,7 +170,7 @@ Contents: |
       - --src=/opt/etcd-v3.5.9/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-5-9
       resources: {}
       volumeMounts:
@@ -257,7 +257,7 @@ Contents: |
       - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: kops-utils-cp
       resources: {}
       volumeMounts:
@@ -294,7 +294,7 @@ Contents: |
       - --src=/opt/etcd-v3.4.13/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-4-13
       resources: {}
       volumeMounts:
@@ -312,7 +312,7 @@ Contents: |
       - --src=/opt/etcd-v3.5.9/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-5-9
       resources: {}
       volumeMounts:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -121,7 +121,7 @@ Contents: |
       - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: kops-utils-cp
       resources: {}
       volumeMounts:
@@ -158,7 +158,7 @@ Contents: |
       - --src=/opt/etcd-v3.4.13/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-4-13
       resources: {}
       volumeMounts:
@@ -176,7 +176,7 @@ Contents: |
       - --src=/opt/etcd-v3.5.9/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-5-9
       resources: {}
       volumeMounts:
@@ -269,7 +269,7 @@ Contents: |
       - --src=/ko-app/kops-utils-cp
       command:
       - /ko-app/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: kops-utils-cp
       resources: {}
       volumeMounts:
@@ -306,7 +306,7 @@ Contents: |
       - --src=/opt/etcd-v3.4.13/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-4-13
       resources: {}
       volumeMounts:
@@ -324,7 +324,7 @@ Contents: |
       - --src=/opt/etcd-v3.5.9/etcdctl
       command:
       - /opt/kops-utils/kops-utils-cp
-      image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+      image: registry.k8s.io/kops/kops-utils-cp:1.28.3
       name: init-etcd-symlinks-3-5-9
       resources: {}
       volumeMounts:

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -79,7 +79,7 @@ kind: Pod
 spec:
   containers:
   - name: healthcheck
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         # The sidecar serves a healthcheck on the same port,

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -10,7 +10,7 @@ Contents: |
       - --ca-cert=/secrets/ca.crt
       - --client-cert=/secrets/client.crt
       - --client-key=/secrets/client.key
-      image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+      image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9ec4659742e5509b794e936c9f5838fee28e5d09fa18879d9d33e7e169d88093
+    manifestHash: 6f1834eaa7c2401880a1c47b6582e46fa5d24ca315fe0b7d3046046b13b7390e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -51,7 +51,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -88,7 +88,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -106,7 +106,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -51,7 +51,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -88,7 +88,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -106,7 +106,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ecb86e0931e0b0aea2b96770f6bde489c1e77bf883e084f9e122befbe97538c3
+    manifestHash: 90053e671dd79938362fa4e7eae4b239c6dddc0dc67958f252219d0c6714b497
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b7d31c922051900b891e1e331e77736d7cfc50b4791c84138fae071ffd820b3d
+    manifestHash: 28de16c8b1b57c270b000cadf18449a140f358e0ba42cbbc428a0771cc3e9b3e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -51,7 +51,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e2a7e3158705c4a55534a6659cbb3b8b013ecae223627007eb77505852ec63cf
+    manifestHash: cadcc32f90c60396c2ab7efab3a0b57b640f3a8c0b7d0720e93ef9c2dc5c2946
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1af74bd69d538bf17b86d33432ea425f8fc0002fce097ec81930ba69af41a7ba
+    manifestHash: ff9c43b83dac1723ec3f9adc70c71f50ec3b072d79ef22e8c9995f9193b42afb
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 612dacf4f4c8c2687a6598e26242a5b5dd4e9f3a25681e30f0a9999278cc3627
+    manifestHash: 9f184dca38d134ca570648685c80a80e2ee85924eb2d4b8d16fc6c666a8c9340
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7af6f168202a37b35707558e54e133ba44b0f5d9b3631a396ab744d3f14ac233
+    manifestHash: 909da3841adf65c1bce9e00c7023675ebb403e74cba4567d2e8e1b916d3fb86d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 049cf63800605e1ffba638a96477304a2d8b6b0e4c2558d4a1e374a1a53f9072
+    manifestHash: a10cd82a66f3f7f2bedbda212309a2e29e9ade7a1b401a05152a66dbf5894ca3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7de1959f9fd1b46d8fe714de55bbce1e8921dcd9995ca2a358231d670d46ceb0
+    manifestHash: b94395ab0043d30542b018ab34c38823bca45df4188fba7f8588ddd982ce843e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7de1959f9fd1b46d8fe714de55bbce1e8921dcd9995ca2a358231d670d46ceb0
+    manifestHash: b94395ab0043d30542b018ab34c38823bca45df4188fba7f8588ddd982ce843e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7d6f3061413ce859605d055cde857bf28a6cf2ac91637870703c050f779a7033
+    manifestHash: 19458944ed74672748c810f7312b686493abf97de584dc14d0dec6d007bad53d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 97b1c566a918e12f935935e5998232b6db163a814c9ca51368e6e8a34f8042c7
+    manifestHash: f4f9f228df2adbe5b90a0ae87d26859702a553293f0b89c06cdc61c4e288052a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_docker.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/docker-custom/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7bdfed7ac8a8833f8e31a6599a1c20e829e0cdd3ee11c85a08793671578bded2
+    manifestHash: 6d9b23fa0734cb61824371c1cff0ed620cc0b0767270c32abe1b6d3b52a8f309
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 939b8c19a2add03a27cf60885f13ccef60ff629e034a760339fd90452fd653b0
+    manifestHash: 8380ae7a2effe7fa55adc2a736f68611d7da2a2cb08fa38d3b969aa3e5a05477
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bb1cce01038d78df997745bdf1cdce5f778161d96f51a39d7081c89b424f06fd
+    manifestHash: ea6c9b5a564cd37cdf4455b62611d827643d169033cbb53527bc26fc80cb235e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: aedf53bf8e1b002c54e4de9d12ef3f25346c9daa2fca755c4bd3cac9f99aa4af
+    manifestHash: 78ef8b17dffb2d4bebd3f0f72b2997359d2d4a467bce9b2d7d081a6784d74aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 481a6af4d3c5dc4a17c32f66c12492fe830c204eecee6095d17417ee7ae9e50f
+    manifestHash: c017224ed6fbb170c631581f8c5631d10a33a8a2c0a40f0d6be4113104eae972
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4abfb04c1b4b7920e09d2f0f14c1f4277ab3605281524290f4f4e7e1bd71aab5
+    manifestHash: c052235c4cf507633e8a7760a03b1b4f98b91288028e7064cf4f7fdae16d3111
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 84247a9ae187c832315b3061579c0059c0ded8baf4b9a4b926027e26a3d8d593
+    manifestHash: 28fb9992186e5218357e6277607191ad247b39e12821dd00d7b122bb87413c68
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-b_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-c_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-b_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-c_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b7d31c922051900b891e1e331e77736d7cfc50b4791c84138fae071ffd820b3d
+    manifestHash: 28de16c8b1b57c270b000cadf18449a140f358e0ba42cbbc428a0771cc3e9b3e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -51,7 +51,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b7d31c922051900b891e1e331e77736d7cfc50b4791c84138fae071ffd820b3d
+    manifestHash: 28de16c8b1b57c270b000cadf18449a140f358e0ba42cbbc428a0771cc3e9b3e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -51,7 +51,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b7d31c922051900b891e1e331e77736d7cfc50b4791c84138fae071ffd820b3d
+    manifestHash: 28de16c8b1b57c270b000cadf18449a140f358e0ba42cbbc428a0771cc3e9b3e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -51,7 +51,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b7d31c922051900b891e1e331e77736d7cfc50b4791c84138fae071ffd820b3d
+    manifestHash: 28de16c8b1b57c270b000cadf18449a140f358e0ba42cbbc428a0771cc3e9b3e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -51,7 +51,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b7d31c922051900b891e1e331e77736d7cfc50b4791c84138fae071ffd820b3d
+    manifestHash: 28de16c8b1b57c270b000cadf18449a140f358e0ba42cbbc428a0771cc3e9b3e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -51,7 +51,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b7d31c922051900b891e1e331e77736d7cfc50b4791c84138fae071ffd820b3d
+    manifestHash: 28de16c8b1b57c270b000cadf18449a140f358e0ba42cbbc428a0771cc3e9b3e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -51,7 +51,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 17f417a069a1fd19bf7f2e852fe60fa7a6124feb1b13abc9571de0b53a499509
+    manifestHash: df380a73c33b75e3237f84eb1d4e2591eb1a7d80f20902a565a9f5323901670c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 84247a9ae187c832315b3061579c0059c0ded8baf4b9a4b926027e26a3d8d593
+    manifestHash: 28fb9992186e5218357e6277607191ad247b39e12821dd00d7b122bb87413c68
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 608de5fac95fbe4d00a860105e9cab2b2803b786cd5d347357028d7c3a70a9c8
+    manifestHash: 53a485c861b84708e9d8fb7f375cbd620322460332f3f1b481bb66252285484b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 799bde28859e834942f6924d680040f5af9ca89c29bac454c15d414a42fb0534
+    manifestHash: 3508812743a626136a737cf3f350144338fd228e2e4c7f245b1093e7b681b224
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 799bde28859e834942f6924d680040f5af9ca89c29bac454c15d414a42fb0534
+    manifestHash: 3508812743a626136a737cf3f350144338fd228e2e4c7f245b1093e7b681b224
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 799bde28859e834942f6924d680040f5af9ca89c29bac454c15d414a42fb0534
+    manifestHash: 3508812743a626136a737cf3f350144338fd228e2e4c7f245b1093e7b681b224
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 799bde28859e834942f6924d680040f5af9ca89c29bac454c15d414a42fb0534
+    manifestHash: 3508812743a626136a737cf3f350144338fd228e2e4c7f245b1093e7b681b224
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 799bde28859e834942f6924d680040f5af9ca89c29bac454c15d414a42fb0534
+    manifestHash: 3508812743a626136a737cf3f350144338fd228e2e4c7f245b1093e7b681b224
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -51,7 +51,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -88,7 +88,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -106,7 +106,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a23c38a8726a05db1813a13f47fd8646fdce66f4906131a1f1cc01fda4aa28c3
+    manifestHash: 7b1c761e624ae2f5361113ac544f1c30d78de83c3484a3dcfe7cf457cbf445cf
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0720eeed2b434d05713c07fb9f548890bb51b06981a640608e0741f42527149
+    manifestHash: 2febdbf50d04aa6e5ae50ec4b7a51c714d26ebcd19faef68d7a276efcd2f1945
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e361f8d469f7eb3dedceb6159453e18679c728a81b7e414a95710ac25f76674a
+    manifestHash: 029c3b36b1ded96744fc77c6e346afa641d06fe10d49abdc56b45349597759fc
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0720eeed2b434d05713c07fb9f548890bb51b06981a640608e0741f42527149
+    manifestHash: 2febdbf50d04aa6e5ae50ec4b7a51c714d26ebcd19faef68d7a276efcd2f1945
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e361f8d469f7eb3dedceb6159453e18679c728a81b7e414a95710ac25f76674a
+    manifestHash: 029c3b36b1ded96744fc77c6e346afa641d06fe10d49abdc56b45349597759fc
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0720eeed2b434d05713c07fb9f548890bb51b06981a640608e0741f42527149
+    manifestHash: 2febdbf50d04aa6e5ae50ec4b7a51c714d26ebcd19faef68d7a276efcd2f1945
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e361f8d469f7eb3dedceb6159453e18679c728a81b7e414a95710ac25f76674a
+    manifestHash: 029c3b36b1ded96744fc77c6e346afa641d06fe10d49abdc56b45349597759fc
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0720eeed2b434d05713c07fb9f548890bb51b06981a640608e0741f42527149
+    manifestHash: 2febdbf50d04aa6e5ae50ec4b7a51c714d26ebcd19faef68d7a276efcd2f1945
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e361f8d469f7eb3dedceb6159453e18679c728a81b7e414a95710ac25f76674a
+    manifestHash: 029c3b36b1ded96744fc77c6e346afa641d06fe10d49abdc56b45349597759fc
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d5fcd65ba3bf5f8910436cca9b4258a53db7edfc3e1ff97577ad476603eaa64f
+    manifestHash: f79952cfa891f8d3ba340d8da1021302f9808edf0e4447c3145249edd82c041c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b9ddc00e3b701612b27e0576fed7ff42f481b7166afa55697ff252e63ab73c1
+    manifestHash: 432a6ab928d9eb100366c760af238c838aafb11a54f83c78a3ee80fbf4c159d9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 117ae07d315f1226b33c7bdc41f02edf541eeb04ce44793ab994efb2e78c5088
+    manifestHash: 94488410d0ad23ff66c036da361b4f0446cf3c2ad0acbbb8c0c130c1f24e4166
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 84247a9ae187c832315b3061579c0059c0ded8baf4b9a4b926027e26a3d8d593
+    manifestHash: 28fb9992186e5218357e6277607191ad247b39e12821dd00d7b122bb87413c68
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 117ae07d315f1226b33c7bdc41f02edf541eeb04ce44793ab994efb2e78c5088
+    manifestHash: 94488410d0ad23ff66c036da361b4f0446cf3c2ad0acbbb8c0c130c1f24e4166
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 14789c604757295efd92ed8ae88d7d7f433eedcc819175c88c094ed36a3d1700
+    manifestHash: b62f406679f71ae9b86c581accfe5f4ce135c12839c0dc4d6495a82bb0d37010
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 84247a9ae187c832315b3061579c0059c0ded8baf4b9a4b926027e26a3d8d593
+    manifestHash: 28fb9992186e5218357e6277607191ad247b39e12821dd00d7b122bb87413c68
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 12b34d180634f77efaea76950e8f361cc908c8b5fd46ebca56b0b69040476854
+    manifestHash: 6995fc785bcffafdc3253b32598bd4604f142f17719e29d74362fc11337275e3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 84247a9ae187c832315b3061579c0059c0ded8baf4b9a4b926027e26a3d8d593
+    manifestHash: 28fb9992186e5218357e6277607191ad247b39e12821dd00d7b122bb87413c68
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 12b34d180634f77efaea76950e8f361cc908c8b5fd46ebca56b0b69040476854
+    manifestHash: 6995fc785bcffafdc3253b32598bd4604f142f17719e29d74362fc11337275e3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 84247a9ae187c832315b3061579c0059c0ded8baf4b9a4b926027e26a3d8d593
+    manifestHash: 28fb9992186e5218357e6277607191ad247b39e12821dd00d7b122bb87413c68
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6bba6f2ecd3df5369f53a4babfdcd87838ffb1e7c9f4455d118d936f432b2936
+    manifestHash: 89b1b5001118aca6dc4d7424eb5847d692b1efb052b9fa0d9944a0549681b8d2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 84247a9ae187c832315b3061579c0059c0ded8baf4b9a4b926027e26a3d8d593
+    manifestHash: 28fb9992186e5218357e6277607191ad247b39e12821dd00d7b122bb87413c68
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-events-master-us-test1-a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-etcdmanager-main-master-us-test1-a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a0c1d6ecacbcfc66fe0eb301ab26f73b0580b248ed4fd7bc305d8ed8968e8ac
+    manifestHash: 692788cdb41f9fdff543b62ac48692dac357fa917dac874af00f7a5b1a453326
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 84247a9ae187c832315b3061579c0059c0ded8baf4b9a4b926027e26a3d8d593
+    manifestHash: 28fb9992186e5218357e6277607191ad247b39e12821dd00d7b122bb87413c68
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 55634a3783708caccc74108fc51b4cda77b275ce698165ad58cb2c3ad3852973
+    manifestHash: 961e19fbc5aade91d704eebde4cbf88c6327a345469f318f8f93bfa2c4541283
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 1f9a29b874f9b8625c1db7fd225d9cf370dd99a6a8c8f96a78bc21052a0fc755
+    manifestHash: eb556db28a3843cfdc839f3dffd999ecb396c3de62c8767f32dbb3d7e00d7b94
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -51,7 +51,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 55634a3783708caccc74108fc51b4cda77b275ce698165ad58cb2c3ad3852973
+    manifestHash: 961e19fbc5aade91d704eebde4cbf88c6327a345469f318f8f93bfa2c4541283
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2cc061a6b4b78c871aa63bd02b06a1f8fa3dad504313009ba2364df164f430c7
+    manifestHash: fb2b2f4edb277d9bad6d8b7b112e0c8a89ef45ac1c4b3491e377ceb772778a1a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -54,7 +54,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.k8s.local
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-events-master-fsn1_content
@@ -50,7 +50,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -87,7 +87,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -105,7 +105,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-etcdmanager-main-master-fsn1_content
@@ -50,7 +50,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -87,7 +87,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -105,7 +105,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1089ca941c5adc38603550065f520581f0d02a4eb272a8e9f32a6e033afb50ed
+    manifestHash: ed45cf6d48baee2b9dee9fcf45d659a704611790abc77d3db3afc49349d7b9cc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -65,7 +65,7 @@ spec:
           value: 127.0.0.1
         - name: HCLOUD_TOKEN
           value: REDACTED
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-events-control-plane-fr-par-1_content
@@ -52,7 +52,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -89,7 +89,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -107,7 +107,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-etcdmanager-main-control-plane-fr-par-1_content
@@ -52,7 +52,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -89,7 +89,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -107,7 +107,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b7eb9306a2a51b892b0757bf2cc7bad89c63f07477060b3ac0bd532dae9b21b1
+    manifestHash: c6a8c778f2273935afecbb3c1fdb29450eeac95842ed5b870c5293c243f2ef46
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 26d6887a7d6d2bb70968144dc33b1c74cef0f95926ec60b2de99324027dc2956
+    manifestHash: 2cfce3c5ecb900bf3826d69c74e10abae78458922deab35025aecf1ac3437d09
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -54,7 +54,7 @@ spec:
         envFrom:
         - secretRef:
             name: scaleway-secret
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -69,7 +69,7 @@ spec:
           value: null
         - name: SCW_SECRET_KEY
           value: null
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ab9b5f488e2f05029132bbece4ca0da547f201f17ea260557f5329e24a8c94df
+    manifestHash: 9a9e51b1f66126da5ed76e2193f87ebc044732dbccfda15b24957b0de4711573
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1b_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1c_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1b_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1c_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ab9b5f488e2f05029132bbece4ca0da547f201f17ea260557f5329e24a8c94df
+    manifestHash: 9a9e51b1f66126da5ed76e2193f87ebc044732dbccfda15b24957b0de4711573
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5940e9c1c665fc7777daf7d0a2c7e4bb3db39086449f15ec6b1fe807f5cb6a94
+    manifestHash: aa75f2508393bf9b8d29da831d2947e55bda024d79b27280bf79d3abe2f4ed91
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 26fdb5fdb2920ffa250860e8ef6162dfe08f05228fdc6f028bbc19db62ce4ef8
+    manifestHash: 2bcf89a2b648a9c88d2d8bb224a25f455358f9fd3420b8ad4f24c4fda16add44
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -51,7 +51,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.nthimdsprocessor.longcluste-e6uuer
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5940e9c1c665fc7777daf7d0a2c7e4bb3db39086449f15ec6b1fe807f5cb6a94
+    manifestHash: aa75f2508393bf9b8d29da831d2947e55bda024d79b27280bf79d3abe2f4ed91
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f3bf76569d6f2562dfc6e5f4856c2f696a18d160bebc3ce81d745057dc025e0d
+    manifestHash: 9389168a1942463de15c69105a7abc99a65cbe1e1d18029e6129c3efeea76a71
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0f195e2144df5a17b0da617cef13a3d7db3b0d0f65aaa02f4138023f41ca939b
+    manifestHash: 46ccdbd5a4eac4b4fc226d610c5e51cb9c66739221df7e4773d0ac76134ea10e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b8a29153d6ad99ee005f99e1d898f82f768a9fab11ac97ea118a258c2b3feaf2
+    manifestHash: 54d9fc676a5220f664b63b4f1fa4bb2e0a14c8ac4a58c0518d89834a59e0887f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5b13f6ebcfc430f9cccded2bf777dbc6ce531fc555046b148906b9201f743ea3
+    manifestHash: 67b5c7909553dc861058e94118e10fd55f6ef8c54d487fb5537d2814f22f9fcf
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 089808e5759d8469ac137d9e466e181090f67002fa7cbf2ad73b4799ddb0face
+    manifestHash: a2b2aad80abb33d36620c59b3874018bffd8b6b120fdcc78d2aeae4a73448846
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 089808e5759d8469ac137d9e466e181090f67002fa7cbf2ad73b4799ddb0face
+    manifestHash: a2b2aad80abb33d36620c59b3874018bffd8b6b120fdcc78d2aeae4a73448846
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 089808e5759d8469ac137d9e466e181090f67002fa7cbf2ad73b4799ddb0face
+    manifestHash: a2b2aad80abb33d36620c59b3874018bffd8b6b120fdcc78d2aeae4a73448846
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-cilium-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b90bac5507d53652dfa1619077ce2f2af1d4e2e2256fa72939c878ed7df6452d
+    manifestHash: de74202f8f60ad956244d31a4a8a64b0669196a01e66285a1bc2cba92b093b9e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d3b7d87260ec6024a8ce9ba06bc4d643f7927f9943d18a18cbadfd19ae64e316
+    manifestHash: aaf5508c988ad28f920f6dff9b1a8ececce83dc8b59f6f5aa13c6172eab6dc65
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4013118bfcea9d9b69b064cfbe38bbcc7e6543c331b2e9289bd78ac762b58db1
+    manifestHash: d78d19c82bd59418edcd3116519aeaa79d16d228bf1f1049e039f4283a6eab81
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: eb02844446a2aeecbaea4974398617038e3c3eba8b629602c54f917e82a69cfe
+    manifestHash: 78c2aab41fb7e35fe95c774be72ed33c240b4533220437a1b188992687799590
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 3e97bf656221b7d614185fcfb131f14cba5208e6f21ce68200aa4c6bcb5339d5
+    manifestHash: 36b795725446c903aa722966a47a8697d558ea24152c3738ea0b7fe5ff4326c9
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e57db4927579417eb44f93a87623fd37c3586122cfdebab9a003554c1a4ea5eb
+    manifestHash: 1ac09badbac13ef13c07d1ab7417124a9ffc14541bef1ba6450e9aa5d2478d8f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e54f8c47d3f62b2b4ff5b96157378b5cce91e86195c729f38e1f17872d003467
+    manifestHash: e1b3988961a8135c2e369e078ec365376d50dee419d95ce7b895fa4c14f4b88f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b7d31c922051900b891e1e331e77736d7cfc50b4791c84138fae071ffd820b3d
+    manifestHash: 28de16c8b1b57c270b000cadf18449a140f358e0ba42cbbc428a0771cc3e9b3e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -51,7 +51,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2625307cf163309549e62c372dd086fe5156a82d51a0ee629900a5f867049a5
+    manifestHash: d1126978ece6246a87e474377d77cb67a09ae17507042a042a101d45e8797e92
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6cdc3e6db7304f5deb0af5a4f643ae13f2d1748aa2eaae4383e958197fddb5a8
+    manifestHash: a9c04e70efb2d3d68347fb997beb3651adf10ffc7c7d16e4728e1dee27fefbf7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -49,7 +49,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -104,7 +104,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d0720eeed2b434d05713c07fb9f548890bb51b06981a640608e0741f42527149
+    manifestHash: 2febdbf50d04aa6e5ae50ec4b7a51c714d26ebcd19faef68d7a276efcd2f1945
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e361f8d469f7eb3dedceb6159453e18679c728a81b7e414a95710ac25f76674a
+    manifestHash: 029c3b36b1ded96744fc77c6e346afa641d06fe10d49abdc56b45349597759fc
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33509ede68a9e2a8b56f5953721175e4435e1c1630ba24ea7c1812e92c3d98a4
+    manifestHash: 0686bded1e5ba30438634d211c5107d20f9a1c1bd36170b67b48a7c217b49040
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-events-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-etcdmanager-main-master-us-test-1a_content
@@ -48,7 +48,7 @@ spec:
     - --src=/ko-app/kops-utils-cp
     command:
     - /ko-app/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: kops-utils-cp
     resources: {}
     volumeMounts:
@@ -85,7 +85,7 @@ spec:
     - --src=/opt/etcd-v3.4.13/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-4-13
     resources: {}
     volumeMounts:
@@ -103,7 +103,7 @@ spec:
     - --src=/opt/etcd-v3.5.9/etcdctl
     command:
     - /opt/kops-utils/kops-utils-cp
-    image: registry.k8s.io/kops/kops-utils-cp:1.28.2
+    image: registry.k8s.io/kops/kops-utils-cp:1.28.3
     name: init-etcd-symlinks-3-5-9
     resources: {}
     volumeMounts:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.2
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.28.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 215af496df96747fd17b091c4b79ac9b8962f09d6a46d3f23664b9d188d0cd56
+    manifestHash: 678d61365d3b860224dfd08e4fc1e1e9d90a67afa40aee3068b7f5a70242d86e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -48,7 +48,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dc6081e5c96931a2322631806da7ab4401feed983d15251ededc22c1e0af66fc
+    manifestHash: fba8fb406134151fc90768caa818b8975fc3c9e4b4f29d59dddb200ab38b027a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dc6081e5c96931a2322631806da7ab4401feed983d15251ededc22c1e0af66fc
+    manifestHash: fba8fb406134151fc90768caa818b8975fc3c9e4b4f29d59dddb200ab38b027a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dc6081e5c96931a2322631806da7ab4401feed983d15251ededc22c1e0af66fc
+    manifestHash: fba8fb406134151fc90768caa818b8975fc3c9e4b4f29d59dddb200ab38b027a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dc6081e5c96931a2322631806da7ab4401feed983d15251ededc22c1e0af66fc
+    manifestHash: fba8fb406134151fc90768caa818b8975fc3c9e4b4f29d59dddb200ab38b027a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dc6081e5c96931a2322631806da7ab4401feed983d15251ededc22c1e0af66fc
+    manifestHash: fba8fb406134151fc90768caa818b8975fc3c9e4b4f29d59dddb200ab38b027a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dc6081e5c96931a2322631806da7ab4401feed983d15251ededc22c1e0af66fc
+    manifestHash: fba8fb406134151fc90768caa818b8975fc3c9e4b4f29d59dddb200ab38b027a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dc6081e5c96931a2322631806da7ab4401feed983d15251ededc22c1e0af66fc
+    manifestHash: fba8fb406134151fc90768caa818b8975fc3c9e4b4f29d59dddb200ab38b027a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 088eb940c1305d782d2313032fc19a001b0f8df9971226e848b6370aab03d99f
+    manifestHash: 5c4db5386ccadd80a74c8a0716bff229e63af4fc45816e8780af0747fded3a94
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 088eb940c1305d782d2313032fc19a001b0f8df9971226e848b6370aab03d99f
+    manifestHash: 5c4db5386ccadd80a74c8a0716bff229e63af4fc45816e8780af0747fded3a94
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.28.2
+    version: v1.28.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -24,7 +24,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -51,7 +51,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.28.2
+        image: registry.k8s.io/kops/dns-controller:1.28.3
         name: dns-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dc6081e5c96931a2322631806da7ab4401feed983d15251ededc22c1e0af66fc
+    manifestHash: fba8fb406134151fc90768caa818b8975fc3c9e4b4f29d59dddb200ab38b027a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b7d31c922051900b891e1e331e77736d7cfc50b4791c84138fae071ffd820b3d
+    manifestHash: 28de16c8b1b57c270b000cadf18449a140f358e0ba42cbbc428a0771cc3e9b3e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.28.2
+    version: v1.28.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.28.2
+        version: v1.28.3
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.28.2
+        image: registry.k8s.io/kops/kops-controller:1.28.3
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dc6081e5c96931a2322631806da7ab4401feed983d15251ededc22c1e0af66fc
+    manifestHash: fba8fb406134151fc90768caa818b8975fc3c9e4b4f29d59dddb200ab38b027a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11e670c0117056d06826874e976dd803b807a6bfb970bbd7849b43c224d68e78
+    manifestHash: d693573deb392d37bf075df9ea1f49bf58be87223367525ab2dbf7c3e67dbdc1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/urls_test.go
+++ b/upup/pkg/fi/cloudup/urls_test.go
@@ -36,15 +36,15 @@ func Test_BuildMirroredAsset(t *testing.T) {
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/amd64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.28.2/linux/amd64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.28.2/nodeup-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.28.3/linux/amd64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.28.3/nodeup-linux-amd64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/arm64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.28.2/linux/arm64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.28.2/nodeup-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.28.3/linux/arm64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.28.3/nodeup-linux-arm64",
 			},
 		},
 	}


### PR DESCRIPTION
In particular, we want to pick up the aws-sdk-go cherry-pick, as that will enable running kOps with IRSA in an EKS cluster, which is potentially useful but also the plan for the new community testing clusters.