### PR TITLE
e2e tests: When upgrading, wait for the new configuration

### DIFF
--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -132,6 +132,9 @@ kubectl get nodes -owide --kubeconfig "${KUBECONFIG_A}"
 # Sleep to ensure channels has done its thing
 sleep 120s
 
+# Make sure configuration B has been applied (e.g. new load balancer is ready)
+"${KOPS_B}" validate cluster --wait=10m
+
 ${CHANNELS} apply channel "$KOPS_STATE_STORE"/"${CLUSTER_NAME}"/addons/bootstrap-channel.yaml --yes -v4
 
 "${KOPS_B}" rolling-update cluster


### PR DESCRIPTION
In our upgrade-ab tests, we might be making non-trivial cloud
infrastructure changes, such as waiting for a new load balancer.

Add a `kops validate cluster` step to wait for those changes to be
applied.
