### PR TITLE
target group: refactor discovery into awsup

### DIFF
--- a/cloudmock/aws/mockelb/tags.go
+++ b/cloudmock/aws/mockelb/tags.go
@@ -17,14 +17,20 @@ limitations under the License.
 package mockelb
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"k8s.io/klog/v2"
 )
 
 func (m *MockELB) DescribeTags(request *elb.DescribeTagsInput) (*elb.DescribeTagsOutput, error) {
+	return m.DescribeTagsWithContext(context.TODO(), request)
+}
+
+func (m *MockELB) DescribeTagsWithContext(ctx aws.Context, request *elb.DescribeTagsInput, opt ...request.Option) (*elb.DescribeTagsOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/cloudmock/aws/mockelbv2/targetgroups.go
+++ b/cloudmock/aws/mockelbv2/targetgroups.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func (m *MockELBV2) DescribeTargetGroups(request *elbv2.DescribeTargetGroupsInput) (*elbv2.DescribeTargetGroupsOutput, error) {
+func (m *MockELBV2) DescribeTargetGroupsWithContext(ctx context.Context, request *elbv2.DescribeTargetGroupsInput, opts ...request.Option) (*elbv2.DescribeTargetGroupsOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -79,7 +79,7 @@ func (m *MockELBV2) DescribeTargetGroups(request *elbv2.DescribeTargetGroupsInpu
 }
 
 func (m *MockELBV2) DescribeTargetGroupsPagesWithContext(ctx context.Context, request *elbv2.DescribeTargetGroupsInput, callback func(p *elbv2.DescribeTargetGroupsOutput, lastPage bool) (shouldContinue bool), opt ...request.Option) error {
-	page, err := m.DescribeTargetGroups(request)
+	page, err := m.DescribeTargetGroupsWithContext(ctx, request)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This sets us up to support multiple generations of target groups,
needed if we want to support adding SecurityGroups to the NLB.
