### PR TITLE
Refactor IAM Policy Builder

### DIFF
--- a/pkg/model/awsmodel/iam.go
+++ b/pkg/model/awsmodel/iam.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/iam"
-	"k8s.io/kops/pkg/util/stringorslice"
+	"k8s.io/kops/pkg/util/stringorset"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
@@ -432,7 +432,7 @@ func formatAWSIAMStatement(accountId, partition, oidcProvider, namespace, name s
 			Principal: iam.Principal{
 				Federated: "arn:" + partition + ":iam::" + accountId + ":oidc-provider/" + oidcProvider,
 			},
-			Action: stringorslice.String("sts:AssumeRoleWithWebIdentity"),
+			Action: stringorset.String("sts:AssumeRoleWithWebIdentity"),
 			Condition: map[string]interface{}{
 				condition: map[string]interface{}{
 					oidcProvider + ":sub": "system:serviceaccount:" + namespace + ":" + name,

--- a/pkg/model/awsmodel/iam_test.go
+++ b/pkg/model/awsmodel/iam_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kops/pkg/model/iam"
-	"k8s.io/kops/pkg/util/stringorslice"
+	"k8s.io/kops/pkg/util/stringorset"
 )
 
 func TestIAMServiceEC2(t *testing.T) {
@@ -70,7 +70,7 @@ func Test_formatAWSIAMStatement(t *testing.T) {
 				Principal: iam.Principal{
 					Federated: "arn:aws-test:iam::0123456789:oidc-provider/oidc-test",
 				},
-				Action: stringorslice.String("sts:AssumeRoleWithWebIdentity"),
+				Action: stringorset.String("sts:AssumeRoleWithWebIdentity"),
 				Condition: map[string]interface{}{
 					"StringEquals": map[string]interface{}{
 						"oidc-test:sub": "system:serviceaccount:test:test",
@@ -104,7 +104,7 @@ func Test_formatAWSIAMStatement(t *testing.T) {
 				Principal: iam.Principal{
 					Federated: "arn:aws-test:iam::0123456789:oidc-provider/oidc-test",
 				},
-				Action: stringorslice.String("sts:AssumeRoleWithWebIdentity"),
+				Action: stringorset.String("sts:AssumeRoleWithWebIdentity"),
 				Condition: map[string]interface{}{
 					"StringLike": map[string]interface{}{
 						"oidc-test:sub": "system:serviceaccount:test-*:test",

--- a/pkg/model/components/addonmanifests/certmanager/iam.go
+++ b/pkg/model/components/addonmanifests/certmanager/iam.go
@@ -60,19 +60,19 @@ func addCertManagerPermissions(b *iam.PolicyBuilder, p *iam.Policy) {
 		Action: stringorslice.Of("route53:ChangeResourceRecordSets",
 			"route53:ListResourceRecordSets",
 		),
-		Resource: stringorslice.Slice(zoneResources),
+		Resource: stringorslice.Set(zoneResources),
 	})
 
 	p.Statement = append(p.Statement, &iam.Statement{
 		Effect:   iam.StatementEffectAllow,
-		Action:   stringorslice.Slice([]string{"route53:GetChange"}),
-		Resource: stringorslice.Slice([]string{fmt.Sprintf("arn:%v:route53:::change/*", b.Partition)}),
+		Action:   stringorslice.Set([]string{"route53:GetChange"}),
+		Resource: stringorslice.Set([]string{fmt.Sprintf("arn:%v:route53:::change/*", b.Partition)}),
 	})
 
-	wildcard := stringorslice.Slice([]string{"*"})
+	wildcard := stringorslice.Set([]string{"*"})
 	p.Statement = append(p.Statement, &iam.Statement{
 		Effect:   iam.StatementEffectAllow,
-		Action:   stringorslice.Slice([]string{"route53:ListHostedZonesByName"}),
+		Action:   stringorslice.Set([]string{"route53:ListHostedZonesByName"}),
 		Resource: wildcard,
 	})
 }

--- a/pkg/model/components/addonmanifests/certmanager/iam.go
+++ b/pkg/model/components/addonmanifests/certmanager/iam.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/kops/pkg/model/iam"
-	"k8s.io/kops/pkg/util/stringorslice"
+	"k8s.io/kops/pkg/util/stringorset"
 )
 
 // ServiceAccount represents the service-account used by cert-manager.
@@ -57,22 +57,22 @@ func addCertManagerPermissions(b *iam.PolicyBuilder, p *iam.Policy) {
 
 	p.Statement = append(p.Statement, &iam.Statement{
 		Effect: iam.StatementEffectAllow,
-		Action: stringorslice.Of("route53:ChangeResourceRecordSets",
+		Action: stringorset.Of("route53:ChangeResourceRecordSets",
 			"route53:ListResourceRecordSets",
 		),
-		Resource: stringorslice.Set(zoneResources),
+		Resource: stringorset.Set(zoneResources),
 	})
 
 	p.Statement = append(p.Statement, &iam.Statement{
 		Effect:   iam.StatementEffectAllow,
-		Action:   stringorslice.Set([]string{"route53:GetChange"}),
-		Resource: stringorslice.Set([]string{fmt.Sprintf("arn:%v:route53:::change/*", b.Partition)}),
+		Action:   stringorset.Set([]string{"route53:GetChange"}),
+		Resource: stringorset.Set([]string{fmt.Sprintf("arn:%v:route53:::change/*", b.Partition)}),
 	})
 
-	wildcard := stringorslice.Set([]string{"*"})
+	wildcard := stringorset.Set([]string{"*"})
 	p.Statement = append(p.Statement, &iam.Statement{
 		Effect:   iam.StatementEffectAllow,
-		Action:   stringorslice.Set([]string{"route53:ListHostedZonesByName"}),
+		Action:   stringorset.Set([]string{"route53:ListHostedZonesByName"}),
 		Resource: wildcard,
 	})
 }

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -78,7 +78,7 @@ func (p *Policy) AddEC2CreateAction(actions, resources []string) {
 		&Statement{
 			Effect:   StatementEffectAllow,
 			Action:   stringorslice.String("ec2:CreateTags"),
-			Resource: stringorslice.Slice(actualResources),
+			Resource: stringorslice.Set(actualResources),
 			Condition: Condition{
 				"StringEquals": map[string]interface{}{
 					"aws:RequestTag/KubernetesCluster": p.clusterName,
@@ -89,11 +89,11 @@ func (p *Policy) AddEC2CreateAction(actions, resources []string) {
 
 		&Statement{
 			Effect: StatementEffectAllow,
-			Action: stringorslice.Slice([]string{
+			Action: stringorslice.Set([]string{
 				"ec2:CreateTags",
 				"ec2:DeleteTags", // aws.go, tag.go
 			}),
-			Resource: stringorslice.Slice(actualResources),
+			Resource: stringorslice.Set(actualResources),
 			Condition: Condition{
 				"Null": map[string]string{
 					"aws:RequestTag/KubernetesCluster": "true",
@@ -176,8 +176,8 @@ type Condition map[string]interface{}
 type Statement struct {
 	Effect    StatementEffect
 	Principal Principal
-	Action    stringorslice.StringOrSlice
-	Resource  stringorslice.StringOrSlice
+	Action    stringorslice.StringOrSet
+	Resource  stringorslice.StringOrSet
 	Condition Condition
 }
 
@@ -600,7 +600,7 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 				"s3:ListBucket",
 				"s3:ListBucketVersions",
 			),
-			Resource: stringorslice.Slice([]string{
+			Resource: stringorslice.Set([]string{
 				fmt.Sprintf("arn:%v:s3:::%v", p.partition, s3Bucket),
 			}),
 		})
@@ -612,7 +612,7 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 func (b *PolicyBuilder) buildS3WriteStatements(p *Policy, iamS3Path string) {
 	p.Statement = append(p.Statement, &Statement{
 		Effect: StatementEffectAllow,
-		Action: stringorslice.Slice([]string{
+		Action: stringorslice.Set([]string{
 			"s3:GetObject",
 			"s3:DeleteObject",
 			"s3:DeleteObjectVersion",
@@ -640,7 +640,7 @@ func (b *PolicyBuilder) buildS3GetStatements(p *Policy, iamS3Path string) error 
 
 		p.Statement = append(p.Statement, &Statement{
 			Effect:   StatementEffectAllow,
-			Action:   stringorslice.Slice([]string{"s3:Get*"}),
+			Action:   stringorslice.Set([]string{"s3:Get*"}),
 			Resource: stringorslice.Of(resources...),
 		})
 	}
@@ -803,7 +803,7 @@ func addEtcdManagerPermissions(p *Policy) {
 			Action: stringorslice.Of(
 				"ec2:AttachVolume",
 			),
-			Resource: stringorslice.Slice([]string{"*"}),
+			Resource: stringorslice.Set([]string{"*"}),
 			Condition: Condition{
 				"StringEquals": map[string]string{
 					"aws:ResourceTag/k8s.io/role/master": "1",
@@ -1064,19 +1064,19 @@ func AddDNSControllerPermissions(b *PolicyBuilder, p *Policy) {
 		Action: stringorslice.Of("route53:ChangeResourceRecordSets",
 			"route53:ListResourceRecordSets",
 			"route53:GetHostedZone"),
-		Resource: stringorslice.Slice([]string{fmt.Sprintf("arn:%v:route53:::hostedzone/%v", b.Partition, hostedZoneID)}),
+		Resource: stringorslice.Set([]string{fmt.Sprintf("arn:%v:route53:::hostedzone/%v", b.Partition, hostedZoneID)}),
 	})
 
 	p.Statement = append(p.Statement, &Statement{
 		Effect:   StatementEffectAllow,
-		Action:   stringorslice.Slice([]string{"route53:GetChange"}),
-		Resource: stringorslice.Slice([]string{fmt.Sprintf("arn:%v:route53:::change/*", b.Partition)}),
+		Action:   stringorslice.Set([]string{"route53:GetChange"}),
+		Resource: stringorslice.Set([]string{fmt.Sprintf("arn:%v:route53:::change/*", b.Partition)}),
 	})
 
-	wildcard := stringorslice.Slice([]string{"*"})
+	wildcard := stringorslice.Set([]string{"*"})
 	p.Statement = append(p.Statement, &Statement{
 		Effect:   StatementEffectAllow,
-		Action:   stringorslice.Slice([]string{"route53:ListHostedZones", "route53:ListTagsForResource"}),
+		Action:   stringorslice.Set([]string{"route53:ListHostedZones", "route53:ListTagsForResource"}),
 		Resource: wildcard,
 	})
 }
@@ -1169,10 +1169,10 @@ func addAmazonVPCCNIPermissions(p *Policy) {
 	p.Statement = append(p.Statement,
 		&Statement{
 			Effect: StatementEffectAllow,
-			Action: stringorslice.Slice([]string{
+			Action: stringorslice.Set([]string{
 				"ec2:CreateTags",
 			}),
-			Resource: stringorslice.Slice([]string{
+			Resource: stringorslice.Set([]string{
 				strings.Join([]string{"arn:", p.partition, ":ec2:*:*:network-interface/*"}, ""),
 			}),
 		},

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -38,7 +38,7 @@ import (
 
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/model"
-	"k8s.io/kops/pkg/util/stringorslice"
+	"k8s.io/kops/pkg/util/stringorset"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/util/pkg/vfs"
@@ -77,8 +77,8 @@ func (p *Policy) AddEC2CreateAction(actions, resources []string) {
 	p.Statement = append(p.Statement,
 		&Statement{
 			Effect:   StatementEffectAllow,
-			Action:   stringorslice.String("ec2:CreateTags"),
-			Resource: stringorslice.Set(actualResources),
+			Action:   stringorset.String("ec2:CreateTags"),
+			Resource: stringorset.Set(actualResources),
 			Condition: Condition{
 				"StringEquals": map[string]interface{}{
 					"aws:RequestTag/KubernetesCluster": p.clusterName,
@@ -89,11 +89,11 @@ func (p *Policy) AddEC2CreateAction(actions, resources []string) {
 
 		&Statement{
 			Effect: StatementEffectAllow,
-			Action: stringorslice.Set([]string{
+			Action: stringorset.Set([]string{
 				"ec2:CreateTags",
 				"ec2:DeleteTags", // aws.go, tag.go
 			}),
-			Resource: stringorslice.Set(actualResources),
+			Resource: stringorset.Set(actualResources),
 			Condition: Condition{
 				"Null": map[string]string{
 					"aws:RequestTag/KubernetesCluster": "true",
@@ -111,15 +111,15 @@ func (p *Policy) AsJSON() (string, error) {
 	if len(p.unconditionalAction) > 0 {
 		p.Statement = append(p.Statement, &Statement{
 			Effect:   StatementEffectAllow,
-			Action:   stringorslice.Of(sets.List(p.unconditionalAction)...),
-			Resource: stringorslice.String("*"),
+			Action:   stringorset.Of(sets.List(p.unconditionalAction)...),
+			Resource: stringorset.String("*"),
 		})
 	}
 	if len(p.clusterTaggedAction) > 0 {
 		p.Statement = append(p.Statement, &Statement{
 			Effect:   StatementEffectAllow,
-			Action:   stringorslice.Of(sets.List(p.clusterTaggedAction)...),
-			Resource: stringorslice.String("*"),
+			Action:   stringorset.Of(sets.List(p.clusterTaggedAction)...),
+			Resource: stringorset.String("*"),
 			Condition: Condition{
 				"StringEquals": map[string]string{
 					"aws:ResourceTag/KubernetesCluster": p.clusterName,
@@ -130,8 +130,8 @@ func (p *Policy) AsJSON() (string, error) {
 	if len(p.clusterTaggedCreateAction) > 0 {
 		p.Statement = append(p.Statement, &Statement{
 			Effect:   StatementEffectAllow,
-			Action:   stringorslice.Of(sets.List(p.clusterTaggedCreateAction)...),
-			Resource: stringorslice.String("*"),
+			Action:   stringorset.Of(sets.List(p.clusterTaggedCreateAction)...),
+			Resource: stringorset.String("*"),
 			Condition: Condition{
 				"StringEquals": map[string]string{
 					"aws:RequestTag/KubernetesCluster": p.clusterName,
@@ -143,8 +143,8 @@ func (p *Policy) AsJSON() (string, error) {
 		if p.clusterTaggedCreateAction.Has("ec2:CreateSecurityGroup") {
 			p.Statement = append(p.Statement, &Statement{
 				Effect:   StatementEffectAllow,
-				Action:   stringorslice.Of("ec2:CreateSecurityGroup"),
-				Resource: stringorslice.String(fmt.Sprintf("arn:%s:ec2:*:*:vpc/*", p.partition)),
+				Action:   stringorset.Of("ec2:CreateSecurityGroup"),
+				Resource: stringorset.String(fmt.Sprintf("arn:%s:ec2:*:*:vpc/*", p.partition)),
 			})
 		}
 	}
@@ -176,8 +176,8 @@ type Condition map[string]interface{}
 type Statement struct {
 	Effect    StatementEffect
 	Principal Principal
-	Action    stringorslice.StringOrSet
-	Resource  stringorslice.StringOrSet
+	Action    stringorset.StringOrSet
+	Resource  stringorset.StringOrSet
 	Condition Condition
 }
 
@@ -594,13 +594,13 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 	for _, s3Bucket := range s3Buckets.List() {
 		p.Statement = append(p.Statement, &Statement{
 			Effect: StatementEffectAllow,
-			Action: stringorslice.Of(
+			Action: stringorset.Of(
 				"s3:GetBucketLocation",
 				"s3:GetEncryptionConfiguration",
 				"s3:ListBucket",
 				"s3:ListBucketVersions",
 			),
-			Resource: stringorslice.Set([]string{
+			Resource: stringorset.Set([]string{
 				fmt.Sprintf("arn:%v:s3:::%v", p.partition, s3Bucket),
 			}),
 		})
@@ -612,13 +612,13 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 func (b *PolicyBuilder) buildS3WriteStatements(p *Policy, iamS3Path string) {
 	p.Statement = append(p.Statement, &Statement{
 		Effect: StatementEffectAllow,
-		Action: stringorslice.Set([]string{
+		Action: stringorset.Set([]string{
 			"s3:GetObject",
 			"s3:DeleteObject",
 			"s3:DeleteObjectVersion",
 			"s3:PutObject",
 		}),
-		Resource: stringorslice.Of(
+		Resource: stringorset.Of(
 			fmt.Sprintf("arn:%v:s3:::%v/*", p.partition, iamS3Path),
 		),
 	})
@@ -640,8 +640,8 @@ func (b *PolicyBuilder) buildS3GetStatements(p *Policy, iamS3Path string) error 
 
 		p.Statement = append(p.Statement, &Statement{
 			Effect:   StatementEffectAllow,
-			Action:   stringorslice.Set([]string{"s3:Get*"}),
-			Resource: stringorslice.Of(resources...),
+			Action:   stringorset.Set([]string{"s3:Get*"}),
+			Resource: stringorset.Of(resources...),
 		})
 	}
 	return nil
@@ -800,10 +800,10 @@ func addEtcdManagerPermissions(p *Policy) {
 	p.Statement = append(p.Statement,
 		&Statement{
 			Effect: StatementEffectAllow,
-			Action: stringorslice.Of(
+			Action: stringorset.Of(
 				"ec2:AttachVolume",
 			),
-			Resource: stringorslice.Set([]string{"*"}),
+			Resource: stringorset.Set([]string{"*"}),
 			Condition: Condition{
 				"StringEquals": map[string]string{
 					"aws:ResourceTag/k8s.io/role/master": "1",
@@ -1061,22 +1061,22 @@ func AddDNSControllerPermissions(b *PolicyBuilder, p *Policy) {
 
 	p.Statement = append(p.Statement, &Statement{
 		Effect: StatementEffectAllow,
-		Action: stringorslice.Of("route53:ChangeResourceRecordSets",
+		Action: stringorset.Of("route53:ChangeResourceRecordSets",
 			"route53:ListResourceRecordSets",
 			"route53:GetHostedZone"),
-		Resource: stringorslice.Set([]string{fmt.Sprintf("arn:%v:route53:::hostedzone/%v", b.Partition, hostedZoneID)}),
+		Resource: stringorset.Set([]string{fmt.Sprintf("arn:%v:route53:::hostedzone/%v", b.Partition, hostedZoneID)}),
 	})
 
 	p.Statement = append(p.Statement, &Statement{
 		Effect:   StatementEffectAllow,
-		Action:   stringorslice.Set([]string{"route53:GetChange"}),
-		Resource: stringorslice.Set([]string{fmt.Sprintf("arn:%v:route53:::change/*", b.Partition)}),
+		Action:   stringorset.Set([]string{"route53:GetChange"}),
+		Resource: stringorset.Set([]string{fmt.Sprintf("arn:%v:route53:::change/*", b.Partition)}),
 	})
 
-	wildcard := stringorslice.Set([]string{"*"})
+	wildcard := stringorset.Set([]string{"*"})
 	p.Statement = append(p.Statement, &Statement{
 		Effect:   StatementEffectAllow,
-		Action:   stringorslice.Set([]string{"route53:ListHostedZones", "route53:ListTagsForResource"}),
+		Action:   stringorset.Set([]string{"route53:ListHostedZones", "route53:ListTagsForResource"}),
 		Resource: wildcard,
 	})
 }
@@ -1169,10 +1169,10 @@ func addAmazonVPCCNIPermissions(p *Policy) {
 	p.Statement = append(p.Statement,
 		&Statement{
 			Effect: StatementEffectAllow,
-			Action: stringorslice.Set([]string{
+			Action: stringorset.Set([]string{
 				"ec2:CreateTags",
 			}),
-			Resource: stringorslice.Set([]string{
+			Resource: stringorset.Set([]string{
 				strings.Join([]string{"arn:", p.partition, ":ec2:*:*:network-interface/*"}, ""),
 			}),
 		},

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -50,9 +50,9 @@ const PolicyDefaultVersion = "2012-10-17"
 // Policy Struct is a collection of fields that form a valid AWS policy document
 type Policy struct {
 	clusterName               string
-	unconditionalAction       sets.String
-	clusterTaggedAction       sets.String
-	clusterTaggedCreateAction sets.String
+	unconditionalAction       sets.Set[string]
+	clusterTaggedAction       sets.Set[string]
+	clusterTaggedCreateAction sets.Set[string]
 	Statement                 []*Statement
 	partition                 string
 	Version                   string
@@ -111,14 +111,14 @@ func (p *Policy) AsJSON() (string, error) {
 	if len(p.unconditionalAction) > 0 {
 		p.Statement = append(p.Statement, &Statement{
 			Effect:   StatementEffectAllow,
-			Action:   stringorslice.Of(p.unconditionalAction.List()...),
+			Action:   stringorslice.Of(sets.List(p.unconditionalAction)...),
 			Resource: stringorslice.String("*"),
 		})
 	}
 	if len(p.clusterTaggedAction) > 0 {
 		p.Statement = append(p.Statement, &Statement{
 			Effect:   StatementEffectAllow,
-			Action:   stringorslice.Of(p.clusterTaggedAction.List()...),
+			Action:   stringorslice.Of(sets.List(p.clusterTaggedAction)...),
 			Resource: stringorslice.String("*"),
 			Condition: Condition{
 				"StringEquals": map[string]string{
@@ -130,7 +130,7 @@ func (p *Policy) AsJSON() (string, error) {
 	if len(p.clusterTaggedCreateAction) > 0 {
 		p.Statement = append(p.Statement, &Statement{
 			Effect:   StatementEffectAllow,
-			Action:   stringorslice.Of(p.clusterTaggedCreateAction.List()...),
+			Action:   stringorslice.Of(sets.List(p.clusterTaggedCreateAction)...),
 			Resource: stringorslice.String("*"),
 			Condition: Condition{
 				"StringEquals": map[string]string{
@@ -338,9 +338,9 @@ func NewPolicy(clusterName, partition string) *Policy {
 	p := &Policy{
 		Version:                   PolicyDefaultVersion,
 		clusterName:               clusterName,
-		unconditionalAction:       sets.NewString(),
-		clusterTaggedAction:       sets.NewString(),
-		clusterTaggedCreateAction: sets.NewString(),
+		unconditionalAction:       sets.New[string](),
+		clusterTaggedAction:       sets.New[string](),
+		clusterTaggedCreateAction: sets.New[string](),
 		partition:                 partition,
 	}
 	return p

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/testutils"
 	"k8s.io/kops/pkg/testutils/golden"
-	"k8s.io/kops/pkg/util/stringorslice"
+	"k8s.io/kops/pkg/util/stringorset"
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -38,16 +38,16 @@ func TestRoundTrip(t *testing.T) {
 		{
 			IAM: &Statement{
 				Effect:   StatementEffectAllow,
-				Action:   stringorslice.Of("ec2:DescribeRegions"),
-				Resource: stringorslice.Of("*"),
+				Action:   stringorset.Of("ec2:DescribeRegions"),
+				Resource: stringorset.Of("*"),
 			},
 			JSON: "{\"Action\":\"ec2:DescribeRegions\",\"Effect\":\"Allow\",\"Resource\":\"*\"}",
 		},
 		{
 			IAM: &Statement{
 				Effect:   StatementEffectDeny,
-				Action:   stringorslice.Of("ec2:DescribeRegions", "ec2:DescribeInstances"),
-				Resource: stringorslice.Of("a", "b"),
+				Action:   stringorset.Of("ec2:DescribeRegions", "ec2:DescribeInstances"),
+				Resource: stringorset.Of("a", "b"),
 			},
 			JSON: "{\"Action\":[\"ec2:DescribeInstances\",\"ec2:DescribeRegions\"],\"Effect\":\"Deny\",\"Resource\":[\"a\",\"b\"]}",
 		},

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -49,7 +49,7 @@ func TestRoundTrip(t *testing.T) {
 				Action:   stringorslice.Of("ec2:DescribeRegions", "ec2:DescribeInstances"),
 				Resource: stringorslice.Of("a", "b"),
 			},
-			JSON: "{\"Action\":[\"ec2:DescribeRegions\",\"ec2:DescribeInstances\"],\"Effect\":\"Deny\",\"Resource\":[\"a\",\"b\"]}",
+			JSON: "{\"Action\":[\"ec2:DescribeInstances\",\"ec2:DescribeRegions\"],\"Effect\":\"Deny\",\"Resource\":[\"a\",\"b\"]}",
 		},
 		{
 			IAM: &Statement{

--- a/pkg/model/iam/tests/iam_builder_master_gossip.json
+++ b/pkg/model/iam/tests/iam_builder_master_gossip.json
@@ -45,8 +45,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -64,8 +64,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/pkg/model/iam/tests/iam_builder_master_gossip_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_gossip_ecr.json
@@ -45,8 +45,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -64,8 +64,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -45,8 +45,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -64,8 +64,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -45,8 +45,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -64,8 +64,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/pkg/util/stringorset/stringorset.go
+++ b/pkg/util/stringorset/stringorset.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package stringorslice
+package stringorset
 
 import (
 	"encoding/json"

--- a/pkg/util/stringorset/stringorset_test.go
+++ b/pkg/util/stringorset/stringorset_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package stringorslice
+package stringorset
 
 import (
 	"encoding/json"

--- a/pkg/util/stringorslice/stringorslice.go
+++ b/pkg/util/stringorslice/stringorslice.go
@@ -18,45 +18,54 @@ package stringorslice
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// StringOrSlice is a type that holds a []string, but marshals to a []string or a string.
-type StringOrSlice struct {
-	values             []string
+// StringOrSet is a type that holds a []string, but marshals to a []string or a string.
+type StringOrSet struct {
+	values             sets.Set[string]
 	forceEncodeAsArray bool
 }
 
-func (s *StringOrSlice) IsEmpty() bool {
+func (s *StringOrSet) IsEmpty() bool {
 	return len(s.values) == 0
 }
 
-// Slice will build a value that marshals to a JSON array
-func Slice(v []string) StringOrSlice {
-	return StringOrSlice{values: v, forceEncodeAsArray: true}
+// Set will build a value that marshals to a JSON array
+func Set(v []string) StringOrSet {
+	values := sets.Set[string]{}
+	values.Insert(v...)
+	return StringOrSet{values: values, forceEncodeAsArray: true}
 }
 
 // Of will build a value that marshals to a JSON array if len(v) > 1,
 // otherwise to a single string
-func Of(v ...string) StringOrSlice {
+func Of(v ...string) StringOrSet {
 	if v == nil {
 		v = []string{}
 	}
-	return StringOrSlice{values: v}
+	values := sets.Set[string]{}
+	values.Insert(v...)
+	return StringOrSet{values: values}
 }
 
 // String will build a value that marshals to a single string
-func String(v string) StringOrSlice {
-	return StringOrSlice{values: []string{v}, forceEncodeAsArray: false}
+func String(v string) StringOrSet {
+	return StringOrSet{values: sets.New(v), forceEncodeAsArray: false}
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.
-func (s *StringOrSlice) UnmarshalJSON(value []byte) error {
+func (s *StringOrSet) UnmarshalJSON(value []byte) error {
 	if value[0] == '[' {
 		s.forceEncodeAsArray = true
-		if err := json.Unmarshal(value, &s.values); err != nil {
+		var vals []string
+		if err := json.Unmarshal(value, &vals); err != nil {
 			return nil
 		}
+		s.values = sets.New(vals...)
 		return nil
 	}
 	s.forceEncodeAsArray = false
@@ -64,46 +73,39 @@ func (s *StringOrSlice) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &stringValue); err != nil {
 		return err
 	}
-	s.values = []string{stringValue}
+	s.values = sets.New(stringValue)
 	return nil
 }
 
 // String returns the string value, or the Itoa of the int value.
-func (s StringOrSlice) String() string {
-	return strings.Join(s.values, ",")
+func (s StringOrSet) String() string {
+	return strings.Join(sets.List[string](s.values), ",")
 }
 
-func (v *StringOrSlice) Value() []string {
-	return v.values
+func (v *StringOrSet) Value() []string {
+	vals := sets.List[string](v.values)
+	sort.Strings(vals)
+	return vals
 }
 
-func (l StringOrSlice) Equal(r StringOrSlice) bool {
-	if len(l.values) != len(r.values) {
-		return false
-	}
-	for i := 0; i < len(l.values); i++ {
-		if l.values[i] != r.values[i] {
-			return false
-		}
-	}
-	return true
+func (l StringOrSet) Equal(r StringOrSet) bool {
+	return l.values.Equal(r.values)
 }
 
 // MarshalJSON implements the json.Marshaller interface.
-func (v StringOrSlice) MarshalJSON() ([]byte, error) {
+func (v StringOrSet) MarshalJSON() ([]byte, error) {
 	encodeAsJSONArray := v.forceEncodeAsArray
 	if len(v.values) > 1 {
 		encodeAsJSONArray = true
 	}
-	values := v.values
+	values := v.Value()
 	if values == nil {
 		values = []string{}
 	}
 	if encodeAsJSONArray {
 		return json.Marshal(values)
-	} else if len(v.values) == 1 {
-		s := v.values[0]
-		return json.Marshal(&s)
+	} else if len(values) == 1 {
+		return json.Marshal(&values[0])
 	} else {
 		return json.Marshal(values)
 	}

--- a/pkg/util/stringorslice/stringorslice_test.go
+++ b/pkg/util/stringorslice/stringorslice_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestRoundTrip(t *testing.T) {
 	grid := []struct {
-		Value StringOrSlice
+		Value StringOrSet
 		JSON  string
 	}{
 		{
@@ -37,7 +37,7 @@ func TestRoundTrip(t *testing.T) {
 			JSON:  "\"a\"",
 		},
 		{
-			Value: Slice([]string{"a"}),
+			Value: Set([]string{"a"}),
 			JSON:  "[\"a\"]",
 		},
 		{
@@ -45,7 +45,7 @@ func TestRoundTrip(t *testing.T) {
 			JSON:  "[\"a\",\"b\"]",
 		},
 		{
-			Value: Slice([]string{"a", "b"}),
+			Value: Set([]string{"a", "b"}),
 			JSON:  "[\"a\",\"b\"]",
 		},
 		{
@@ -53,7 +53,7 @@ func TestRoundTrip(t *testing.T) {
 			JSON:  "[]",
 		},
 		{
-			Value: Slice(nil),
+			Value: Set(nil),
 			JSON:  "[]",
 		},
 	}
@@ -69,7 +69,7 @@ func TestRoundTrip(t *testing.T) {
 			t.Errorf("Unexpected JSON encoding.  Actual=%q, Expected=%q", string(actualJSON), g.JSON)
 		}
 
-		parsed := &StringOrSlice{}
+		parsed := &StringOrSet{}
 		err = json.Unmarshal([]byte(g.JSON), parsed)
 		if err != nil {
 			t.Errorf("error decoding StringOrSlice %s to json: %v", g.JSON, err)

--- a/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_iam_role_policy_masters.additionalobjects.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -3,8 +3,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -13,8 +13,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -32,8 +32,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_masters.cas-priority-expander-custom.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_iam_role_policy_masters.cas-priority-expander-custom.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_masters.cas-priority-expander.example.com_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_iam_role_policy_masters.cas-priority-expander.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
+++ b/tests/integration/update_cluster/containerd/data/aws_iam_role_policy_masters.containerd.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -13,8 +13,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -32,8 +32,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_external-dns.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_external-dns.kube-system.sa.minimal.example.com_policy
@@ -3,8 +3,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -3,8 +3,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -13,8 +13,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -32,8 +32,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -3,8 +3,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -13,8 +13,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -32,8 +32,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -3,8 +3,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -13,8 +13,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -32,8 +32,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -3,8 +3,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -13,8 +13,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -32,8 +32,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -3,8 +3,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -13,8 +13,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -32,8 +32,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.many-addons.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_masters.minimal-aws.example.com_policy
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_iam_role_policy_masters.minimal-aws.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -77,8 +77,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -96,8 +96,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_iam_role_policy_masters.minimal-etcd.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.long.cluster-name.m-kaamp9_policy
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_iam_role_policy_masters.this.is.truly.a.really.really.long.cluster-name.m-kaamp9_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -77,8 +77,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -96,8 +96,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local_policy
@@ -13,8 +13,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -32,8 +32,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_dns-controller.kube-system.sa.nthimdsprocessor.longcluste-e6uuer_policy
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_dns-controller.kube-system.sa.nthimdsprocessor.longcluste-e6uuer_policy
@@ -3,8 +3,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l_policy
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l_policy
@@ -13,8 +13,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -32,8 +32,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_iam_role_policy_masters.nthimdsprocessor.longclustername.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -42,9 +42,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -77,8 +77,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -117,8 +117,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -136,8 +136,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -3,8 +3,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -13,8 +13,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -32,8 +32,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -22,9 +22,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -32,9 +32,9 @@
     },
     {
       "Action": [
-        "s3:GetObject",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutObject"
       ],
       "Effect": "Allow",
@@ -67,8 +67,8 @@
     {
       "Action": [
         "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets",
-        "route53:GetHostedZone"
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -107,8 +107,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {
@@ -126,8 +126,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws-test:ec2:*:*:volume/*",
-        "arn:aws-test:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:snapshot/*",
+        "arn:aws-test:ec2:*:*:volume/*"
       ]
     },
     {


### PR DESCRIPTION
This is the first of two PRs around IAM Policies. This changes `stringorslice` to `stringorset` to more accurately represent AWS IAM policy lists as unordered. The result is that the snapshot tests have some ordering changes as the final json lists become sorted.

A followup PR will adopt the IAM policy builder for the SQS Queue Policy to mitigate some spurious diffs reported in `kops update cluster`.