### PR TITLE
refactor: wait for load balancer readiness using a private field

### DIFF
--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -193,6 +193,12 @@ func (b *APILoadBalancerBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			Type:              fi.PtrTo("network"),
 		}
 
+		// Wait for all load balancer components to be created (including network interfaces needed for NoneDNS).
+		// Limiting this to clusters using NoneDNS because load balancer creation is quite slow.
+		if b.Cluster.UsesNoneDNS() {
+			nlb.SetWaitForLoadBalancerReady(true)
+		}
+
 		clb = &awstasks.ClassicLoadBalancer{
 			Name:      fi.PtrTo("api." + b.ClusterName()),
 			Lifecycle: b.Lifecycle,


### PR DESCRIPTION
This approach is more explicit than looking at the names of the target
groups, and using a private field is simpler.
