### PR TITLE
refactor: Introduce DeletionProcessingMode

### DIFF
--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -714,6 +714,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 	var target fi.CloudupTarget
 	shouldPrecreateDNS := true
 
+	deletionProcessingMode := fi.DeletionProcessingModeDeleteIfNotDeferrred
 	switch c.TargetName {
 	case TargetDirect:
 		switch cluster.Spec.GetCloudProvider() {
@@ -764,6 +765,9 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		// Can cause conflicts with terraform management
 		shouldPrecreateDNS = false
 
+		// Terraform tracks & performs deletions itself
+		deletionProcessingMode = fi.DeletionProcessingModeIgnore
+
 	case TargetDryRun:
 		var out io.Writer = os.Stdout
 		if c.GetAssets {
@@ -786,7 +790,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		}
 	}
 
-	context, err := fi.NewCloudupContext(ctx, target, cluster, cloud, keyStore, secretStore, configBase, c.TaskMap)
+	context, err := fi.NewCloudupContext(ctx, deletionProcessingMode, target, cluster, cloud, keyStore, secretStore, configBase, c.TaskMap)
 	if err != nil {
 		return fmt.Errorf("error building context: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_test.go
@@ -142,7 +142,7 @@ func runTasks(t *testing.T, cloud awsup.AWSCloud, allTasks map[string]fi.Cloudup
 		Cloud: cloud,
 	}
 
-	context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
+	context, err := fi.NewCloudupContext(ctx, fi.DeletionProcessingModeDeleteIncludingDeferred, target, nil, cloud, nil, nil, nil, allTasks)
 	if err != nil {
 		t.Fatalf("error building context: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
@@ -119,7 +119,7 @@ func checkNoChanges(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks 
 	}
 	assetBuilder := assets.NewAssetBuilder(vfs.Context, cluster.Spec.Assets, cluster.Spec.KubernetesVersion, false)
 	target := fi.NewCloudupDryRunTarget(assetBuilder, os.Stderr)
-	context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
+	context, err := fi.NewCloudupContext(ctx, fi.DeletionProcessingModeDeleteIncludingDeferred, target, nil, cloud, nil, nil, nil, allTasks)
 	if err != nil {
 		t.Fatalf("error building context: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
@@ -38,10 +38,6 @@ func NewAWSAPITarget(cloud AWSCloud) *AWSAPITarget {
 	}
 }
 
-func (t *AWSAPITarget) ProcessDeletions() bool {
-	return true
-}
-
 func (t *AWSAPITarget) DefaultCheckExisting() bool {
 	return true
 }

--- a/upup/pkg/fi/cloudup/azure/azure_apitarget.go
+++ b/upup/pkg/fi/cloudup/azure/azure_apitarget.go
@@ -40,11 +40,6 @@ func (t *AzureAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 
-// ProcessDeletions returns true if we should delete resources.
-func (t *AzureAPITarget) ProcessDeletions() bool {
-	return true
-}
-
 func (t *AzureAPITarget) DefaultCheckExisting() bool {
 	return true
 }

--- a/upup/pkg/fi/cloudup/do/api_target.go
+++ b/upup/pkg/fi/cloudup/do/api_target.go
@@ -36,10 +36,6 @@ func (t *DOAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 
-func (t *DOAPITarget) ProcessDeletions() bool {
-	return true
-}
-
 func (t *DOAPITarget) DefaultCheckExisting() bool {
 	return true
 }

--- a/upup/pkg/fi/cloudup/gce/gce_apitarget.go
+++ b/upup/pkg/fi/cloudup/gce/gce_apitarget.go
@@ -36,10 +36,6 @@ func (t *GCEAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 
-func (t *GCEAPITarget) ProcessDeletions() bool {
-	return true
-}
-
 func (t *GCEAPITarget) DefaultCheckExisting() bool {
 	return true
 }

--- a/upup/pkg/fi/cloudup/gcetasks/serviceaccount_test.go
+++ b/upup/pkg/fi/cloudup/gcetasks/serviceaccount_test.go
@@ -101,7 +101,7 @@ func checkHasChanges(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks
 func runTasks(t *testing.T, ctx context.Context, cloud gce.GCECloud, allTasks map[string]fi.CloudupTask) {
 	target := gce.NewGCEAPITarget(cloud)
 
-	context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
+	context, err := fi.NewCloudupContext(ctx, fi.DeletionProcessingModeDeleteIncludingDeferred, target, nil, cloud, nil, nil, nil, allTasks)
 	if err != nil {
 		t.Fatalf("error building context: %v", err)
 	}
@@ -120,7 +120,7 @@ func doDryRun(t *testing.T, ctx context.Context, cloud fi.Cloud, allTasks map[st
 	}
 	assetBuilder := assets.NewAssetBuilder(vfs.Context, cluster.Spec.Assets, cluster.Spec.KubernetesVersion, false)
 	target := fi.NewCloudupDryRunTarget(assetBuilder, os.Stderr)
-	context, err := fi.NewCloudupContext(ctx, target, nil, cloud, nil, nil, nil, allTasks)
+	context, err := fi.NewCloudupContext(ctx, fi.DeletionProcessingModeDeleteIncludingDeferred, target, nil, cloud, nil, nil, nil, allTasks)
 	if err != nil {
 		t.Fatalf("error building context: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/hetzner/api_target.go
+++ b/upup/pkg/fi/cloudup/hetzner/api_target.go
@@ -36,10 +36,6 @@ func (t *HetznerAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 
-func (t *HetznerAPITarget) ProcessDeletions() bool {
-	return true
-}
-
 func (t *HetznerAPITarget) DefaultCheckExisting() bool {
 	return true
 }

--- a/upup/pkg/fi/cloudup/openstack/apitarget.go
+++ b/upup/pkg/fi/cloudup/openstack/apitarget.go
@@ -36,10 +36,6 @@ func (t *OpenstackAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 
-func (t *OpenstackAPITarget) ProcessDeletions() bool {
-	return true
-}
-
 func (t *OpenstackAPITarget) DefaultCheckExisting() bool {
 	return true
 }

--- a/upup/pkg/fi/cloudup/scaleway/api_target.go
+++ b/upup/pkg/fi/cloudup/scaleway/api_target.go
@@ -34,10 +34,6 @@ func (s ScwAPITarget) Finish(taskMap map[string]fi.CloudupTask) error {
 	return nil
 }
 
-func (s ScwAPITarget) ProcessDeletions() bool {
-	return true
-}
-
 func (t *ScwAPITarget) DefaultCheckExisting() bool {
 	return true
 }

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -63,11 +63,6 @@ func (t *TerraformTarget) AddFileResource(resourceType string, resourceName stri
 	return t.AddFileBytes(resourceType, resourceName, key, d, base64)
 }
 
-func (t *TerraformTarget) ProcessDeletions() bool {
-	// Terraform tracks & performs deletions itself
-	return false
-}
-
 func (t *TerraformTarget) DefaultCheckExisting() bool {
 	return false
 }

--- a/upup/pkg/fi/deletions.go
+++ b/upup/pkg/fi/deletions.go
@@ -16,6 +16,18 @@ limitations under the License.
 
 package fi
 
+type DeletionProcessingMode string
+
+const (
+	// DeletionProcessingModeIgnore will ignore all deletion tasks.
+	DeletionProcessingModeIgnore DeletionProcessingMode = "Ignore"
+	// TODO: implement deferred-deletion in the tasks!
+	// DeletionProcessingModeDeleteIfNotDeferrred will delete resources only if they are not marked for deferred-deletion.
+	DeletionProcessingModeDeleteIfNotDeferrred DeletionProcessingMode = "IfNotDeferred"
+	// DeletionProcessingModeDeleteIncludingDeferrred will delete resources including those marked for deferred-deletion.
+	DeletionProcessingModeDeleteIncludingDeferred DeletionProcessingMode = "DeleteIncludingDeferred"
+)
+
 type ProducesDeletions[T SubContext] interface {
 	FindDeletions(*Context[T]) ([]Deletion[T], error)
 }

--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -92,11 +92,6 @@ func NewNodeupDryRunTarget(assetBuilder *assets.AssetBuilder, out io.Writer) *No
 	return newDryRunTarget[NodeupSubContext](assetBuilder, out)
 }
 
-func (t *DryRunTarget[T]) ProcessDeletions() bool {
-	// We display deletions
-	return true
-}
-
 func (t *DryRunTarget[T]) DefaultCheckExisting() bool {
 	return true
 }
@@ -117,7 +112,7 @@ func (t *DryRunTarget[T]) Render(a, e, changes Task[T]) error {
 	return nil
 }
 
-func (t *DryRunTarget[T]) Delete(deletion Deletion[T]) error {
+func (t *DryRunTarget[T]) RecordDeletion(deletion Deletion[T]) error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 

--- a/upup/pkg/fi/nodeup/install/install_target.go
+++ b/upup/pkg/fi/nodeup/install/install_target.go
@@ -31,11 +31,6 @@ func (t *InstallTarget) Finish(taskMap map[string]fi.InstallTask) error {
 	return nil
 }
 
-func (t *InstallTarget) ProcessDeletions() bool {
-	// We don't expect any, but it would be our job to process them
-	return true
-}
-
 func (t *InstallTarget) DefaultCheckExisting() bool {
 	return true
 }

--- a/upup/pkg/fi/nodeup/local/local_target.go
+++ b/upup/pkg/fi/nodeup/local/local_target.go
@@ -33,11 +33,6 @@ func (t *LocalTarget) Finish(taskMap map[string]fi.NodeupTask) error {
 	return nil
 }
 
-func (t *LocalTarget) ProcessDeletions() bool {
-	// We don't expect any, but it would be our job to process them
-	return true
-}
-
 func (t *LocalTarget) DefaultCheckExisting() bool {
 	return true
 }

--- a/upup/pkg/fi/target.go
+++ b/upup/pkg/fi/target.go
@@ -20,10 +20,6 @@ type Target[T SubContext] interface {
 	// Lifecycle methods, called by the driver
 	Finish(taskMap map[string]Task[T]) error
 
-	// ProcessDeletions returns true if we should delete resources
-	// Some providers (e.g. Terraform) actively keep state, and will delete resources automatically
-	ProcessDeletions() bool
-
 	// DefaultCheckExisting returns true if DefaultDeltaRun tasks which aren't HasCheckExisting
 	// should invoke Find() when running against this Target.
 	DefaultCheckExisting() bool


### PR DESCRIPTION
Deletion processing is not entirely a factor of the target, it is more
a factor of our mode of execution (dry-run vs pre-rolling-update vs
post-rolling-update).  We want to introduce that post-rolling-update
phase, so introduce the DeletionProcessingMode enum and move it from
the target to the context.
