### PR TITLE
Fix bash conditional pattern matching in upgrade script

### DIFF
--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -84,7 +84,7 @@ if [[ ${KOPS_IRSA-} = true ]]; then
 fi
 
 # TODO: remove once we stop testing upgrades from kops <1.29
-if [[ "${CLUSTER_NAME}" == "*tests-kops-aws.k8s.io" && "${KOPS_VERSION_A}" =~ v1.2[678].* ]]; then
+if [[ "${CLUSTER_NAME}" == *"tests-kops-aws.k8s.io" && "${KOPS_VERSION_A}" =~ v1.2[678].* ]]; then
   create_args="${create_args} --dns=none"
 fi
 


### PR DESCRIPTION
Followup to https://github.com/kubernetes/kops/pull/16360

```
bash-5.2$ if [[ "foo.tests-kops-aws.k8s.io" == "*tests-kops-aws.k8s.io" ]]; then echo true; fi
bash-5.2$ if [[ "foo.tests-kops-aws.k8s.io" == *"tests-kops-aws.k8s.io" ]]; then echo true; fi
true
```

/cc @hakman 