### PR TITLE
clockmock: Add more methods that take a context

### DIFF
--- a/cloudmock/aws/mockautoscaling/tags.go
+++ b/cloudmock/aws/mockautoscaling/tags.go
@@ -17,13 +17,15 @@ limitations under the License.
 package mockautoscaling
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"k8s.io/klog/v2"
 )
 
-func (m *MockAutoscaling) DescribeTags(request *autoscaling.DescribeTagsInput) (*autoscaling.DescribeTagsOutput, error) {
+func (m *MockAutoscaling) DescribeTagsWithContext(ctx aws.Context, request *autoscaling.DescribeTagsInput, opt ...request.Option) (*autoscaling.DescribeTagsOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -62,9 +64,8 @@ func (m *MockAutoscaling) DescribeTags(request *autoscaling.DescribeTagsInput) (
 	return response, nil
 }
 
-func (m *MockAutoscaling) DescribeTagsWithContext(aws.Context, *autoscaling.DescribeTagsInput, ...request.Option) (*autoscaling.DescribeTagsOutput, error) {
-	klog.Fatalf("Not implemented")
-	return nil, nil
+func (m *MockAutoscaling) DescribeTags(request *autoscaling.DescribeTagsInput) (*autoscaling.DescribeTagsOutput, error) {
+	return m.DescribeTagsWithContext(context.TODO(), request)
 }
 
 func (m *MockAutoscaling) DescribeTagsRequest(*autoscaling.DescribeTagsInput) (*request.Request, *autoscaling.DescribeTagsOutput) {
@@ -74,7 +75,7 @@ func (m *MockAutoscaling) DescribeTagsRequest(*autoscaling.DescribeTagsInput) (*
 
 func (m *MockAutoscaling) DescribeTagsPagesWithContext(ctx aws.Context, request *autoscaling.DescribeTagsInput, callback func(*autoscaling.DescribeTagsOutput, bool) bool, options ...request.Option) error {
 	// For the mock, we just send everything in one page
-	page, err := m.DescribeTags(request)
+	page, err := m.DescribeTagsWithContext(ctx, request)
 	if err != nil {
 		return err
 	}

--- a/cloudmock/aws/mockelbv2/tags.go
+++ b/cloudmock/aws/mockelbv2/tags.go
@@ -17,7 +17,10 @@ limitations under the License.
 package mockelbv2
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"k8s.io/klog/v2"
 )
@@ -57,7 +60,7 @@ func (m *MockELBV2) AddTags(request *elbv2.AddTagsInput) (*elbv2.AddTagsOutput, 
 	return &elbv2.AddTagsOutput{}, nil
 }
 
-func (m *MockELBV2) DescribeTags(request *elbv2.DescribeTagsInput) (*elbv2.DescribeTagsOutput, error) {
+func (m *MockELBV2) DescribeTagsWithContext(ctx aws.Context, request *elbv2.DescribeTagsInput, opts ...request.Option) (*elbv2.DescribeTagsOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -74,4 +77,8 @@ func (m *MockELBV2) DescribeTags(request *elbv2.DescribeTagsInput) (*elbv2.Descr
 		}
 	}
 	return resp, nil
+}
+
+func (m *MockELBV2) DescribeTags(request *elbv2.DescribeTagsInput) (*elbv2.DescribeTagsOutput, error) {
+	return m.DescribeTagsWithContext(context.TODO(), request)
 }

--- a/cloudmock/aws/mockelbv2/targetgroups.go
+++ b/cloudmock/aws/mockelbv2/targetgroups.go
@@ -17,10 +17,12 @@ limitations under the License.
 package mockelbv2
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"k8s.io/klog/v2"
 )
@@ -76,7 +78,7 @@ func (m *MockELBV2) DescribeTargetGroups(request *elbv2.DescribeTargetGroupsInpu
 	}, nil
 }
 
-func (m *MockELBV2) DescribeTargetGroupsPages(request *elbv2.DescribeTargetGroupsInput, callback func(p *elbv2.DescribeTargetGroupsOutput, lastPage bool) (shouldContinue bool)) error {
+func (m *MockELBV2) DescribeTargetGroupsPagesWithContext(ctx context.Context, request *elbv2.DescribeTargetGroupsInput, callback func(p *elbv2.DescribeTargetGroupsOutput, lastPage bool) (shouldContinue bool), opt ...request.Option) error {
 	page, err := m.DescribeTargetGroups(request)
 	if err != nil {
 		return err
@@ -85,6 +87,10 @@ func (m *MockELBV2) DescribeTargetGroupsPages(request *elbv2.DescribeTargetGroup
 	callback(page, false)
 
 	return nil
+}
+
+func (m *MockELBV2) DescribeTargetGroupsPages(request *elbv2.DescribeTargetGroupsInput, callback func(p *elbv2.DescribeTargetGroupsOutput, lastPage bool) (shouldContinue bool)) error {
+	return m.DescribeTargetGroupsPagesWithContext(context.TODO(), request, callback)
 }
 
 func (m *MockELBV2) CreateTargetGroup(request *elbv2.CreateTargetGroupInput) (*elbv2.CreateTargetGroupOutput, error) {

--- a/cloudmock/aws/mockroute53/records.go
+++ b/cloudmock/aws/mockroute53/records.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mockroute53
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,11 +38,7 @@ func (m *MockRoute53) ListResourceRecordSets(*route53.ListResourceRecordSetsInpu
 	panic("MockRoute53 ListResourceRecordSets not implemented")
 }
 
-func (m *MockRoute53) ListResourceRecordSetsPagesWithContext(aws.Context, *route53.ListResourceRecordSetsInput, func(*route53.ListResourceRecordSetsOutput, bool) bool, ...request.Option) error {
-	panic("Not implemented")
-}
-
-func (m *MockRoute53) ListResourceRecordSetsPages(request *route53.ListResourceRecordSetsInput, callback func(*route53.ListResourceRecordSetsOutput, bool) bool) error {
+func (m *MockRoute53) ListResourceRecordSetsPagesWithContext(ctx aws.Context, request *route53.ListResourceRecordSetsInput, callback func(*route53.ListResourceRecordSetsOutput, bool) bool, opts ...request.Option) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -72,6 +69,10 @@ func (m *MockRoute53) ListResourceRecordSetsPages(request *route53.ListResourceR
 	callback(page, lastPage)
 
 	return nil
+}
+
+func (m *MockRoute53) ListResourceRecordSetsPages(request *route53.ListResourceRecordSetsInput, callback func(*route53.ListResourceRecordSetsOutput, bool) bool) error {
+	return m.ListResourceRecordSetsPagesWithContext(context.TODO(), request, callback)
 }
 
 func (m *MockRoute53) ChangeResourceRecordSetsRequest(*route53.ChangeResourceRecordSetsInput) (*request.Request, *route53.ChangeResourceRecordSetsOutput) {


### PR DESCRIPTION
We're trying to pass more contexts around, but we need the mocks to
support the context forms of the methods.
