### PR TITLE
Set LimitNOFILE to 1048576 instead of `infinity`

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -203,7 +203,7 @@ func (b *ContainerdBuilder) buildSystemdService(sv semver.Version) *nodetasks.Se
 
 	manifest.Set("Service", "LimitNPROC", "infinity")
 	manifest.Set("Service", "LimitCORE", "infinity")
-	manifest.Set("Service", "LimitNOFILE", "infinity")
+	manifest.Set("Service", "LimitNOFILE", "1048576")
 	manifest.Set("Service", "TasksMax", "infinity")
 
 	// make killing of processes of this unit under memory pressure very unlikely

--- a/nodeup/pkg/model/tests/containerdbuilder/complex/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/complex/tasks.yaml
@@ -362,7 +362,7 @@ definition: |
   RestartSec=5
   LimitNPROC=infinity
   LimitCORE=infinity
-  LimitNOFILE=infinity
+  LimitNOFILE=1048576
   TasksMax=infinity
   OOMScoreAdjust=-999
 

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -355,7 +355,7 @@ definition: |
   RestartSec=5
   LimitNPROC=infinity
   LimitCORE=infinity
-  LimitNOFILE=infinity
+  LimitNOFILE=1048576
   TasksMax=infinity
   OOMScoreAdjust=-999
 


### PR DESCRIPTION
When we set `LimitNOFILE` to `infinity` things break .. for example the nfs based tests in kubernetes harness:
https://testgrid.k8s.io/amazon-ec2-al2023#ci-kubernetes-e2e-al2023-aws-canary&width=20

Also see https://github.com/containerd/containerd/pull/9660 which points to more things that are likely to break with `infinity` https://github.com/containerd/containerd/pull/8924#issuecomment-1903629621