### PR TITLE
refactor: Introduce runTests helper method into aws tests

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_test.go
@@ -94,18 +94,7 @@ func TestSharedEgressOnlyInternetGatewayDoesNotRename(t *testing.T) {
 		allTasks := buildTasks()
 		eigw1 := allTasks["eigw1"].(*EgressOnlyInternetGateway)
 
-		target := &awsup.AWSAPITarget{
-			Cloud: cloud,
-		}
-
-		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
-		if err != nil {
-			t.Fatalf("error building context: %v", err)
-		}
-
-		if err := context.RunTasks(testRunTasksOptions); err != nil {
-			t.Fatalf("unexpected error during Run: %v", err)
-		}
+		runTasks(t, cloud, allTasks)
 
 		if fi.ValueOf(eigw1.ID) == "" {
 			t.Fatalf("ID not set after create")
@@ -142,5 +131,23 @@ func TestSharedEgressOnlyInternetGatewayDoesNotRename(t *testing.T) {
 	{
 		allTasks := buildTasks()
 		checkNoChanges(t, ctx, cloud, allTasks)
+	}
+}
+
+func runTasks(t *testing.T, cloud awsup.AWSCloud, allTasks map[string]fi.CloudupTask) {
+	t.Helper()
+	ctx := context.TODO()
+
+	target := &awsup.AWSAPITarget{
+		Cloud: cloud,
+	}
+
+	context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
+	if err != nil {
+		t.Fatalf("error building context: %v", err)
+	}
+
+	if err := context.RunTasks(testRunTasksOptions); err != nil {
+		t.Fatalf("unexpected error during Run: %v", err)
 	}
 }

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
@@ -78,18 +78,7 @@ func TestElasticIPCreate(t *testing.T) {
 		allTasks := buildTasks()
 		eip1 := allTasks["eip1"].(*ElasticIP)
 
-		target := &awsup.AWSAPITarget{
-			Cloud: cloud,
-		}
-
-		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
-		if err != nil {
-			t.Fatalf("error building context: %v", err)
-		}
-
-		if err := context.RunTasks(testRunTasksOptions); err != nil {
-			t.Fatalf("unexpected error during Run: %v", err)
-		}
+		runTasks(t, cloud, allTasks)
 
 		if fi.ValueOf(eip1.ID) == "" {
 			t.Fatalf("ID not set after create")

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
@@ -110,18 +110,7 @@ func TestSharedInternetGatewayDoesNotRename(t *testing.T) {
 		allTasks := buildTasks()
 		igw1 := allTasks["igw1"].(*InternetGateway)
 
-		target := &awsup.AWSAPITarget{
-			Cloud: cloud,
-		}
-
-		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
-		if err != nil {
-			t.Fatalf("error building context: %v", err)
-		}
-
-		if err := context.RunTasks(testRunTasksOptions); err != nil {
-			t.Fatalf("unexpected error during Run: %v", err)
-		}
+		runTasks(t, cloud, allTasks)
 
 		if fi.ValueOf(igw1.ID) == "" {
 			t.Fatalf("ID not set after create")

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
@@ -137,18 +137,7 @@ func TestSecurityGroupCreate(t *testing.T) {
 		sg1 := allTasks["sg1"].(*SecurityGroup)
 		vpc1 := allTasks["vpc1"].(*VPC)
 
-		target := &awsup.AWSAPITarget{
-			Cloud: cloud,
-		}
-
-		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
-		if err != nil {
-			t.Fatalf("error building context: %v", err)
-		}
-
-		if err := context.RunTasks(testRunTasksOptions); err != nil {
-			t.Fatalf("unexpected error during Run: %v", err)
-		}
+		runTasks(t, cloud, allTasks)
 
 		if fi.ValueOf(sg1.ID) == "" {
 			t.Fatalf("ID not set after create")

--- a/upup/pkg/fi/cloudup/awstasks/subnet_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet_test.go
@@ -98,18 +98,7 @@ func TestSubnetCreate(t *testing.T) {
 		allTasks := buildTasks()
 		subnet1 := allTasks["subnet1"].(*Subnet)
 
-		target := &awsup.AWSAPITarget{
-			Cloud: cloud,
-		}
-
-		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
-		if err != nil {
-			t.Fatalf("error building context: %v", err)
-		}
-
-		if err := context.RunTasks(testRunTasksOptions); err != nil {
-			t.Fatalf("unexpected error during Run: %v", err)
-		}
+		runTasks(t, cloud, allTasks)
 
 		if fi.ValueOf(subnet1.ID) == "" {
 			t.Fatalf("ID not set after create")
@@ -190,18 +179,7 @@ func TestSubnetCreateIPv6(t *testing.T) {
 		allTasks := buildTasks()
 		subnet1 := allTasks["subnet1"].(*Subnet)
 
-		target := &awsup.AWSAPITarget{
-			Cloud: cloud,
-		}
-
-		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
-		if err != nil {
-			t.Fatalf("error building context: %v", err)
-		}
-
-		if err := context.RunTasks(testRunTasksOptions); err != nil {
-			t.Fatalf("unexpected error during Run: %v", err)
-		}
+		runTasks(t, cloud, allTasks)
 
 		if fi.ValueOf(subnet1.ID) == "" {
 			t.Fatalf("ID not set after create")
@@ -290,18 +268,7 @@ func TestSubnetCreateIPv6NetNum(t *testing.T) {
 		allTasks := buildTasks()
 		subnet1 := allTasks["subnet1"].(*Subnet)
 
-		target := &awsup.AWSAPITarget{
-			Cloud: cloud,
-		}
-
-		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
-		if err != nil {
-			t.Fatalf("error building context: %v", err)
-		}
-
-		if err := context.RunTasks(testRunTasksOptions); err != nil {
-			t.Fatalf("unexpected error during Run: %v", err)
-		}
+		runTasks(t, cloud, allTasks)
 
 		if fi.ValueOf(subnet1.ID) == "" {
 			t.Fatalf("ID not set after create")
@@ -424,18 +391,7 @@ func TestSharedSubnetCreateDoesNotCreateNew(t *testing.T) {
 		allTasks := buildTasks()
 		subnet1 := allTasks["subnet1"].(*Subnet)
 
-		target := &awsup.AWSAPITarget{
-			Cloud: cloud,
-		}
-
-		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
-		if err != nil {
-			t.Fatalf("error building context: %v", err)
-		}
-
-		if err := context.RunTasks(testRunTasksOptions); err != nil {
-			t.Fatalf("unexpected error during Run: %v", err)
-		}
+		runTasks(t, cloud, allTasks)
 
 		if fi.ValueOf(subnet1.ID) == "" {
 			t.Fatalf("ID not set after create")

--- a/upup/pkg/fi/cloudup/awstasks/vpc_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_test.go
@@ -52,18 +52,7 @@ func TestVPCCreate(t *testing.T) {
 		allTasks := buildTasks()
 		vpc1 := allTasks["vpc1"].(*VPC)
 
-		target := &awsup.AWSAPITarget{
-			Cloud: cloud,
-		}
-
-		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
-		if err != nil {
-			t.Fatalf("error building context: %v", err)
-		}
-
-		if err := context.RunTasks(testRunTasksOptions); err != nil {
-			t.Fatalf("unexpected error during Run: %v", err)
-		}
+		runTasks(t, cloud, allTasks)
 
 		if fi.ValueOf(vpc1.ID) == "" {
 			t.Fatalf("ID not set after create")
@@ -134,8 +123,6 @@ func Test4758(t *testing.T) {
 }
 
 func TestSharedVPCAdditionalCIDR(t *testing.T) {
-	ctx := context.TODO()
-
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
 	c := &mockec2.MockEC2{}
 	c.CreateVpcWithId(&ec2.CreateVpcInput{
@@ -177,18 +164,7 @@ func TestSharedVPCAdditionalCIDR(t *testing.T) {
 		allTasks := buildTasks()
 		vpc1 := allTasks["vpc-1"].(*VPC)
 
-		target := &awsup.AWSAPITarget{
-			Cloud: cloud,
-		}
-
-		context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
-		if err != nil {
-			t.Fatalf("error building context: %v", err)
-		}
-
-		if err := context.RunTasks(testRunTasksOptions); err != nil {
-			t.Fatalf("unexpected error during Run: %v", err)
-		}
+		runTasks(t, cloud, allTasks)
 
 		if fi.ValueOf(vpc1.ID) == "" {
 			t.Fatalf("ID not set")


### PR DESCRIPTION
This mirrors what we do in gce, and eliminates some boilerplate.
