### PR TITLE
Split internal and external kube-apiserver addresses

### DIFF
--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -150,6 +150,7 @@ type BootConfig struct {
 	ConfigServer *ConfigServerOptions `json:",omitempty"`
 	// APIServerIPs is the API server IP addresses.
 	// This field is used for adding an alias for api.internal. in /etc/hosts, when Topology.DNS.Type == DNSTypeNone.
+	// These addresses are also added to the kops-controller TLS certificate.
 	APIServerIPs []string `json:",omitempty"`
 	// ClusterName is the name of the cluster.
 	ClusterName string `json:",omitempty"`

--- a/pkg/commands/toolbox_enroll.go
+++ b/pkg/commands/toolbox_enroll.go
@@ -120,12 +120,12 @@ func RunToolboxEnroll(ctx context.Context, f commandutils.Factory, out io.Writer
 			// 	apiserverAdditionalIPs = append(apiserverAdditionalIPs, ingress.Hostname)
 			// }
 			if ingress.IP != "" {
-				wellKnownAddresses[wellknownservices.KubeAPIServer] = append(wellKnownAddresses[wellknownservices.KubeAPIServer], ingress.IP)
+				wellKnownAddresses[wellknownservices.KubeAPIServerExternal] = append(wellKnownAddresses[wellknownservices.KubeAPIServerExternal], ingress.IP)
 			}
 		}
 	}
 
-	if len(wellKnownAddresses[wellknownservices.KubeAPIServer]) == 0 {
+	if len(wellKnownAddresses[wellknownservices.KubeAPIServerExternal]) == 0 {
 		// TODO: Should we support DNS?
 		return fmt.Errorf("unable to determine IP address for kube-apiserver")
 	}

--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -199,11 +199,14 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			SecurityGroups: []*awstasks.SecurityGroup{
 				b.LinkToELBSecurityGroup("api"),
 			},
-			SubnetMappings:    nlbSubnetMappings,
-			Tags:              tags,
-			WellKnownServices: []wellknownservices.WellKnownService{wellknownservices.KubeAPIServer},
-			VPC:               b.LinkToVPC(),
-			Type:              fi.PtrTo("network"),
+			SubnetMappings: nlbSubnetMappings,
+			Tags:           tags,
+			WellKnownServices: []wellknownservices.WellKnownService{
+				wellknownservices.KubeAPIServerInternal,
+				wellknownservices.KubeAPIServerExternal,
+			},
+			VPC:  b.LinkToVPC(),
+			Type: fi.PtrTo("network"),
 		}
 
 		// Wait for all load balancer components to be created (including network interfaces needed for NoneDNS).
@@ -241,8 +244,11 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				Timeout: fi.PtrTo(int64(300)),
 			},
 
-			Tags:              tags,
-			WellKnownServices: []wellknownservices.WellKnownService{wellknownservices.KubeAPIServer},
+			Tags: tags,
+			WellKnownServices: []wellknownservices.WellKnownService{
+				wellknownservices.KubeAPIServerInternal,
+				wellknownservices.KubeAPIServerExternal,
+			},
 		}
 
 		if b.Cluster.UsesNoneDNS() {
@@ -554,8 +560,8 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 				ToPort:        fi.PtrTo(int64(4)),
 			})
 			if b.Cluster.UsesNoneDNS() {
-				nlb.WellKnownServices = append(nlb.WellKnownServices, wellknownservices.KopsController)
-				clb.WellKnownServices = append(clb.WellKnownServices, wellknownservices.KopsController)
+				nlb.WellKnownServices = append(nlb.WellKnownServices, wellknownservices.KopsControllerInternal)
+				clb.WellKnownServices = append(clb.WellKnownServices, wellknownservices.KopsControllerInternal)
 
 				c.AddTask(&awstasks.SecurityGroupRule{
 					Name:          fi.PtrTo(fmt.Sprintf("kops-controller-elb-to-cp%s", suffix)),

--- a/pkg/model/azuremodel/api_loadbalancer.go
+++ b/pkg/model/azuremodel/api_loadbalancer.go
@@ -50,16 +50,20 @@ func (b *APILoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) er
 
 	// Create LoadBalancer for API ELB
 	lb := &azuretasks.LoadBalancer{
-		Name:              fi.PtrTo(b.NameForLoadBalancer()),
-		Lifecycle:         b.Lifecycle,
-		ResourceGroup:     b.LinkToResourceGroup(),
-		Tags:              map[string]*string{},
-		WellKnownServices: []wellknownservices.WellKnownService{wellknownservices.KubeAPIServer},
+		Name:          fi.PtrTo(b.NameForLoadBalancer()),
+		Lifecycle:     b.Lifecycle,
+		ResourceGroup: b.LinkToResourceGroup(),
+		Tags:          map[string]*string{},
 	}
+
+	lb.WellKnownServices = append(lb.WellKnownServices,
+		wellknownservices.KubeAPIServerExternal,
+		wellknownservices.KubeAPIServerInternal)
 
 	switch lbSpec.Type {
 	case kops.LoadBalancerTypeInternal:
 		lb.External = to.Ptr(false)
+
 		subnet, err := b.subnetForLoadBalancer()
 		if err != nil {
 			return err
@@ -83,7 +87,7 @@ func (b *APILoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) er
 	c.AddTask(lb)
 
 	if b.Cluster.UsesLegacyGossip() || b.Cluster.UsesPrivateDNS() || b.Cluster.UsesNoneDNS() {
-		lb.WellKnownServices = append(lb.WellKnownServices, wellknownservices.KopsController)
+		lb.WellKnownServices = append(lb.WellKnownServices, wellknownservices.KopsControllerInternal)
 	}
 
 	return nil

--- a/pkg/model/domodel/api_loadbalancer.go
+++ b/pkg/model/domodel/api_loadbalancer.go
@@ -61,11 +61,15 @@ func (b *APILoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) er
 
 	// Create LoadBalancer for API LB
 	loadbalancer := &dotasks.LoadBalancer{
-		Name:              fi.PtrTo(loadbalancerName),
-		Region:            fi.PtrTo(b.Cluster.Spec.Networking.Subnets[0].Region),
-		DropletTag:        fi.PtrTo(clusterMasterTag),
-		Lifecycle:         b.Lifecycle,
-		WellKnownServices: []wellknownservices.WellKnownService{wellknownservices.KopsController, wellknownservices.KubeAPIServer},
+		Name:       fi.PtrTo(loadbalancerName),
+		Region:     fi.PtrTo(b.Cluster.Spec.Networking.Subnets[0].Region),
+		DropletTag: fi.PtrTo(clusterMasterTag),
+		Lifecycle:  b.Lifecycle,
+		WellKnownServices: []wellknownservices.WellKnownService{
+			wellknownservices.KopsControllerInternal,
+			wellknownservices.KubeAPIServerExternal,
+			wellknownservices.KubeAPIServerInternal,
+		},
 	}
 
 	if b.Cluster.Spec.Networking.NetworkID != "" {

--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -67,8 +67,11 @@ func (b *APILoadBalancerBuilder) createPublicLB(c *fi.CloudupModelBuilderContext
 	ipAddress := &gcetasks.Address{
 		Name: s(b.NameForIPAddress("api")),
 
-		Lifecycle:         b.Lifecycle,
-		WellKnownServices: []wellknownservices.WellKnownService{wellknownservices.KubeAPIServer},
+		Lifecycle: b.Lifecycle,
+		WellKnownServices: []wellknownservices.WellKnownService{
+			wellknownservices.KubeAPIServerInternal,
+			wellknownservices.KubeAPIServerExternal,
+		},
 	}
 	c.AddTask(ipAddress)
 
@@ -88,7 +91,7 @@ func (b *APILoadBalancerBuilder) createPublicLB(c *fi.CloudupModelBuilderContext
 		},
 	})
 	if b.Cluster.UsesNoneDNS() {
-		ipAddress.WellKnownServices = append(ipAddress.WellKnownServices, wellknownservices.KopsController)
+		ipAddress.WellKnownServices = append(ipAddress.WellKnownServices, wellknownservices.KopsControllerInternal)
 
 		c.AddTask(&gcetasks.ForwardingRule{
 			Name:                s(b.NameForForwardingRule("kops-controller")),
@@ -208,8 +211,11 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 			Purpose:       s("SHARED_LOADBALANCER_VIP"),
 			Subnetwork:    subnet,
 
-			WellKnownServices: []wellknownservices.WellKnownService{wellknownservices.KubeAPIServer},
-			Lifecycle:         b.Lifecycle,
+			WellKnownServices: []wellknownservices.WellKnownService{
+				wellknownservices.KubeAPIServerExternal,
+				wellknownservices.KubeAPIServerInternal,
+			},
+			Lifecycle: b.Lifecycle,
 		}
 		c.AddTask(ipAddress)
 
@@ -229,7 +235,7 @@ func (b *APILoadBalancerBuilder) createInternalLB(c *fi.CloudupModelBuilderConte
 			},
 		})
 		if b.Cluster.UsesNoneDNS() {
-			ipAddress.WellKnownServices = append(ipAddress.WellKnownServices, wellknownservices.KopsController)
+			ipAddress.WellKnownServices = append(ipAddress.WellKnownServices, wellknownservices.KopsControllerInternal)
 
 			c.AddTask(&gcetasks.ForwardingRule{
 				Name:                s(b.NameForForwardingRule("kops-controller-" + sn.Name)),

--- a/pkg/model/hetznermodel/loadbalancer.go
+++ b/pkg/model/hetznermodel/loadbalancer.go
@@ -65,7 +65,11 @@ func (b *LoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) error
 			hetzner.TagKubernetesClusterName: b.ClusterName(),
 		},
 
-		WellKnownServices: []wellknownservices.WellKnownService{wellknownservices.KubeAPIServer, wellknownservices.KopsController},
+		WellKnownServices: []wellknownservices.WellKnownService{
+			wellknownservices.KopsControllerInternal,
+			wellknownservices.KubeAPIServerExternal,
+			wellknownservices.KubeAPIServerInternal,
+		},
 	}
 
 	c.AddTask(&loadbalancer)

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -201,7 +201,9 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.CloudupModelBuilderContex
 		c.AddTask(portTask)
 
 		if b.Cluster.UsesNoneDNS() && ig.Spec.Role == kops.InstanceGroupRoleControlPlane {
-			portTask.WellKnownServices = append(portTask.WellKnownServices, wellknownservices.KubeAPIServer)
+			portTask.WellKnownServices = append(portTask.WellKnownServices,
+				wellknownservices.KubeAPIServerExternal,
+				wellknownservices.KubeAPIServerInternal)
 		}
 
 		metaWithName := make(map[string]string)
@@ -243,7 +245,10 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.CloudupModelBuilderContex
 				if ig.Spec.Role == kops.InstanceGroupRoleControlPlane {
 					// Ensure the floating IP is included in the TLS certificate,
 					// if we're not going to use an alias for it
-					t.WellKnownServices = append(t.WellKnownServices, wellknownservices.KubeAPIServer, wellknownservices.KopsController)
+					t.WellKnownServices = append(t.WellKnownServices,
+						wellknownservices.KubeAPIServerExternal,
+						wellknownservices.KubeAPIServerInternal,
+						wellknownservices.KopsControllerInternal)
 				}
 				instanceTask.FloatingIP = t
 			}
@@ -337,7 +342,8 @@ func (b *ServerGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) error 
 		}
 		c.AddTask(lbfipTask)
 
-		lbfipTask.WellKnownServices = append(lbfipTask.WellKnownServices, wellknownservices.KubeAPIServer)
+		lbfipTask.WellKnownServices = append(lbfipTask.WellKnownServices, wellknownservices.KubeAPIServerInternal)
+		lbfipTask.WellKnownServices = append(lbfipTask.WellKnownServices, wellknownservices.KubeAPIServerExternal)
 
 		poolTask := &openstacktasks.LBPool{
 			Name:         fi.PtrTo(fmt.Sprintf("%s-https", fi.ValueOf(lbTask.Name))),

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -10,7 +10,8 @@ LB: null
 Lifecycle: Sync
 Name: fip-master-1-cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 - kops-controller
 ---
 ID: null
@@ -19,7 +20,8 @@ LB: null
 Lifecycle: Sync
 Name: fip-master-2-cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 - kops-controller
 ---
 ID: null
@@ -28,7 +30,8 @@ LB: null
 Lifecycle: Sync
 Name: fip-master-3-cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 - kops-controller
 ---
 ID: null
@@ -62,7 +65,8 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-1-cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
   - kops-controller
 GroupName: master
 ID: null
@@ -153,7 +157,8 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-2-cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
   - kops-controller
 GroupName: master
 ID: null
@@ -244,7 +249,8 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-3-cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
   - kops-controller
 GroupName: master
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -37,7 +37,8 @@ LB:
 Lifecycle: Sync
 Name: fip-api.cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-internal
+- kube-apiserver-external
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
@@ -96,7 +97,8 @@ Port:
   - KopsName=port-master-a-1
   - KubernetesCluster=cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -174,7 +176,8 @@ Port:
   - KopsName=port-master-b-1
   - KubernetesCluster=cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -252,7 +255,8 @@ Port:
   - KopsName=port-master-c-1
   - KubernetesCluster=cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -866,7 +870,8 @@ Tags:
 - KopsName=port-master-a-1
 - KubernetesCluster=cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
@@ -900,7 +905,8 @@ Tags:
 - KopsName=port-master-b-1
 - KubernetesCluster=cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
@@ -934,7 +940,8 @@ Tags:
 - KopsName=port-master-c-1
 - KubernetesCluster=cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -37,7 +37,8 @@ LB:
 Lifecycle: Sync
 Name: fip-master-public-name
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-internal
+- kube-apiserver-external
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -22,7 +22,8 @@ LB: null
 Lifecycle: Sync
 Name: fip-master-a-1-cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 - kops-controller
 ---
 ID: null
@@ -31,7 +32,8 @@ LB: null
 Lifecycle: Sync
 Name: fip-master-b-1-cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 - kops-controller
 ---
 ID: null
@@ -40,7 +42,8 @@ LB: null
 Lifecycle: Sync
 Name: fip-master-c-1-cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 - kops-controller
 ---
 ID: null
@@ -74,7 +77,8 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-a-1-cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
   - kops-controller
 GroupName: master-a
 ID: null
@@ -165,7 +169,8 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-b-1-cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
   - kops-controller
 GroupName: master-b
 ID: null
@@ -256,7 +261,8 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-c-1-cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
   - kops-controller
 GroupName: master-c
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -10,7 +10,8 @@ LB: null
 Lifecycle: Sync
 Name: fip-master-1-cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 - kops-controller
 ---
 ID: null
@@ -30,7 +31,8 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-1-cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
   - kops-controller
 GroupName: master
 ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/single-zone-setup-3-masters-1-node-without-bastion-with-API-loadbalancer-dns-none.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/single-zone-setup-3-masters-1-node-without-bastion-with-API-loadbalancer-dns-none.yaml
@@ -31,7 +31,8 @@ LB:
 Lifecycle: Sync
 Name: fip-api.cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-internal
+- kube-apiserver-external
 ---
 AvailabilityZone: zone-1
 ConfigDrive: false
@@ -90,7 +91,8 @@ Port:
   - KopsName=port-master-a-1
   - KubernetesCluster=cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -170,7 +172,8 @@ Port:
   - KopsName=port-master-b-1
   - KubernetesCluster=cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -250,7 +253,8 @@ Port:
   - KopsName=port-master-c-1
   - KubernetesCluster=cluster
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
 Region: ""
 Role: ControlPlane
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
@@ -698,7 +702,8 @@ Tags:
 - KopsName=port-master-a-1
 - KubernetesCluster=cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
@@ -732,7 +737,8 @@ Tags:
 - KopsName=port-master-b-1
 - KubernetesCluster=cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null
@@ -766,7 +772,8 @@ Tags:
 - KopsName=port-master-c-1
 - KubernetesCluster=cluster
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 ---
 AdditionalSecurityGroups: null
 AllowedAddressPairs: null

--- a/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/truncate-cluster-names-to-42-characters.yaml
@@ -10,7 +10,8 @@ LB: null
 Lifecycle: Sync
 Name: fip-master-1-tom-software-dev-playground-real33-k8s-local
 WellKnownServices:
-- kube-apiserver
+- kube-apiserver-external
+- kube-apiserver-internal
 - kops-controller
 ---
 ID: null
@@ -30,7 +31,8 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-1-tom-software-dev-playground-real33-k8s-local
   WellKnownServices:
-  - kube-apiserver
+  - kube-apiserver-external
+  - kube-apiserver-internal
   - kops-controller
 GroupName: master
 ID: null

--- a/pkg/model/scalewaymodel/api_loadbalancer.go
+++ b/pkg/model/scalewaymodel/api_loadbalancer.go
@@ -82,7 +82,8 @@ func (b *APILoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) er
 
 	c.AddTask(loadBalancer)
 
-	loadBalancer.WellKnownServices = append(loadBalancer.WellKnownServices, wellknownservices.KubeAPIServer)
+	loadBalancer.WellKnownServices = append(loadBalancer.WellKnownServices, wellknownservices.KubeAPIServerInternal)
+	loadBalancer.WellKnownServices = append(loadBalancer.WellKnownServices, wellknownservices.KubeAPIServerExternal)
 	lbBackendHttps, lbFrontendHttps := createLbBackendAndFrontend("https", wellknownports.KubeAPIServer, zone, loadBalancer)
 	lbBackendHttps.Lifecycle = b.Lifecycle
 	c.AddTask(lbBackendHttps)
@@ -90,7 +91,7 @@ func (b *APILoadBalancerModelBuilder) Build(c *fi.CloudupModelBuilderContext) er
 	c.AddTask(lbFrontendHttps)
 
 	if dns.IsGossipClusterName(b.Cluster.Name) || b.Cluster.UsesPrivateDNS() || b.Cluster.UsesNoneDNS() {
-		loadBalancer.WellKnownServices = append(loadBalancer.WellKnownServices, wellknownservices.KopsController)
+		loadBalancer.WellKnownServices = append(loadBalancer.WellKnownServices, wellknownservices.KopsControllerInternal)
 		lbBackendKopsController, lbFrontendKopsController := createLbBackendAndFrontend("kops-controller", wellknownports.KopsControllerPort, zone, loadBalancer)
 		lbBackendKopsController.Lifecycle = b.Lifecycle
 		c.AddTask(lbBackendKopsController)

--- a/pkg/wellknownservices/wellknownservices.go
+++ b/pkg/wellknownservices/wellknownservices.go
@@ -19,9 +19,20 @@ package wellknownservices
 type WellKnownService string
 
 const (
-	// KubeAPIServer is the service where kube-apiserver listens.
-	KubeAPIServer WellKnownService = "kube-apiserver"
+	// KubeAPIServerExternal is the service where kube-apiserver listens for user traffic.
+	KubeAPIServerExternal WellKnownService = "kube-apiserver-external"
 
-	// KopsController is the service where kops-controller listens.
-	KopsController WellKnownService = "kops-controller"
+	// KubeAPIServerInternal is the service where kube-apiserver listens for internal (in-cluster) traffic.
+	// Note that this might still be exposed publicly, "internal" refers to whether the source of the traffic
+	// is from inside or outside the cluster.
+	KubeAPIServerInternal WellKnownService = "kube-apiserver-internal"
+
+	// KopsControllerInternal is the service where kops-controller listens for internal (in-cluster) traffic.
+	// As with KubeAPIServerInternal, this might still be exposed publicly,
+	// "internal" refers to whether whether the source of the traffic is from inside or outside the cluster.
+	// There is no "KopsControllerExternal" because the only client of kops-controller should be the Nodes;
+	// and generally we do not need or want to expose kops-controller to the internet.
+	// However, on some clouds it's not easy to restrict access, and we don't rely on kops-controller being
+	// unreachable publicly.
+	KopsControllerInternal WellKnownService = "kops-controller"
 )

--- a/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/azuretasks/loadbalancer.go
@@ -207,7 +207,7 @@ func (*LoadBalancer) RenderAzure(t *azure.AzureAPITarget, a, e, changes *LoadBal
 		Tags: e.Tags,
 	}
 
-	if slices.Contains(e.WellKnownServices, wellknownservices.KubeAPIServer) {
+	if slices.Contains(e.WellKnownServices, wellknownservices.KubeAPIServerExternal) || slices.Contains(e.WellKnownServices, wellknownservices.KubeAPIServerInternal) {
 		lb.Properties.Probes = append(lb.Properties.Probes, &network.Probe{
 			Name: to.Ptr("Health-TCP-443"),
 			Properties: &network.ProbePropertiesFormat{
@@ -239,7 +239,7 @@ func (*LoadBalancer) RenderAzure(t *azure.AzureAPITarget, a, e, changes *LoadBal
 		})
 	}
 
-	if slices.Contains(e.WellKnownServices, wellknownservices.KopsController) {
+	if slices.Contains(e.WellKnownServices, wellknownservices.KopsControllerInternal) {
 		lb.Properties.Probes = append(lb.Properties.Probes, &network.Probe{
 			Name: to.Ptr("Health-TCP-3988"),
 			Properties: &network.ProbePropertiesFormat{

--- a/upup/pkg/fi/cloudup/azuretasks/loadbalancer_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/loadbalancer_test.go
@@ -45,7 +45,7 @@ func newTestLoadBalancer() *LoadBalancer {
 			},
 		},
 		External:          to.Ptr(true),
-		WellKnownServices: []wellknownservices.WellKnownService{wellknownservices.KubeAPIServer},
+		WellKnownServices: []wellknownservices.WellKnownService{wellknownservices.KubeAPIServerExternal},
 		Tags: map[string]*string{
 			testTagKey: to.Ptr(testTagValue),
 		},


### PR DESCRIPTION
This allows us to select the right IP address when we have multiple
load balancers (one for internal, one for external) as we are planning
to have on GCE.
