### PR TITLE
gce: Update GCE storage service scope to DevstorageFullControlScope to resolve permission error.

### DIFF
--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -418,7 +418,7 @@ func (c *VFSContext) getGCSClient(ctx context.Context) (*storage.Service, error)
 	}
 
 	// TODO: Should we fall back to read-only?
-	scope := storage.DevstorageReadWriteScope
+	scope := storage.DevstorageFullControlScope
 
 	gcsClient, err := storage.NewService(ctx, option.WithScopes(scope))
 	if err != nil {


### PR DESCRIPTION
This is a fix for the functionality added in https://github.com/kubernetes/kops/pull/16050.

In some cases, kops was unable to query the GCP API to retrieve the bucket IAM policy. 
The API would return a 403 Forbidden. 
e.g.
```
Error: error building tasks: checking if bucket was public: googleapi: Error 403: Access denied., forbidden
```

This PR increases the auth scopes that the GCS client is created with to resolve the permission problem

Strangely this 403 error did not happen until kops was authenticating to GCS using a Service Account created in a different GCP project than where the OIDC Issuer bucket was created.