### PR TITLE
Skip known-failing test on most e2e jobs

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -141,6 +141,14 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|should.verify.that.all.nodes.have.volume.limits"
 	}
 
+	if k8sVersion.Minor < 28 && cluster.Spec.LegacyCloudProvider == "aws" {
+		// This test fails on RHEL-based distros because they return fully qualified hostnames yet the k8s node names are not fully qualified.
+		// Keeping this unskipped in k8s 1.28 so we can still get signal without causing all grid jobs to fail.
+		// ref: https://github.com/kubernetes/kops/issues/16349
+		// ref: https://github.com/kubernetes/kubernetes/issues/123255
+		skipRegex += "|Services.should.function.for.service.endpoints.using.hostNetwork"
+	}
+
 	if cluster.Spec.CloudConfig != nil && cluster.Spec.CloudConfig.AWSEBSCSIDriver != nil && fi.ValueOf(cluster.Spec.CloudConfig.AWSEBSCSIDriver.Enabled) {
 		skipRegex += "|In-tree.Volumes.\\[Driver:.aws\\]"
 	}

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/apis/kops/v1alpha2"
 	"k8s.io/kops/upup/pkg/fi"
-	"k8s.io/kops/upup/pkg/fi/utils"
 )
 
 const (
@@ -125,23 +124,13 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|In-tree.Volumes.\\[Driver:.gcepd\\].*topology.should.provision.a.volume.and.schedule.a.pod.with.AllowedTopologies"
 	}
 
-	if cluster.Spec.LegacyCloudProvider == "gce" || k8sVersion.Minor <= 23 {
+	if cluster.Spec.LegacyCloudProvider == "gce" {
 		// this tests assumes a custom config for containerd:
 		// https://github.com/kubernetes/test-infra/blob/578d86a7be187214be6ccd60e6ea7317b51aeb15/jobs/e2e_node/containerd/config.toml#L19-L21
 		// ref: https://github.com/kubernetes/kubernetes/pull/104803
 		skipRegex += "|RuntimeClass.should.run"
 		// https://github.com/kubernetes/kubernetes/pull/108694
 		skipRegex += "|Metadata.Concealment"
-	}
-
-	if k8sVersion.Minor == 23 && cluster.Spec.LegacyCloudProvider == "aws" && utils.IsIPv6CIDR(cluster.Spec.NonMasqueradeCIDR) {
-		// ref: https://github.com/kubernetes/kubernetes/pull/106992
-		skipRegex += "|should.not.disrupt.a.cloud.load-balancer.s.connectivity.during.rollout"
-	}
-
-	if k8sVersion.Minor == 23 {
-		// beta feature not enabled by default
-		skipRegex += "|Topology.Hints"
 	}
 
 	if k8sVersion.Minor >= 22 {


### PR DESCRIPTION
skipping test due to https://github.com/kubernetes/kops/issues/16349. We're not skipping it in _all_ jobs so that we can still get signal on it in a subset of jobs without dealing with hundreds of failing prow jobs. We also dont have an easy way to only skip for certain distros so we're skipping it for all distros. The easiest way to skip per-distro would be in test-infra's build_jobs.py but this would override all the other behavior in skip_regex.go.

Almost all of these jobs are failing due to this test:
```
curl -SsL https://storage.googleapis.com/k8s-metrics/failures-latest.json | grep -c kops
193
```

Also removing some regexes from old k8s versions we no longer test.

/cc @hakman