### PR TITLE
Add support to configure HPA Controller concurrent syncs flag in HPA/KCM Controller

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2147,6 +2147,11 @@ spec:
                       sync concurrently.
                     format: int32
                     type: integer
+                  concurrentHorizontalPodAustoscalerSyncs:
+                    description: The number of horizontal pod autoscaler objects that
+                      are allowed to sync concurrently (default 5).
+                    format: int32
+                    type: integer
                   concurrentNamespaceSyncs:
                     description: The number of namespace objects that are allowed
                       to sync concurrently.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -653,6 +653,8 @@ type KubeControllerManagerConfig struct {
 	ConcurrentServiceaccountTokenSyncs *int32 `json:"concurrentServiceaccountTokenSyncs,omitempty" flag:"concurrent-serviceaccount-token-syncs"`
 	// The number of replicationcontroller objects that are allowed to sync concurrently.
 	ConcurrentRCSyncs *int32 `json:"concurrentRCSyncs,omitempty" flag:"concurrent-rc-syncs"`
+	// The number of horizontal pod autoscaler objects that are allowed to sync concurrently (default 5).
+	ConcurrentHorizontalPodAustoscalerSyncs *int32 `json:"concurrentHorizontalPodAustoscalerSyncs,omitempty" flag:"concurrent-horizontal-pod-autoscaler-syncs"`
 	// AuthenticationKubeconfig is the path to an Authentication Kubeconfig
 	AuthenticationKubeconfig string `json:"authenticationKubeconfig,omitempty" flag:"authentication-kubeconfig"`
 	// AuthorizationKubeconfig is the path to an Authorization Kubeconfig

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -661,6 +661,8 @@ type KubeControllerManagerConfig struct {
 	// The number of replicationcontroller objects that are allowed to sync concurrently.
 	// This only works on kubernetes >= 1.14
 	ConcurrentRCSyncs *int32 `json:"concurrentRcSyncs,omitempty" flag:"concurrent-rc-syncs"`
+	// The number of horizontal pod autoscaler objects that are allowed to sync concurrently (default 5).
+	ConcurrentHorizontalPodAustoscalerSyncs *int32 `json:"concurrentHorizontalPodAustoscalerSyncs,omitempty" flag:"concurrent-horizontal-pod-autoscaler-syncs"`
 	// AuthenticationKubeconfig is the path to an Authentication Kubeconfig
 	AuthenticationKubeconfig string `json:"authenticationKubeconfig,omitempty" flag:"authentication-kubeconfig"`
 	// AuthorizationKubeconfig is the path to an Authorization Kubeconfig

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5139,6 +5139,7 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
 	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
 	out.ConcurrentRCSyncs = in.ConcurrentRCSyncs
+	out.ConcurrentHorizontalPodAustoscalerSyncs = in.ConcurrentHorizontalPodAustoscalerSyncs
 	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
 	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
 	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
@@ -5213,6 +5214,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
 	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
 	out.ConcurrentRCSyncs = in.ConcurrentRCSyncs
+	out.ConcurrentHorizontalPodAustoscalerSyncs = in.ConcurrentHorizontalPodAustoscalerSyncs
 	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
 	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
 	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3591,6 +3591,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ConcurrentHorizontalPodAustoscalerSyncs != nil {
+		in, out := &in.ConcurrentHorizontalPodAustoscalerSyncs, &out.ConcurrentHorizontalPodAustoscalerSyncs
+		*out = new(int32)
+		**out = **in
+	}
 	if in.AuthorizationAlwaysAllowPaths != nil {
 		in, out := &in.AuthorizationAlwaysAllowPaths, &out.AuthorizationAlwaysAllowPaths
 		*out = make([]string, len(*in))

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -652,6 +652,8 @@ type KubeControllerManagerConfig struct {
 	// The number of replicationcontroller objects that are allowed to sync concurrently.
 	// This only works on kubernetes >= 1.14
 	ConcurrentRCSyncs *int32 `json:"concurrentRCSyncs,omitempty" flag:"concurrent-rc-syncs"`
+	// The number of horizontal pod autoscaler objects that are allowed to sync concurrently (default 5).
+	ConcurrentHorizontalPodAustoscalerSyncs *int32 `json:"concurrentHorizontalPodAustoscalerSyncs,omitempty" flag:"concurrent-horizontal-pod-autoscaler-syncs"`
 	// AuthenticationKubeconfig is the path to an Authentication Kubeconfig
 	AuthenticationKubeconfig string `json:"authenticationKubeconfig,omitempty" flag:"authentication-kubeconfig"`
 	// AuthorizationKubeconfig is the path to an Authorization Kubeconfig

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5534,6 +5534,7 @@ func autoConvert_v1alpha3_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
 	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
 	out.ConcurrentRCSyncs = in.ConcurrentRCSyncs
+	out.ConcurrentHorizontalPodAustoscalerSyncs = in.ConcurrentHorizontalPodAustoscalerSyncs
 	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
 	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
 	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
@@ -5608,6 +5609,7 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha3_KubeControllerMana
 	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
 	out.ConcurrentServiceaccountTokenSyncs = in.ConcurrentServiceaccountTokenSyncs
 	out.ConcurrentRCSyncs = in.ConcurrentRCSyncs
+	out.ConcurrentHorizontalPodAustoscalerSyncs = in.ConcurrentHorizontalPodAustoscalerSyncs
 	out.AuthenticationKubeconfig = in.AuthenticationKubeconfig
 	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
 	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3565,6 +3565,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ConcurrentHorizontalPodAustoscalerSyncs != nil {
+		in, out := &in.ConcurrentHorizontalPodAustoscalerSyncs, &out.ConcurrentHorizontalPodAustoscalerSyncs
+		*out = new(int32)
+		**out = **in
+	}
 	if in.AuthorizationAlwaysAllowPaths != nil {
 		in, out := &in.AuthorizationAlwaysAllowPaths, &out.AuthorizationAlwaysAllowPaths
 		*out = make([]string, len(*in))

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3668,6 +3668,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ConcurrentHorizontalPodAustoscalerSyncs != nil {
+		in, out := &in.ConcurrentHorizontalPodAustoscalerSyncs, &out.ConcurrentHorizontalPodAustoscalerSyncs
+		*out = new(int32)
+		**out = **in
+	}
 	if in.AuthorizationAlwaysAllowPaths != nil {
 		in, out := &in.AuthorizationAlwaysAllowPaths, &out.AuthorizationAlwaysAllowPaths
 		*out = make([]string, len(*in))

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -137,7 +137,7 @@ ClusterName: complex.example.com
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: 8llBgMPmer0wwNgQzc6HgHOziAIsfsuBrULCqM5rJ8g=
+NodeupConfigHash: oS9f/2989IOxnyiWmx1lnkIQsogeQAhSZLPP6TSUsKo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -135,6 +135,7 @@ spec:
     cloudProvider: external
     clusterCIDR: 100.96.0.0/11
     clusterName: complex.example.com
+    concurrentHorizontalPodAustoscalerSyncs: 10
     configureCloudRoutes: false
     featureGates:
       CSIMigrationAWS: "true"

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -241,6 +241,7 @@ ControlPlaneConfig:
     cloudProvider: external
     clusterCIDR: 100.96.0.0/11
     clusterName: complex.example.com
+    concurrentHorizontalPodAustoscalerSyncs: 10
     configureCloudRoutes: false
     featureGates:
       CSIMigrationAWS: "true"

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -50,6 +50,8 @@ spec:
     cpuLimit: 500m
     memoryRequest: 800Mi
     memoryLimit: 1000Mi
+  kubeControllerManager:
+    concurrentHorizontalPodAustoscalerSyncs: 10
   kubelet:
     anonymousAuth: false
   kubernetesVersion: v1.24.0

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -27,6 +27,8 @@ spec:
   channel: stable
   cloudControllerManager:
     concurrentNodeSyncs: 5
+  kubeControllerManager:
+    concurrentHorizontalPodAustoscalerSyncs: 10
   cloudProvider: aws
   cloudLabels:
     Owner: John Doe


### PR DESCRIPTION
Add support to configure HPA Controller concurrent syncs flag in HPA/KCM Controller
This value requires to be tweaked to get more performance out of HPA controller on large scale clusters using HPAs.
Plan to leverage this in scale tests in future.

### fixes 
https://github.com/kubernetes/kops/issues/16278
