### PR TITLE
Update kube-router to v2.1.0

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -468,6 +468,10 @@ func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		addCalicoSrcDstCheckPermissions(p)
 	}
 
+	if b.Cluster.Spec.Networking.KubeRouter != nil {
+		addKubeRouterSrcDstCheckPermissions(p)
+	}
+
 	return p, nil
 }
 
@@ -766,6 +770,12 @@ func addCalicoSrcDstCheckPermissions(p *Policy) {
 	p.unconditionalAction.Insert(
 		"ec2:DescribeInstances",
 		"ec2:ModifyNetworkInterfaceAttribute",
+	)
+}
+
+func addKubeRouterSrcDstCheckPermissions(p *Policy) {
+	p.unconditionalAction.Insert(
+		"ec2:ModifyInstanceAttribute",
 	)
 }
 

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -98,7 +98,7 @@ func (t *Tester) setSkipRegexFlag() error {
 			skipRegex += "|should.create.a.Pod.with.SCTP.HostPort"
 		}
 	} else if networking.KubeRouter != nil {
-		skipRegex += "|load-balancer|hairpin|service\\.kubernetes\\.io|CLOSE_WAIT"
+		skipRegex += "|load-balancer|service\\.kubernetes\\.io|CLOSE_WAIT"
 		skipRegex += "|EndpointSlice.should.support.a.Service.with.multiple"
 		skipRegex += "|internalTrafficPolicy|externallTrafficPolicy|only.terminating.endpoints"
 	} else if networking.Kubenet != nil {

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -98,9 +98,7 @@ func (t *Tester) setSkipRegexFlag() error {
 			skipRegex += "|should.create.a.Pod.with.SCTP.HostPort"
 		}
 	} else if networking.KubeRouter != nil {
-		skipRegex += "|load-balancer|service\\.kubernetes\\.io|CLOSE_WAIT"
-		skipRegex += "|EndpointSlice.should.support.a.Service.with.multiple"
-		skipRegex += "|internalTrafficPolicy|externallTrafficPolicy|only.terminating.endpoints"
+		skipRegex += "|should set TCP CLOSE_WAIT timeout|should check kube-proxy urls"
 	} else if networking.Kubenet != nil {
 		skipRegex += "|Services.*affinity"
 	}

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -62,7 +62,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v1.6.0
+        image: docker.io/cloudnativelabs/kube-router:v2.1.0
         args:
         - --run-router=true
         - --run-firewall=true
@@ -70,11 +70,17 @@ spec:
         - --bgp-graceful-restart=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
         - --metrics-port=12013
+        - --runtime-endpoint=unix:///run/containerd/containerd.sock
+        - --hairpin-mode=true
         env:
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
@@ -101,6 +107,12 @@ spec:
         - name: xtables-lock
           mountPath: /run/xtables.lock
           readOnly: false
+        - name: rt-tables
+          mountPath: /etc/iproute2/rt_tables
+          readOnly: false
+        - name: containerd-sock
+          mountPath: /run/containerd/containerd.sock
+          readOnly: true
       initContainers:
       - name: install-cni
         image: docker.io/cloudnativelabs/kube-router:v1.6.0
@@ -122,6 +134,7 @@ spec:
         - mountPath: /etc/kube-router
           name: kube-router-cfg
       hostNetwork: true
+      hostPID: true
       tolerations:
       - operator: Exists
       volumes:
@@ -141,6 +154,13 @@ spec:
         hostPath:
           path: /run/xtables.lock
           type: FileOrCreate
+      - name: rt-tables
+        hostPath:
+          path: /etc/iproute2/rt_tables
+          type: FileOrCreate
+      - name: containerd-sock
+        hostPath:
+          path: /run/containerd/containerd.sock
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -177,6 +197,28 @@ rules:
     - extensions
     resources:
       - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - update
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
     verbs:
       - get
       - list


### PR DESCRIPTION
@hakman for review

Changes:

* Bump kube-router version to v2.1.0 from v1.6.0
* Enable hairpin mode for kube-router by default - From the e2e tests this seems to be expected functionality of a CNI
* Add the runtime endpoint into the container so that user's are able to utilize DSR functionality
* Mount `/etc/iproute2/rt_tables` into the container as well which is used by kube-router to configure source routing for DSR
* Add `hostPID: true` functionality for DSR
* Add environment var `POD_NAME` so that user's can easily enable load-balancing mode for kube-router
* Add additional RBAC for the following:
  * leases / services/status - For loadbalancer controller which can be optionally enabled
  * endpointslices - This is needed in kube-router v2.X and on so that kube-router is able to handle dual-stack endpoints

I found that in the current main branch of kops that kube-router's old method of adding instance modify permissions to the nodes no longer works correctly. I believe that this permission should be coming in when kube-router is chosen as the networking provider:

* https://github.com/kubernetes/kops/blob/master/pkg/model/components/addonmanifests/kuberouter/iam.go#L35
* https://github.com/kubernetes/kops/blob/master/pkg/model/iam/iam_builder.go#L1086-L1090

However, this no longer seems to be applying to nodes correctly and when this is missing kube-router is not able to forward pod traffic to other nodes.

After poking around a bit, I also noticed that other CNIs like Calico have special logic in the IAM builder like the following to add similar functionality in the IAM node builder code: https://github.com/kubernetes/kops/blob/master/pkg/model/iam/iam_builder.go#L467-L469

So I added this functionality for kube-router as well and found that it works correctly and enables kube-router to disable the src-dest check in AWS.

Additionally removed all of the skip_regex.go exceptions that were kept for kube-router as with this version update kube-router now passes all of the upstream e2e conformance tests.