### PR TITLE
Move DNS topology setup earlier in cluster creation

### DIFF
--- a/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
@@ -122,8 +122,6 @@ spec:
     type: Utility
     zone: us-test-1a
   topology:
-    bastion:
-      bastionPublicName: bastion.complex.example.com
     dns:
       type: None
 

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -59,8 +59,6 @@ spec:
     type: Utility
     zone: us-test-1a
   topology:
-    bastion:
-      bastionPublicName: bastion.private.example.com
     dns:
       type: None
 

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -59,8 +59,6 @@ spec:
     type: Utility
     zone: us-test-1a
   topology:
-    bastion:
-      bastionPublicName: bastion.private.example.com
     dns:
       type: None
 

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -62,8 +62,6 @@ spec:
     type: Utility
     zone: us-test-1a
   topology:
-    bastion:
-      bastionPublicName: bastion.private.example.com
     dns:
       type: None
 

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -57,8 +57,6 @@ spec:
     region: us-test1
     type: Private
   topology:
-    bastion:
-      bastionPublicName: bastion.private.example.com
     dns:
       type: None
 

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1267,6 +1267,12 @@ func setupTopology(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.S
 	}
 
 	cluster.Spec.Networking.Topology = &api.TopologySpec{}
+
+	err := setupDNSTopology(opt, cluster)
+	if err != nil {
+		return nil, err
+	}
+
 	switch opt.Topology {
 	case api.TopologyPublic:
 
@@ -1405,10 +1411,6 @@ func setupTopology(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.S
 		}
 	}
 
-	err := setupDNSTopology(opt, cluster)
-	if err != nil {
-		return nil, err
-	}
 	return bastions, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/16336

This is needed because setting the bastion public name field depends on the DNS topology.
We were incorrectly setting bastion.publicName for dns=none clusters because the dns=none field wasn't yet set on the cluster.