### PR TITLE
Skip hostname e2e test on digitalocean

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -107,7 +107,7 @@ func (t *Tester) setSkipRegexFlag() error {
 
 	if cluster.Spec.LegacyCloudProvider == "digitalocean" {
 		// https://github.com/kubernetes/kubernetes/issues/121018
-		skipRegex += "|Services.should.respect.internalTrafficPolicy=Local.Pod.and.Node,.to.Pod"
+		skipRegex += "|Services.should.respect.internalTrafficPolicy=Local.Pod.and.Node,.to.Pod|Services.should.function.for.service.endpoints.using.hostNetwork"
 	}
 
 	if cluster.Spec.LegacyCloudProvider == "gce" {


### PR DESCRIPTION
Followup to https://github.com/kubernetes/kops/pull/16373

https://testgrid.k8s.io/kops-misc#e2e-kops-do-calico-fqdn

These DO jobs are also failing the test for the same reason, so skip them for now.
