### PR TITLE
gce: Limit health check names to 63 chars

### DIFF
--- a/pkg/model/gcemodel/context.go
+++ b/pkg/model/gcemodel/context.go
@@ -101,7 +101,7 @@ func (c *GCEModelContext) NameForTargetPool(id string) string {
 }
 
 func (c *GCEModelContext) NameForHealthCheck(id string) string {
-	return c.SafeObjectName(id)
+	return c.SafeSuffixedObjectName(id)
 }
 
 func (c *GCEModelContext) NameForBackendService(id string) string {

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -189,7 +189,7 @@ resource "google_compute_backend_service" "api-minimal-gce-with-a-very-very-very
   backend {
     group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f.instance_group
   }
-  health_checks         = [google_compute_health_check.api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.id]
+  health_checks         = [google_compute_health_check.api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi.id]
   load_balancing_scheme = "INTERNAL_SELF_MANAGED"
   name                  = "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
   protocol              = "TCP"
@@ -447,8 +447,8 @@ resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-with-a-very-
   subnetwork            = google_compute_subnetwork.us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi.name
 }
 
-resource "google_compute_health_check" "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com" {
-  name = "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
+resource "google_compute_health_check" "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi" {
+  name = "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi"
   tcp_health_check {
     port = 443
   }


### PR DESCRIPTION
/cc @rifelpet @justinsb 

https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/16381/pull-kops-kubernetes-e2e-ubuntu-gce-build/1761600343730294784/build-log.txt
```
I0225 04:26:45.617246   84937 executor.go:171] Continuing to run 1 task(s)
I0225 04:26:55.617745   84937 executor.go:113] Tasks: 71 done / 75 total; 1 can run
W0225 04:26:55.643080   84937 executor.go:141] error running task "HealthCheck/api-e2e-pr16381-pull-kops-kubernetes-e2e-ubuntu-gce-build-k8s-local" (2m17s remaining to succeed): error listing Health Checks: googleapi: Error 400: Invalid value for field 'healthCheck': 'api-e2e-pr16381-pull-kops-kubernetes-e2e-ubuntu-gce-build-k8s-local'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}', invalid
```