### PR TITLE
Skip gen-cli-docs on depup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ goget:
 	go get $(shell go list -f '{{if not (or .Main .Indirect)}}{{.Path}}{{end}}' -mod=mod -m all | grep -v spotinst-sdk-go)
 
 .PHONY: depup
-depup: goget gomod gen-cli-docs
+depup: goget gomod
 
 .PHONY: gofmt
 gofmt:


### PR DESCRIPTION
This is preventing the dependencies update action to finish and show errors in tests:
https://github.com/kubernetes/kops/actions/runs/7752057353

/cc @rifelpet @justinsb