### PR TITLE
Dont set -num-nodes on karpenter-managed clusters

### DIFF
--- a/tests/e2e/pkg/tester/tester.go
+++ b/tests/e2e/pkg/tester/tester.go
@@ -199,9 +199,11 @@ func (t *Tester) addNodeIG() error {
 			ig = v
 		}
 	}
-	numNodes := int(*ig.Spec.MaxSize) // we assume that MinSize = Maxsize, this is true for e2e testing
-	klog.Infof("Setting -num-nodes=%v", numNodes)
-	t.TestArgs += " -num-nodes=" + strconv.Itoa(numNodes)
+	if ig.Spec.MaxSize != nil {
+		numNodes := int(*ig.Spec.MaxSize) // we assume that MinSize = Maxsize, this is true for e2e testing
+		klog.Infof("Setting -num-nodes=%v", numNodes)
+		t.TestArgs += " -num-nodes=" + strconv.Itoa(numNodes)
+	}
 
 	// Skip the rest of this function for non gce clusters
 	if cluster.Spec.LegacyCloudProvider != "gce" {


### PR DESCRIPTION
Fixes a panic during karpenter e2e tests introduced by https://github.com/kubernetes/kops/pull/16176

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-karpenter/1754176571796623360

```
I0204 16:34:13.468238   14042 tester.go:75] Adding --host=https://api-e2e-e2e-kops-aws-karp-3r2ait-3bb67354234fd44a.elb.eu-central-1.amazonaws.com/
I0204 16:34:14.085494   14042 tester.go:158] Setting --provider=aws
I0204 16:34:14.808979   14042 tester.go:177] Setting --gce-zone=eu-central-1a
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2e280fd]
goroutine 1 [running]:
k8s.io/kops/tests/e2e/pkg/tester.(*Tester).addNodeIG(0xc000c6f260)
	/home/prow/go/src/k8s.io/kops/tests/e2e/pkg/tester/tester.go:202 +0xbd
k8s.io/kops/tests/e2e/pkg/tester.(*Tester).execute(0xc000c6f260)
	/home/prow/go/src/k8s.io/kops/tests/e2e/pkg/tester/tester.go:465 +0x193
k8s.io/kops/tests/e2e/pkg/tester.Main()
	/home/prow/go/src/k8s.io/kops/tests/e2e/pkg/tester/tester.go:512 +0xc5
main.main()
	/home/prow/go/src/k8s.io/kops/tests/e2e/kubetest2-tester-kops/main.go:24 +0xf
```

[Example IG manifest](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-karpenter/1754176571796623360/artifacts/instancegroups.yaml)

/cc @upodroid 