### PR TITLE
refactor: NetworkLoadBalancer Name should match Name tag

### DIFF
--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -167,16 +167,15 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			klog.V(1).Infof("WARNING: You are overwriting the Load Balancers, Security Group. When this is done you are responsible for ensure the correct rules!")
 		}
 
-		tags := b.CloudTags(loadBalancerName, false)
+		tags := b.CloudTags("", false)
 		for k, v := range b.Cluster.Spec.CloudLabels {
 			tags[k] = v
 		}
 		// Override the returned name to be the expected ELB name
 		tags["Name"] = "api." + b.ClusterName()
 
-		name := b.NLBName("api")
 		nlb = &awstasks.NetworkLoadBalancer{
-			Name:      &name,
+			Name:      fi.PtrTo(b.NLBName("api")),
 			Lifecycle: b.Lifecycle,
 
 			LoadBalancerName: fi.PtrTo(loadBalancerName),

--- a/pkg/model/awsmodel/bastion.go
+++ b/pkg/model/awsmodel/bastion.go
@@ -321,7 +321,7 @@ func (b *BastionModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	{
 		loadBalancerName := b.LBName32("bastion")
 
-		tags := b.CloudTags(loadBalancerName, false)
+		tags := b.CloudTags("", false)
 		for k, v := range b.Cluster.Spec.CloudLabels {
 			tags[k] = v
 		}

--- a/pkg/model/names.go
+++ b/pkg/model/names.go
@@ -98,7 +98,7 @@ func (b *KopsModelContext) CLBName(prefix string) string {
 }
 
 func (b *KopsModelContext) NLBName(prefix string) string {
-	return strings.ReplaceAll(prefix+"-"+b.ClusterName(), ".", "-")
+	return prefix + "." + b.ClusterName()
 }
 
 func (b *KopsModelContext) NLBTargetGroupName(prefix string) string {

--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -160,7 +160,6 @@ func findDNSTargetNLB(cloud awsup.AWSCloud, aliasTarget *route53.AliasTarget, dn
 		if nameTag == "" {
 			return nil, fmt.Errorf("Found NLB %q linked to DNS name %q, but it did not have a Name tag", loadBalancerName, fi.ValueOf(targetDNSName))
 		}
-		nameTag = strings.Replace(nameTag, ".", "-", -1)
 		return &NetworkLoadBalancer{Name: fi.PtrTo(nameTag)}, nil
 	}
 	return nil, nil

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -870,13 +870,18 @@ func (_ *NetworkLoadBalancer) RenderTerraform(t *terraform.TerraformTarget, a, e
 			listenerTF.Protocol = elbv2.ProtocolEnumTcp
 		}
 
-		err = t.RenderResource("aws_lb_listener", fmt.Sprintf("%v-%v", *e.Name, listener.Port), listenerTF)
+		err = t.RenderResource("aws_lb_listener", fmt.Sprintf("%v-%v", e.TerraformName(), listener.Port), listenerTF)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (e *NetworkLoadBalancer) TerraformName() string {
+	tfName := strings.Replace(fi.ValueOf(e.Name), ".", "-", -1)
+	return tfName
 }
 
 func (e *NetworkLoadBalancer) TerraformLink(params ...string) *terraformWriter.Literal {


### PR DESCRIPTION
It was actually the terraform name, and didn't match the tag.

This change should have no externally-visible effect.
