### PR TITLE
Set --dns=none on upgrade tests from older kops versions

### DIFF
--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -83,6 +83,11 @@ if [[ ${KOPS_IRSA-} = true ]]; then
   create_args="${create_args} --discovery-store=${DISCOVERY_STORE}/${CLUSTER_NAME}/discovery"
 fi
 
+# TODO: remove once we stop testing upgrades from kops <1.29
+if [[ "${CLUSTER_NAME}" == "*tests-kops-aws.k8s.io" && "${KOPS_VERSION_A}" =~ v1.2[678].* ]]; then
+  create_args="${create_args} --dns=none"
+fi
+
 # TODO: Switch scripts to use KOPS_CONTROL_PLANE_COUNT
 if [[ -n "${KOPS_CONTROL_PLANE_SIZE:-}" ]]; then
   echo "Recognized (deprecated) KOPS_CONTROL_PLANE_SIZE=${KOPS_CONTROL_PLANE_SIZE}, please set KOPS_CONTROL_PLANE_COUNT instead"


### PR DESCRIPTION
This should fix some "missing zone" errors on these upgrade tests. Newer kops versions default to --dns=none.

Example: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-k126-ko128-to-k127-kolatest/1758945690790137856