### PR TITLE
gce: Limit backend names to 63 chars

### DIFF
--- a/pkg/model/gcemodel/context.go
+++ b/pkg/model/gcemodel/context.go
@@ -105,7 +105,7 @@ func (c *GCEModelContext) NameForHealthCheck(id string) string {
 }
 
 func (c *GCEModelContext) NameForBackendService(id string) string {
-	return c.SafeObjectName(id)
+	return c.SafeSuffixedObjectName(id)
 }
 
 func (c *GCEModelContext) NameForForwardingRule(id string) string {

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -185,13 +185,13 @@ resource "google_compute_address" "api-us-test1-minimal-gce-with-a-very-very-ver
   subnetwork   = google_compute_subnetwork.us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi.name
 }
 
-resource "google_compute_backend_service" "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com" {
+resource "google_compute_backend_service" "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi" {
   backend {
     group = google_compute_instance_group_manager.a-master-us-test1-a-minimal-gce-with-a-very-very-very-ve-j0fh8f.instance_group
   }
   health_checks         = [google_compute_health_check.api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi.id]
   load_balancing_scheme = "INTERNAL_SELF_MANAGED"
-  name                  = "api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
+  name                  = "api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi"
   protocol              = "TCP"
 }
 
@@ -433,7 +433,7 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-with-a-very
 }
 
 resource "google_compute_forwarding_rule" "api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi" {
-  backend_service = google_compute_backend_service.api-minimal-gce-with-a-very-very-very-very-very-long-name-example-com.id
+  backend_service = google_compute_backend_service.api-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi.id
   ip_address      = google_compute_address.api-us-test1-minimal-gce-with-a-very-very-very-very-very-96dqvi.address
   ip_protocol     = "TCP"
   labels = {


### PR DESCRIPTION
/cc @justinsb @rifelpet 

https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/16363/pull-kops-kubernetes-e2e-ubuntu-gce-build/1761774440057671680/build-log.txt
```
I0225 15:56:30.290869   85974 executor.go:171] Continuing to run 1 task(s)
I0225 15:56:40.291710   85974 executor.go:113] Tasks: 72 done / 75 total; 1 can run
W0225 15:56:40.361587   85974 executor.go:141] error running task "BackendService/api-e2e-pr16363-pull-kops-kubernetes-e2e-ubuntu-gce-build-k8s-local" (4m57s remaining to succeed): error listing Backend Services: googleapi: Error 400: Invalid value for field 'backendService': 'api-e2e-pr16363-pull-kops-kubernetes-e2e-ubuntu-gce-build-k8s-local'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}', invalid
```