### PR TITLE
Have kops-controller create headless k8s services for dns=none clusters 

### DIFF
--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -231,7 +231,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := addGossipController(mgr, &opt); err != nil {
+	if err := addDNSHostsController(mgr, &opt); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GossipController")
 		os.Exit(1)
 	}
@@ -342,7 +342,7 @@ func addNodeController(mgr manager.Manager, vfsContext *vfs.VFSContext, opt *con
 	return nil
 }
 
-func addGossipController(mgr manager.Manager, opt *config.Options) error {
+func addDNSHostsController(mgr manager.Manager, opt *config.Options) error {
 	if opt.Discovery == nil || !opt.Discovery.Enabled {
 		return nil
 	}

--- a/pkg/model/components/kopscontroller/template_functions.go
+++ b/pkg/model/components/kopscontroller/template_functions.go
@@ -43,8 +43,8 @@ type templateFunctions struct {
 	Cluster *kops.Cluster
 }
 
-// KopsControllerConfig returns the yaml configuration for kops-controller
-func (t *templateFunctions) GossipServices() ([]*corev1.Service, error) {
+// DNSHeadlessServices returns a list of headless k8s services for clusters that dont have a public DNS zone
+func (t *templateFunctions) DNSHeadlessServices() ([]*corev1.Service, error) {
 	if !t.Cluster.UsesLegacyGossip() {
 		return nil, nil
 	}

--- a/pkg/model/components/kopscontroller/template_functions.go
+++ b/pkg/model/components/kopscontroller/template_functions.go
@@ -45,7 +45,7 @@ type templateFunctions struct {
 
 // DNSHeadlessServices returns a list of headless k8s services for clusters that dont have a public DNS zone
 func (t *templateFunctions) DNSHeadlessServices() ([]*corev1.Service, error) {
-	if !t.Cluster.UsesLegacyGossip() {
+	if t.Cluster.PublishesDNSRecords() {
 		return nil, nil
 	}
 

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d1721b520554fcb342dce2d1e6c4da40ead20efc14d872472f854d42f845618e
+    manifestHash: 27df640749581db0bf1c0fb37baf2fd539c6da51175077049131ba323925ecb5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -223,3 +223,51 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: system:serviceaccount:kube-system:kops-controller
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: kops-controller.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    discovery.kops.k8s.io/internal-name: api
+    k8s-addon: kops-controller.addons.k8s.io
+  name: api-internal
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    k8s-app: kops-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: kops-controller.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    discovery.kops.k8s.io/internal-name: kops-controller
+    k8s-addon: kops-controller.addons.k8s.io
+  name: kops-controller-internal
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 3988
+    protocol: TCP
+    targetPort: 3988
+  selector:
+    k8s-app: kops-controller
+  type: ClusterIP

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 436ac04e02cb1a62a84876be88f6bd9f6e77329709c084e271ac3827f9e1e0ad
+    manifestHash: 506cfd2288a2c8a0c8e5bdb07b88d1ab75986906d323ff61ee11ba5819e40d05
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -223,3 +223,51 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: system:serviceaccount:kube-system:kops-controller
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: kops-controller.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    discovery.kops.k8s.io/internal-name: api
+    k8s-addon: kops-controller.addons.k8s.io
+  name: api-internal
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    k8s-app: kops-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: kops-controller.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    discovery.kops.k8s.io/internal-name: kops-controller
+    k8s-addon: kops-controller.addons.k8s.io
+  name: kops-controller-internal
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 3988
+    protocol: TCP
+    targetPort: 3988
+  selector:
+    k8s-app: kops-controller
+  type: ClusterIP

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d43ec11bfdc59ea071784f7b54a277efee32384aecf293ae80e6d90a3bffc5f3
+    manifestHash: 7c4029c5547845aa6837c284211e421cd4bebb5c709a028d81be1450b141ee82
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -225,3 +225,51 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: system:serviceaccount:kube-system:kops-controller
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: kops-controller.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    discovery.kops.k8s.io/internal-name: api
+    k8s-addon: kops-controller.addons.k8s.io
+  name: api-internal
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    k8s-app: kops-controller
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: kops-controller.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    discovery.kops.k8s.io/internal-name: kops-controller
+    k8s-addon: kops-controller.addons.k8s.io
+  name: kops-controller-internal
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 3988
+    protocol: TCP
+    targetPort: 3988
+  selector:
+    k8s-app: kops-controller
+  type: ClusterIP

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -246,7 +246,7 @@ subjects:
   kind: User
   name: system:serviceaccount:kube-system:kops-controller
 
-{{- range $service := KopsController.GossipServices }}
+{{- range $service := KopsController.DNSHeadlessServices }}
 ---
 {{ KubeObjectToApplyYAML $service }}
 {{- end }}


### PR DESCRIPTION
Fixes #16332

Like gossip clusters, dns=none clusters wont be able to resolve these DNS names which causes e2e test failures for OIDC tests. This ensures the OIDC test pods can resolve the DNS names.

Example failure: https://testgrid.k8s.io/kops-grid#kops-grid-calico-amzn2-k26

`I0204 15:43:18.460415       1 log.go:198] Get "https://api.internal.e2e-e2e-kops-grid-calico-amzn2-k26.test-cncf-aws.k8s.io/.well-known/openid-configuration": dial tcp: lookup api.internal.e2e-e2e-kops-grid-calico-amzn2-k26.test-cncf-aws.k8s.io on 100.64.0.10:53: no such host`