### PR TITLE
WIP: Introduce cleanup phase

### DIFF
--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -27,6 +27,7 @@ kops update cluster [CLUSTER] [flags]
 ```
       --admin duration[=18h0m0s]      Also export a cluster admin user credential with the specified lifetime and add it to the cluster context
       --allow-kops-downgrade          Allow an older version of kOps to update the cluster than last used
+      --cleanup-after-upgrade         Delete old revisions of cloud resources that were needed during an upgrade
       --create-kube-config            Will control automatically creating the kube config file on your local filesystem (default true)
   -h, --help                          help for cluster
       --internal                      Use the cluster's internal DNS name. Implies --create-kube-config

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -492,6 +492,8 @@ func (c *RollingUpdateCluster) reconcileInstanceGroup() error {
 		Phase:              "",
 		TargetName:         "direct",
 		LifecycleOverrides: map[string]fi.Lifecycle{},
+
+		DeletionProcessing: fi.DeletionProcessingModeDeleteIfNotDeferrred,
 	}
 
 	return applyCmd.Run(c.Ctx)

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -492,7 +492,7 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.CloudupMo
 		}
 
 		if extLB.TargetGroupARN != nil {
-			targetGroupName, err := awsup.GetTargetGroupNameFromARN(fi.ValueOf(extLB.TargetGroupARN))
+			targetGroupName, err := awsup.NameForExternalTargetGroup(fi.ValueOf(extLB.TargetGroupARN))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/model/awsmodel/bastion.go
+++ b/pkg/model/awsmodel/bastion.go
@@ -319,8 +319,6 @@ func (b *BastionModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	// Create NLB itself
 	var nlb *awstasks.NetworkLoadBalancer
 	{
-		loadBalancerName := b.LBName32("bastion")
-
 		tags := b.CloudTags("", false)
 		for k, v := range b.Cluster.Spec.CloudLabels {
 			tags[k] = v
@@ -341,13 +339,12 @@ func (b *BastionModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			Name:      fi.PtrTo(b.NLBName("bastion")),
 			Lifecycle: b.Lifecycle,
 
-			LoadBalancerName: fi.PtrTo(loadBalancerName),
-			CLBName:          fi.PtrTo("bastion." + b.ClusterName()),
-			SubnetMappings:   nlbSubnetMappings,
+			LoadBalancerBaseName: fi.PtrTo(b.LBName32("bastion")),
+			CLBName:              fi.PtrTo("bastion." + b.ClusterName()),
+			SubnetMappings:       nlbSubnetMappings,
 			SecurityGroups: []*awstasks.SecurityGroup{
 				b.LinkToELBSecurityGroup("bastion"),
 			},
-
 			Tags:          tags,
 			VPC:           b.LinkToVPC(),
 			Type:          fi.PtrTo("network"),
@@ -390,6 +387,7 @@ func (b *BastionModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			UnhealthyThreshold: fi.PtrTo(int64(2)),
 			Shared:             fi.PtrTo(false),
 		}
+		tg.CreateNewRevisionsWith(nlb)
 
 		c.AddTask(tg)
 

--- a/pkg/model/awsmodel/spotinst.go
+++ b/pkg/model/awsmodel/spotinst.go
@@ -851,7 +851,7 @@ func (b *SpotInstanceGroupModelBuilder) buildLoadBalancers(c *fi.CloudupModelBui
 			c.EnsureTask(lb)
 		}
 		if extLB.TargetGroupARN != nil {
-			targetGroupName, err := awsup.GetTargetGroupNameFromARN(fi.ValueOf(extLB.TargetGroupARN))
+			targetGroupName, err := awsup.NameForExternalTargetGroup(fi.ValueOf(extLB.TargetGroupARN))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -155,6 +155,9 @@ type ApplyClusterCmd struct {
 
 	// AdditionalObjects holds cluster-asssociated configuration objects, other than the Cluster and InstanceGroups.
 	AdditionalObjects kubemanifest.ObjectList
+
+	// DeletionProcessing controls whether we process deletions.
+	DeletionProcessing fi.DeletionProcessingMode
 }
 
 func (c *ApplyClusterCmd) Run(ctx context.Context) error {
@@ -714,7 +717,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 	var target fi.CloudupTarget
 	shouldPrecreateDNS := true
 
-	deletionProcessingMode := fi.DeletionProcessingModeDeleteIfNotDeferrred
+	deletionProcessingMode := c.DeletionProcessing
 	switch c.TargetName {
 	case TargetDirect:
 		switch cluster.Spec.GetCloudProvider() {

--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -50,6 +50,7 @@ type DNSTarget interface {
 }
 
 func (e *DNSName) Find(c *fi.CloudupContext) (*DNSName, error) {
+	ctx := c.Context()
 	cloud := c.T.Cloud.(awsup.AWSCloud)
 
 	if e.Zone == nil || e.Zone.ZoneID == nil {
@@ -75,7 +76,7 @@ func (e *DNSName) Find(c *fi.CloudupContext) (*DNSName, error) {
 
 	var found *route53.ResourceRecordSet
 
-	err := cloud.Route53().ListResourceRecordSetsPages(request, func(p *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool) {
+	err := cloud.Route53().ListResourceRecordSetsPagesWithContext(ctx, request, func(p *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool) {
 		for _, rr := range p.ResourceRecordSets {
 			resourceType := aws.StringValue(rr.Type)
 			name := aws.StringValue(rr.Name)

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -402,7 +402,7 @@ func (t *LaunchTemplate) findLatestLaunchTemplateVersion(c *fi.CloudupContext) (
 }
 
 // deleteLaunchTemplate tracks a LaunchConfiguration that we're going to delete
-// It implements fi.Deletion
+// It implements fi.CloudupDeletion
 type deleteLaunchTemplate struct {
 	lc *ec2.LaunchTemplate
 }
@@ -437,4 +437,8 @@ func (d *deleteLaunchTemplate) Delete(t fi.CloudupTarget) error {
 // String returns a string representation of the task
 func (d *deleteLaunchTemplate) String() string {
 	return d.TaskName() + "-" + d.Item()
+}
+
+func (d *deleteLaunchTemplate) DeferDeletion() bool {
+	return false // TODO: Should we defer deletion?
 }

--- a/upup/pkg/fi/cloudup/awstasks/networkloadbalancer_attributes.go
+++ b/upup/pkg/fi/cloudup/awstasks/networkloadbalancer_attributes.go
@@ -72,8 +72,6 @@ func (_ *NetworkLoadBalancer) modifyLoadBalancerAttributes(t *awsup.AWSAPITarget
 		return nil
 	}
 
-	loadBalancerName := fi.ValueOf(e.LoadBalancerName)
-
 	request := &elbv2.ModifyLoadBalancerAttributesInput{
 		LoadBalancerArn: aws.String(loadBalancerArn),
 	}
@@ -113,14 +111,14 @@ func (_ *NetworkLoadBalancer) modifyLoadBalancerAttributes(t *awsup.AWSAPITarget
 
 	request.Attributes = attributes
 
-	klog.V(2).Infof("Configuring NLB attributes for NLB %q", loadBalancerName)
+	klog.V(2).Infof("Configuring NLB attributes for NLB %q", loadBalancerArn)
 
 	response, err := t.Cloud.ELBV2().ModifyLoadBalancerAttributes(request)
 	if err != nil {
-		return fmt.Errorf("error configuring NLB attributes for NLB %q: %v", loadBalancerName, err)
+		return fmt.Errorf("error configuring NLB attributes for NLB %q: %v", loadBalancerArn, err)
 	}
 
-	klog.V(4).Infof("modified NLB attributes for NLB %q, response %+v", loadBalancerName, response)
+	klog.V(4).Infof("modified NLB attributes for NLB %q, response %+v", loadBalancerArn, response)
 
 	return nil
 }

--- a/upup/pkg/fi/cloudup/awstasks/networkloadbalancerlistener.go
+++ b/upup/pkg/fi/cloudup/awstasks/networkloadbalancerlistener.go
@@ -31,6 +31,8 @@ import (
 
 // +kops:fitask
 type NetworkLoadBalancerListener struct {
+	// We use the Name tag to find the existing NLB, because we are (more or less) unrestricted when
+	// it comes to tag values, but the LoadBalancerName is length limited
 	Name      *string
 	Lifecycle fi.Lifecycle
 
@@ -203,8 +205,6 @@ func (*NetworkLoadBalancerListener) RenderAWS(t *awsup.AWSAPITarget, a, e, chang
 		}
 	}
 
-	// TODO: Tags on the listener?
-
 	return nil
 }
 
@@ -226,7 +226,6 @@ func (_ *NetworkLoadBalancerListener) RenderTerraform(t *terraform.TerraformTarg
 	if e.TargetGroup == nil {
 		return fi.RequiredField("TargetGroup")
 	}
-
 	listenerTF := &terraformNetworkLoadBalancerListener{
 		LoadBalancer: e.NetworkLoadBalancer.TerraformLink(),
 		Port:         int64(e.Port),

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -541,6 +541,10 @@ func (d *deleteSubnetIPv6CIDRBlock) Item() string {
 	return fmt.Sprintf("%v: ipv6cidr=%v", *d.vpcID, *d.ipv6CidrBlock)
 }
 
+func (d *deleteSubnetIPv6CIDRBlock) DeferDeletion() bool {
+	return false // TODO: should we defer this?
+}
+
 func calculateSubnetCIDR(vpcCIDR, subnetCIDR *string) (*string, error) {
 	if vpcCIDR == nil {
 		return nil, fmt.Errorf("expecting VPC CIDR to not be <nil>")

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -391,3 +391,7 @@ func (d *deleteVPCCIDRBlock) TaskName() string {
 func (d *deleteVPCCIDRBlock) Item() string {
 	return fmt.Sprintf("%v: cidr=%v", *d.vpcID, *d.cidrBlock)
 }
+
+func (d *deleteVPCCIDRBlock) DeferDeletion() bool {
+	return false // TODO: should we defer this?
+}

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -241,8 +241,8 @@ func GetResourceName32(cluster string, prefix string) string {
 	return truncate.TruncateString(s, opt)
 }
 
-// GetTargetGroupNameFromARN will attempt to parse a target group ARN and return its name
-func GetTargetGroupNameFromARN(targetGroupARN string) (string, error) {
+// NameForExternalTargetGroup will attempt to calculate a meaningful name for a target group given an ARN.
+func NameForExternalTargetGroup(targetGroupARN string) (string, error) {
 	parsed, err := arn.Parse(targetGroupARN)
 	if err != nil {
 		return "", fmt.Errorf("error parsing target group ARN: %v", err)

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -211,10 +211,6 @@ func (c *MockAWSCloud) DescribeELBTags(loadBalancerNames []string) (map[string][
 	return describeELBTags(c, loadBalancerNames)
 }
 
-func (c *MockAWSCloud) FindELBV2ByNameTag(findNameTag string) (*elbv2.LoadBalancer, error) {
-	return findELBV2ByNameTag(c, findNameTag)
-}
-
 func (c *MockAWSCloud) DescribeELBV2Tags(loadBalancerArns []string) (map[string][]*elbv2.Tag, error) {
 	return describeELBV2Tags(c, loadBalancerArns)
 }

--- a/upup/pkg/fi/cloudup/awsup/tags.go
+++ b/upup/pkg/fi/cloudup/awsup/tags.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsup
+
+// KopsResourceRevisionTag is the tag used to store the revision timestamp,
+// when we are forced to create a new version of a resource because we cannot modify it in-place.
+// This happens when the resource field is immutable;
+// it also happens for ELBs, when we cannot have two ELBs pointing at the same target group
+// and thus must create a second.
+const KopsResourceRevisionTag = "kops.k8s.io/revision"

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
@@ -259,6 +259,10 @@ func (d *deleteSecurityGroup) Item() string {
 	return s
 }
 
+func (d *deleteSecurityGroup) DeferDeletion() bool {
+	return false // TODO: Should we defer deletion?
+}
+
 type deleteSecurityGroupRule struct {
 	rule          sgr.SecGroupRule
 	securityGroup *SecurityGroup
@@ -296,6 +300,10 @@ func (d *deleteSecurityGroupRule) Item() string {
 	s += fmt.Sprintf(" ip=%s", d.rule.RemoteIPPrefix)
 	s += fmt.Sprintf(" securitygroup=%s", fi.ValueOf(d.securityGroup.Name))
 	return s
+}
+
+func (d *deleteSecurityGroupRule) DeferDeletion() bool {
+	return false // TODO: Should we defer deletion?
 }
 
 // RemovalRule is a rule that filters the permissions we should remove

--- a/upup/pkg/fi/deletions.go
+++ b/upup/pkg/fi/deletions.go
@@ -38,6 +38,7 @@ type Deletion[T SubContext] interface {
 	Delete(target Target[T]) error
 	TaskName() string
 	Item() string
+	DeferDeletion() bool
 }
 
 type CloudupDeletion = Deletion[CloudupSubContext]

--- a/upup/pkg/fi/topological_sort.go
+++ b/upup/pkg/fi/topological_sort.go
@@ -66,9 +66,13 @@ func FindTaskDependencies[T SubContext](tasks map[string]Task[T]) map[string][]s
 
 		var dependencyKeys []string
 		for _, dep := range dependencies {
+			// Skip nils, including interface nils
+			if dep == nil || reflect.ValueOf(dep).IsNil() {
+				continue
+			}
 			dependencyKey, found := taskToId[dep]
 			if !found {
-				klog.Fatalf("dependency not found: %v", dep)
+				klog.Fatalf("dependency for task %T:%q not found: %v", t, k, dep)
 			}
 			dependencyKeys = append(dependencyKeys, dependencyKey)
 		}


### PR DESCRIPTION
A large "integration branch" PR to show the big picture; I will whittle this down with smaller PRs but want to show & agree the direction.

Because of the challenges of adding security groups to an existing NLB - see issue #16276 - the best way around this seems to be to create a second NLB during `kops update`, do a `kops rolling-update` (the old nodes use the old NLB, the new nodes use the new NLB), then do a cleanup phase where we delete the original (now unused) NLB and associated resources.

Even with this, as @zetaab pointed out the kubeconfig DNS name will change if we're using the ELB, though this "just" means that users will need to distribute a new kubeconfig.  Users using a real domain will not need to distribute a new kubeconfig.

Generally, the trick here is to introduce the idea of "revisions" of a Task or Cloud Resource.  Two NLBs / TargetGroups / etc might have the same Name tag on AWS, but would have a different revision tag (`kops.k8s.io/revision`).

Another trick we use is to stash more state in private fields in the Task; we already have a "linking" phase such that if you refer to a Task with its "ID" (as defined by CompareWithID) that gets replaced with the canonical Task object.