### PR TITLE
Allow scaling events to be logged during cluster validation

### DIFF
--- a/cloudmock/gce/mockcompute/instance_group_manager.go
+++ b/cloudmock/gce/mockcompute/instance_group_manager.go
@@ -125,6 +125,10 @@ func (c *instanceGroupManagerClient) List(ctx context.Context, project, zone str
 	return l, nil
 }
 
+func (c *instanceGroupManagerClient) ListErrors(ctx context.Context, project, zone, name string) ([]*compute.InstanceManagedByIgmError, error) {
+	return []*compute.InstanceManagedByIgmError{}, nil
+}
+
 func (c *instanceGroupManagerClient) ListManagedInstances(ctx context.Context, project, zone, name string) ([]*compute.ManagedInstance, error) {
 	var instances []*compute.ManagedInstance
 	return instances, nil

--- a/pkg/cloudinstances/cloud_instance_group.go
+++ b/pkg/cloudinstances/cloud_instance_group.go
@@ -19,6 +19,7 @@ package cloudinstances
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -35,9 +36,19 @@ type CloudInstanceGroup struct {
 	MinSize       int
 	TargetSize    int
 	MaxSize       int
+	Events        []ScalingEvent
 
 	// Raw allows for the implementer to attach an object, for tracking additional state
 	Raw interface{}
+}
+
+type ScalingEvent struct {
+	Timestamp   time.Time
+	Description string
+}
+
+func (e ScalingEvent) String() string {
+	return fmt.Sprintf("%s: %s", e.Timestamp.Format(time.RFC3339), e.Description)
 }
 
 // NewCloudInstance creates a new CloudInstance

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -301,6 +301,16 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 					cloudGroup.TargetSize),
 				InstanceGroup: cloudGroup.InstanceGroup,
 			})
+			if klog.V(4).Enabled() {
+				// Log scaling events
+				klog.V(4).Infof("Scaling events for instance group: %v", cloudGroup.InstanceGroup.Name)
+				sort.Slice(cloudGroup.Events, func(i, j int) bool {
+					return cloudGroup.Events[i].Timestamp.Before(cloudGroup.Events[j].Timestamp)
+				})
+				for _, event := range cloudGroup.Events {
+					klog.Infof("%v", event)
+				}
+			}
 		}
 
 		for _, member := range allMembers {

--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -129,10 +129,9 @@ sleep 120s
 
 ${CHANNELS} apply channel "$KOPS_STATE_STORE"/"${CLUSTER_NAME}"/addons/bootstrap-channel.yaml --yes -v4
 
-"${KOPS_B}" rolling-update cluster
-"${KOPS_B}" rolling-update cluster --yes --validation-timeout 30m
+"${KOPS_B}" rolling-update cluster --yes --validation-timeout 30m -v 4
 
-"${KOPS_B}" validate cluster
+"${KOPS_B}" validate cluster -v 4
 
 # Verify kubeconfig-a still works
 kubectl get nodes -owide --kubeconfig="${KUBECONFIG_A}"

--- a/upup/pkg/fi/cloudup/gce/compute.go
+++ b/upup/pkg/fi/cloudup/gce/compute.go
@@ -673,6 +673,7 @@ type InstanceGroupManagerClient interface {
 	Delete(project, zone, name string) (*compute.Operation, error)
 	Get(project, zone, name string) (*compute.InstanceGroupManager, error)
 	List(ctx context.Context, project, zone string) ([]*compute.InstanceGroupManager, error)
+	ListErrors(ctx context.Context, project, zone, name string) ([]*compute.InstanceManagedByIgmError, error)
 	ListManagedInstances(ctx context.Context, project, zone, name string) ([]*compute.ManagedInstance, error)
 	RecreateInstances(project, zone, name, id string) (*compute.Operation, error)
 	SetTargetPools(project, zone, name string, targetPools []string) (*compute.Operation, error)
@@ -707,6 +708,17 @@ func (c *instanceGroupManagerClientImpl) List(ctx context.Context, project, zone
 		return nil, err
 	}
 	return ms, nil
+}
+
+func (c *instanceGroupManagerClientImpl) ListErrors(ctx context.Context, project, zone, name string) ([]*compute.InstanceManagedByIgmError, error) {
+	var igmErrors []*compute.InstanceManagedByIgmError
+	if err := c.srv.ListErrors(project, zone, name).Pages(ctx, func(page *compute.InstanceGroupManagersListErrorsResponse) error {
+		igmErrors = append(igmErrors, page.Items...)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return igmErrors, nil
 }
 
 func (c *instanceGroupManagerClientImpl) ListManagedInstances(ctx context.Context, project, zone, name string) ([]*compute.ManagedInstance, error) {


### PR DESCRIPTION
The [e2e upgrade jobs](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-k127-ko127-to-k128-ko128-many-addons/1755930711879061504) that have been migrated to the new prow cluster are failing to validate mid rolling-update

`I0209 13:36:37.740937   14123 instancegroups.go:560] Cluster did not pass validation within deadline: InstanceGroup "nodes-us-west-2a" did not have enough nodes 1 vs 4.`

We can get scaling activities on the ASG which should mention if the AWS autoscaling service is failing to launch nodes for some reason (resource quota, capacity, etc.)

This allows those events to be logged at `--v=4` level, and sets that level on the upgrade scripts.

I included autoscaling activity for both AWS and GCE. other providers can add their implementations separately.