### PR TITLE
Migrate many-addons e2e template to dns=none

### DIFF
--- a/tests/e2e/templates/many-addons.yaml.tmpl
+++ b/tests/e2e/templates/many-addons.yaml.tmpl
@@ -3,6 +3,10 @@ kind: Cluster
 metadata:
   name: {{.clusterName}}
 spec:
+  api:
+    loadBalancer:
+      class: Network
+      type: Public
   awsLoadBalancerController:
     enabled: true
   kubernetesApiAccess:
@@ -62,6 +66,9 @@ spec:
   {{end}}
   rollingUpdate:
     maxSurge: "100%"
+  topology:
+    dns:
+      type: None
 ---
 
 apiVersion: kops.k8s.io/v1alpha2


### PR DESCRIPTION
All of the many-addons upgrade jobs are failing: https://testgrid.k8s.io/kops-upgrades-many-addons

These prow jobs have been migrated to the new cluster and need to use dns=none since the dns zones are in the old cluster's account.

Diffing the working "not many-addons" jobs' [cluster manifest](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-kstable-kolatest-to-kci-kolatest/1760784773682302976/artifacts/cluster.yaml) which doesnt use an e2e template, vs the failing [cluster manifest](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-kstable-kolatest-to-kci-kolatest-many-addons/1760746520459612160/artifacts/cluster.yaml), shows these fields as the relevant differences. This updates them to match.