### PR TITLE
Fix: support comparison of int types in dry-run

### DIFF
--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -328,6 +328,9 @@ func buildChangeList[T SubContext](a, e, changes Task[T]) ([]change, error) {
 
 			case reflect.String:
 				changed = fieldValC.Convert(reflect.TypeOf("")).Interface() != ""
+
+			case reflect.Int:
+				changed = fieldValA.Int() != fieldValE.Int()
 			}
 			if !changed {
 				continue


### PR DESCRIPTION
This avoids printing a change when the before and after values are the
same.
