### PR TITLE
Set KUBECONFIG for LBC's ginkgo tests

### DIFF
--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -33,6 +33,10 @@ ZONES="eu-west-1a,eu-west-1b,eu-west-1c"
 
 kops-up
 
+KUBECONFIG=$(mktemp -t kops.XXXXXXXXX)
+export KUBECONFIG
+"${KOPS}" export kubecfg --name "${CLUSTER_NAME}" --admin --kubeconfig "${KUBECONFIG}"
+
 VPC=$(${KOPS} toolbox dump -o json | jq -r .vpc.id)
 
 ZONE=$(${KOPS} get ig -o json | jq -r '[.[] | select(.spec.role=="Node") | .spec.subnets[0]][0]')


### PR DESCRIPTION
Hoping to fix these tests: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-aws-load-balancer-controller/1755828286962798592

The test failures seem to be using the wrong kubeconfig settings, potentially using the "in cluster" config of the prow job pod itself.

This explicitly sets KUBECONFIG so that the ginkgo tests will use the kops cluster's admin credentials 

ref: https://kubernetes.slack.com/archives/C8MKE2G5P/p1707502477184889?thread_ts=1707242089.155659&cid=C8MKE2G5P