### PR TITLE
Add support for AL2023 AMI to use Amazon VPC CNI

### DIFF
--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -60,7 +60,12 @@ func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 		c.AddTask(&nodetasks.Package{Name: "conntrack-tools"})
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})
 		c.AddTask(&nodetasks.Package{Name: "ethtool"})
-		c.AddTask(&nodetasks.Package{Name: "iptables"})
+		if b.Distribution == distributions.DistributionAmazonLinux2023 {
+			// install iptables-nft in al2023 (NOT the iptables-legacy!)
+			c.AddTask(&nodetasks.Package{Name: "iptables-nft"})
+		} else {
+			c.AddTask(&nodetasks.Package{Name: "iptables"})
+		}
 		c.AddTask(&nodetasks.Package{Name: "libseccomp"})
 		c.AddTask(&nodetasks.Package{Name: "libtool-ltdl"})
 		c.AddTask(&nodetasks.Package{Name: "socat"})


### PR DESCRIPTION
Related to issue : https://github.com/kubernetes/kops/issues/16333

based on the changes in the EKS AMI: 
https://github.com/awslabs/amazon-eks-ami/blob/976fe67e4c359737be71d892a8f55015cc1475f5/scripts/install-worker.sh#L86-L105