### PR TITLE
refactor: move assets into their own package

### DIFF
--- a/pkg/nodemodel/wellknownassets/containerd.go
+++ b/pkg/nodemodel/wellknownassets/containerd.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudup
+package wellknownassets
 
 import (
 	"fmt"
@@ -37,7 +37,7 @@ const (
 	containerdBundleUrlAmd64 = "https://github.com/containerd/containerd/releases/download/v%s/cri-containerd-cni-%s-linux-amd64.tar.gz"
 )
 
-func findContainerdAsset(c *kops.Cluster, assetBuilder *assets.AssetBuilder, arch architectures.Architecture) (*url.URL, *hashing.Hash, error) {
+func FindContainerdAsset(c *kops.Cluster, assetBuilder *assets.AssetBuilder, arch architectures.Architecture) (*url.URL, *hashing.Hash, error) {
 	if c.Spec.Containerd == nil {
 		return nil, nil, fmt.Errorf("unable to find containerd config")
 	}

--- a/pkg/nodemodel/wellknownassets/containerd_test.go
+++ b/pkg/nodemodel/wellknownassets/containerd_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudup
+package wellknownassets
 
 import (
 	"fmt"

--- a/pkg/nodemodel/wellknownassets/crictl.go
+++ b/pkg/nodemodel/wellknownassets/crictl.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudup
+package wellknownassets
 
 import (
 	"fmt"
@@ -31,7 +31,7 @@ const (
 	crictlAssetUrlArm64 = "https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.29.0/crictl-v1.29.0-linux-arm64.tar.gz"
 )
 
-func findCrictlAsset(c *kops.Cluster, assetBuilder *assets.AssetBuilder, arch architectures.Architecture) (*url.URL, *hashing.Hash, error) {
+func FindCrictlAsset(c *kops.Cluster, assetBuilder *assets.AssetBuilder, arch architectures.Architecture) (*url.URL, *hashing.Hash, error) {
 	var assetURL string
 	switch arch {
 	case architectures.ArchitectureAmd64:

--- a/pkg/nodemodel/wellknownassets/crictl_test.go
+++ b/pkg/nodemodel/wellknownassets/crictl_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudup
+package wellknownassets
 
 import (
 	"testing"
@@ -33,7 +33,7 @@ func Test_FindCrictlVersionHash(t *testing.T) {
 	cluster.Spec.KubernetesVersion = "v1.29.0"
 
 	assetBuilder := assets.NewAssetBuilder(vfs.Context, cluster.Spec.Assets, cluster.Spec.KubernetesVersion, false)
-	crictlAsset, crictlAssetHash, err := findCrictlAsset(cluster, assetBuilder, architectures.ArchitectureAmd64)
+	crictlAsset, crictlAssetHash, err := FindCrictlAsset(cluster, assetBuilder, architectures.ArchitectureAmd64)
 	if err != nil {
 		t.Errorf("Unable to parse crictl version %s", err)
 	}

--- a/pkg/nodemodel/wellknownassets/nerdctl.go
+++ b/pkg/nodemodel/wellknownassets/nerdctl.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudup
+package wellknownassets
 
 import (
 	"fmt"
@@ -33,7 +33,7 @@ const (
 	nerdctlAssetHashArm64 = "d8df47708ca57b9cd7f498055126ba7dcfc811d9ba43aae1830c93a09e70e22d"
 )
 
-func findNerdctlAsset(c *kops.Cluster, assetBuilder *assets.AssetBuilder, arch architectures.Architecture) (*url.URL, *hashing.Hash, error) {
+func FindNerdctlAsset(c *kops.Cluster, assetBuilder *assets.AssetBuilder, arch architectures.Architecture) (*url.URL, *hashing.Hash, error) {
 	var assetURL, assetHash string
 	switch arch {
 	case architectures.ArchitectureAmd64:

--- a/pkg/nodemodel/wellknownassets/runc.go
+++ b/pkg/nodemodel/wellknownassets/runc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudup
+package wellknownassets
 
 import (
 	"fmt"
@@ -34,7 +34,7 @@ const (
 	runcVersionUrlArm64 = "https://github.com/opencontainers/runc/releases/download/v%s/runc.arm64"
 )
 
-func findRuncAsset(c *kops.Cluster, assetBuilder *assets.AssetBuilder, arch architectures.Architecture) (*url.URL, *hashing.Hash, error) {
+func FindRuncAsset(c *kops.Cluster, assetBuilder *assets.AssetBuilder, arch architectures.Architecture) (*url.URL, *hashing.Hash, error) {
 	if c.Spec.Containerd == nil {
 		return nil, nil, fmt.Errorf("unable to find containerd config")
 	}

--- a/pkg/nodemodel/wellknownassets/runc_test.go
+++ b/pkg/nodemodel/wellknownassets/runc_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudup
+package wellknownassets
 
 import (
 	"fmt"

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/kops/pkg/model/iam"
 	"k8s.io/kops/pkg/model/openstackmodel"
 	"k8s.io/kops/pkg/model/scalewaymodel"
+	"k8s.io/kops/pkg/nodemodel/wellknownassets"
 	"k8s.io/kops/pkg/templates"
 	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/pkg/wellknownservices"
@@ -1130,7 +1131,7 @@ func (c *ApplyClusterCmd) addFileAssets(assetBuilder *assets.AssetBuilder) error
 		}
 
 		if c.Cluster.Spec.Containerd == nil || !c.Cluster.Spec.Containerd.SkipInstall {
-			containerdAssetUrl, containerdAssetHash, err := findContainerdAsset(c.Cluster, assetBuilder, arch)
+			containerdAssetUrl, containerdAssetHash, err := wellknownassets.FindContainerdAsset(c.Cluster, assetBuilder, arch)
 			if err != nil {
 				return err
 			}
@@ -1138,14 +1139,14 @@ func (c *ApplyClusterCmd) addFileAssets(assetBuilder *assets.AssetBuilder) error
 				c.Assets[arch] = append(c.Assets[arch], mirrors.BuildMirroredAsset(containerdAssetUrl, containerdAssetHash))
 			}
 
-			runcAssetUrl, runcAssetHash, err := findRuncAsset(c.Cluster, assetBuilder, arch)
+			runcAssetUrl, runcAssetHash, err := wellknownassets.FindRuncAsset(c.Cluster, assetBuilder, arch)
 			if err != nil {
 				return err
 			}
 			if runcAssetUrl != nil && runcAssetHash != nil {
 				c.Assets[arch] = append(c.Assets[arch], mirrors.BuildMirroredAsset(runcAssetUrl, runcAssetHash))
 			}
-			nerdctlAssetUrl, nerdctlAssetHash, err := findNerdctlAsset(c.Cluster, assetBuilder, arch)
+			nerdctlAssetUrl, nerdctlAssetHash, err := wellknownassets.FindNerdctlAsset(c.Cluster, assetBuilder, arch)
 			if err != nil {
 				return err
 			}
@@ -1154,7 +1155,7 @@ func (c *ApplyClusterCmd) addFileAssets(assetBuilder *assets.AssetBuilder) error
 			}
 		}
 
-		crictlAssetUrl, crictlAssetHash, err := findCrictlAsset(c.Cluster, assetBuilder, arch)
+		crictlAssetUrl, crictlAssetHash, err := wellknownassets.FindCrictlAsset(c.Cluster, assetBuilder, arch)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This refactoring will split nodeup configuration out of cloudup, to
enable us to generate a nodeup configuration more easily, for example
in kops-controller.  That in turn will allow more dynamic usage with
e.g. cluster-api
