### PR TITLE
Generate revisions of NLB objects, and introduce cleanup phase

### DIFF
--- a/cloudmock/aws/mockautoscaling/attach.go
+++ b/cloudmock/aws/mockautoscaling/attach.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mockautoscaling
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -52,7 +53,7 @@ func (m *MockAutoscaling) AttachLoadBalancersRequest(*autoscaling.AttachLoadBala
 	return nil, nil
 }
 
-func (m *MockAutoscaling) AttachLoadBalancerTargetGroups(request *autoscaling.AttachLoadBalancerTargetGroupsInput) (*autoscaling.AttachLoadBalancerTargetGroupsOutput, error) {
+func (m *MockAutoscaling) AttachLoadBalancerTargetGroupsWithContext(ctx aws.Context, request *autoscaling.AttachLoadBalancerTargetGroupsInput, opts ...request.Option) (*autoscaling.AttachLoadBalancerTargetGroupsOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -62,9 +63,13 @@ func (m *MockAutoscaling) AttachLoadBalancerTargetGroups(request *autoscaling.At
 
 	asg := m.Groups[name]
 	if asg == nil {
-		return nil, fmt.Errorf("Group %q not found", name)
+		return nil, fmt.Errorf("group %q not found", name)
 	}
 
-	asg.TargetGroupARNs = request.TargetGroupARNs
+	asg.TargetGroupARNs = append(asg.TargetGroupARNs, request.TargetGroupARNs...)
 	return &autoscaling.AttachLoadBalancerTargetGroupsOutput{}, nil
+}
+
+func (m *MockAutoscaling) AttachLoadBalancerTargetGroups(request *autoscaling.AttachLoadBalancerTargetGroupsInput) (*autoscaling.AttachLoadBalancerTargetGroupsOutput, error) {
+	return m.AttachLoadBalancerTargetGroupsWithContext(context.TODO(), request)
 }

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -33,6 +33,7 @@ kops update cluster [CLUSTER] [flags]
       --lifecycle-overrides strings   comma separated list of phase overrides, example: SecurityGroups=Ignore,InternetGateway=ExistsAndWarnIfChanges
       --out string                    Path to write any local output
       --phase string                  Subset of tasks to run: cluster, network, security
+      --prune                         Delete old revisions of cloud resources that were needed during an upgrade
       --ssh-public-key string         SSH public key to use (deprecated: use kops create secret instead)
       --target string                 Target - direct, terraform (default "direct")
       --user string                   Existing user in kubeconfig file to use.  Implies --create-kube-config

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -492,6 +492,8 @@ func (c *RollingUpdateCluster) reconcileInstanceGroup() error {
 		Phase:              "",
 		TargetName:         "direct",
 		LifecycleOverrides: map[string]fi.Lifecycle{},
+
+		DeletionProcessing: fi.DeletionProcessingModeDeleteIfNotDeferrred,
 	}
 
 	return applyCmd.Run(c.Ctx)

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -492,7 +492,7 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.CloudupMo
 		}
 
 		if extLB.TargetGroupARN != nil {
-			targetGroupName, err := awsup.GetTargetGroupNameFromARN(fi.ValueOf(extLB.TargetGroupARN))
+			targetGroupName, err := awsup.NameForExternalTargetGroup(fi.ValueOf(extLB.TargetGroupARN))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/model/awsmodel/bastion.go
+++ b/pkg/model/awsmodel/bastion.go
@@ -319,8 +319,6 @@ func (b *BastionModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	// Create NLB itself
 	var nlb *awstasks.NetworkLoadBalancer
 	{
-		loadBalancerName := b.LBName32("bastion")
-
 		tags := b.CloudTags("", false)
 		for k, v := range b.Cluster.Spec.CloudLabels {
 			tags[k] = v
@@ -341,13 +339,12 @@ func (b *BastionModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			Name:      fi.PtrTo(b.NLBName("bastion")),
 			Lifecycle: b.Lifecycle,
 
-			LoadBalancerName: fi.PtrTo(loadBalancerName),
-			CLBName:          fi.PtrTo("bastion." + b.ClusterName()),
-			SubnetMappings:   nlbSubnetMappings,
+			LoadBalancerBaseName: fi.PtrTo(b.LBName32("bastion")),
+			CLBName:              fi.PtrTo("bastion." + b.ClusterName()),
+			SubnetMappings:       nlbSubnetMappings,
 			SecurityGroups: []*awstasks.SecurityGroup{
 				b.LinkToELBSecurityGroup("bastion"),
 			},
-
 			Tags:          tags,
 			VPC:           b.LinkToVPC(),
 			Type:          fi.PtrTo("network"),
@@ -390,6 +387,7 @@ func (b *BastionModelBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			UnhealthyThreshold: fi.PtrTo(int64(2)),
 			Shared:             fi.PtrTo(false),
 		}
+		tg.CreateNewRevisionsWith(nlb)
 
 		c.AddTask(tg)
 

--- a/pkg/model/awsmodel/spotinst.go
+++ b/pkg/model/awsmodel/spotinst.go
@@ -851,7 +851,7 @@ func (b *SpotInstanceGroupModelBuilder) buildLoadBalancers(c *fi.CloudupModelBui
 			c.EnsureTask(lb)
 		}
 		if extLB.TargetGroupARN != nil {
-			targetGroupName, err := awsup.GetTargetGroupNameFromARN(fi.ValueOf(extLB.TargetGroupARN))
+			targetGroupName, err := awsup.NameForExternalTargetGroup(fi.ValueOf(extLB.TargetGroupARN))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -1624,7 +1624,7 @@ func ListTargetGroups(cloud fi.Cloud, vpcID, clusterName string) ([]*resources.R
 		id := aws.StringValue(tg.TargetGroupName)
 		resourceTracker := &resources.Resource{
 			Name:    id,
-			ID:      targetGroup.ARN(),
+			ID:      targetGroup.ARN,
 			Type:    TypeTargetGroup,
 			Deleter: DeleteTargetGroup,
 			Dumper:  DumpTargetGroup,

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -155,6 +155,9 @@ type ApplyClusterCmd struct {
 
 	// AdditionalObjects holds cluster-asssociated configuration objects, other than the Cluster and InstanceGroups.
 	AdditionalObjects kubemanifest.ObjectList
+
+	// DeletionProcessing controls whether we process deletions.
+	DeletionProcessing fi.DeletionProcessingMode
 }
 
 func (c *ApplyClusterCmd) Run(ctx context.Context) error {
@@ -714,7 +717,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 	var target fi.CloudupTarget
 	shouldPrecreateDNS := true
 
-	deletionProcessingMode := fi.DeletionProcessingModeDeleteIfNotDeferrred
+	deletionProcessingMode := c.DeletionProcessing
 	switch c.TargetName {
 	case TargetDirect:
 		switch cluster.Spec.GetCloudProvider() {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -101,8 +101,11 @@ type AutoscalingGroup struct {
 	CapacityRebalance *bool
 	// WarmPool is the WarmPool config for the ASG
 	WarmPool *WarmPool
+
+	deletions []fi.CloudupDeletion
 }
 
+var _ fi.CloudupProducesDeletions = &AutoscalingGroup{}
 var _ fi.CompareWithID = &AutoscalingGroup{}
 var _ fi.CloudupTaskNormalize = &AutoscalingGroup{}
 
@@ -212,13 +215,21 @@ func (e *AutoscalingGroup) Find(c *fi.CloudupContext) (*AutoscalingGroup, error)
 	sort.Stable(OrderLoadBalancersByName(actual.LoadBalancers))
 
 	actual.TargetGroups = []*TargetGroup{}
-	if len(g.TargetGroupARNs) > 0 {
-		for _, tg := range g.TargetGroupARNs {
-			targetGroupName, err := awsup.GetTargetGroupNameFromARN(fi.ValueOf(tg))
-			if err != nil {
-				return nil, err
+	{
+		byARN := make(map[string]*TargetGroup)
+		for _, tg := range e.TargetGroups {
+			if tg.info != nil {
+				byARN[tg.info.ARN] = tg
 			}
-			actual.TargetGroups = append(actual.TargetGroups, &TargetGroup{ARN: aws.String(*tg), Name: aws.String(targetGroupName)})
+		}
+		for _, arn := range g.TargetGroupARNs {
+			tg := byARN[aws.StringValue(arn)]
+			if tg != nil {
+				actual.TargetGroups = append(actual.TargetGroups, tg)
+				continue
+			}
+			actual.TargetGroups = append(actual.TargetGroups, &TargetGroup{ARN: arn})
+			e.deletions = append(e.deletions, buildDeleteAutoscalingTargetGroupAttachment(aws.StringValue(g.AutoScalingGroupName), aws.StringValue(arn)))
 		}
 	}
 	sort.Stable(OrderTargetGroupsByName(actual.TargetGroups))
@@ -612,7 +623,6 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 		}
 
 		var attachTGRequests []*autoscaling.AttachLoadBalancerTargetGroupsInput
-		var detachTGRequests []*autoscaling.DetachLoadBalancerTargetGroupsInput
 		if changes.TargetGroups != nil {
 			if e != nil && len(e.TargetGroups) > 0 {
 				for _, tgsChunkToAttach := range sliceChunks(e.AutoscalingTargetGroups(), attachLoadBalancerTargetGroupsMaxItems) {
@@ -623,14 +633,8 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 				}
 			}
 
-			if a != nil && len(a.TargetGroups) > 0 {
-				for _, tgsChunkToDetach := range sliceChunks(e.getTGsToDetach(a.TargetGroups), detachLoadBalancerTargetGroupsMaxItems) {
-					detachTGRequests = append(detachTGRequests, &autoscaling.DetachLoadBalancerTargetGroupsInput{
-						AutoScalingGroupName: e.Name,
-						TargetGroupARNs:      tgsChunkToDetach,
-					})
-				}
-			}
+			// Detaching is done in a deletion task
+
 			changes.TargetGroups = nil
 		}
 
@@ -717,13 +721,6 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 		if attachLBRequest != nil {
 			if _, err := t.Cloud.Autoscaling().AttachLoadBalancersWithContext(ctx, attachLBRequest); err != nil {
 				return fmt.Errorf("error attaching LoadBalancers: %v", err)
-			}
-		}
-		if len(detachTGRequests) > 0 {
-			for _, detachTGRequest := range detachTGRequests {
-				if _, err := t.Cloud.Autoscaling().DetachLoadBalancerTargetGroupsWithContext(ctx, detachTGRequest); err != nil {
-					return fmt.Errorf("failed to detach target groups: %v", err)
-				}
 			}
 		}
 		if len(attachTGRequests) > 0 {
@@ -1120,4 +1117,53 @@ func (_ *AutoscalingGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, c
 // TerraformLink fills in the property
 func (e *AutoscalingGroup) TerraformLink() *terraformWriter.Literal {
 	return terraformWriter.LiteralProperty("aws_autoscaling_group", fi.ValueOf(e.Name), "id")
+}
+
+func (e *AutoscalingGroup) FindDeletions(context *fi.CloudupContext) ([]fi.CloudupDeletion, error) {
+	return e.deletions, nil
+}
+
+type deleteAutoscalingTargetGroupAttachment struct {
+	autoScalingGroupName string
+	targetGroupARN       string
+}
+
+var _ fi.CloudupDeletion = &deleteAutoscalingTargetGroupAttachment{}
+
+func buildDeleteAutoscalingTargetGroupAttachment(autoScalingGroupName string, targetGroupARN string) *deleteAutoscalingTargetGroupAttachment {
+	d := &deleteAutoscalingTargetGroupAttachment{}
+	d.autoScalingGroupName = autoScalingGroupName
+	d.targetGroupARN = targetGroupARN
+	return d
+}
+
+func (d *deleteAutoscalingTargetGroupAttachment) Delete(t fi.CloudupTarget) error {
+	ctx := context.TODO()
+
+	awsTarget, ok := t.(*awsup.AWSAPITarget)
+	if !ok {
+		return fmt.Errorf("unexpected target type for deletion: %T", t)
+	}
+
+	req := &autoscaling.DetachLoadBalancerTargetGroupsInput{
+		AutoScalingGroupName: aws.String(d.autoScalingGroupName),
+		TargetGroupARNs:      aws.StringSlice([]string{d.targetGroupARN}),
+	}
+	if _, err := awsTarget.Cloud.Autoscaling().DetachLoadBalancerTargetGroupsWithContext(ctx, req); err != nil {
+		return fmt.Errorf("failed to detach target groups from autoscaling group: %v", err)
+	}
+
+	return nil
+}
+
+func (d *deleteAutoscalingTargetGroupAttachment) TaskName() string {
+	return "autoscaling-elb-attachment"
+
+}
+func (d *deleteAutoscalingTargetGroupAttachment) Item() string {
+	return d.autoScalingGroupName + ":" + d.targetGroupARN
+}
+
+func (d *deleteAutoscalingTargetGroupAttachment) DeferDeletion() bool {
+	return true
 }

--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -50,6 +50,7 @@ type DNSTarget interface {
 }
 
 func (e *DNSName) Find(c *fi.CloudupContext) (*DNSName, error) {
+	ctx := c.Context()
 	cloud := c.T.Cloud.(awsup.AWSCloud)
 
 	if e.Zone == nil || e.Zone.ZoneID == nil {
@@ -75,7 +76,7 @@ func (e *DNSName) Find(c *fi.CloudupContext) (*DNSName, error) {
 
 	var found *route53.ResourceRecordSet
 
-	err := cloud.Route53().ListResourceRecordSetsPages(request, func(p *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool) {
+	err := cloud.Route53().ListResourceRecordSetsPagesWithContext(ctx, request, func(p *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool) {
 		for _, rr := range p.ResourceRecordSets {
 			resourceType := aws.StringValue(rr.Type)
 			name := aws.StringValue(rr.Name)

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -402,7 +402,7 @@ func (t *LaunchTemplate) findLatestLaunchTemplateVersion(c *fi.CloudupContext) (
 }
 
 // deleteLaunchTemplate tracks a LaunchConfiguration that we're going to delete
-// It implements fi.Deletion
+// It implements fi.CloudupDeletion
 type deleteLaunchTemplate struct {
 	lc *ec2.LaunchTemplate
 }
@@ -437,4 +437,8 @@ func (d *deleteLaunchTemplate) Delete(t fi.CloudupTarget) error {
 // String returns a string representation of the task
 func (d *deleteLaunchTemplate) String() string {
 	return d.TaskName() + "-" + d.Item()
+}
+
+func (d *deleteLaunchTemplate) DeferDeletion() bool {
+	return false // TODO: Should we defer deletion?
 }

--- a/upup/pkg/fi/cloudup/awstasks/networkloadbalancer_attributes.go
+++ b/upup/pkg/fi/cloudup/awstasks/networkloadbalancer_attributes.go
@@ -72,8 +72,6 @@ func (_ *NetworkLoadBalancer) modifyLoadBalancerAttributes(t *awsup.AWSAPITarget
 		return nil
 	}
 
-	loadBalancerName := fi.ValueOf(e.LoadBalancerName)
-
 	request := &elbv2.ModifyLoadBalancerAttributesInput{
 		LoadBalancerArn: aws.String(loadBalancerArn),
 	}
@@ -113,14 +111,14 @@ func (_ *NetworkLoadBalancer) modifyLoadBalancerAttributes(t *awsup.AWSAPITarget
 
 	request.Attributes = attributes
 
-	klog.V(2).Infof("Configuring NLB attributes for NLB %q", loadBalancerName)
+	klog.V(2).Infof("Configuring NLB attributes for NLB %q", loadBalancerArn)
 
 	response, err := t.Cloud.ELBV2().ModifyLoadBalancerAttributes(request)
 	if err != nil {
-		return fmt.Errorf("error configuring NLB attributes for NLB %q: %v", loadBalancerName, err)
+		return fmt.Errorf("error configuring NLB attributes for NLB %q: %v", loadBalancerArn, err)
 	}
 
-	klog.V(4).Infof("modified NLB attributes for NLB %q, response %+v", loadBalancerName, response)
+	klog.V(4).Infof("modified NLB attributes for NLB %q, response %+v", loadBalancerArn, response)
 
 	return nil
 }

--- a/upup/pkg/fi/cloudup/awstasks/networkloadbalancerlistener.go
+++ b/upup/pkg/fi/cloudup/awstasks/networkloadbalancerlistener.go
@@ -31,6 +31,8 @@ import (
 
 // +kops:fitask
 type NetworkLoadBalancerListener struct {
+	// We use the Name tag to find the existing NLB, because we are (more or less) unrestricted when
+	// it comes to tag values, but the LoadBalancerName is length limited
 	Name      *string
 	Lifecycle fi.Lifecycle
 
@@ -203,8 +205,6 @@ func (*NetworkLoadBalancerListener) RenderAWS(t *awsup.AWSAPITarget, a, e, chang
 		}
 	}
 
-	// TODO: Tags on the listener?
-
 	return nil
 }
 
@@ -226,7 +226,6 @@ func (_ *NetworkLoadBalancerListener) RenderTerraform(t *terraform.TerraformTarg
 	if e.TargetGroup == nil {
 		return fi.RequiredField("TargetGroup")
 	}
-
 	listenerTF := &terraformNetworkLoadBalancerListener{
 		LoadBalancer: e.NetworkLoadBalancer.TerraformLink(),
 		Port:         int64(e.Port),

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -541,6 +541,10 @@ func (d *deleteSubnetIPv6CIDRBlock) Item() string {
 	return fmt.Sprintf("%v: ipv6cidr=%v", *d.vpcID, *d.ipv6CidrBlock)
 }
 
+func (d *deleteSubnetIPv6CIDRBlock) DeferDeletion() bool {
+	return false // TODO: should we defer this?
+}
+
 func calculateSubnetCIDR(vpcCIDR, subnetCIDR *string) (*string, error) {
 	if vpcCIDR == nil {
 		return nil, fmt.Errorf("expecting VPC CIDR to not be <nil>")

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -19,11 +19,13 @@ package awstasks
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/truncate"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
@@ -50,6 +52,9 @@ type TargetGroup struct {
 	Port      *int64
 	Protocol  *string
 
+	// networkLoadBalancer, if set, will create a new Target Group for each revision of the Network Load Balancer
+	networkLoadBalancer *NetworkLoadBalancer
+
 	// ARN is the Amazon Resource Name for the Target Group
 	ARN *string
 
@@ -61,15 +66,41 @@ type TargetGroup struct {
 	Interval           *int64
 	HealthyThreshold   *int64
 	UnhealthyThreshold *int64
+
+	info     *awsup.TargetGroupInfo
+	revision string
+
+	// deletions is a list of previous versions of this object, that we should delete when asked to clean up.
+	deletions []fi.CloudupDeletion
+}
+
+// CreateNewRevisionsWith will create new revisions of the TargetGroup when the given networkLoadBalancer has a new revision.
+// This works around the fact that TargetGroups can only be attached to a single NetworkLoadBalancer.
+func (e *TargetGroup) CreateNewRevisionsWith(nlb *NetworkLoadBalancer) {
+	e.networkLoadBalancer = nlb
+}
+
+var _ fi.CloudupHasDependencies = &TargetGroup{}
+
+// GetDependencies returns the dependencies of the TargetGroup task
+// We need to do this because we hide the networkLoadBalancer field
+func (e *TargetGroup) GetDependencies(tasks map[string]fi.CloudupTask) []fi.CloudupTask {
+	var deps []fi.CloudupTask
+	deps = append(deps, e.VPC)
+	deps = append(deps, e.networkLoadBalancer)
+	return deps
 }
 
 var _ fi.CompareWithID = &TargetGroup{}
 
 func (e *TargetGroup) CompareWithID() *string {
-	return e.ARN
+	if e.ARN != nil {
+		return e.ARN
+	}
+	return e.Name
 }
 
-func (e *TargetGroup) findTargetGroupByName(ctx context.Context, cloud awsup.AWSCloud) (*awsup.TargetGroupInfo, error) {
+func (e *TargetGroup) findLatestTargetGroupByName(ctx context.Context, cloud awsup.AWSCloud) (*awsup.TargetGroupInfo, error) {
 	name := fi.ValueOf(e.Name)
 
 	targetGroups, err := awsup.ListELBV2TargetGroups(ctx, cloud)
@@ -78,15 +109,56 @@ func (e *TargetGroup) findTargetGroupByName(ctx context.Context, cloud awsup.AWS
 	}
 
 	var latest *awsup.TargetGroupInfo
+	var latestRevision int
 	for _, targetGroup := range targetGroups {
 		// We accept the name tag _or_ the TargetGroupName itself, to allow matching groups that might predate tagging.
 		if aws.StringValue(targetGroup.TargetGroup.TargetGroupName) != name && targetGroup.NameTag() != name {
 			continue
 		}
-		if latest != nil {
-			return nil, fmt.Errorf("found multiple TargetGroups with name %q, expected 1", fi.ValueOf(e.Name))
+		revisionTag, _ := targetGroup.GetTag(awsup.KopsResourceRevisionTag)
+
+		revision := -1
+		if revisionTag == "" {
+			revision = 0
+		} else {
+			n, err := strconv.Atoi(revisionTag)
+			if err != nil {
+				klog.Warningf("ignoring target group %q with revision %q", targetGroup.ARN, revision)
+				continue
+			}
+			revision = n
 		}
-		latest = targetGroup
+
+		if latest == nil || revision > latestRevision {
+			latestRevision = revision
+			latest = targetGroup
+		}
+	}
+
+	if latest != nil && e.networkLoadBalancer != nil {
+		matchRevision := e.networkLoadBalancer.revision
+		arn := e.networkLoadBalancer.loadBalancerArn
+		if arn == "" {
+			return nil, fmt.Errorf("load balancer not ready (no ARN)")
+		}
+		revisionTag, _ := latest.GetTag(awsup.KopsResourceRevisionTag)
+
+		if revisionTag != matchRevision {
+			klog.Warningf("found target group but revision %q does not match load balancer revision %q; will create a new target group", revisionTag, matchRevision)
+			latest = nil
+		}
+	}
+
+	// Record deletions for later
+	for _, targetGroup := range targetGroups {
+		if aws.StringValue(targetGroup.TargetGroup.TargetGroupName) != name && targetGroup.NameTag() != name {
+			continue
+		}
+		if latest != nil && latest.ARN == targetGroup.ARN {
+			continue
+		}
+
+		e.deletions = append(e.deletions, buildDeleteTargetGroup(targetGroup))
 	}
 
 	return latest, nil
@@ -124,6 +196,7 @@ func (e *TargetGroup) findTargetGroupByARN(ctx context.Context, cloud awsup.AWSC
 
 	info := &awsup.TargetGroupInfo{
 		TargetGroup: tg,
+		ARN:         aws.StringValue(tg.TargetGroupArn),
 	}
 
 	for _, t := range tagResponse.TagDescriptions {
@@ -140,7 +213,7 @@ func (e *TargetGroup) Find(c *fi.CloudupContext) (*TargetGroup, error) {
 	var targetGroupInfo *awsup.TargetGroupInfo
 
 	if e.ARN == nil {
-		tgi, err := e.findTargetGroupByName(ctx, cloud)
+		tgi, err := e.findLatestTargetGroupByName(ctx, cloud)
 		if err != nil {
 			return nil, err
 		}
@@ -169,15 +242,23 @@ func (e *TargetGroup) Find(c *fi.CloudupContext) (*TargetGroup, error) {
 		UnhealthyThreshold: tg.UnhealthyThresholdCount,
 		VPC:                &VPC{ID: tg.VpcId},
 	}
+	actual.info = targetGroupInfo
+	e.info = targetGroupInfo
+	actual.revision, _ = targetGroupInfo.GetTag(awsup.KopsResourceRevisionTag)
+	e.revision = actual.revision
+
 	// Interval cannot be changed after TargetGroup creation
 	e.Interval = actual.Interval
 
 	e.ARN = tg.TargetGroupArn
-
 	tags := make(map[string]string)
 	for _, tag := range targetGroupInfo.Tags {
 		k := fi.ValueOf(tag.Key)
 		v := fi.ValueOf(tag.Value)
+		if k == awsup.KopsResourceRevisionTag {
+			actual.revision = v
+			continue
+		}
 		tags[k] = v
 	}
 	actual.Tags = tags
@@ -230,26 +311,58 @@ func (_ *TargetGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *TargetGrou
 		return nil
 	}
 
+	tags := make(map[string]string)
+	for k, v := range e.Tags {
+		tags[k] = v
+	}
+	if a != nil {
+		if a.revision != "" {
+			tags[awsup.KopsResourceRevisionTag] = a.revision
+		}
+	}
+
+	if e.networkLoadBalancer != nil {
+		if e.networkLoadBalancer.loadBalancerArn == "" {
+			return fmt.Errorf("load balancer not yet ready (arn is empty)")
+		}
+		nlbRevision := e.networkLoadBalancer.revision
+		if nlbRevision != "" {
+			tags[awsup.KopsResourceRevisionTag] = nlbRevision
+		}
+	}
+
 	// You register targets for your Network Load Balancer with a target group. By default, the load balancer sends requests
 	// to registered targets using the port and protocol that you specified for the target group. You can override this port
 	// when you register each target with the target group.
 
 	if a == nil {
+		createTargetGroupName := *e.Name
+		if tags[awsup.KopsResourceRevisionTag] != "" {
+			s := *e.Name + tags[awsup.KopsResourceRevisionTag]
+			// We always compute the hash and add it, lest we trick users into assuming that we never do this
+			opt := truncate.TruncateStringOptions{
+				MaxLength:     32,
+				AlwaysAddHash: true,
+				HashLength:    6,
+			}
+			createTargetGroupName = truncate.TruncateString(s, opt)
+		}
+
 		request := &elbv2.CreateTargetGroupInput{
-			Name:                       e.Name,
+			Name:                       &createTargetGroupName,
 			Port:                       e.Port,
 			Protocol:                   e.Protocol,
 			VpcId:                      e.VPC.ID,
 			HealthCheckIntervalSeconds: e.Interval,
 			HealthyThresholdCount:      e.HealthyThreshold,
 			UnhealthyThresholdCount:    e.UnhealthyThreshold,
-			Tags:                       awsup.ELBv2Tags(e.Tags),
+			Tags:                       awsup.ELBv2Tags(tags),
 		}
 
 		klog.V(2).Infof("Creating Target Group for NLB")
 		response, err := t.Cloud.ELBV2().CreateTargetGroup(request)
 		if err != nil {
-			return fmt.Errorf("Error creating target group for NLB : %v", err)
+			return fmt.Errorf("creating NLB target group: %w", err)
 		}
 
 		if err := ModifyTargetGroupAttributes(t.Cloud, response.TargetGroups[0].TargetGroupArn, e.Attributes); err != nil {
@@ -259,6 +372,7 @@ func (_ *TargetGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *TargetGrou
 		// Avoid spurious changes
 		e.ARN = response.TargetGroups[0].TargetGroupArn
 
+		// TODO: Set revision or info?
 	} else {
 		if a.ARN != nil {
 			if err := t.AddELBV2Tags(fi.ValueOf(a.ARN), e.Tags); err != nil {
@@ -363,4 +477,63 @@ func (e *TargetGroup) TerraformLink() *terraformWriter.Literal {
 		}
 	}
 	return terraformWriter.LiteralProperty("aws_lb_target_group", *e.Name, "id")
+}
+
+var _ fi.CloudupProducesDeletions = &TargetGroup{}
+
+// FindDeletions is responsible for finding launch templates which can be deleted
+func (e *TargetGroup) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletion, error) {
+	var removals []fi.CloudupDeletion
+	removals = append(removals, e.deletions...)
+	return removals, nil
+}
+
+// deleteTargetGroup tracks a TargetGroup that we're going to delete
+// It implements fi.CloudupDeletion
+type deleteTargetGroup struct {
+	obj *awsup.TargetGroupInfo
+}
+
+func buildDeleteTargetGroup(obj *awsup.TargetGroupInfo) *deleteTargetGroup {
+	d := &deleteTargetGroup{}
+	d.obj = obj
+	return d
+}
+
+var _ fi.CloudupDeletion = &deleteTargetGroup{}
+
+func (d *deleteTargetGroup) Delete(t fi.CloudupTarget) error {
+	ctx := context.TODO()
+
+	awsTarget, ok := t.(*awsup.AWSAPITarget)
+	if !ok {
+		return fmt.Errorf("unexpected target type for deletion: %T", t)
+	}
+
+	arn := d.obj.ARN
+	klog.V(2).Infof("deleting target group %q", arn)
+	if _, err := awsTarget.Cloud.ELBV2().DeleteTargetGroupWithContext(ctx, &elbv2.DeleteTargetGroupInput{
+		TargetGroupArn: &arn,
+	}); err != nil {
+		return fmt.Errorf("error deleting ELB TargetGroup %q: %w", arn, err)
+	}
+
+	return nil
+}
+
+// String returns a string representation of the task
+func (d *deleteTargetGroup) String() string {
+	return d.TaskName() + "-" + d.Item()
+}
+
+func (d *deleteTargetGroup) TaskName() string {
+	return "target-group"
+}
+
+func (d *deleteTargetGroup) Item() string {
+	return d.obj.ARN
+}
+
+func (d *deleteTargetGroup) DeferDeletion() bool {
+	return true
 }

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -391,3 +391,7 @@ func (d *deleteVPCCIDRBlock) TaskName() string {
 func (d *deleteVPCCIDRBlock) Item() string {
 	return fmt.Sprintf("%v: cidr=%v", *d.vpcID, *d.cidrBlock)
 }
+
+func (d *deleteVPCCIDRBlock) DeferDeletion() bool {
+	return false // TODO: should we defer this?
+}

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -241,8 +241,8 @@ func GetResourceName32(cluster string, prefix string) string {
 	return truncate.TruncateString(s, opt)
 }
 
-// GetTargetGroupNameFromARN will attempt to parse a target group ARN and return its name
-func GetTargetGroupNameFromARN(targetGroupARN string) (string, error) {
+// NameForExternalTargetGroup will attempt to calculate a meaningful name for a target group given an ARN.
+func NameForExternalTargetGroup(targetGroupARN string) (string, error) {
 	parsed, err := arn.Parse(targetGroupARN)
 	if err != nil {
 		return "", fmt.Errorf("error parsing target group ARN: %v", err)

--- a/upup/pkg/fi/cloudup/awsup/elbv2_targetgroups.go
+++ b/upup/pkg/fi/cloudup/awsup/elbv2_targetgroups.go
@@ -29,12 +29,9 @@ import (
 type TargetGroupInfo struct {
 	TargetGroup *elbv2.TargetGroup
 	Tags        []*elbv2.Tag
-	arn         string
-}
 
-// ARN returns the ARN of the load balancer.
-func (i *TargetGroupInfo) ARN() string {
-	return i.arn
+	// ARN holds the arn (amazon id) of the target group.
+	ARN string
 }
 
 // NameTag returns the value of the tag with the key "Name".
@@ -72,7 +69,7 @@ func ListELBV2TargetGroups(ctx context.Context, cloud AWSCloud) ([]*TargetGroupI
 
 		for _, tg := range p.TargetGroups {
 			arn := aws.StringValue(tg.TargetGroupArn)
-			byARN[arn] = &TargetGroupInfo{TargetGroup: tg, arn: arn}
+			byARN[arn] = &TargetGroupInfo{TargetGroup: tg, ARN: arn}
 
 			tagRequest.ResourceArns = append(tagRequest.ResourceArns, tg.TargetGroupArn)
 		}

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -211,10 +211,6 @@ func (c *MockAWSCloud) DescribeELBTags(loadBalancerNames []string) (map[string][
 	return describeELBTags(c, loadBalancerNames)
 }
 
-func (c *MockAWSCloud) FindELBV2ByNameTag(findNameTag string) (*elbv2.LoadBalancer, error) {
-	return findELBV2ByNameTag(c, findNameTag)
-}
-
 func (c *MockAWSCloud) DescribeELBV2Tags(loadBalancerArns []string) (map[string][]*elbv2.Tag, error) {
 	return describeELBV2Tags(c, loadBalancerArns)
 }

--- a/upup/pkg/fi/cloudup/awsup/tags.go
+++ b/upup/pkg/fi/cloudup/awsup/tags.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsup
+
+// KopsResourceRevisionTag is the tag used to store the revision timestamp,
+// when we are forced to create a new version of a resource because we cannot modify it in-place.
+// This happens when the resource field is immutable;
+// it also happens for ELBs, when we cannot have two ELBs pointing at the same target group
+// and thus must create a second.
+const KopsResourceRevisionTag = "kops.k8s.io/revision"

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
@@ -259,6 +259,10 @@ func (d *deleteSecurityGroup) Item() string {
 	return s
 }
 
+func (d *deleteSecurityGroup) DeferDeletion() bool {
+	return false // TODO: Should we defer deletion?
+}
+
 type deleteSecurityGroupRule struct {
 	rule          sgr.SecGroupRule
 	securityGroup *SecurityGroup
@@ -296,6 +300,10 @@ func (d *deleteSecurityGroupRule) Item() string {
 	s += fmt.Sprintf(" ip=%s", d.rule.RemoteIPPrefix)
 	s += fmt.Sprintf(" securitygroup=%s", fi.ValueOf(d.securityGroup.Name))
 	return s
+}
+
+func (d *deleteSecurityGroupRule) DeferDeletion() bool {
+	return false // TODO: Should we defer deletion?
 }
 
 // RemovalRule is a rule that filters the permissions we should remove

--- a/upup/pkg/fi/deletions.go
+++ b/upup/pkg/fi/deletions.go
@@ -20,11 +20,13 @@ type DeletionProcessingMode string
 
 const (
 	// DeletionProcessingModeIgnore will ignore all deletion tasks.
+	// This is typically used when the target implements pruning directly (e.g. terraform)
 	DeletionProcessingModeIgnore DeletionProcessingMode = "Ignore"
-	// TODO: implement deferred-deletion in the tasks!
 	// DeletionProcessingModeDeleteIfNotDeferrred will delete resources only if they are not marked for deferred-deletion.
+	// This corresponds to a cluster update with --prune=false.
 	DeletionProcessingModeDeleteIfNotDeferrred DeletionProcessingMode = "IfNotDeferred"
 	// DeletionProcessingModeDeleteIncludingDeferrred will delete resources including those marked for deferred-deletion.
+	// This corresponds to a cluster update with --prune=true.
 	DeletionProcessingModeDeleteIncludingDeferred DeletionProcessingMode = "DeleteIncludingDeferred"
 )
 
@@ -38,6 +40,7 @@ type Deletion[T SubContext] interface {
 	Delete(target Target[T]) error
 	TaskName() string
 	Item() string
+	DeferDeletion() bool
 }
 
 type CloudupDeletion = Deletion[CloudupSubContext]

--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -256,9 +256,30 @@ func (t *DryRunTarget[T]) PrintReport(taskMap map[string]Task[T], out io.Writer)
 		// Give everything a consistent ordering
 		sort.Sort(DeletionByTaskName[T](t.deletions))
 
-		fmt.Fprintf(b, "Will delete items:\n")
+		var deferred []Deletion[T]
+		var immediate []Deletion[T]
+
 		for _, d := range t.deletions {
-			fmt.Fprintf(b, "  %-20s %s\n", d.TaskName(), d.Item())
+			if d.DeferDeletion() {
+				deferred = append(deferred, d)
+			} else {
+				immediate = append(immediate, d)
+			}
+		}
+
+		if len(deferred) != 0 {
+			fmt.Fprintf(b, "Items will be deleted only when the --prune flag is specified:\n")
+			for _, d := range deferred {
+				fmt.Fprintf(b, "  %-20s %s\n", d.TaskName(), d.Item())
+			}
+			fmt.Fprintf(b, "\n")
+		}
+		if len(immediate) != 0 {
+			fmt.Fprintf(b, "Items will be deleted during update:\n")
+			for _, d := range immediate {
+				fmt.Fprintf(b, "  %-20s %s\n", d.TaskName(), d.Item())
+			}
+			fmt.Fprintf(b, "\n")
 		}
 	}
 

--- a/upup/pkg/fi/topological_sort.go
+++ b/upup/pkg/fi/topological_sort.go
@@ -66,9 +66,13 @@ func FindTaskDependencies[T SubContext](tasks map[string]Task[T]) map[string][]s
 
 		var dependencyKeys []string
 		for _, dep := range dependencies {
+			// Skip nils, including interface nils
+			if dep == nil || reflect.ValueOf(dep).IsNil() {
+				continue
+			}
 			dependencyKey, found := taskToId[dep]
 			if !found {
-				klog.Fatalf("dependency not found: %v", dep)
+				klog.Fatalf("dependency for task %T:%q not found: %v", t, k, dep)
 			}
 			dependencyKeys = append(dependencyKeys, dependencyKey)
 		}


### PR DESCRIPTION
This lets us safely make changes to otherwise immutable fields, in
particular for adding security groups to NLBs created without them.

We detect the older versions, and create deletion tasks to remove
them.  These tasks can be deferred, and we expect them to be
deferred to a "prune" phase that runs after cluster apply.
