### PR TITLE
aws/cert-manager: Tighten IAM permissions for cert-manager

### DIFF
--- a/pkg/model/components/addonmanifests/certmanager/iam.go
+++ b/pkg/model/components/addonmanifests/certmanager/iam.go
@@ -56,11 +56,23 @@ func addCertManagerPermissions(b *iam.PolicyBuilder, p *iam.Policy) {
 	}
 
 	p.Statement = append(p.Statement, &iam.Statement{
-		Effect: iam.StatementEffectAllow,
-		Action: stringorset.Of("route53:ChangeResourceRecordSets",
-			"route53:ListResourceRecordSets",
-		),
+		Effect:   iam.StatementEffectAllow,
+		Action:   stringorset.Of("route53:ListResourceRecordSets"),
 		Resource: stringorset.Set(zoneResources),
+	})
+
+	p.Statement = append(p.Statement, &iam.Statement{
+		Effect:   iam.StatementEffectAllow,
+		Action:   stringorset.Of("route53:ChangeResourceRecordSets"),
+		Resource: stringorset.Set(zoneResources),
+		Condition: iam.Condition{
+			"ForAllValues:StringLike": map[string]interface{}{
+				"route53:ChangeResourceRecordSetsNormalizedRecordNames": []string{"_acme-challenge.*"},
+			},
+			"ForAllValues:StringEquals": map[string]interface{}{
+				"route53:ChangeResourceRecordSetsRecordTypes": []string{"TXT"},
+			},
+		},
 	})
 
 	p.Statement = append(p.Statement, &iam.Statement{


### PR DESCRIPTION
This change restricts which record types and domain prefixes cert-manager is allowed to change for DNS01 acme challenges.

Only `_acme-challenge.*` TXT records may be created/updated/removed.

Implements kubernetes/kops#15680

I ran `make all examples test` and it compiles, but beyond that I have not created any tests for this (knowledge of go is ankle deep) so I hope someone is kind enough to help me out and add that :-)