### PR TITLE
Revert "Don't set LimitNoFile for containerd systemd unit file"

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -203,6 +203,7 @@ func (b *ContainerdBuilder) buildSystemdService(sv semver.Version) *nodetasks.Se
 
 	manifest.Set("Service", "LimitNPROC", "infinity")
 	manifest.Set("Service", "LimitCORE", "infinity")
+	manifest.Set("Service", "LimitNOFILE", "infinity")
 	manifest.Set("Service", "TasksMax", "infinity")
 
 	// make killing of processes of this unit under memory pressure very unlikely

--- a/nodeup/pkg/model/tests/containerdbuilder/complex/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/complex/tasks.yaml
@@ -362,6 +362,7 @@ definition: |
   RestartSec=5
   LimitNPROC=infinity
   LimitCORE=infinity
+  LimitNOFILE=infinity
   TasksMax=infinity
   OOMScoreAdjust=-999
 

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -355,6 +355,7 @@ definition: |
   RestartSec=5
   LimitNPROC=infinity
   LimitCORE=infinity
+  LimitNOFILE=infinity
   TasksMax=infinity
   OOMScoreAdjust=-999
 


### PR DESCRIPTION
Reverts kubernetes/kops#16151

see comments in issue https://github.com/kubernetes/kops/issues/16298

and also see https://github.com/awslabs/amazon-eks-ami/pulls?q=is%3Apr++LimitNOFILE+ and it was reverted there as well https://github.com/awslabs/amazon-eks-ami/pull/1552

cc @hakman 


fixes https://github.com/kubernetes/kops/issues/16298