### PR TITLE
gce: refactor regional/global GCE API methods

### DIFF
--- a/cloudmock/gce/mockcompute/api.go
+++ b/cloudmock/gce/mockcompute/api.go
@@ -137,11 +137,11 @@ func (c *MockClient) HTTPHealthChecks() gce.HttpHealthChecksClient {
 	return c.httpHealthChecksClient
 }
 
-func (c *MockClient) RegionHealthChecks() gce.RegionHealthChecksClient {
+func (c *MockClient) HealthChecks() gce.HealthChecksClient {
 	return c.healthCheckClient
 }
 
-func (c *MockClient) RegionBackendServices() gce.RegionBackendServiceClient {
+func (c *MockClient) BackendServices() gce.BackendServiceClient {
 	return c.backendServiceClient
 }
 

--- a/cloudmock/gce/mockcompute/backend_services.go
+++ b/cloudmock/gce/mockcompute/backend_services.go
@@ -31,7 +31,7 @@ type backendServiceClient struct {
 	sync.Mutex
 }
 
-var _ gce.RegionBackendServiceClient = &backendServiceClient{}
+var _ gce.BackendServiceClient = &backendServiceClient{}
 
 func newBackendServiceClient() *backendServiceClient {
 	return &backendServiceClient{

--- a/cloudmock/gce/mockcompute/health_checks.go
+++ b/cloudmock/gce/mockcompute/health_checks.go
@@ -31,7 +31,7 @@ type healthCheckClient struct {
 	sync.Mutex
 }
 
-var _ gce.RegionHealthChecksClient = &healthCheckClient{}
+var _ gce.HealthChecksClient = &healthCheckClient{}
 
 func newHealthCheckClient() *healthCheckClient {
 	return &healthCheckClient{

--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -511,7 +511,11 @@ func deleteForwardingRule(cloud fi.Cloud, r *resources.Resource) error {
 		return err
 	}
 
-	op, err := c.Compute().ForwardingRules().Delete(ctx, u.Project, u.Region, u.Name)
+	region := ""
+	if !u.Global {
+		region = u.Region
+	}
+	op, err := c.Compute().ForwardingRules().Delete(ctx, u.Project, region, u.Name)
 	if err != nil {
 		if gce.IsNotFound(err) {
 			klog.Infof("ForwardingRule not found, assuming deleted: %q", t.SelfLink)
@@ -828,9 +832,14 @@ func (d *clusterDiscoveryGCE) listAddresses() ([]*resources.Resource, error) {
 
 	addrs, err := c.Compute().Addresses().List(ctx, c.Project(), c.Region())
 	if err != nil {
-		return nil, fmt.Errorf("error listing Addresses: %v", err)
+		return nil, fmt.Errorf("error listing regional Addresses: %v", err)
+	}
+	globalAddrs, err := c.Compute().Addresses().List(ctx, c.Project(), "")
+	if err != nil {
+		return nil, fmt.Errorf("error listing global Addresses: %v", err)
 	}
 
+	addrs = append(addrs, globalAddrs...)
 	for _, a := range addrs {
 		if !d.matchesClusterName(a.Name) {
 			klog.V(8).Infof("Skipping Address with name %q", a.Name)
@@ -861,8 +870,12 @@ func deleteAddress(cloud fi.Cloud, r *resources.Resource) error {
 	if err != nil {
 		return err
 	}
+	region := ""
+	if !u.Global {
+		region = u.Region
+	}
 
-	op, err := c.Compute().Addresses().Delete(u.Project, u.Region, u.Name)
+	op, err := c.Compute().Addresses().Delete(u.Project, region, u.Name)
 	if err != nil {
 		if gce.IsNotFound(err) {
 			klog.Infof("Address not found, assuming deleted: %q", t.SelfLink)
@@ -1079,15 +1092,26 @@ func containsOnlyListedIGMs(svc *compute.BackendService, igms []*resources.Resou
 
 func (d *clusterDiscoveryGCE) listBackendServices() ([]*resources.Resource, error) {
 	c := d.gceCloud
-
-	svcs, err := c.Compute().RegionBackendServices().List(context.Background(), c.Project(), c.Region())
+	// list global backendservices first
+	svcs, err := c.Compute().BackendServices().List(context.Background(), c.Project(), "")
 	if err != nil {
 		if gce.IsNotFound(err) {
 			klog.Infof("backend services not found, assuming none exist in project: %q region: %q", c.Project(), c.Region())
 			return nil, nil
 		}
-		return nil, fmt.Errorf("Failed to list backend services: %w", err)
+		return nil, fmt.Errorf("failed to list global backend services: %w", err)
 	}
+
+	// list regional backendservices as well
+	regionalsvcs, err := c.Compute().BackendServices().List(context.Background(), c.Project(), c.Region())
+	if err != nil {
+		if gce.IsNotFound(err) {
+			klog.Infof("backend services not found, assuming none exist in project: %q region: %q", c.Project(), c.Region())
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to list regional backend services: %w", err)
+	}
+	svcs = append(svcs, regionalsvcs...)
 	// TODO: cache, for efficiency, if needed.
 	// Find all relevant backend services by finding all the cluster's IGMs, and then
 	// listing all backend services in the project / region, then selecting
@@ -1104,7 +1128,15 @@ func (d *clusterDiscoveryGCE) listBackendServices() ([]*resources.Resource, erro
 				ID:   svc.Name,
 				Type: typeBackendService,
 				Deleter: func(cloud fi.Cloud, r *resources.Resource) error {
-					op, err := c.Compute().RegionBackendServices().Delete(c.Project(), c.Region(), svc.Name)
+					u, err := gce.ParseGoogleCloudURL(svc.SelfLink)
+					if err != nil {
+						return err
+					}
+					region := ""
+					if !u.Global {
+						region = u.Region
+					}
+					op, err := c.Compute().BackendServices().Delete(c.Project(), region, svc.Name)
 					if err != nil {
 						return err
 					}
@@ -1139,12 +1171,20 @@ func (d *clusterDiscoveryGCE) listHealthchecks() ([]*resources.Resource, error) 
 	}
 	var hcResources []*resources.Resource
 	for hc := range hcs {
+		u, err := gce.ParseGoogleCloudURL(hc)
+		if err != nil {
+			return nil, err
+		}
+		region := ""
+		if !u.Global {
+			region = u.Region
+		}
 		hcResources = append(hcResources, &resources.Resource{
-			Name: gce.LastComponent(hc),
-			ID:   gce.LastComponent(hc),
+			Name: u.Name,
+			ID:   u.Name,
 			Type: typeHealthcheck,
 			Deleter: func(cloud fi.Cloud, r *resources.Resource) error {
-				op, err := c.Compute().RegionHealthChecks().Delete(c.Project(), c.Region(), gce.LastComponent(hc))
+				op, err := c.Compute().HealthChecks().Delete(u.Project, region, u.Name)
 				if err != nil {
 					return err
 				}

--- a/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/kubernetes.tf
@@ -174,17 +174,8 @@ resource "google_compute_address" "api-us-test1-minimal-gce-example-com" {
   address_type = "INTERNAL"
   name         = "api-us-test1-minimal-gce-example-com"
   purpose      = "SHARED_LOADBALANCER_VIP"
+  region       = "us-test1"
   subnetwork   = google_compute_subnetwork.us-test1-minimal-gce-example-com.name
-}
-
-resource "google_compute_backend_service" "api-minimal-gce-example-com" {
-  backend {
-    group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-example-com.instance_group
-  }
-  health_checks         = [google_compute_health_check.api-minimal-gce-example-com.id]
-  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
-  name                  = "api-minimal-gce-example-com"
-  protocol              = "TCP"
 }
 
 resource "google_compute_disk" "a-etcd-events-minimal-gce-example-com" {
@@ -449,7 +440,7 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-example-com
 }
 
 resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-example-com" {
-  backend_service = google_compute_backend_service.api-minimal-gce-example-com.id
+  backend_service = google_compute_region_backend_service.api-minimal-gce-example-com.id
   ip_address      = google_compute_address.api-us-test1-minimal-gce-example-com.address
   ip_protocol     = "TCP"
   labels = {
@@ -460,11 +451,12 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-example-com"
   name                  = "api-us-test1-minimal-gce-example-com"
   network               = google_compute_network.minimal-gce-example-com.name
   ports                 = ["443"]
+  region                = "us-test1"
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-example-com.name
 }
 
 resource "google_compute_forwarding_rule" "kops-controller-us-test1-minimal-gce-example-com" {
-  backend_service = google_compute_backend_service.api-minimal-gce-example-com.id
+  backend_service = google_compute_region_backend_service.api-minimal-gce-example-com.id
   ip_address      = google_compute_address.api-us-test1-minimal-gce-example-com.address
   ip_protocol     = "TCP"
   labels = {
@@ -475,14 +467,8 @@ resource "google_compute_forwarding_rule" "kops-controller-us-test1-minimal-gce-
   name                  = "kops-controller-us-test1-minimal-gce-example-com"
   network               = google_compute_network.minimal-gce-example-com.name
   ports                 = ["3988"]
+  region                = "us-test1"
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-example-com.name
-}
-
-resource "google_compute_health_check" "api-minimal-gce-example-com" {
-  name = "api-minimal-gce-example-com"
-  tcp_health_check {
-    port = 443
-  }
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-example-com" {
@@ -610,6 +596,26 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
 resource "google_compute_network" "minimal-gce-example-com" {
   auto_create_subnetworks = false
   name                    = "minimal-gce-example-com"
+}
+
+resource "google_compute_region_backend_service" "api-minimal-gce-example-com" {
+  backend {
+    group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-example-com.instance_group
+  }
+  health_checks         = [google_compute_region_health_check.api-minimal-gce-example-com.id]
+  load_balancing_scheme = "INTERNAL"
+  name                  = "api-minimal-gce-example-com"
+  protocol              = "TCP"
+  region                = "us-test1"
+}
+
+resource "google_compute_region_health_check" "api-minimal-gce-example-com" {
+  http_health_check {
+    port         = 443
+    request_path = "/healthz"
+  }
+  name   = "api-minimal-gce-example-com"
+  region = "us-test1"
 }
 
 resource "google_compute_router" "nat-minimal-gce-example-com" {

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -182,17 +182,8 @@ resource "google_compute_address" "api-us-test1-minimal-gce-ilb-example-com" {
   address_type = "INTERNAL"
   name         = "api-us-test1-minimal-gce-ilb-example-com"
   purpose      = "SHARED_LOADBALANCER_VIP"
+  region       = "us-test1"
   subnetwork   = google_compute_subnetwork.us-test1-minimal-gce-ilb-example-com.name
-}
-
-resource "google_compute_backend_service" "api-minimal-gce-ilb-example-com" {
-  backend {
-    group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-ilb-example-com.instance_group
-  }
-  health_checks         = [google_compute_health_check.api-minimal-gce-ilb-example-com.id]
-  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
-  name                  = "api-minimal-gce-ilb-example-com"
-  protocol              = "TCP"
 }
 
 resource "google_compute_disk" "a-etcd-events-minimal-gce-ilb-example-com" {
@@ -433,7 +424,7 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-ilb-example
 }
 
 resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-ilb-example-com" {
-  backend_service = google_compute_backend_service.api-minimal-gce-ilb-example-com.id
+  backend_service = google_compute_region_backend_service.api-minimal-gce-ilb-example-com.id
   ip_address      = google_compute_address.api-us-test1-minimal-gce-ilb-example-com.address
   ip_protocol     = "TCP"
   labels = {
@@ -444,14 +435,8 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-ilb-example-
   name                  = "api-us-test1-minimal-gce-ilb-example-com"
   network               = google_compute_network.minimal-gce-ilb-example-com.name
   ports                 = ["443"]
+  region                = "us-test1"
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-ilb-example-com.name
-}
-
-resource "google_compute_health_check" "api-minimal-gce-ilb-example-com" {
-  name = "api-minimal-gce-ilb-example-com"
-  tcp_health_check {
-    port = 443
-  }
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-ilb-example-com" {
@@ -579,6 +564,26 @@ resource "google_compute_instance_template" "nodes-minimal-gce-ilb-example-com" 
 resource "google_compute_network" "minimal-gce-ilb-example-com" {
   auto_create_subnetworks = false
   name                    = "minimal-gce-ilb-example-com"
+}
+
+resource "google_compute_region_backend_service" "api-minimal-gce-ilb-example-com" {
+  backend {
+    group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-ilb-example-com.instance_group
+  }
+  health_checks         = [google_compute_region_health_check.api-minimal-gce-ilb-example-com.id]
+  load_balancing_scheme = "INTERNAL"
+  name                  = "api-minimal-gce-ilb-example-com"
+  protocol              = "TCP"
+  region                = "us-test1"
+}
+
+resource "google_compute_region_health_check" "api-minimal-gce-ilb-example-com" {
+  http_health_check {
+    port         = 443
+    request_path = "/healthz"
+  }
+  name   = "api-minimal-gce-ilb-example-com"
+  region = "us-test1"
 }
 
 resource "google_compute_router" "nat-minimal-gce-ilb-example-com" {

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -182,17 +182,8 @@ resource "google_compute_address" "api-us-test1-minimal-gce-with-a-very-very-ver
   address_type = "INTERNAL"
   name         = "api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi"
   purpose      = "SHARED_LOADBALANCER_VIP"
+  region       = "us-test1"
   subnetwork   = google_compute_subnetwork.us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi.name
-}
-
-resource "google_compute_backend_service" "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com" {
-  backend {
-    group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f.instance_group
-  }
-  health_checks         = [google_compute_health_check.api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.id]
-  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
-  name                  = "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
-  protocol              = "TCP"
 }
 
 resource "google_compute_disk" "a-etcd-events-minimal-gce-with-a-very-very-very-very-ver-96dqvi" {
@@ -433,7 +424,7 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-with-a-very
 }
 
 resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi" {
-  backend_service = google_compute_backend_service.api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.id
+  backend_service = google_compute_region_backend_service.api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.id
   ip_address      = google_compute_address.api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi.address
   ip_protocol     = "TCP"
   labels = {
@@ -444,14 +435,8 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-with-a-very-
   name                  = "api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi"
   network               = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   ports                 = ["443"]
+  region                = "us-test1"
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi.name
-}
-
-resource "google_compute_health_check" "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com" {
-  name = "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
-  tcp_health_check {
-    port = 443
-  }
 }
 
 resource "google_compute_instance_group_manager" "a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f" {
@@ -579,6 +564,26 @@ resource "google_compute_instance_template" "nodes-minimal-gce-with-a-very-very-
 resource "google_compute_network" "minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi" {
   auto_create_subnetworks = false
   name                    = "minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi"
+}
+
+resource "google_compute_region_backend_service" "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com" {
+  backend {
+    group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f.instance_group
+  }
+  health_checks         = [google_compute_region_health_check.api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.id]
+  load_balancing_scheme = "INTERNAL"
+  name                  = "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
+  protocol              = "TCP"
+  region                = "us-test1"
+}
+
+resource "google_compute_region_health_check" "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com" {
+  http_health_check {
+    port         = 443
+    request_path = "/healthz"
+  }
+  name   = "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
+  region = "us-test1"
 }
 
 resource "google_compute_router" "nat-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi" {

--- a/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_plb/kubernetes.tf
@@ -179,7 +179,8 @@ resource "aws_s3_object" "nodeupconfig-nodes" {
 }
 
 resource "google_compute_address" "api-minimal-gce-plb-example-com" {
-  name = "api-minimal-gce-plb-example-com"
+  name   = "api-minimal-gce-plb-example-com"
+  region = "us-test1"
 }
 
 resource "google_compute_disk" "a-etcd-events-minimal-gce-plb-example-com" {
@@ -429,6 +430,7 @@ resource "google_compute_forwarding_rule" "api-minimal-gce-plb-example-com" {
   load_balancing_scheme = "EXTERNAL"
   name                  = "api-minimal-gce-plb-example-com"
   port_range            = "443-443"
+  region                = "us-test1"
   target                = google_compute_target_pool.api-minimal-gce-plb-example-com.self_link
 }
 

--- a/upup/pkg/fi/cloudup/gce/compute.go
+++ b/upup/pkg/fi/cloudup/gce/compute.go
@@ -32,7 +32,7 @@ type ComputeClient interface {
 	Routes() RouteClient
 	ForwardingRules() ForwardingRuleClient
 	HTTPHealthChecks() HttpHealthChecksClient
-	RegionHealthChecks() RegionHealthChecksClient
+	HealthChecks() HealthChecksClient
 	Addresses() AddressClient
 	Firewalls() FirewallClient
 	Routers() RouterClient
@@ -41,7 +41,7 @@ type ComputeClient interface {
 	InstanceGroupManagers() InstanceGroupManagerClient
 	TargetPools() TargetPoolClient
 	Disks() DiskClient
-	RegionBackendServices() RegionBackendServiceClient
+	BackendServices() BackendServiceClient
 }
 
 type computeClientImpl struct {
@@ -98,13 +98,15 @@ func (c *computeClientImpl) Routes() RouteClient {
 
 func (c *computeClientImpl) ForwardingRules() ForwardingRuleClient {
 	return &forwardingRuleClientImpl{
-		srv: c.srv.ForwardingRules,
+		srv:  c.srv.ForwardingRules,
+		gsrv: c.srv.GlobalForwardingRules,
 	}
 }
 
-func (c *computeClientImpl) RegionBackendServices() RegionBackendServiceClient {
-	return &regionBackendServiceClientImpl{
-		srv: c.srv.RegionBackendServices,
+func (c *computeClientImpl) BackendServices() BackendServiceClient {
+	return &backendServiceClientImpl{
+		srv:  c.srv.BackendServices,
+		rsrv: c.srv.RegionBackendServices,
 	}
 }
 
@@ -114,15 +116,17 @@ func (c *computeClientImpl) HTTPHealthChecks() HttpHealthChecksClient {
 	}
 }
 
-func (c *computeClientImpl) RegionHealthChecks() RegionHealthChecksClient {
+func (c *computeClientImpl) HealthChecks() HealthChecksClient {
 	return &healthCheckClientImpl{
-		srv: c.srv.RegionHealthChecks,
+		srv:  c.srv.HealthChecks,
+		rsrv: c.srv.RegionHealthChecks,
 	}
 }
 
 func (c *computeClientImpl) Addresses() AddressClient {
 	return &addressClientImpl{
-		srv: c.srv.Addresses,
+		srv:  c.srv.Addresses,
+		gsrv: c.srv.GlobalAddresses,
 	}
 }
 
@@ -297,40 +301,59 @@ func (c *subnetworkClientImpl) List(ctx context.Context, project, region string)
 }
 
 // ===
-type RegionBackendServiceClient interface {
+type BackendServiceClient interface {
 	Insert(project, region string, fr *compute.BackendService) (*compute.Operation, error)
 	Delete(project, region, name string) (*compute.Operation, error)
 	Get(project, region, name string) (*compute.BackendService, error)
 	List(ctx context.Context, project, region string) ([]*compute.BackendService, error)
 }
 
-type regionBackendServiceClientImpl struct {
-	srv *compute.RegionBackendServicesService
+type backendServiceClientImpl struct {
+	srv  *compute.BackendServicesService
+	rsrv *compute.RegionBackendServicesService
 }
 
-var _ RegionBackendServiceClient = &regionBackendServiceClientImpl{}
+var _ BackendServiceClient = &backendServiceClientImpl{}
 
-func (c *regionBackendServiceClientImpl) Insert(project, region string, fr *compute.BackendService) (*compute.Operation, error) {
-	return c.srv.Insert(project, region, fr).Do()
+func (c *backendServiceClientImpl) Insert(project, region string, fr *compute.BackendService) (*compute.Operation, error) {
+	if region == "" {
+		return c.srv.Insert(project, fr).Do()
+	}
+	return c.rsrv.Insert(project, region, fr).Do()
 }
 
-func (c *regionBackendServiceClientImpl) Delete(project, region, name string) (*compute.Operation, error) {
-	return c.srv.Delete(project, region, name).Do()
+func (c *backendServiceClientImpl) Delete(project, region, name string) (*compute.Operation, error) {
+	if region == "" {
+		return c.srv.Delete(project, name).Do()
+	}
+	return c.rsrv.Delete(project, region, name).Do()
 }
 
-func (c *regionBackendServiceClientImpl) Get(project, region, name string) (*compute.BackendService, error) {
-	return c.srv.Get(project, region, name).Do()
+func (c *backendServiceClientImpl) Get(project, region, name string) (*compute.BackendService, error) {
+	if region == "" {
+		return c.srv.Get(project, name).Do()
+	}
+	return c.rsrv.Get(project, region, name).Do()
 }
 
-func (c *regionBackendServiceClientImpl) List(ctx context.Context, project, region string) ([]*compute.BackendService, error) {
-	var hcs []*compute.BackendService
-	if err := c.srv.List(project, region).Pages(ctx, func(p *compute.BackendServiceList) error {
-		hcs = append(hcs, p.Items...)
+func (c *backendServiceClientImpl) List(ctx context.Context, project, region string) ([]*compute.BackendService, error) {
+	var bs []*compute.BackendService
+	if region == "" {
+		if err := c.srv.List(project).Pages(ctx, func(p *compute.BackendServiceList) error {
+			bs = append(bs, p.Items...)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		return bs, nil
+	}
+	if err := c.rsrv.List(project, region).Pages(ctx, func(p *compute.BackendServiceList) error {
+		bs = append(bs, p.Items...)
 		return nil
 	}); err != nil {
 		return nil, err
 	}
-	return hcs, nil
+	return bs, nil
 }
 
 // ===
@@ -370,29 +393,55 @@ type ForwardingRuleClient interface {
 }
 
 type forwardingRuleClientImpl struct {
-	srv *compute.ForwardingRulesService
+	srv  *compute.ForwardingRulesService
+	gsrv *compute.GlobalForwardingRulesService
 }
 
 var _ ForwardingRuleClient = &forwardingRuleClientImpl{}
 
 func (c *forwardingRuleClientImpl) Insert(ctx context.Context, project, region string, fr *compute.ForwardingRule) (*compute.Operation, error) {
+	if region == "" {
+		return c.gsrv.Insert(project, fr).Context(ctx).Do()
+	}
 	return c.srv.Insert(project, region, fr).Context(ctx).Do()
 }
 
 func (c *forwardingRuleClientImpl) Delete(ctx context.Context, project, region, name string) (*compute.Operation, error) {
+	if region == "" {
+		return c.gsrv.Delete(project, name).Context(ctx).Do()
+	}
 	return c.srv.Delete(project, region, name).Context(ctx).Do()
 }
 
 func (c *forwardingRuleClientImpl) Get(ctx context.Context, project, region, name string) (*compute.ForwardingRule, error) {
-	return c.srv.Get(project, region, name).Context(ctx).Do()
+	if region == "" {
+		return c.gsrv.Get(project, name).Do()
+	}
+	return c.srv.Get(project, region, name).Do()
 }
 
 func (c *forwardingRuleClientImpl) SetLabels(ctx context.Context, project string, region string, resource string, request *compute.RegionSetLabelsRequest) (*compute.Operation, error) {
+	if region == "" {
+		grequest := &compute.GlobalSetLabelsRequest{
+			LabelFingerprint: request.LabelFingerprint,
+			Labels:           request.Labels,
+		}
+		return c.gsrv.SetLabels(project, resource, grequest).Context(ctx).Do()
+	}
 	return c.srv.SetLabels(project, region, resource, request).Context(ctx).Do()
 }
 
 func (c *forwardingRuleClientImpl) List(ctx context.Context, project, region string) ([]*compute.ForwardingRule, error) {
 	var frs []*compute.ForwardingRule
+	if region == "" {
+		if err := c.gsrv.List(project).Pages(ctx, func(p *compute.ForwardingRuleList) error {
+			frs = append(frs, p.Items...)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		return frs, nil
+	}
 	if err := c.srv.List(project, region).Pages(ctx, func(p *compute.ForwardingRuleList) error {
 		frs = append(frs, p.Items...)
 		return nil
@@ -402,7 +451,7 @@ func (c *forwardingRuleClientImpl) List(ctx context.Context, project, region str
 	return frs, nil
 }
 
-type RegionHealthChecksClient interface {
+type HealthChecksClient interface {
 	Insert(project, region string, fr *compute.HealthCheck) (*compute.Operation, error)
 	Delete(project, region, name string) (*compute.Operation, error)
 	Get(project, region, name string) (*compute.HealthCheck, error)
@@ -410,26 +459,44 @@ type RegionHealthChecksClient interface {
 }
 
 type healthCheckClientImpl struct {
-	srv *compute.RegionHealthChecksService
+	srv  *compute.HealthChecksService
+	rsrv *compute.RegionHealthChecksService
 }
 
-var _ RegionHealthChecksClient = &healthCheckClientImpl{}
+var _ HealthChecksClient = &healthCheckClientImpl{}
 
-func (c *healthCheckClientImpl) Insert(project, region string, fr *compute.HealthCheck) (*compute.Operation, error) {
-	return c.srv.Insert(project, region, fr).Do()
+func (c *healthCheckClientImpl) Insert(project, region string, hc *compute.HealthCheck) (*compute.Operation, error) {
+	if region == "" {
+		return c.srv.Insert(project, hc).Do()
+	}
+	return c.rsrv.Insert(project, region, hc).Do()
 }
 
 func (c *healthCheckClientImpl) Delete(project, region, name string) (*compute.Operation, error) {
-	return c.srv.Delete(project, region, name).Do()
+	if region == "" {
+		return c.srv.Delete(project, name).Do()
+	}
+	return c.rsrv.Delete(project, region, name).Do()
 }
 
 func (c *healthCheckClientImpl) Get(project, region, name string) (*compute.HealthCheck, error) {
-	return c.srv.Get(project, region, name).Do()
+	if region == "" {
+		return c.srv.Get(project, name).Do()
+	}
+	return c.rsrv.Get(project, region, name).Do()
 }
 
 func (c *healthCheckClientImpl) List(ctx context.Context, project, region string) ([]*compute.HealthCheck, error) {
 	var hcs []*compute.HealthCheck
-	if err := c.srv.List(project, region).Pages(ctx, func(p *compute.HealthCheckList) error {
+	if region == "" {
+		if err := c.srv.List(project).Pages(ctx, func(p *compute.HealthCheckList) error {
+			hcs = append(hcs, p.Items...)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	if err := c.rsrv.List(project, region).Pages(ctx, func(p *compute.HealthCheckList) error {
 		hcs = append(hcs, p.Items...)
 		return nil
 	}); err != nil {
@@ -483,25 +550,44 @@ type AddressClient interface {
 }
 
 type addressClientImpl struct {
-	srv *compute.AddressesService
+	srv  *compute.AddressesService
+	gsrv *compute.GlobalAddressesService
 }
 
 var _ AddressClient = &addressClientImpl{}
 
 func (c *addressClientImpl) Insert(project, region string, addr *compute.Address) (*compute.Operation, error) {
+	if region == "" {
+		return c.gsrv.Insert(project, addr).Do()
+	}
 	return c.srv.Insert(project, region, addr).Do()
 }
 
 func (c *addressClientImpl) Delete(project, region, name string) (*compute.Operation, error) {
+	if region == "" {
+		return c.gsrv.Delete(project, name).Do()
+	}
 	return c.srv.Delete(project, region, name).Do()
 }
 
 func (c *addressClientImpl) Get(project, region, name string) (*compute.Address, error) {
+	if region == "" {
+		return c.gsrv.Get(project, name).Do()
+	}
 	return c.srv.Get(project, region, name).Do()
 }
 
 func (c *addressClientImpl) List(ctx context.Context, project, region string) ([]*compute.Address, error) {
 	var addrs []*compute.Address
+	if region == "" {
+		if err := c.gsrv.List(project).Pages(ctx, func(p *compute.AddressList) error {
+			addrs = append(addrs, p.Items...)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		return addrs, nil
+	}
 	if err := c.srv.List(project, region).Pages(ctx, func(p *compute.AddressList) error {
 		addrs = append(addrs, p.Items...)
 		return nil
@@ -512,6 +598,13 @@ func (c *addressClientImpl) List(ctx context.Context, project, region string) ([
 }
 
 func (c *addressClientImpl) ListWithFilter(project, region, filter string) ([]*compute.Address, error) {
+	if region == "" {
+		addrs, err := c.gsrv.List(project).Filter(filter).Do()
+		if err != nil {
+			return nil, err
+		}
+		return addrs.Items, nil
+	}
 	addrs, err := c.srv.List(project, region).Filter(filter).Do()
 	if err != nil {
 		return nil, err

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -318,6 +318,7 @@ func (c *gceCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]f
 	var ingresses []fi.ApiIngressStatus
 
 	klog.V(2).Infof("Querying GCE to find forwardingRules for API")
+	region := c.region // TODO: tweak this when LoadBalancerClass for GCE is global
 	// These are the ingress rules, so we search for them in the network project.
 	_, project, err := ParseNameAndProjectFromNetworkID(cluster.Spec.Networking.NetworkID)
 	if err != nil {
@@ -326,7 +327,7 @@ func (c *gceCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]f
 		project = c.Project()
 	}
 
-	forwardingRules, err := c.compute.ForwardingRules().List(context.Background(), project, c.region)
+	forwardingRules, err := c.compute.ForwardingRules().List(context.Background(), project, region)
 	if err != nil {
 		if !IsNotFound(err) {
 			forwardingRules = nil

--- a/upup/pkg/fi/cloudup/gcetasks/backend_service.go
+++ b/upup/pkg/fi/cloudup/gcetasks/backend_service.go
@@ -35,6 +35,7 @@ type BackendService struct {
 	HealthChecks          []*HealthCheck
 	LoadBalancingScheme   *string
 	Protocol              *string
+	Region                string
 	InstanceGroupManagers []*InstanceGroupManager
 
 	Lifecycle    fi.Lifecycle
@@ -48,7 +49,7 @@ func (e *BackendService) CompareWithID() *string {
 }
 
 func (e *BackendService) Find(c *fi.CloudupContext) (*BackendService, error) {
-	actual, err := e.find(c.T.Cloud.(gce.GCECloud))
+	actual, err := e.find(c.T.Cloud.(gce.GCECloud), e.Region)
 	if actual != nil && err == nil {
 		// Ignore system fields
 		actual.Lifecycle = e.Lifecycle
@@ -57,8 +58,8 @@ func (e *BackendService) Find(c *fi.CloudupContext) (*BackendService, error) {
 	return actual, err
 }
 
-func (e *BackendService) find(cloud gce.GCECloud) (*BackendService, error) {
-	r, err := cloud.Compute().RegionBackendServices().Get(cloud.Project(), cloud.Region(), *e.Name)
+func (e *BackendService) find(cloud gce.GCECloud, region string) (*BackendService, error) {
+	r, err := cloud.Compute().BackendServices().Get(cloud.Project(), e.Region, *e.Name)
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -107,7 +108,7 @@ func (_ *BackendService) RenderGCE(t *gce.GCEAPITarget, a, e, changes *BackendSe
 	cloud := t.Cloud
 	var hcs []string
 	for _, hc := range e.HealthChecks {
-		hcs = append(hcs, hc.URL(cloud))
+		hcs = append(hcs, hc.URL(cloud, e.Region))
 	}
 	var backends []*compute.Backend
 	for _, igm := range e.InstanceGroupManagers {
@@ -121,12 +122,13 @@ func (_ *BackendService) RenderGCE(t *gce.GCEAPITarget, a, e, changes *BackendSe
 		HealthChecks:        hcs,
 		LoadBalancingScheme: *e.LoadBalancingScheme,
 		Backends:            backends,
+		PortName:            "http",
 	}
 
 	if a == nil {
 		klog.V(2).Infof("Creating BackendService: %q", bs.Name)
 
-		op, err := cloud.Compute().RegionBackendServices().Insert(cloud.Project(), cloud.Region(), bs)
+		op, err := cloud.Compute().BackendServices().Insert(cloud.Project(), e.Region, bs)
 		if err != nil {
 			return fmt.Errorf("error creating backend service: %v", err)
 		}
@@ -141,7 +143,12 @@ func (_ *BackendService) RenderGCE(t *gce.GCEAPITarget, a, e, changes *BackendSe
 	return nil
 }
 
-func (a *BackendService) URL(cloud gce.GCECloud) string {
+func (a *BackendService) URL(cloud gce.GCECloud, region string) string {
+	if region == "" {
+		return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/backendServices/%s",
+			cloud.Project(),
+			*a.Name)
+	}
 	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/%s",
 		cloud.Project(),
 		cloud.Region(),
@@ -158,6 +165,7 @@ type terraformBackendService struct {
 	LoadBalancingScheme *string                    `cty:"load_balancing_scheme"`
 	Protocol            *string                    `cty:"protocol"`
 	Backend             []terraformBackend         `cty:"backend"`
+	Region              string                     `cty:"region"`
 }
 
 func (_ *BackendService) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *BackendService) error {
@@ -166,11 +174,7 @@ func (_ *BackendService) RenderTerraform(t *terraform.TerraformTarget, a, e, cha
 		LoadBalancingScheme: e.LoadBalancingScheme,
 		Protocol:            e.Protocol,
 	}
-	// Terraform has a different name for this scheme:
-	if tf.LoadBalancingScheme != nil && *tf.LoadBalancingScheme == "INTERNAL" {
-		sm := "INTERNAL_SELF_MANAGED"
-		tf.LoadBalancingScheme = &sm
-	}
+
 	var igms []terraformBackend
 	for _, ig := range e.InstanceGroupManagers {
 		igms = append(igms, terraformBackend{
@@ -181,15 +185,25 @@ func (_ *BackendService) RenderTerraform(t *terraform.TerraformTarget, a, e, cha
 
 	var hcs []*terraformWriter.Literal
 	for _, hc := range e.HealthChecks {
-		hcs = append(hcs, terraformWriter.LiteralProperty("google_compute_health_check", *hc.Name, "id"))
+		if e.Region == "" {
+			hcs = append(hcs, terraformWriter.LiteralProperty("google_compute_health_check", *hc.Name, "id"))
+
+		} else {
+			hcs = append(hcs, terraformWriter.LiteralProperty("google_compute_region_health_check", *hc.Name, "id"))
+		}
 	}
 	tf.HealthChecks = hcs
-
-	return t.RenderResource("google_compute_backend_service", *e.Name, tf)
+	if e.Region == "" {
+		return t.RenderResource("google_compute_backend_service", *e.Name, tf)
+	}
+	tf.Region = e.Region
+	return t.RenderResource("google_compute_region_backend_service", *e.Name, tf)
 }
 
 func (e *BackendService) TerraformAddress() *terraformWriter.Literal {
 	name := fi.ValueOf(e.Name)
-
-	return terraformWriter.LiteralProperty("google_compute_backend_service", name, "id")
+	if e.Region == "" {
+		return terraformWriter.LiteralProperty("google_compute_backend_service", name, "id")
+	}
+	return terraformWriter.LiteralProperty("google_compute_region_backend_service", name, "id")
 }

--- a/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
+++ b/upup/pkg/fi/cloudup/gcetasks/healthcheck.go
@@ -33,9 +33,11 @@ import (
 // and HTTPSHealthCheck.  Those HCs are still needed for some types, so both
 // are implemented in kops, but this one should be preferred when possible.
 type HealthCheck struct {
-	Name      *string
-	Port      int64
-	Lifecycle fi.Lifecycle
+	Name        *string
+	Port        *int64
+	Lifecycle   fi.Lifecycle
+	Region      string
+	RequestPath *string
 }
 
 var _ fi.CompareWithID = &HealthCheck{}
@@ -53,15 +55,21 @@ func (e *HealthCheck) Find(c *fi.CloudupContext) (*HealthCheck, error) {
 	return actual, err
 }
 
-func (e *HealthCheck) URL(cloud gce.GCECloud) string {
+func (e *HealthCheck) URL(cloud gce.GCECloud, region string) string {
+	if region == "" {
+		return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/healthChecks/%s",
+			cloud.Project(),
+			*e.Name)
+	}
+
 	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/healthChecks/%s",
 		cloud.Project(),
-		cloud.Region(),
+		e.Region,
 		*e.Name)
 }
 
 func (e *HealthCheck) find(cloud gce.GCECloud) (*HealthCheck, error) {
-	r, err := cloud.Compute().RegionHealthChecks().Get(cloud.Project(), cloud.Region(), *e.Name)
+	r, err := cloud.Compute().HealthChecks().Get(cloud.Project(), e.Region, *e.Name)
 	if err != nil {
 		if gce.IsNotFound(err) {
 			return nil, nil
@@ -72,9 +80,6 @@ func (e *HealthCheck) find(cloud gce.GCECloud) (*HealthCheck, error) {
 
 	actual := &HealthCheck{}
 	actual.Name = &r.Name
-	if r.TcpHealthCheck != nil {
-		actual.Port = r.TcpHealthCheck.Port
-	}
 
 	return actual, nil
 }
@@ -83,7 +88,7 @@ func (e *HealthCheck) Run(c *fi.CloudupContext) error {
 	return fi.CloudupDefaultDeltaRunMethod(e, c)
 }
 
-func (_ *HealthCheck) CheckChanges(a, e, changes *HealthCheck) error {
+func (*HealthCheck) CheckChanges(a, e, changes *HealthCheck) error {
 	if a != nil {
 		if changes.Name != nil {
 			return fi.CannotChangeField("Name")
@@ -95,22 +100,21 @@ func (_ *HealthCheck) CheckChanges(a, e, changes *HealthCheck) error {
 	return nil
 }
 
-func (_ *HealthCheck) RenderGCE(t *gce.GCEAPITarget, a, e, changes *HealthCheck) error {
+func (*HealthCheck) RenderGCE(t *gce.GCEAPITarget, a, e, changes *HealthCheck) error {
 	cloud := t.Cloud
 	hc := &compute.HealthCheck{
 		Name: *e.Name,
-		TcpHealthCheck: &compute.TCPHealthCheck{
-			Port: e.Port,
+		HttpHealthCheck: &compute.HTTPHealthCheck{
+			Port:        fi.ValueOf(e.Port),
+			RequestPath: fi.ValueOf(e.RequestPath),
 		},
-		Type: "TCP",
-
-		Region: cloud.Region(),
+		Type: "HTTP",
 	}
 
 	if a == nil {
 		klog.V(2).Infof("Creating HealthCheck %q", hc.Name)
 
-		op, err := cloud.Compute().RegionHealthChecks().Insert(cloud.Project(), cloud.Region(), hc)
+		op, err := cloud.Compute().HealthChecks().Insert(cloud.Project(), e.Region, hc)
 		if err != nil {
 			return fmt.Errorf("error creating healthcheck: %v", err)
 		}
@@ -125,25 +129,35 @@ func (_ *HealthCheck) RenderGCE(t *gce.GCEAPITarget, a, e, changes *HealthCheck)
 	return nil
 }
 
-type terraformTCPBlock struct {
-	Port int64 `cty:"port"`
+type terraformHTTPBlock struct {
+	Port        int64  `cty:"port"`
+	RequestPath string `cty:"request_path"`
 }
 
 type terraformHealthCheck struct {
-	Name           string            `cty:"name"`
-	TCPHealthCheck terraformTCPBlock `cty:"tcp_health_check"`
+	Name            string             `cty:"name"`
+	Region          string             `cty:"region"`
+	HTTPHealthCheck terraformHTTPBlock `cty:"http_health_check"`
 }
 
-func (_ *HealthCheck) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *HealthCheck) error {
+func (*HealthCheck) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *HealthCheck) error {
 	tf := &terraformHealthCheck{
 		Name: *e.Name,
-		TCPHealthCheck: terraformTCPBlock{
-			Port: e.Port,
+		HTTPHealthCheck: terraformHTTPBlock{
+			Port:        fi.ValueOf(e.Port),
+			RequestPath: fi.ValueOf(e.RequestPath),
 		},
 	}
-	return t.RenderResource("google_compute_health_check", *e.Name, tf)
+	if e.Region == "" {
+		return t.RenderResource("google_compute_health_check", *e.Name, tf)
+	}
+	tf.Region = e.Region
+	return t.RenderResource("google_compute_region_health_check", *e.Name, tf)
 }
 
 func (e *HealthCheck) TerraformAddress() *terraformWriter.Literal {
+	if e.Region == "" {
+		return terraformWriter.LiteralProperty("google_compute_region_health_check", *e.Name, "id")
+	}
 	return terraformWriter.LiteralProperty("google_compute_health_check", *e.Name, "id")
 }


### PR DESCRIPTION
Google splits some services in to regional vs global with identical object types. I fixed the methods to detect if a region is being supplied.

Required for:
- #16233 
- https://github.com/kubernetes/kops/pull/16249

Also, we don't have an e2e test for gce internal only clusters :( bit tricky to set one up.

/cc @justinsb @hakman 
