### PR TITLE
Automated cherry pick of #16412: aws/cert-manager: Tighten IAM permissions for cert-manager

### DIFF
--- a/pkg/model/components/addonmanifests/certmanager/iam.go
+++ b/pkg/model/components/addonmanifests/certmanager/iam.go
@@ -56,11 +56,23 @@ func addCertManagerPermissions(b *iam.PolicyBuilder, p *iam.Policy) {
 	}
 
 	p.Statement = append(p.Statement, &iam.Statement{
-		Effect: iam.StatementEffectAllow,
-		Action: stringorset.Of("route53:ChangeResourceRecordSets",
-			"route53:ListResourceRecordSets",
-		),
+		Effect:   iam.StatementEffectAllow,
+		Action:   stringorset.Of("route53:ListResourceRecordSets"),
 		Resource: stringorset.Set(zoneResources),
+	})
+
+	p.Statement = append(p.Statement, &iam.Statement{
+		Effect:   iam.StatementEffectAllow,
+		Action:   stringorset.Of("route53:ChangeResourceRecordSets"),
+		Resource: stringorset.Set(zoneResources),
+		Condition: iam.Condition{
+			"ForAllValues:StringLike": map[string]interface{}{
+				"route53:ChangeResourceRecordSetsNormalizedRecordNames": []string{"_acme-challenge.*"},
+			},
+			"ForAllValues:StringEquals": map[string]interface{}{
+				"route53:ChangeResourceRecordSetsRecordTypes": []string{"TXT"},
+			},
+		},
 	})
 
 	p.Statement = append(p.Statement, &iam.Statement{


### PR DESCRIPTION
Cherry pick of #16412 on release-1.29.

#16412: aws/cert-manager: Tighten IAM permissions for cert-manager

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```