### PR TITLE
Automated cherry pick of #16174: Bump metrics-server to 0.6.4

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: d6501f6f54c0481b0016afb0abfababc0796b9831d101691e9defc38adc2a3b2
+    manifestHash: 2a581e64f6b6655b7108a06a668e37dcf1140c426faa66a9e76369519ba54e11
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -173,7 +173,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: d6501f6f54c0481b0016afb0abfababc0796b9831d101691e9defc38adc2a3b2
+    manifestHash: 2a581e64f6b6655b7108a06a668e37dcf1140c426faa66a9e76369519ba54e11
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -173,7 +173,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: d6501f6f54c0481b0016afb0abfababc0796b9831d101691e9defc38adc2a3b2
+    manifestHash: 2a581e64f6b6655b7108a06a668e37dcf1140c426faa66a9e76369519ba54e11
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -173,7 +173,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: d6501f6f54c0481b0016afb0abfababc0796b9831d101691e9defc38adc2a3b2
+    manifestHash: 2a581e64f6b6655b7108a06a668e37dcf1140c426faa66a9e76369519ba54e11
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -173,7 +173,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: d6501f6f54c0481b0016afb0abfababc0796b9831d101691e9defc38adc2a3b2
+    manifestHash: 2a581e64f6b6655b7108a06a668e37dcf1140c426faa66a9e76369519ba54e11
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -173,7 +173,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: d6501f6f54c0481b0016afb0abfababc0796b9831d101691e9defc38adc2a3b2
+    manifestHash: 2a581e64f6b6655b7108a06a668e37dcf1140c426faa66a9e76369519ba54e11
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -173,7 +173,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 1d5b0034bc9bda796cedeb26e0b4892939562a7919e17fa319f38a5069a6f9fb
+    manifestHash: bc9afaa3bbf77cb6be3666cf2d048f21bed0003987ba01b75e5804703039aee9
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -173,7 +173,7 @@ spec:
         - --kubelet-preferred-address-types=InternalIP
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: d6501f6f54c0481b0016afb0abfababc0796b9831d101691e9defc38adc2a3b2
+    manifestHash: 2a581e64f6b6655b7108a06a668e37dcf1140c426faa66a9e76369519ba54e11
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -173,7 +173,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -142,7 +142,7 @@ spec:
 {{ if WithDefaultBool .MetricsServer.Insecure true }}
           - --kubelet-insecure-tls
 {{ end }}
-        image: {{ or .MetricsServer.Image "registry.k8s.io/metrics-server/metrics-server:v0.6.2" }}
+        image: {{ or .MetricsServer.Image "registry.k8s.io/metrics-server/metrics-server:v0.6.4" }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 0313211d108d06b2332842135605cc774e5742dad7830fd68c708783e7df0e0a
+    manifestHash: 2a581e64f6b6655b7108a06a668e37dcf1140c426faa66a9e76369519ba54e11
     name: metrics-server.addons.k8s.io
     selector:
       k8s-app: metrics-server

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 2a581e64f6b6655b7108a06a668e37dcf1140c426faa66a9e76369519ba54e11
+    manifestHash: 63c63e31b9463ea1214e6d8784cf55af7c53f70da79ddadf3191830b11fa05a9
     name: metrics-server.addons.k8s.io
     selector:
       k8s-app: metrics-server

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -173,7 +173,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: c9046814cac007371319981f6521e43eefd7a9322d2a75247553b2bbb1dcfb9d
+    manifestHash: ff1fbf2db53502bc8e6f9a22a27941e07cac6fe8f6a5af31f9f24ee04536f50d
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 792148f10c61db4ea85ec7765b2e612d7d70edbb20c596ee0f06d010262dbf9f
+    manifestHash: c9046814cac007371319981f6521e43eefd7a9322d2a75247553b2bbb1dcfb9d
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -173,7 +173,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --tls-cert-file=/srv/tls.crt
         - --tls-private-key-file=/srv/tls.key
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
Cherry pick of #16174 on release-1.28.

#16174: Bump metrics-server to 0.6.4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```