### PR TITLE
Continue attemps to dump artifacts in `toolbox dump`

### DIFF
--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -232,7 +232,7 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 		}
 
 		if err := dumper.DumpAllNodes(ctx, nodes, options.MaxNodes, additionalIPs, additionalPrivateIPs); err != nil {
-			return fmt.Errorf("error dumping nodes: %v", err)
+			klog.Warningf("error dumping nodes: %v", err)
 		}
 
 		if kubeConfig != nil && options.K8sResources {
@@ -241,7 +241,7 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 				return fmt.Errorf("error creating resource dumper: %w", err)
 			}
 			if err := dumper.DumpResources(ctx); err != nil {
-				return fmt.Errorf("error dumping resources: %w", err)
+				klog.Warningf("error dumping resources: %v", err)
 			}
 
 			logDumper, err := dump.NewPodLogDumper(kubeConfig, options.Dir)
@@ -249,7 +249,7 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 				return fmt.Errorf("error creating pod log dumper: %w", err)
 			}
 			if err := logDumper.DumpLogs(ctx); err != nil {
-				return fmt.Errorf("error dumping pod logs: %w", err)
+				klog.Warningf("error dumping pod logs: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
This way if one of the earlier methods fails, we can still get some artifacts from the later methods

Should help with troubleshooting this e2e failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-aws-load-balancer-controller/1762834387029725184


```
I0228 14:03:05.653189   14058 dumplogs.go:51] /tmp/kops.bVBE86uZS toolbox dump --name e2e-4342699135-9b4dd.tests-kops-aws.k8s.io --dir /logs/artifacts --private-key /tmp/kops/e2e-4342699135-9b4dd.tests-kops-aws.k8s.io/id_ed25519 --ssh-user ubuntu
W0228 14:03:45.930637   14081 toolbox_dump.go:181] error listing nodes in cluster: Get "https://api-e2e-4342699135-9b4dd--6fmnhp-2386d72d5d112597.elb.eu-west-1.amazonaws.com/api/v1/nodes": dial tcp 54.195.97.121:443: i/o timeout
2024/02/28 14:03:45 starting to dump 0 nodes fetched through the Kubernetes APIs
I0228 14:03:45.930778   14081 resourcedumper.go:91] Dumping k8s resources
Error: error dumping resources: listing namespaces: Get "https://api-e2e-4342699135-9b4dd--6fmnhp-2386d72d5d112597.elb.eu-west-1.amazonaws.com/api/v1/namespaces": dial tcp 3.248.101.43:443: i/o timeout
W0228 14:04:15.935630   14058 dumplogs.go:59] kops toolbox dump failed: exit status 1
```