### PR TITLE
doc/aws: Add space before the k8s slack url

### DIFF
--- a/docs/getting_started/aws.md
+++ b/docs/getting_started/aws.md
@@ -435,7 +435,7 @@ Now that you have a working kOps cluster, read through the [recommendations for 
 
 There's an incredible team behind kOps and we encourage you to reach out to the
 community on the Kubernetes
-Slack(<http://slack.k8s.io/>).  Bring your
+Slack (<http://slack.k8s.io/>).  Bring your
 questions, comments, and requests and meet the people behind the project!
 
 ## Legal


### PR DESCRIPTION
Minor updates in [docs/getting_started/aws.md](https://github.com/tungbq/kops/blob/master/docs/getting_started/aws.md) by adding a space before the opening parenthesis in "Slack(http://slack.k8s.io/)"

**Current view:**
https://kops.sigs.k8s.io/getting_started/aws/#feedback
![image](https://github.com/kubernetes/kops/assets/85242618/c600a5a3-6acc-4408-ba9b-5242d6311aad)

**New change from this PR:**
![image](https://github.com/kubernetes/kops/assets/85242618/37a61432-e296-4909-a264-0550d180ae49)
