### PR TITLE
chore(networking): bump aws cni to 1.16.2

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 7783f69ff595f86c5bab56d6ca740493e77ef2dc4124182232d69df934fb4581
+    manifestHash: 825a4a1a72e77ff17148cea1963e2758030e88c81e9b04f8f19304990778cc55
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -26,6 +26,246 @@ spec:
 
 ---
 
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: amazon-network-policy-controller-k8s
+    role.kubernetes.io/networking: "1"
+  name: policyendpoints.networking.k8s.aws
+spec:
+  group: networking.k8s.aws
+  names:
+    kind: PolicyEndpoint
+    listKind: PolicyEndpointList
+    plural: policyendpoints
+    singular: policyendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyEndpoint is the Schema for the policyendpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyEndpointSpec defines the desired state of PolicyEndpoint
+            properties:
+              egress:
+                description: Egress is the list of egress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              ingress:
+                description: Ingress is the list of ingress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              podIsolation:
+                description: PodIsolation specifies whether the pod needs to be isolated
+                  for a particular traffic direction Ingress or Egress, or both. If
+                  default isolation is not specified, and there are no ingress/egress
+                  rules, then the pod is not isolated from the point of view of this
+                  policy. This follows the NetworkPolicy spec.PolicyTypes.
+                items:
+                  description: PolicyType string describes the NetworkPolicy type
+                    This type is beta-level in 1.8
+                  type: string
+                type: array
+              podSelector:
+                description: PodSelector is the podSelector from the policy resource
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelectorEndpoints:
+                description: PodSelectorEndpoints contains information about the pods
+                  matching the podSelector
+                items:
+                  description: PodEndpoint defines the summary information for the
+                    pods
+                  properties:
+                    hostIP:
+                      description: HostIP is the IP address of the host the pod is
+                        currently running on
+                      type: string
+                    name:
+                      description: Name is the pod name
+                      type: string
+                    namespace:
+                      description: Namespace is the pod namespace
+                      type: string
+                    podIP:
+                      description: PodIP is the IP address of the pod
+                      type: string
+                  required:
+                  - hostIP
+                  - name
+                  - namespace
+                  - podIP
+                  type: object
+                type: array
+              policyRef:
+                description: PolicyRef is a reference to the Kubernetes NetworkPolicy
+                  resource.
+                properties:
+                  name:
+                    description: Name is the name of the Policy
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Policy
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - policyRef
+            type: object
+          status:
+            description: PolicyEndpointStatus defines the observed state of PolicyEndpoint
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -35,10 +275,35 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
+  namespace: kube-system
+
+---
+
+apiVersion: v1
+data:
+  branch-eni-cooldown: "60"
+  enable-network-policy-controller: "false"
+  enable-windows-ipam: "false"
+  enable-windows-prefix-delegation: "false"
+  minimum-ip-target: "3"
+  warm-ip-target: "1"
+  warm-prefix-target: "0"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.16.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: amazon-vpc-cni
   namespace: kube-system
 
 ---
@@ -52,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -99,6 +364,29 @@ rules:
   - create
   - patch
   - list
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints/status
+  verbs:
+  - get
+- apiGroups:
+  - vpcresources.k8s.aws
+  resources:
+  - cninodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
 
 ---
 
@@ -111,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -135,7 +423,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -227,7 +515,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.16.2
         livenessProbe:
           exec:
             command:
@@ -269,6 +557,39 @@ spec:
           name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
+      - args:
+        - --enable-ipv6=false
+        - --enable-network-policy=false
+        - --enable-cloudwatch-logs=false
+        - --enable-policy-event-logs=false
+        - --metrics-bind-addr=:8162
+        - --health-probe-bind-addr=:8163
+        - --conntrack-cache-cleanup-period=300
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.7
+        name: aws-eks-nodeagent
+        resources:
+          requests:
+            cpu: 25m
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /sys/fs/bpf
+          name: bpf-pin-path
+        - mountPath: /var/log/aws-routed-eni
+          name: log-dir
+        - mountPath: /var/run/aws-node
+          name: run-dir
       hostNetwork: true
       initContainers:
       - env:
@@ -276,7 +597,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.2
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -292,6 +613,9 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
+      - hostPath:
+          path: /sys/fs/bpf
+        name: bpf-pin-path
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 7783f69ff595f86c5bab56d6ca740493e77ef2dc4124182232d69df934fb4581
+    manifestHash: 825a4a1a72e77ff17148cea1963e2758030e88c81e9b04f8f19304990778cc55
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -26,6 +26,246 @@ spec:
 
 ---
 
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: amazon-network-policy-controller-k8s
+    role.kubernetes.io/networking: "1"
+  name: policyendpoints.networking.k8s.aws
+spec:
+  group: networking.k8s.aws
+  names:
+    kind: PolicyEndpoint
+    listKind: PolicyEndpointList
+    plural: policyendpoints
+    singular: policyendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyEndpoint is the Schema for the policyendpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyEndpointSpec defines the desired state of PolicyEndpoint
+            properties:
+              egress:
+                description: Egress is the list of egress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              ingress:
+                description: Ingress is the list of ingress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              podIsolation:
+                description: PodIsolation specifies whether the pod needs to be isolated
+                  for a particular traffic direction Ingress or Egress, or both. If
+                  default isolation is not specified, and there are no ingress/egress
+                  rules, then the pod is not isolated from the point of view of this
+                  policy. This follows the NetworkPolicy spec.PolicyTypes.
+                items:
+                  description: PolicyType string describes the NetworkPolicy type
+                    This type is beta-level in 1.8
+                  type: string
+                type: array
+              podSelector:
+                description: PodSelector is the podSelector from the policy resource
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelectorEndpoints:
+                description: PodSelectorEndpoints contains information about the pods
+                  matching the podSelector
+                items:
+                  description: PodEndpoint defines the summary information for the
+                    pods
+                  properties:
+                    hostIP:
+                      description: HostIP is the IP address of the host the pod is
+                        currently running on
+                      type: string
+                    name:
+                      description: Name is the pod name
+                      type: string
+                    namespace:
+                      description: Namespace is the pod namespace
+                      type: string
+                    podIP:
+                      description: PodIP is the IP address of the pod
+                      type: string
+                  required:
+                  - hostIP
+                  - name
+                  - namespace
+                  - podIP
+                  type: object
+                type: array
+              policyRef:
+                description: PolicyRef is a reference to the Kubernetes NetworkPolicy
+                  resource.
+                properties:
+                  name:
+                    description: Name is the name of the Policy
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Policy
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - policyRef
+            type: object
+          status:
+            description: PolicyEndpointStatus defines the observed state of PolicyEndpoint
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -35,10 +275,35 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
+  namespace: kube-system
+
+---
+
+apiVersion: v1
+data:
+  branch-eni-cooldown: "60"
+  enable-network-policy-controller: "false"
+  enable-windows-ipam: "false"
+  enable-windows-prefix-delegation: "false"
+  minimum-ip-target: "3"
+  warm-ip-target: "1"
+  warm-prefix-target: "0"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.16.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: amazon-vpc-cni
   namespace: kube-system
 
 ---
@@ -52,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -99,6 +364,29 @@ rules:
   - create
   - patch
   - list
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints/status
+  verbs:
+  - get
+- apiGroups:
+  - vpcresources.k8s.aws
+  resources:
+  - cninodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
 
 ---
 
@@ -111,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -135,7 +423,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -227,7 +515,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.16.2
         livenessProbe:
           exec:
             command:
@@ -269,6 +557,39 @@ spec:
           name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
+      - args:
+        - --enable-ipv6=false
+        - --enable-network-policy=false
+        - --enable-cloudwatch-logs=false
+        - --enable-policy-event-logs=false
+        - --metrics-bind-addr=:8162
+        - --health-probe-bind-addr=:8163
+        - --conntrack-cache-cleanup-period=300
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.7
+        name: aws-eks-nodeagent
+        resources:
+          requests:
+            cpu: 25m
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /sys/fs/bpf
+          name: bpf-pin-path
+        - mountPath: /var/log/aws-routed-eni
+          name: log-dir
+        - mountPath: /var/run/aws-node
+          name: run-dir
       hostNetwork: true
       initContainers:
       - env:
@@ -276,7 +597,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.2
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -292,6 +613,9 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
+      - hostPath:
+          path: /sys/fs/bpf
+        name: bpf-pin-path
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 7783f69ff595f86c5bab56d6ca740493e77ef2dc4124182232d69df934fb4581
+    manifestHash: 825a4a1a72e77ff17148cea1963e2758030e88c81e9b04f8f19304990778cc55
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -26,6 +26,246 @@ spec:
 
 ---
 
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: amazon-network-policy-controller-k8s
+    role.kubernetes.io/networking: "1"
+  name: policyendpoints.networking.k8s.aws
+spec:
+  group: networking.k8s.aws
+  names:
+    kind: PolicyEndpoint
+    listKind: PolicyEndpointList
+    plural: policyendpoints
+    singular: policyendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyEndpoint is the Schema for the policyendpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyEndpointSpec defines the desired state of PolicyEndpoint
+            properties:
+              egress:
+                description: Egress is the list of egress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              ingress:
+                description: Ingress is the list of ingress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              podIsolation:
+                description: PodIsolation specifies whether the pod needs to be isolated
+                  for a particular traffic direction Ingress or Egress, or both. If
+                  default isolation is not specified, and there are no ingress/egress
+                  rules, then the pod is not isolated from the point of view of this
+                  policy. This follows the NetworkPolicy spec.PolicyTypes.
+                items:
+                  description: PolicyType string describes the NetworkPolicy type
+                    This type is beta-level in 1.8
+                  type: string
+                type: array
+              podSelector:
+                description: PodSelector is the podSelector from the policy resource
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelectorEndpoints:
+                description: PodSelectorEndpoints contains information about the pods
+                  matching the podSelector
+                items:
+                  description: PodEndpoint defines the summary information for the
+                    pods
+                  properties:
+                    hostIP:
+                      description: HostIP is the IP address of the host the pod is
+                        currently running on
+                      type: string
+                    name:
+                      description: Name is the pod name
+                      type: string
+                    namespace:
+                      description: Namespace is the pod namespace
+                      type: string
+                    podIP:
+                      description: PodIP is the IP address of the pod
+                      type: string
+                  required:
+                  - hostIP
+                  - name
+                  - namespace
+                  - podIP
+                  type: object
+                type: array
+              policyRef:
+                description: PolicyRef is a reference to the Kubernetes NetworkPolicy
+                  resource.
+                properties:
+                  name:
+                    description: Name is the name of the Policy
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Policy
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - policyRef
+            type: object
+          status:
+            description: PolicyEndpointStatus defines the observed state of PolicyEndpoint
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -35,10 +275,35 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
+  namespace: kube-system
+
+---
+
+apiVersion: v1
+data:
+  branch-eni-cooldown: "60"
+  enable-network-policy-controller: "false"
+  enable-windows-ipam: "false"
+  enable-windows-prefix-delegation: "false"
+  minimum-ip-target: "3"
+  warm-ip-target: "1"
+  warm-prefix-target: "0"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.16.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: amazon-vpc-cni
   namespace: kube-system
 
 ---
@@ -52,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -99,6 +364,29 @@ rules:
   - create
   - patch
   - list
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints/status
+  verbs:
+  - get
+- apiGroups:
+  - vpcresources.k8s.aws
+  resources:
+  - cninodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
 
 ---
 
@@ -111,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -135,7 +423,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -227,7 +515,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.16.2
         livenessProbe:
           exec:
             command:
@@ -269,6 +557,39 @@ spec:
           name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
+      - args:
+        - --enable-ipv6=false
+        - --enable-network-policy=false
+        - --enable-cloudwatch-logs=false
+        - --enable-policy-event-logs=false
+        - --metrics-bind-addr=:8162
+        - --health-probe-bind-addr=:8163
+        - --conntrack-cache-cleanup-period=300
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.7
+        name: aws-eks-nodeagent
+        resources:
+          requests:
+            cpu: 25m
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /sys/fs/bpf
+          name: bpf-pin-path
+        - mountPath: /var/log/aws-routed-eni
+          name: log-dir
+        - mountPath: /var/run/aws-node
+          name: run-dir
       hostNetwork: true
       initContainers:
       - env:
@@ -276,7 +597,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.2
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -292,6 +613,9 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
+      - hostPath:
+          path: /sys/fs/bpf
+        name: bpf-pin-path
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -186,7 +186,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 7783f69ff595f86c5bab56d6ca740493e77ef2dc4124182232d69df934fb4581
+    manifestHash: 825a4a1a72e77ff17148cea1963e2758030e88c81e9b04f8f19304990778cc55
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -26,6 +26,246 @@ spec:
 
 ---
 
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: amazon-network-policy-controller-k8s
+    role.kubernetes.io/networking: "1"
+  name: policyendpoints.networking.k8s.aws
+spec:
+  group: networking.k8s.aws
+  names:
+    kind: PolicyEndpoint
+    listKind: PolicyEndpointList
+    plural: policyendpoints
+    singular: policyendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyEndpoint is the Schema for the policyendpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyEndpointSpec defines the desired state of PolicyEndpoint
+            properties:
+              egress:
+                description: Egress is the list of egress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              ingress:
+                description: Ingress is the list of ingress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              podIsolation:
+                description: PodIsolation specifies whether the pod needs to be isolated
+                  for a particular traffic direction Ingress or Egress, or both. If
+                  default isolation is not specified, and there are no ingress/egress
+                  rules, then the pod is not isolated from the point of view of this
+                  policy. This follows the NetworkPolicy spec.PolicyTypes.
+                items:
+                  description: PolicyType string describes the NetworkPolicy type
+                    This type is beta-level in 1.8
+                  type: string
+                type: array
+              podSelector:
+                description: PodSelector is the podSelector from the policy resource
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelectorEndpoints:
+                description: PodSelectorEndpoints contains information about the pods
+                  matching the podSelector
+                items:
+                  description: PodEndpoint defines the summary information for the
+                    pods
+                  properties:
+                    hostIP:
+                      description: HostIP is the IP address of the host the pod is
+                        currently running on
+                      type: string
+                    name:
+                      description: Name is the pod name
+                      type: string
+                    namespace:
+                      description: Namespace is the pod namespace
+                      type: string
+                    podIP:
+                      description: PodIP is the IP address of the pod
+                      type: string
+                  required:
+                  - hostIP
+                  - name
+                  - namespace
+                  - podIP
+                  type: object
+                type: array
+              policyRef:
+                description: PolicyRef is a reference to the Kubernetes NetworkPolicy
+                  resource.
+                properties:
+                  name:
+                    description: Name is the name of the Policy
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Policy
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - policyRef
+            type: object
+          status:
+            description: PolicyEndpointStatus defines the observed state of PolicyEndpoint
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -35,10 +275,35 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
+  namespace: kube-system
+
+---
+
+apiVersion: v1
+data:
+  branch-eni-cooldown: "60"
+  enable-network-policy-controller: "false"
+  enable-windows-ipam: "false"
+  enable-windows-prefix-delegation: "false"
+  minimum-ip-target: "3"
+  warm-ip-target: "1"
+  warm-prefix-target: "0"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.16.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: amazon-vpc-cni
   namespace: kube-system
 
 ---
@@ -52,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -99,6 +364,29 @@ rules:
   - create
   - patch
   - list
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints/status
+  verbs:
+  - get
+- apiGroups:
+  - vpcresources.k8s.aws
+  resources:
+  - cninodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
 
 ---
 
@@ -111,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -135,7 +423,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -227,7 +515,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.16.2
         livenessProbe:
           exec:
             command:
@@ -269,6 +557,39 @@ spec:
           name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
+      - args:
+        - --enable-ipv6=false
+        - --enable-network-policy=false
+        - --enable-cloudwatch-logs=false
+        - --enable-policy-event-logs=false
+        - --metrics-bind-addr=:8162
+        - --health-probe-bind-addr=:8163
+        - --conntrack-cache-cleanup-period=300
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.7
+        name: aws-eks-nodeagent
+        resources:
+          requests:
+            cpu: 25m
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /sys/fs/bpf
+          name: bpf-pin-path
+        - mountPath: /var/log/aws-routed-eni
+          name: log-dir
+        - mountPath: /var/run/aws-node
+          name: run-dir
       hostNetwork: true
       initContainers:
       - env:
@@ -276,7 +597,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.2
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -292,6 +613,9 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
+      - hostPath:
+          path: /sys/fs/bpf
+        name: bpf-pin-path
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 7783f69ff595f86c5bab56d6ca740493e77ef2dc4124182232d69df934fb4581
+    manifestHash: 825a4a1a72e77ff17148cea1963e2758030e88c81e9b04f8f19304990778cc55
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -26,6 +26,246 @@ spec:
 
 ---
 
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: amazon-network-policy-controller-k8s
+    role.kubernetes.io/networking: "1"
+  name: policyendpoints.networking.k8s.aws
+spec:
+  group: networking.k8s.aws
+  names:
+    kind: PolicyEndpoint
+    listKind: PolicyEndpointList
+    plural: policyendpoints
+    singular: policyendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyEndpoint is the Schema for the policyendpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyEndpointSpec defines the desired state of PolicyEndpoint
+            properties:
+              egress:
+                description: Egress is the list of egress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              ingress:
+                description: Ingress is the list of ingress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              podIsolation:
+                description: PodIsolation specifies whether the pod needs to be isolated
+                  for a particular traffic direction Ingress or Egress, or both. If
+                  default isolation is not specified, and there are no ingress/egress
+                  rules, then the pod is not isolated from the point of view of this
+                  policy. This follows the NetworkPolicy spec.PolicyTypes.
+                items:
+                  description: PolicyType string describes the NetworkPolicy type
+                    This type is beta-level in 1.8
+                  type: string
+                type: array
+              podSelector:
+                description: PodSelector is the podSelector from the policy resource
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelectorEndpoints:
+                description: PodSelectorEndpoints contains information about the pods
+                  matching the podSelector
+                items:
+                  description: PodEndpoint defines the summary information for the
+                    pods
+                  properties:
+                    hostIP:
+                      description: HostIP is the IP address of the host the pod is
+                        currently running on
+                      type: string
+                    name:
+                      description: Name is the pod name
+                      type: string
+                    namespace:
+                      description: Namespace is the pod namespace
+                      type: string
+                    podIP:
+                      description: PodIP is the IP address of the pod
+                      type: string
+                  required:
+                  - hostIP
+                  - name
+                  - namespace
+                  - podIP
+                  type: object
+                type: array
+              policyRef:
+                description: PolicyRef is a reference to the Kubernetes NetworkPolicy
+                  resource.
+                properties:
+                  name:
+                    description: Name is the name of the Policy
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Policy
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - policyRef
+            type: object
+          status:
+            description: PolicyEndpointStatus defines the observed state of PolicyEndpoint
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -35,10 +275,35 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
+  namespace: kube-system
+
+---
+
+apiVersion: v1
+data:
+  branch-eni-cooldown: "60"
+  enable-network-policy-controller: "false"
+  enable-windows-ipam: "false"
+  enable-windows-prefix-delegation: "false"
+  minimum-ip-target: "3"
+  warm-ip-target: "1"
+  warm-prefix-target: "0"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.16.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: amazon-vpc-cni
   namespace: kube-system
 
 ---
@@ -52,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -99,6 +364,29 @@ rules:
   - create
   - patch
   - list
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints/status
+  verbs:
+  - get
+- apiGroups:
+  - vpcresources.k8s.aws
+  resources:
+  - cninodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
 
 ---
 
@@ -111,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -135,7 +423,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -227,7 +515,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.16.2
         livenessProbe:
           exec:
             command:
@@ -269,6 +557,39 @@ spec:
           name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
+      - args:
+        - --enable-ipv6=false
+        - --enable-network-policy=false
+        - --enable-cloudwatch-logs=false
+        - --enable-policy-event-logs=false
+        - --metrics-bind-addr=:8162
+        - --health-probe-bind-addr=:8163
+        - --conntrack-cache-cleanup-period=300
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.7
+        name: aws-eks-nodeagent
+        resources:
+          requests:
+            cpu: 25m
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /sys/fs/bpf
+          name: bpf-pin-path
+        - mountPath: /var/log/aws-routed-eni
+          name: log-dir
+        - mountPath: /var/run/aws-node
+          name: run-dir
       hostNetwork: true
       initContainers:
       - env:
@@ -276,7 +597,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.2
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -292,6 +613,9 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
+      - hostPath:
+          path: /sys/fs/bpf
+        name: bpf-pin-path
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3b388375350b777e1408e31851682b3bddf09db872cfed97f19e3ea58e16bdc8
+    manifestHash: 3d8b7d856d8b3abdcc2d9569ccb171510e36c6186f3ccc01fb8c079876b684ad
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -26,6 +26,246 @@ spec:
 
 ---
 
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: amazon-network-policy-controller-k8s
+    role.kubernetes.io/networking: "1"
+  name: policyendpoints.networking.k8s.aws
+spec:
+  group: networking.k8s.aws
+  names:
+    kind: PolicyEndpoint
+    listKind: PolicyEndpointList
+    plural: policyendpoints
+    singular: policyendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyEndpoint is the Schema for the policyendpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyEndpointSpec defines the desired state of PolicyEndpoint
+            properties:
+              egress:
+                description: Egress is the list of egress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              ingress:
+                description: Ingress is the list of ingress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              podIsolation:
+                description: PodIsolation specifies whether the pod needs to be isolated
+                  for a particular traffic direction Ingress or Egress, or both. If
+                  default isolation is not specified, and there are no ingress/egress
+                  rules, then the pod is not isolated from the point of view of this
+                  policy. This follows the NetworkPolicy spec.PolicyTypes.
+                items:
+                  description: PolicyType string describes the NetworkPolicy type
+                    This type is beta-level in 1.8
+                  type: string
+                type: array
+              podSelector:
+                description: PodSelector is the podSelector from the policy resource
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelectorEndpoints:
+                description: PodSelectorEndpoints contains information about the pods
+                  matching the podSelector
+                items:
+                  description: PodEndpoint defines the summary information for the
+                    pods
+                  properties:
+                    hostIP:
+                      description: HostIP is the IP address of the host the pod is
+                        currently running on
+                      type: string
+                    name:
+                      description: Name is the pod name
+                      type: string
+                    namespace:
+                      description: Namespace is the pod namespace
+                      type: string
+                    podIP:
+                      description: PodIP is the IP address of the pod
+                      type: string
+                  required:
+                  - hostIP
+                  - name
+                  - namespace
+                  - podIP
+                  type: object
+                type: array
+              policyRef:
+                description: PolicyRef is a reference to the Kubernetes NetworkPolicy
+                  resource.
+                properties:
+                  name:
+                    description: Name is the name of the Policy
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Policy
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - policyRef
+            type: object
+          status:
+            description: PolicyEndpointStatus defines the observed state of PolicyEndpoint
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -35,10 +275,35 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
+  namespace: kube-system
+
+---
+
+apiVersion: v1
+data:
+  branch-eni-cooldown: "60"
+  enable-network-policy-controller: "false"
+  enable-windows-ipam: "false"
+  enable-windows-prefix-delegation: "false"
+  minimum-ip-target: "3"
+  warm-ip-target: "1"
+  warm-prefix-target: "0"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.16.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: amazon-vpc-cni
   namespace: kube-system
 
 ---
@@ -52,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -99,6 +364,29 @@ rules:
   - create
   - patch
   - list
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints/status
+  verbs:
+  - get
+- apiGroups:
+  - vpcresources.k8s.aws
+  resources:
+  - cninodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
 
 ---
 
@@ -111,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -135,7 +423,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -227,7 +515,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: many-addons.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.16.2
         livenessProbe:
           exec:
             command:
@@ -269,6 +557,39 @@ spec:
           name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
+      - args:
+        - --enable-ipv6=false
+        - --enable-network-policy=false
+        - --enable-cloudwatch-logs=false
+        - --enable-policy-event-logs=false
+        - --metrics-bind-addr=:8162
+        - --health-probe-bind-addr=:8163
+        - --conntrack-cache-cleanup-period=300
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.7
+        name: aws-eks-nodeagent
+        resources:
+          requests:
+            cpu: 25m
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /sys/fs/bpf
+          name: bpf-pin-path
+        - mountPath: /var/log/aws-routed-eni
+          name: log-dir
+        - mountPath: /var/run/aws-node
+          name: run-dir
       hostNetwork: true
       initContainers:
       - env:
@@ -276,7 +597,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.2
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -292,6 +613,9 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
+      - hostPath:
+          path: /sys/fs/bpf
+        name: bpf-pin-path
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,6 +1,6 @@
-# Vendored from https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.13/config/master/aws-k8s-cni.yaml
+# Vendored from https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.16/config/master/aws-k8s-cni.yaml
 ---
-# Source: crds/customresourcedefinition.yaml
+# Source: aws-vpc-cni/crds/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -21,7 +21,241 @@ spec:
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig
-
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: amazon-network-policy-controller-k8s
+  name: policyendpoints.networking.k8s.aws
+spec:
+  group: networking.k8s.aws
+  names:
+    kind: PolicyEndpoint
+    listKind: PolicyEndpointList
+    plural: policyendpoints
+    singular: policyendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyEndpoint is the Schema for the policyendpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyEndpointSpec defines the desired state of PolicyEndpoint
+            properties:
+              egress:
+                description: Egress is the list of egress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              ingress:
+                description: Ingress is the list of ingress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              podIsolation:
+                description: PodIsolation specifies whether the pod needs to be isolated
+                  for a particular traffic direction Ingress or Egress, or both. If
+                  default isolation is not specified, and there are no ingress/egress
+                  rules, then the pod is not isolated from the point of view of this
+                  policy. This follows the NetworkPolicy spec.PolicyTypes.
+                items:
+                  description: PolicyType string describes the NetworkPolicy type
+                    This type is beta-level in 1.8
+                  type: string
+                type: array
+              podSelector:
+                description: PodSelector is the podSelector from the policy resource
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelectorEndpoints:
+                description: PodSelectorEndpoints contains information about the pods
+                  matching the podSelector
+                items:
+                  description: PodEndpoint defines the summary information for the
+                    pods
+                  properties:
+                    hostIP:
+                      description: HostIP is the IP address of the host the pod is
+                        currently running on
+                      type: string
+                    name:
+                      description: Name is the pod name
+                      type: string
+                    namespace:
+                      description: Namespace is the pod namespace
+                      type: string
+                    podIP:
+                      description: PodIP is the IP address of the pod
+                      type: string
+                  required:
+                  - hostIP
+                  - name
+                  - namespace
+                  - podIP
+                  type: object
+                type: array
+              policyRef:
+                description: PolicyRef is a reference to the Kubernetes NetworkPolicy
+                  resource.
+                properties:
+                  name:
+                    description: Name is the name of the Policy
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Policy
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - policyRef
+            type: object
+          status:
+            description: PolicyEndpointStatus defines the observed state of PolicyEndpoint
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 # Source: aws-vpc-cni/templates/serviceaccount.yaml
 apiVersion: v1
@@ -33,7 +267,27 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.4"
+    app.kubernetes.io/version: "v1.16.2"
+---
+# Source: aws-vpc-cni/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: amazon-vpc-cni
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.16.2"
+data:
+  enable-windows-ipam: "false"
+  enable-network-policy-controller: "false"
+  enable-windows-prefix-delegation: "false"
+  warm-prefix-target: "0"
+  warm-ip-target: "1"
+  minimum-ip-target: "3"
+  branch-eni-cooldown: "60"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -44,7 +298,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.4"
+    app.kubernetes.io/version: "v1.16.2"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -74,6 +328,19 @@ rules:
     resources:
       - events
     verbs: ["create", "patch", "list"]
+  - apiGroups: ["networking.k8s.aws"]
+    resources:
+      - policyendpoints
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.aws"]
+    resources:
+      - policyendpoints/status
+    verbs: ["get"]
+  - apiGroups:
+      - vpcresources.k8s.aws
+    resources:
+      - cninodes
+    verbs: ["get", "list", "watch", "patch"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -84,7 +351,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.4"
+    app.kubernetes.io/version: "v1.16.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -104,7 +371,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.13.4"
+    app.kubernetes.io/version: "v1.16.2"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -125,7 +392,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.4" }}"
+        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.2" }}"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -134,8 +401,8 @@ spec:
         securityContext:
             privileged: true
         resources:
-          requests:
-            cpu: 25m
+            requests:
+              cpu: 25m
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
@@ -150,7 +417,7 @@ spec:
 {{ end }}
       containers:
         - name: aws-node
-          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.4" }}"
+          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.16.2" }}"
           ports:
             - containerPort: 61678
               name: metrics
@@ -250,7 +517,43 @@ spec:
             name: run-dir
           - mountPath: /run/xtables.lock
             name: xtables-lock
+        - name: aws-eks-nodeagent
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.7
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          args:
+            - --enable-ipv6=false
+            - --enable-network-policy=false
+            - --enable-cloudwatch-logs=false
+            - --enable-policy-event-logs=false
+            - --metrics-bind-addr=:8162
+            - --health-probe-bind-addr=:8163
+            - --conntrack-cache-cleanup-period=300
+          resources:
+            requests:
+              cpu: 25m
+          securityContext:
+            capabilities:
+              add:
+              - NET_ADMIN
+            privileged: true
+          volumeMounts:
+          - mountPath: /host/opt/cni/bin
+            name: cni-bin-dir
+          - mountPath: /sys/fs/bpf
+            name: bpf-pin-path
+          - mountPath: /var/log/aws-routed-eni
+            name: log-dir
+          - mountPath: /var/run/aws-node
+            name: run-dir
       volumes:
+      - name: bpf-pin-path
+        hostPath:
+          path: /sys/fs/bpf
       - name: cni-bin-dir
         hostPath:
           path: /opt/cni/bin

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: d5a88ecd4337ff205a6dc01636ce908c012f705b261ebf7c8624192ffb76ea59
+    manifestHash: b7ae477ebee2aed671e08cccd0a9ab9147d60124c3ea83e96187f5c0774ad1c2
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -26,6 +26,246 @@ spec:
 
 ---
 
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: amazon-network-policy-controller-k8s
+    role.kubernetes.io/networking: "1"
+  name: policyendpoints.networking.k8s.aws
+spec:
+  group: networking.k8s.aws
+  names:
+    kind: PolicyEndpoint
+    listKind: PolicyEndpointList
+    plural: policyendpoints
+    singular: policyendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyEndpoint is the Schema for the policyendpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyEndpointSpec defines the desired state of PolicyEndpoint
+            properties:
+              egress:
+                description: Egress is the list of egress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              ingress:
+                description: Ingress is the list of ingress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              podIsolation:
+                description: PodIsolation specifies whether the pod needs to be isolated
+                  for a particular traffic direction Ingress or Egress, or both. If
+                  default isolation is not specified, and there are no ingress/egress
+                  rules, then the pod is not isolated from the point of view of this
+                  policy. This follows the NetworkPolicy spec.PolicyTypes.
+                items:
+                  description: PolicyType string describes the NetworkPolicy type
+                    This type is beta-level in 1.8
+                  type: string
+                type: array
+              podSelector:
+                description: PodSelector is the podSelector from the policy resource
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelectorEndpoints:
+                description: PodSelectorEndpoints contains information about the pods
+                  matching the podSelector
+                items:
+                  description: PodEndpoint defines the summary information for the
+                    pods
+                  properties:
+                    hostIP:
+                      description: HostIP is the IP address of the host the pod is
+                        currently running on
+                      type: string
+                    name:
+                      description: Name is the pod name
+                      type: string
+                    namespace:
+                      description: Namespace is the pod namespace
+                      type: string
+                    podIP:
+                      description: PodIP is the IP address of the pod
+                      type: string
+                  required:
+                  - hostIP
+                  - name
+                  - namespace
+                  - podIP
+                  type: object
+                type: array
+              policyRef:
+                description: PolicyRef is a reference to the Kubernetes NetworkPolicy
+                  resource.
+                properties:
+                  name:
+                    description: Name is the name of the Policy
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Policy
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - policyRef
+            type: object
+          status:
+            description: PolicyEndpointStatus defines the observed state of PolicyEndpoint
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -35,10 +275,35 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
+  namespace: kube-system
+
+---
+
+apiVersion: v1
+data:
+  branch-eni-cooldown: "60"
+  enable-network-policy-controller: "false"
+  enable-windows-ipam: "false"
+  enable-windows-prefix-delegation: "false"
+  minimum-ip-target: "3"
+  warm-ip-target: "1"
+  warm-prefix-target: "0"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.16.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: amazon-vpc-cni
   namespace: kube-system
 
 ---
@@ -52,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -99,6 +364,29 @@ rules:
   - create
   - patch
   - list
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints/status
+  verbs:
+  - get
+- apiGroups:
+  - vpcresources.k8s.aws
+  resources:
+  - cninodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
 
 ---
 
@@ -111,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -135,7 +423,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -229,7 +517,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.16.2
         livenessProbe:
           exec:
             command:
@@ -271,6 +559,39 @@ spec:
           name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
+      - args:
+        - --enable-ipv6=false
+        - --enable-network-policy=false
+        - --enable-cloudwatch-logs=false
+        - --enable-policy-event-logs=false
+        - --metrics-bind-addr=:8162
+        - --health-probe-bind-addr=:8163
+        - --conntrack-cache-cleanup-period=300
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.7
+        name: aws-eks-nodeagent
+        resources:
+          requests:
+            cpu: 25m
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /sys/fs/bpf
+          name: bpf-pin-path
+        - mountPath: /var/log/aws-routed-eni
+          name: log-dir
+        - mountPath: /var/run/aws-node
+          name: run-dir
       hostNetwork: true
       initContainers:
       - env:
@@ -278,7 +599,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.2
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -294,6 +615,9 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
+      - hostPath:
+          path: /sys/fs/bpf
+        name: bpf-pin-path
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: d5a88ecd4337ff205a6dc01636ce908c012f705b261ebf7c8624192ffb76ea59
+    manifestHash: b7ae477ebee2aed671e08cccd0a9ab9147d60124c3ea83e96187f5c0774ad1c2
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -26,6 +26,246 @@ spec:
 
 ---
 
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: amazon-network-policy-controller-k8s
+    role.kubernetes.io/networking: "1"
+  name: policyendpoints.networking.k8s.aws
+spec:
+  group: networking.k8s.aws
+  names:
+    kind: PolicyEndpoint
+    listKind: PolicyEndpointList
+    plural: policyendpoints
+    singular: policyendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyEndpoint is the Schema for the policyendpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyEndpointSpec defines the desired state of PolicyEndpoint
+            properties:
+              egress:
+                description: Egress is the list of egress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              ingress:
+                description: Ingress is the list of ingress rules containing resolved
+                  network addresses
+                items:
+                  description: EndpointInfo defines the network endpoint information
+                    for the policy ingress/egress
+                  properties:
+                    cidr:
+                      description: CIDR is the network address(s) of the endpoint
+                      type: string
+                    except:
+                      description: Except is the exceptions to the CIDR ranges mentioned
+                        above.
+                      items:
+                        type: string
+                      type: array
+                    ports:
+                      description: Ports is the list of ports
+                      items:
+                        description: Port contains information about the transport
+                          port/protocol
+                        properties:
+                          endPort:
+                            description: Endport specifies the port range port to
+                              endPort port must be defined and an integer, endPort
+                              > port
+                            format: int32
+                            type: integer
+                          port:
+                            description: Port specifies the numerical port for the
+                              protocol. If empty applies to all ports
+                            format: int32
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol specifies the transport protocol,
+                              default TCP
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - cidr
+                  type: object
+                type: array
+              podIsolation:
+                description: PodIsolation specifies whether the pod needs to be isolated
+                  for a particular traffic direction Ingress or Egress, or both. If
+                  default isolation is not specified, and there are no ingress/egress
+                  rules, then the pod is not isolated from the point of view of this
+                  policy. This follows the NetworkPolicy spec.PolicyTypes.
+                items:
+                  description: PolicyType string describes the NetworkPolicy type
+                    This type is beta-level in 1.8
+                  type: string
+                type: array
+              podSelector:
+                description: PodSelector is the podSelector from the policy resource
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelectorEndpoints:
+                description: PodSelectorEndpoints contains information about the pods
+                  matching the podSelector
+                items:
+                  description: PodEndpoint defines the summary information for the
+                    pods
+                  properties:
+                    hostIP:
+                      description: HostIP is the IP address of the host the pod is
+                        currently running on
+                      type: string
+                    name:
+                      description: Name is the pod name
+                      type: string
+                    namespace:
+                      description: Namespace is the pod namespace
+                      type: string
+                    podIP:
+                      description: PodIP is the IP address of the pod
+                      type: string
+                  required:
+                  - hostIP
+                  - name
+                  - namespace
+                  - podIP
+                  type: object
+                type: array
+              policyRef:
+                description: PolicyRef is a reference to the Kubernetes NetworkPolicy
+                  resource.
+                properties:
+                  name:
+                    description: Name is the name of the Policy
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Policy
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - policyRef
+            type: object
+          status:
+            description: PolicyEndpointStatus defines the observed state of PolicyEndpoint
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -35,10 +275,35 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
+  namespace: kube-system
+
+---
+
+apiVersion: v1
+data:
+  branch-eni-cooldown: "60"
+  enable-network-policy-controller: "false"
+  enable-windows-ipam: "false"
+  enable-windows-prefix-delegation: "false"
+  minimum-ip-target: "3"
+  warm-ip-target: "1"
+  warm-prefix-target: "0"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.16.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: amazon-vpc-cni
   namespace: kube-system
 
 ---
@@ -52,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -99,6 +364,29 @@ rules:
   - create
   - patch
   - list
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.aws
+  resources:
+  - policyendpoints/status
+  verbs:
+  - get
+- apiGroups:
+  - vpcresources.k8s.aws
+  resources:
+  - cninodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
 
 ---
 
@@ -111,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -135,7 +423,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.13.4
+    app.kubernetes.io/version: v1.16.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -229,7 +517,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.16.2
         livenessProbe:
           exec:
             command:
@@ -271,6 +559,39 @@ spec:
           name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
+      - args:
+        - --enable-ipv6=false
+        - --enable-network-policy=false
+        - --enable-cloudwatch-logs=false
+        - --enable-policy-event-logs=false
+        - --metrics-bind-addr=:8162
+        - --health-probe-bind-addr=:8163
+        - --conntrack-cache-cleanup-period=300
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.0.7
+        name: aws-eks-nodeagent
+        resources:
+          requests:
+            cpu: 25m
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /sys/fs/bpf
+          name: bpf-pin-path
+        - mountPath: /var/log/aws-routed-eni
+          name: log-dir
+        - mountPath: /var/run/aws-node
+          name: run-dir
       hostNetwork: true
       initContainers:
       - env:
@@ -278,7 +599,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.13.4
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.2
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -294,6 +615,9 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
+      - hostPath:
+          path: /sys/fs/bpf
+        name: bpf-pin-path
       - hostPath:
           path: /opt/cni/bin
         name: cni-bin-dir


### PR DESCRIPTION
**What this PR does / why we need it**:
Update AWS CNI Version to latest release (v1.16.2)


**Special notes for your reviewer**:
Release page: https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.16.2

/cc @hakman