### PR TITLE
docs: Remove warning about Amazon VPC CNI not being compatible with Ubuntu 22.04

### DIFF
--- a/docs/networking/aws-vpc.md
+++ b/docs/networking/aws-vpc.md
@@ -2,6 +2,8 @@
 
 The Amazon VPC CNI uses the native AWS networking for Pods. Every pod gets an Elastic Network Interface (ENI) on the node it is running and an IP address belonging to the subnets assigned to the node.
 
+**WARNING**: The Amazon VPC CNI is not compatible with Ubuntu 22.04 and kOps versions earlier than 1.29. See [kubernetes/kops#15720](https://github.com/kubernetes/kops/issues/15720) and [aws/amazon-vpc-cni-k8s#2103](https://github.com/aws/amazon-vpc-cni-k8s/issues/2103) for more info (Fix was applied via [kubernetes/kops#16313](https://github.com/kubernetes/kops/issues/16313) in kOps 1.29).
+
 ## Installing
 
 To use Amazon VPC, specify the following in the cluster spec:

--- a/docs/networking/aws-vpc.md
+++ b/docs/networking/aws-vpc.md
@@ -2,8 +2,6 @@
 
 The Amazon VPC CNI uses the native AWS networking for Pods. Every pod gets an Elastic Network Interface (ENI) on the node it is running and an IP address belonging to the subnets assigned to the node.
 
-**WARNING**: The Amazon VPC CNI is not compatible with Ubuntu 22.04. See [kubernetes/kops#15720](https://github.com/kubernetes/kops/issues/15720) and [aws/amazon-vpc-cni-k8s#2103](https://github.com/aws/amazon-vpc-cni-k8s/issues/2103) for more info.
-
 ## Installing
 
 To use Amazon VPC, specify the following in the cluster spec:
@@ -25,7 +23,6 @@ kops create cluster \
 ```
 
 **Important:** pods use the VPC CIDR, i.e. there is no isolation between the master, node/s and the internal k8s network. In addition, this CNI does not enforce network policies.
-
 
 ## Configuration
 

--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -5,6 +5,7 @@ As of Kubernetes 1.27 the default images used by kOps are the **[official Ubuntu
 You can choose a different image for an instance group by editing it with `kops edit ig nodes`.
 
 For AWS, you should set the `image` field in one of the following formats:
+
 * `ami-abcdef` - specifies an image by id directly (image id is precise, but ids vary by region)
 * `<owner>/<name>` specifies an image by its owner's account ID  and name properties
 * `<alias>/<name>` specifies an image by its [owner's alias](#owner-aliases) and name properties
@@ -223,8 +224,6 @@ az vm image list --all --output table \
 ### Ubuntu 22.04 (Jammy)
 
 Ubuntu 22.04 is based on Kernel version **5.15** which fixes all the known major Kernel bugs.
-
-**WARNING**: The Amazon VPC CNI is not compatible with Ubuntu 22.04. See [kubernetes/kops#15720](https://github.com/kubernetes/kops/issues/15720) and [aws/amazon-vpc-cni-k8s#2103](https://github.com/aws/amazon-vpc-cni-k8s/issues/2103) for more info.
 
 Available images can be listed using:
 

--- a/docs/releases/1.29-NOTES.md
+++ b/docs/releases/1.29-NOTES.md
@@ -43,12 +43,10 @@ instances.
 ## Other breaking changes
 
 * `kops toolbox dump` limits the number of nodes dumped to 500 by default. Use `--max-nodes` to override.
- 
+
 * Support for Kubernetes version 1.23 has been removed.
 
 # Known Issues
-
-* The Amazon VPC CNI is not compatible with Ubuntu 22.04. See [kubernetes/kops#15720](https://github.com/kubernetes/kops/issues/15720) and [aws/amazon-vpc-cni-k8s#2103](https://github.com/aws/amazon-vpc-cni-k8s/issues/2103) for more info.
 
 # Deprecations
 

--- a/docs/releases/1.29-NOTES.md
+++ b/docs/releases/1.29-NOTES.md
@@ -48,6 +48,8 @@ instances.
 
 # Known Issues
 
+* The Amazon VPC CNI is now compatible with Ubuntu 22.04. Fix applied via [kubernetes/kops#16313](https://github.com/kubernetes/kops/issues/16313).
+
 # Deprecations
 
 * Support for Kubernetes version 1.24 is deprecated and will be removed in kOps 1.30.


### PR DESCRIPTION
**What this PR does / why we need it**:
Following merge of #16313, Amazon VPC CNI is now compatible with Ubuntu 22.04, thus we can remove the warnings across the code.


**Special notes for your reviewer**:
/cc @hakman
/cc @rifelpet
Hey folks!
I took the liberty of removing the note from 1.29 release notes as well, since it's still in alpha and doesn't have a release branch yet, I hope that's okay.
Also- let me know if ya'll think it's worth backporting #16313 to 1.27 and 1.28 release branches, and I can take care of that.

Thanks! :pray: