### PR TITLE
Automated cherry pick of #16410: upgraded cert-manager to 1.12.9

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -2869,7 +2869,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -8262,7 +8262,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -8511,7 +8511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 
@@ -8547,7 +8547,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8565,7 +8565,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -8655,7 +8655,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -8706,7 +8706,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -8757,7 +8757,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -8902,7 +8902,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -9012,7 +9012,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -9125,7 +9125,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -9173,7 +9173,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -9199,7 +9199,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -9270,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9294,7 +9294,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9318,7 +9318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9342,7 +9342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9366,7 +9366,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9390,7 +9390,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9414,7 +9414,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9462,7 +9462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9486,7 +9486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9511,7 +9511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -9546,7 +9546,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -9580,7 +9580,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -9640,7 +9640,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -9666,7 +9666,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9720,7 +9720,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9748,7 +9748,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -9766,7 +9766,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9788,7 +9788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.12.7
+        image: quay.io/jetstack/cert-manager-cainjector:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         securityContext:
@@ -9822,7 +9822,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9844,7 +9844,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9862,7 +9862,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -9870,7 +9870,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.12.7
+        image: quay.io/jetstack/cert-manager-controller:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
         ports:
@@ -9911,7 +9911,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9929,7 +9929,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9956,7 +9956,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.12.7
+        image: quay.io/jetstack/cert-manager-webhook:v1.12.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10019,7 +10019,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -10061,7 +10061,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -2869,7 +2869,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -8262,7 +8262,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -8511,7 +8511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 
@@ -8547,7 +8547,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8565,7 +8565,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -8655,7 +8655,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -8706,7 +8706,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -8757,7 +8757,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -8902,7 +8902,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -9012,7 +9012,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -9125,7 +9125,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -9173,7 +9173,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -9199,7 +9199,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -9270,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9294,7 +9294,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9318,7 +9318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9342,7 +9342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9366,7 +9366,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9390,7 +9390,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9414,7 +9414,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9462,7 +9462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9486,7 +9486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9511,7 +9511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -9546,7 +9546,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -9580,7 +9580,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -9640,7 +9640,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -9666,7 +9666,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9720,7 +9720,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9748,7 +9748,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -9766,7 +9766,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9788,7 +9788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.12.7
+        image: quay.io/jetstack/cert-manager-cainjector:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         securityContext:
@@ -9822,7 +9822,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9844,7 +9844,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9862,7 +9862,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -9870,7 +9870,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.12.7
+        image: quay.io/jetstack/cert-manager-controller:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
         ports:
@@ -9911,7 +9911,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9929,7 +9929,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9956,7 +9956,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.12.7
+        image: quay.io/jetstack/cert-manager-webhook:v1.12.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10019,7 +10019,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -10061,7 +10061,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -2869,7 +2869,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -8262,7 +8262,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -8511,7 +8511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 
@@ -8547,7 +8547,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8565,7 +8565,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -8655,7 +8655,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -8706,7 +8706,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -8757,7 +8757,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -8902,7 +8902,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -9012,7 +9012,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -9125,7 +9125,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -9173,7 +9173,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -9199,7 +9199,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -9270,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9294,7 +9294,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9318,7 +9318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9342,7 +9342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9366,7 +9366,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9390,7 +9390,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9414,7 +9414,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9462,7 +9462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9486,7 +9486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9511,7 +9511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -9546,7 +9546,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -9580,7 +9580,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -9640,7 +9640,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -9666,7 +9666,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9720,7 +9720,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9748,7 +9748,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -9766,7 +9766,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9788,7 +9788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.12.7
+        image: quay.io/jetstack/cert-manager-cainjector:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         securityContext:
@@ -9822,7 +9822,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9844,7 +9844,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9862,7 +9862,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -9870,7 +9870,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.12.7
+        image: quay.io/jetstack/cert-manager-controller:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
         ports:
@@ -9911,7 +9911,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9929,7 +9929,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9956,7 +9956,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.12.7
+        image: quay.io/jetstack/cert-manager-webhook:v1.12.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10019,7 +10019,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -10061,7 +10061,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -63,7 +63,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -2869,7 +2869,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -8262,7 +8262,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -8511,7 +8511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 
@@ -8547,7 +8547,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8565,7 +8565,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -8655,7 +8655,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -8706,7 +8706,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -8757,7 +8757,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -8902,7 +8902,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -9012,7 +9012,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -9125,7 +9125,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -9173,7 +9173,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -9199,7 +9199,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -9270,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9294,7 +9294,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9318,7 +9318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9342,7 +9342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9366,7 +9366,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9390,7 +9390,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9414,7 +9414,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9462,7 +9462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9486,7 +9486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9511,7 +9511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -9546,7 +9546,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -9580,7 +9580,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -9640,7 +9640,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -9666,7 +9666,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9720,7 +9720,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9748,7 +9748,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -9766,7 +9766,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9788,7 +9788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.12.7
+        image: quay.io/jetstack/cert-manager-cainjector:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         securityContext:
@@ -9822,7 +9822,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9844,7 +9844,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9862,7 +9862,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -9870,7 +9870,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.12.7
+        image: quay.io/jetstack/cert-manager-controller:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
         ports:
@@ -9911,7 +9911,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9929,7 +9929,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9956,7 +9956,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.12.7
+        image: quay.io/jetstack/cert-manager-webhook:v1.12.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10019,7 +10019,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -10061,7 +10061,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -63,7 +63,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -2869,7 +2869,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -8262,7 +8262,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -8511,7 +8511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 
@@ -8547,7 +8547,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8565,7 +8565,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -8655,7 +8655,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -8706,7 +8706,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -8757,7 +8757,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -8902,7 +8902,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -9012,7 +9012,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -9125,7 +9125,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -9173,7 +9173,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -9199,7 +9199,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -9270,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9294,7 +9294,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9318,7 +9318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9342,7 +9342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9366,7 +9366,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9390,7 +9390,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9414,7 +9414,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9462,7 +9462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9486,7 +9486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9511,7 +9511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -9546,7 +9546,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -9580,7 +9580,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -9640,7 +9640,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -9666,7 +9666,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9720,7 +9720,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9748,7 +9748,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -9766,7 +9766,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9788,7 +9788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.12.7
+        image: quay.io/jetstack/cert-manager-cainjector:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         securityContext:
@@ -9822,7 +9822,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9844,7 +9844,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9862,7 +9862,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -9870,7 +9870,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.12.7
+        image: quay.io/jetstack/cert-manager-controller:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
         ports:
@@ -9911,7 +9911,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9929,7 +9929,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9956,7 +9956,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.12.7
+        image: quay.io/jetstack/cert-manager-webhook:v1.12.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10019,7 +10019,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -10061,7 +10061,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -63,7 +63,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -2869,7 +2869,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -8262,7 +8262,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -8511,7 +8511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 
@@ -8547,7 +8547,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8565,7 +8565,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -8655,7 +8655,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -8706,7 +8706,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -8757,7 +8757,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -8902,7 +8902,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -9012,7 +9012,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -9125,7 +9125,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -9173,7 +9173,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -9199,7 +9199,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -9270,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9294,7 +9294,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9318,7 +9318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9342,7 +9342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9366,7 +9366,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9390,7 +9390,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9414,7 +9414,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9462,7 +9462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9486,7 +9486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9511,7 +9511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -9546,7 +9546,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -9580,7 +9580,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -9640,7 +9640,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -9666,7 +9666,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9720,7 +9720,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9748,7 +9748,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -9766,7 +9766,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9788,7 +9788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.12.7
+        image: quay.io/jetstack/cert-manager-cainjector:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         securityContext:
@@ -9822,7 +9822,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9844,7 +9844,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9862,7 +9862,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -9870,7 +9870,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.12.7
+        image: quay.io/jetstack/cert-manager-controller:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
         ports:
@@ -9911,7 +9911,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9929,7 +9929,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9956,7 +9956,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.12.7
+        image: quay.io/jetstack/cert-manager-webhook:v1.12.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10019,7 +10019,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -10061,7 +10061,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -64,7 +64,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -2869,7 +2869,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -8262,7 +8262,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -8511,7 +8511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 
@@ -8547,7 +8547,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8565,7 +8565,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -8655,7 +8655,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -8706,7 +8706,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -8757,7 +8757,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -8902,7 +8902,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -9012,7 +9012,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -9125,7 +9125,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -9173,7 +9173,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -9199,7 +9199,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -9270,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9294,7 +9294,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9318,7 +9318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9342,7 +9342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9366,7 +9366,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9390,7 +9390,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9414,7 +9414,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9462,7 +9462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9486,7 +9486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9511,7 +9511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -9546,7 +9546,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -9580,7 +9580,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -9640,7 +9640,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -9666,7 +9666,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9720,7 +9720,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9748,7 +9748,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -9766,7 +9766,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9788,7 +9788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.12.7
+        image: quay.io/jetstack/cert-manager-cainjector:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         securityContext:
@@ -9822,7 +9822,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9844,7 +9844,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9862,7 +9862,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -9870,7 +9870,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.12.7
+        image: quay.io/jetstack/cert-manager-controller:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
         ports:
@@ -9911,7 +9911,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9929,7 +9929,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9956,7 +9956,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.12.7
+        image: quay.io/jetstack/cert-manager-webhook:v1.12.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10019,7 +10019,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -10061,7 +10061,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -2869,7 +2869,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -8262,7 +8262,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -8511,7 +8511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 
@@ -8547,7 +8547,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8565,7 +8565,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -8655,7 +8655,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -8706,7 +8706,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -8757,7 +8757,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -8902,7 +8902,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -9012,7 +9012,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -9125,7 +9125,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -9173,7 +9173,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -9199,7 +9199,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -9270,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9294,7 +9294,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9318,7 +9318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9342,7 +9342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9366,7 +9366,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9390,7 +9390,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9414,7 +9414,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9462,7 +9462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9486,7 +9486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9511,7 +9511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -9546,7 +9546,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -9580,7 +9580,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -9640,7 +9640,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -9666,7 +9666,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9720,7 +9720,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9748,7 +9748,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -9766,7 +9766,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9788,7 +9788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.12.7
+        image: quay.io/jetstack/cert-manager-cainjector:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         securityContext:
@@ -9822,7 +9822,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9844,7 +9844,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9862,7 +9862,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -9870,7 +9870,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.12.7
+        image: quay.io/jetstack/cert-manager-controller:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
         ports:
@@ -9911,7 +9911,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9929,7 +9929,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9956,7 +9956,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.12.7
+        image: quay.io/jetstack/cert-manager-webhook:v1.12.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10019,7 +10019,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -10061,7 +10061,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -2869,7 +2869,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -8262,7 +8262,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -8511,7 +8511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 
@@ -8547,7 +8547,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8565,7 +8565,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -8655,7 +8655,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -8706,7 +8706,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -8757,7 +8757,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -8902,7 +8902,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -9012,7 +9012,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -9125,7 +9125,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -9173,7 +9173,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -9199,7 +9199,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -9270,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9294,7 +9294,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9318,7 +9318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9342,7 +9342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9366,7 +9366,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9390,7 +9390,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9414,7 +9414,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9462,7 +9462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9486,7 +9486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9511,7 +9511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -9546,7 +9546,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -9580,7 +9580,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -9640,7 +9640,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -9666,7 +9666,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9720,7 +9720,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9748,7 +9748,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -9766,7 +9766,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9788,7 +9788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.12.7
+        image: quay.io/jetstack/cert-manager-cainjector:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         securityContext:
@@ -9822,7 +9822,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9844,7 +9844,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9862,7 +9862,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -9870,7 +9870,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.12.7
+        image: quay.io/jetstack/cert-manager-controller:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
         ports:
@@ -9911,7 +9911,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9929,7 +9929,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9956,7 +9956,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.12.7
+        image: quay.io/jetstack/cert-manager-webhook:v1.12.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10019,7 +10019,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -10061,7 +10061,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -2869,7 +2869,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -8262,7 +8262,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -8511,7 +8511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 
@@ -8547,7 +8547,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8565,7 +8565,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -8655,7 +8655,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -8706,7 +8706,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -8757,7 +8757,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -8902,7 +8902,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -9012,7 +9012,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -9125,7 +9125,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -9173,7 +9173,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -9199,7 +9199,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -9270,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9294,7 +9294,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9318,7 +9318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9342,7 +9342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9366,7 +9366,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9390,7 +9390,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9414,7 +9414,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9462,7 +9462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9486,7 +9486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9511,7 +9511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -9546,7 +9546,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -9580,7 +9580,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -9640,7 +9640,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -9666,7 +9666,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9720,7 +9720,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9748,7 +9748,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -9766,7 +9766,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9788,7 +9788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.12.7
+        image: quay.io/jetstack/cert-manager-cainjector:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         securityContext:
@@ -9822,7 +9822,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9844,7 +9844,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9862,7 +9862,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -9870,7 +9870,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.12.7
+        image: quay.io/jetstack/cert-manager-controller:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
         ports:
@@ -9911,7 +9911,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9929,7 +9929,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9956,7 +9956,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.12.7
+        image: quay.io/jetstack/cert-manager-webhook:v1.12.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10019,7 +10019,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -10061,7 +10061,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-certmanager.io-k8s-1.16_content
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -2869,7 +2869,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -8262,7 +8262,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -8511,7 +8511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -8529,7 +8529,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 
@@ -8547,7 +8547,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8565,7 +8565,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -8655,7 +8655,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -8706,7 +8706,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -8757,7 +8757,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -8902,7 +8902,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -9012,7 +9012,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -9086,7 +9086,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -9125,7 +9125,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -9173,7 +9173,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -9199,7 +9199,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -9270,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9294,7 +9294,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9318,7 +9318,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9342,7 +9342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9366,7 +9366,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9390,7 +9390,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9414,7 +9414,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9462,7 +9462,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9486,7 +9486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9511,7 +9511,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -9546,7 +9546,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -9580,7 +9580,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -9640,7 +9640,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -9666,7 +9666,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -9692,7 +9692,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9720,7 +9720,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9748,7 +9748,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -9766,7 +9766,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9788,7 +9788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.12.7
+        image: quay.io/jetstack/cert-manager-cainjector:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-cainjector
         securityContext:
@@ -9822,7 +9822,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager
   namespace: kube-system
 spec:
@@ -9844,7 +9844,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9862,7 +9862,7 @@ spec:
         - --v=2
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
-        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+        - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
         - --max-concurrent-challenges=60
         - --enable-certificate-owner-ref=true
         env:
@@ -9870,7 +9870,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.12.7
+        image: quay.io/jetstack/cert-manager-controller:v1.12.9
         imagePullPolicy: IfNotPresent
         name: cert-manager-controller
         ports:
@@ -9911,7 +9911,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -9929,7 +9929,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.12.7
+        app.kubernetes.io/version: v1.12.9
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -9956,7 +9956,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.12.7
+        image: quay.io/jetstack/cert-manager-webhook:v1.12.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10019,7 +10019,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -10061,7 +10061,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.12.7
+    app.kubernetes.io/version: v1.12.9
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 spec:
   group: cert-manager.io
   names:
@@ -223,7 +223,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 spec:
   group: cert-manager.io
   names:
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 spec:
   group: acme.cert-manager.io
   names:
@@ -1674,7 +1674,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: "cert-manager"
     # Generated labels
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 spec:
   group: cert-manager.io
   names:
@@ -2994,7 +2994,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: "cert-manager"
     # Generated labels
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 spec:
   group: cert-manager.io
   names:
@@ -4314,7 +4314,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 spec:
   group: acme.cert-manager.io
   names:
@@ -4498,7 +4498,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 ---
 # Source: cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -4512,7 +4512,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 ---
 # Source: cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -4526,7 +4526,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 ---
 # Source: cert-manager/templates/webhook-config.yaml
 apiVersion: v1
@@ -4539,7 +4539,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 data:
 ---
 # Source: cert-manager/templates/cainjector-rbac.yaml
@@ -4552,7 +4552,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -4584,7 +4584,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -4610,7 +4610,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -4636,7 +4636,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -4671,7 +4671,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -4709,7 +4709,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -4769,7 +4769,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -4806,7 +4806,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -4828,7 +4828,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -4853,7 +4853,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -4873,7 +4873,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -4899,7 +4899,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -4915,7 +4915,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -4935,7 +4935,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -4955,7 +4955,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -4975,7 +4975,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -4995,7 +4995,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -5015,7 +5015,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -5035,7 +5035,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -5055,7 +5055,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -5075,7 +5075,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -5095,7 +5095,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -5118,7 +5118,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -5144,7 +5144,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -5165,7 +5165,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -5190,7 +5190,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -5213,7 +5213,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -5235,7 +5235,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -5257,7 +5257,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 spec:
   type: ClusterIP
   ports:
@@ -5281,7 +5281,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 spec:
   type: ClusterIP
   ports:
@@ -5305,7 +5305,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 spec:
   replicas: 1
   selector:
@@ -5320,7 +5320,7 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.12.7"
+        app.kubernetes.io/version: "v1.12.9"
     spec:
       nodeSelector: null
       affinity:
@@ -5346,7 +5346,7 @@ spec:
         operator: Exists
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.12.7"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.12.9"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -5373,7 +5373,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 spec:
   replicas: 1
   selector:
@@ -5388,7 +5388,7 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.12.7"
+        app.kubernetes.io/version: "v1.12.9"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -5426,13 +5426,13 @@ spec:
         operator: Exists
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.12.7"
+          image: "quay.io/jetstack/cert-manager-controller:v1.12.9"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.9
           - --max-concurrent-challenges=60
           - --enable-certificate-owner-ref=true
           {{ if .CertManager.DefaultIssuer }}
@@ -5469,7 +5469,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
 spec:
   replicas: 1
   selector:
@@ -5484,7 +5484,7 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.12.7"
+        app.kubernetes.io/version: "v1.12.9"
     spec:
       nodeSelector: null
       affinity:
@@ -5510,7 +5510,7 @@ spec:
         operator: Exists
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.12.7"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.12.9"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -5569,7 +5569,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
   annotations:
     cert-manager.io/inject-ca-from-secret: "kube-system/cert-manager-webhook-ca"
 webhooks:
@@ -5610,7 +5610,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.12.7"
+    app.kubernetes.io/version: "v1.12.9"
   annotations:
     cert-manager.io/inject-ca-from-secret: "kube-system/cert-manager-webhook-ca"
 webhooks:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 06cf576a2daaf783556d3160b8f19c529bba969f272cb220a896b5a062744a81
+    manifestHash: 7c710a540a37f00a03459eb669034e6233741d508248ae7b83c9305beec0287c
     name: certmanager.io
     prune:
       kinds:


### PR DESCRIPTION
Cherry pick of #16410 on release-1.28.

#16410: upgraded cert-manager to 1.12.9

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```