### PR TITLE
Automated cherry pick of #16318: added image minimum and maximum gc age

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3814,6 +3814,17 @@ spec:
                       disk usage to garbage collect to.
                     format: int32
                     type: integer
+                  imageMaximumGCAge:
+                    description: 'imageMaximumGCAge is the maximum age an image can
+                      be unused before it is garbage collected. The default of this
+                      field is "0s", which disables this field--meaning images won''t
+                      be garbage collected based on being unused for too long. Default:
+                      "0s" (disabled)'
+                    type: string
+                  imageMinimumGCAge:
+                    description: 'imageMinimumGCAge is the minimum age for an unused
+                      image before it is garbage collected. Default: "2m"'
+                    type: string
                   imagePullProgressDeadline:
                     description: ImagePullProgressDeadline is the timeout for image
                       pulls If no pulling progress is made before this deadline, the
@@ -4255,6 +4266,17 @@ spec:
                       disk usage to garbage collect to.
                     format: int32
                     type: integer
+                  imageMaximumGCAge:
+                    description: 'imageMaximumGCAge is the maximum age an image can
+                      be unused before it is garbage collected. The default of this
+                      field is "0s", which disables this field--meaning images won''t
+                      be garbage collected based on being unused for too long. Default:
+                      "0s" (disabled)'
+                    type: string
+                  imageMinimumGCAge:
+                    description: 'imageMinimumGCAge is the minimum age for an unused
+                      image before it is garbage collected. Default: "2m"'
+                    type: string
                   imagePullProgressDeadline:
                     description: ImagePullProgressDeadline is the timeout for image
                       pulls If no pulling progress is made before this deadline, the

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -585,6 +585,17 @@ spec:
                       disk usage to garbage collect to.
                     format: int32
                     type: integer
+                  imageMaximumGCAge:
+                    description: 'imageMaximumGCAge is the maximum age an image can
+                      be unused before it is garbage collected. The default of this
+                      field is "0s", which disables this field--meaning images won''t
+                      be garbage collected based on being unused for too long. Default:
+                      "0s" (disabled)'
+                    type: string
+                  imageMinimumGCAge:
+                    description: 'imageMinimumGCAge is the minimum age for an unused
+                      image before it is garbage collected. Default: "2m"'
+                    type: string
                   imagePullProgressDeadline:
                     description: ImagePullProgressDeadline is the timeout for image
                       pulls If no pulling progress is made before this deadline, the

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -133,6 +133,12 @@ type KubeletConfigSpec struct {
 	// and overrides the default MTU for cases where it cannot be automatically
 	// computed (such as IPSEC).
 	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitempty" flag:"network-plugin-mtu"`
+	// imageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: "2m"
+	ImageMinimumGCAge *string `json:"imageMinimumGCAge,omitempty" flag:"image-minimum-gc-age"`
+	// imageMaximumGCAge is the maximum age an image can be unused before it is garbage collected.
+	// The default of this field is "0s", which disables this field--meaning images won't be garbage
+	// collected based on being unused for too long. Default: "0s" (disabled)
+	ImageMaximumGCAge *string `json:"imageMaximumGCAge,omitempty" flag:"image-maximum-gc-age"`
 	// ImageGCHighThresholdPercent is the percent of disk usage after which
 	// image garbage collection is always run.
 	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty" flag:"image-gc-high-threshold"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -133,6 +133,12 @@ type KubeletConfigSpec struct {
 	// and overrides the default MTU for cases where it cannot be automatically
 	// computed (such as IPSEC).
 	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitempty" flag:"network-plugin-mtu"`
+	// imageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: "2m"
+	ImageMinimumGCAge *string `json:"imageMinimumGCAge,omitempty" flag:"image-minimum-gc-age"`
+	// imageMaximumGCAge is the maximum age an image can be unused before it is garbage collected.
+	// The default of this field is "0s", which disables this field--meaning images won't be garbage
+	// collected based on being unused for too long. Default: "0s" (disabled)
+	ImageMaximumGCAge *string `json:"imageMaximumGCAge,omitempty" flag:"image-maximum-gc-age"`
 	// ImageGCHighThresholdPercent is the percent of disk usage after which
 	// image garbage collection is always run.
 	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty" flag:"image-gc-high-threshold"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5364,6 +5364,8 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.NonMasqueradeCIDR = in.NonMasqueradeCIDR
 	out.EnableCustomMetrics = in.EnableCustomMetrics
 	out.NetworkPluginMTU = in.NetworkPluginMTU
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	out.ImageMaximumGCAge = in.ImageMaximumGCAge
 	out.ImageGCHighThresholdPercent = in.ImageGCHighThresholdPercent
 	out.ImageGCLowThresholdPercent = in.ImageGCLowThresholdPercent
 	out.ImagePullProgressDeadline = in.ImagePullProgressDeadline
@@ -5466,6 +5468,8 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.NonMasqueradeCIDR = in.NonMasqueradeCIDR
 	out.EnableCustomMetrics = in.EnableCustomMetrics
 	out.NetworkPluginMTU = in.NetworkPluginMTU
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	out.ImageMaximumGCAge = in.ImageMaximumGCAge
 	out.ImageGCHighThresholdPercent = in.ImageGCHighThresholdPercent
 	out.ImageGCLowThresholdPercent = in.ImageGCLowThresholdPercent
 	out.ImagePullProgressDeadline = in.ImagePullProgressDeadline

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3809,6 +3809,16 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ImageMinimumGCAge != nil {
+		in, out := &in.ImageMinimumGCAge, &out.ImageMinimumGCAge
+		*out = new(string)
+		**out = **in
+	}
+	if in.ImageMaximumGCAge != nil {
+		in, out := &in.ImageMaximumGCAge, &out.ImageMaximumGCAge
+		*out = new(string)
+		**out = **in
+	}
 	if in.ImageGCHighThresholdPercent != nil {
 		in, out := &in.ImageGCHighThresholdPercent, &out.ImageGCHighThresholdPercent
 		*out = new(int32)

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -132,6 +132,12 @@ type KubeletConfigSpec struct {
 	// and overrides the default MTU for cases where it cannot be automatically
 	// computed (such as IPSEC).
 	NetworkPluginMTU *int32 `json:"networkPluginMTU,omitempty" flag:"network-plugin-mtu"`
+	// imageMinimumGCAge is the minimum age for an unused image before it is garbage collected. Default: "2m"
+	ImageMinimumGCAge *string `json:"imageMinimumGCAge,omitempty" flag:"image-minimum-gc-age"`
+	// imageMaximumGCAge is the maximum age an image can be unused before it is garbage collected.
+	// The default of this field is "0s", which disables this field--meaning images won't be garbage
+	// collected based on being unused for too long. Default: "0s" (disabled)
+	ImageMaximumGCAge *string `json:"imageMaximumGCAge,omitempty" flag:"image-maximum-gc-age"`
 	// ImageGCHighThresholdPercent is the percent of disk usage after which
 	// image garbage collection is always run.
 	ImageGCHighThresholdPercent *int32 `json:"imageGCHighThresholdPercent,omitempty" flag:"image-gc-high-threshold"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5755,6 +5755,8 @@ func autoConvert_v1alpha3_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.NonMasqueradeCIDR = in.NonMasqueradeCIDR
 	out.EnableCustomMetrics = in.EnableCustomMetrics
 	out.NetworkPluginMTU = in.NetworkPluginMTU
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	out.ImageMaximumGCAge = in.ImageMaximumGCAge
 	out.ImageGCHighThresholdPercent = in.ImageGCHighThresholdPercent
 	out.ImageGCLowThresholdPercent = in.ImageGCLowThresholdPercent
 	out.ImagePullProgressDeadline = in.ImagePullProgressDeadline
@@ -5857,6 +5859,8 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha3_KubeletConfigSpec(in *kops.K
 	out.NonMasqueradeCIDR = in.NonMasqueradeCIDR
 	out.EnableCustomMetrics = in.EnableCustomMetrics
 	out.NetworkPluginMTU = in.NetworkPluginMTU
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	out.ImageMaximumGCAge = in.ImageMaximumGCAge
 	out.ImageGCHighThresholdPercent = in.ImageGCHighThresholdPercent
 	out.ImageGCLowThresholdPercent = in.ImageGCLowThresholdPercent
 	out.ImagePullProgressDeadline = in.ImagePullProgressDeadline

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3778,6 +3778,16 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ImageMinimumGCAge != nil {
+		in, out := &in.ImageMinimumGCAge, &out.ImageMinimumGCAge
+		*out = new(string)
+		**out = **in
+	}
+	if in.ImageMaximumGCAge != nil {
+		in, out := &in.ImageMaximumGCAge, &out.ImageMaximumGCAge
+		*out = new(string)
+		**out = **in
+	}
 	if in.ImageGCHighThresholdPercent != nil {
 		in, out := &in.ImageGCHighThresholdPercent, &out.ImageGCHighThresholdPercent
 		*out = new(int32)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3957,6 +3957,16 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ImageMinimumGCAge != nil {
+		in, out := &in.ImageMinimumGCAge, &out.ImageMinimumGCAge
+		*out = new(string)
+		**out = **in
+	}
+	if in.ImageMaximumGCAge != nil {
+		in, out := &in.ImageMaximumGCAge, &out.ImageMaximumGCAge
+		*out = new(string)
+		**out = **in
+	}
 	if in.ImageGCHighThresholdPercent != nil {
 		in, out := &in.ImageGCHighThresholdPercent, &out.ImageGCHighThresholdPercent
 		*out = new(int32)


### PR DESCRIPTION
Cherry pick of #16318 on release-1.28.

#16318: added image minimum and maximum gc age

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```