### PR TITLE
Use IAM Policy Builder for SQS Queue Policy

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -278,12 +278,12 @@ func (s *Statement) MarshalJSON() ([]byte, error) {
 }
 
 type Principal struct {
-	Federated string `json:",omitempty"`
-	Service   string `json:",omitempty"`
+	Federated string                   `json:",omitempty"`
+	Service   *stringorset.StringOrSet `json:",omitempty"`
 }
 
 func (p *Principal) IsEmpty() bool {
-	return *p == Principal{}
+	return p.Federated == "" && (p.Service == nil || p.Service.IsEmpty())
 }
 
 // Equal compares two IAM Statements and returns a bool

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -64,7 +64,7 @@ func TestRoundTrip(t *testing.T) {
 		{
 			IAM: &Statement{
 				Effect:    StatementEffectDeny,
-				Principal: Principal{Service: "service"},
+				Principal: Principal{Service: fi.PtrTo(stringorset.Of("service"))},
 				Condition: map[string]interface{}{
 					"bar": "baz",
 				},

--- a/tests/integration/update_cluster/additionalobjects/data/aws_sqs_queue_additionalobjects-example-com-nth_policy
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_sqs_queue_additionalobjects-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:additionalobjects-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:additionalobjects-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/apiservernodes/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_sqs_queue_bastionuserdata-example-com-nth_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_sqs_queue_bastionuserdata-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:bastionuserdata-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:bastionuserdata-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_sqs_queue_cas-priority-expander-custom-example-com-nth_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_sqs_queue_cas-priority-expander-custom-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:cas-priority-expander-custom-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:cas-priority-expander-custom-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_sqs_queue_cas-priority-expander-example-com-nth_policy
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_sqs_queue_cas-priority-expander-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:cas-priority-expander-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:cas-priority-expander-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/complex/data/aws_sqs_queue_complex-example-com-nth_policy
+++ b/tests/integration/update_cluster/complex/data/aws_sqs_queue_complex-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:complex-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:complex-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/compress/data/aws_sqs_queue_compress-example-com-nth_policy
+++ b/tests/integration/update_cluster/compress/data/aws_sqs_queue_compress-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:compress-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:compress-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/containerd-custom/data/aws_sqs_queue_containerd-example-com-nth_policy
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_sqs_queue_containerd-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:containerd-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:containerd-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/containerd/data/aws_sqs_queue_containerd-example-com-nth_policy
+++ b/tests/integration/update_cluster/containerd/data/aws_sqs_queue_containerd-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:containerd-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:containerd-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/digit/data/aws_sqs_queue_123-example-com-nth_policy
+++ b/tests/integration/update_cluster/digit/data/aws_sqs_queue_123-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:123-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:123-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/existing_iam/data/aws_sqs_queue_existing-iam-example-com-nth_policy
+++ b/tests/integration/update_cluster/existing_iam/data/aws_sqs_queue_existing-iam-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:existing-iam-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:existing-iam-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/existing_sg/data/aws_sqs_queue_existingsg-example-com-nth_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_sqs_queue_existingsg-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:existingsg-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:existingsg-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/external_dns/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/externallb/data/aws_sqs_queue_externallb-example-com-nth_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_sqs_queue_externallb-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:externallb-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:externallb-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/externalpolicies/data/aws_sqs_queue_externalpolicies-example-com-nth_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_sqs_queue_externalpolicies-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:externalpolicies-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:externalpolicies-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/ha/data/aws_sqs_queue_ha-example-com-nth_policy
+++ b/tests/integration/update_cluster/ha/data/aws_sqs_queue_ha-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:ha-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:ha-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/irsa/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/karpenter/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/karpenter/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/many-addons/data/aws_sqs_queue_many-addons-example-com-nth_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_sqs_queue_many-addons-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:many-addons-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:many-addons-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-aws/data/aws_sqs_queue_minimal-aws-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_sqs_queue_minimal-aws-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-aws-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-aws-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_sqs_queue_minimal-etcd-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_sqs_queue_minimal-etcd-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-etcd-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-etcd-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_sqs_queue_minimal-ipv6-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_sqs_queue_minimal-ipv6-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-ipv6-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-ipv6-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_sqs_queue_minimal-ipv6-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_sqs_queue_minimal-ipv6-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-ipv6-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-ipv6-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_sqs_queue_minimal-ipv6-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_sqs_queue_minimal-ipv6-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-ipv6-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-ipv6-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_sqs_queue_minimal-ipv6-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_sqs_queue_minimal-ipv6-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-ipv6-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-ipv6-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_sqs_queue_this-is-truly-a-really-really-long-cluster-name-minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_sqs_queue_this-is-truly-a-really-really-long-cluster-name-minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:this-is-truly-a-really-really-long-cluster-name-minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:this-is-truly-a-really-really-long-cluster-name-minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_sqs_queue_minimal-warmpool-example-com-nth_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_sqs_queue_minimal-warmpool-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-warmpool-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-warmpool-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_sqs_queue_minimal-k8s-local-nth_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_sqs_queue_minimal-k8s-local-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-k8s-local-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-k8s-local-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_sqs_queue_minimal-k8s-local-nth_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_sqs_queue_minimal-k8s-local-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-k8s-local-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-k8s-local-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/mixed_instances/data/aws_sqs_queue_mixedinstances-example-com-nth_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_sqs_queue_mixedinstances-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:mixedinstances-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:mixedinstances-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_sqs_queue_mixedinstances-example-com-nth_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_sqs_queue_mixedinstances-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:mixedinstances-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:mixedinstances-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/nvidia/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_sqs_queue_private-shared-ip-example-com-nth_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_sqs_queue_private-shared-ip-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:private-shared-ip-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:private-shared-ip-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_sqs_queue_private-shared-subnet-example-com-nth_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_sqs_queue_private-shared-subnet-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:private-shared-subnet-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:private-shared-subnet-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/privatecalico/data/aws_sqs_queue_privatecalico-example-com-nth_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_sqs_queue_privatecalico-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatecalico-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatecalico-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/privatecanal/data/aws_sqs_queue_privatecanal-example-com-nth_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_sqs_queue_privatecanal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatecanal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatecanal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_sqs_queue_privatecilium-example-com-nth_policy
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_sqs_queue_privatecilium-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatecilium-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatecilium-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/privatecilium/data/aws_sqs_queue_privatecilium-example-com-nth_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_sqs_queue_privatecilium-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatecilium-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatecilium-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/privatecilium2/data/aws_sqs_queue_privatecilium-example-com-nth_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_sqs_queue_privatecilium-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatecilium-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatecilium-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_sqs_queue_privateciliumadvanced-example-com-nth_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_sqs_queue_privateciliumadvanced-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:privateciliumadvanced-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:privateciliumadvanced-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/privatedns1/data/aws_sqs_queue_privatedns1-example-com-nth_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_sqs_queue_privatedns1-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatedns1-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatedns1-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/privatedns2/data/aws_sqs_queue_privatedns2-example-com-nth_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_sqs_queue_privatedns2-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatedns2-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatedns2-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/privateflannel/data/aws_sqs_queue_privateflannel-example-com-nth_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_sqs_queue_privateflannel-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:privateflannel-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:privateflannel-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/privatekopeio/data/aws_sqs_queue_privatekopeio-example-com-nth_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_sqs_queue_privatekopeio-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatekopeio-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:privatekopeio-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/shared_subnet/data/aws_sqs_queue_sharedsubnet-example-com-nth_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_sqs_queue_sharedsubnet-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:sharedsubnet-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:sharedsubnet-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/shared_vpc/data/aws_sqs_queue_sharedvpc-example-com-nth_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_sqs_queue_sharedvpc-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:sharedvpc-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:sharedvpc-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_sqs_queue_minimal-ipv6-example-com-nth_policy
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_sqs_queue_minimal-ipv6-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-ipv6-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-ipv6-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/unmanaged/data/aws_sqs_queue_unmanaged-example-com-nth_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_sqs_queue_unmanaged-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:unmanaged-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:unmanaged-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration/update_cluster/vfs-said/data/aws_sqs_queue_minimal-example-com-nth_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_sqs_queue_minimal-example-com-nth_policy
@@ -1,11 +1,16 @@
 {
-		"Version": "2012-10-17",
-		"Statement": [{                     
-			"Effect": "Allow",
-			"Principal": {
-				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
-			},
-			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
-		}]
-	}
+  "Statement": [
+    {
+      "Action": "sqs:SendMessage",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com"
+        ]
+      },
+      "Resource": "arn:aws-test:sqs:us-test-1:123456789012:minimal-example-com-nth"
+    }
+  ],
+  "Version": "2012-10-17"
+}


### PR DESCRIPTION
Followup to https://github.com/kubernetes/kops/pull/16351. This uses `pkg/model/iam` to build node termination handler's SQS queue policy.

Note, this wont fix the spurious diffs yet. We need one more refactor to move the `pkg/model/iam` types into their own package that can be imported by both `awstasks` and `pkg/model/...` so we can have `awstasks/sqs.go`'s Find() parse the existing policy for comparison.