### PR TITLE
Update NVIDIA Container Toolkit URL

### DIFF
--- a/nodeup/pkg/model/nvidia.go
+++ b/nodeup/pkg/model/nvidia.go
@@ -35,7 +35,7 @@ func (b *NvidiaBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 			Name:    "nvidia-container-toolkit",
 			Keyring: "https://nvidia.github.io/libnvidia-container/gpgkey",
 			Sources: []string{
-				"deb https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/$(ARCH) /",
+				"deb https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /",
 			},
 		})
 		c.AddTask(&nodetasks.Package{Name: "nvidia-container-toolkit"})


### PR DESCRIPTION
The NVIDIA Container Toolkit packaging has been simplified to produce a single deb (or rpm) package. This means that the URL is no longer distribution dependent and the stable/deb repository path is used instead.

See https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installing-with-apt