### PR TITLE
Migrate aws-sdk-go/aws to aws-sdk-go-v2/aws

### DIFF
--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53_test.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53_test.go
@@ -27,7 +27,7 @@ import (
 	route53testing "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/aws/route53/stubs"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider/rrstype"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider/tests"
 )

--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
@@ -142,7 +142,7 @@ func (c *ResourceRecordChangeset) Apply(ctx context.Context) error {
 		if klog.V(8).Enabled() {
 			var sb bytes.Buffer
 			for _, change := range batch {
-				sb.WriteString(fmt.Sprintf("\t%s %s %s\n", aws.StringValue(change.Action), aws.StringValue(change.ResourceRecordSet.Type), aws.StringValue(change.ResourceRecordSet.Name)))
+				sb.WriteString(fmt.Sprintf("\t%s %s %s\n", aws.ToString(change.Action), aws.ToString(change.ResourceRecordSet.Type), aws.ToString(change.ResourceRecordSet.Name)))
 			}
 
 			klog.V(8).Infof("Route53 MaxBatchSize: %v\n", MaxBatchSize)

--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/rrset.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/rrset.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider/rrstype"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
@@ -33,24 +33,24 @@ type ResourceRecordSet struct {
 }
 
 func (rrset ResourceRecordSet) Name() string {
-	return aws.StringValue(rrset.impl.Name)
+	return aws.ToString(rrset.impl.Name)
 }
 
 func (rrset ResourceRecordSet) Rrdatas() []string {
 	// Sigh - need to unpack the strings out of the route53 ResourceRecords
 	result := make([]string, len(rrset.impl.ResourceRecords))
 	for i, record := range rrset.impl.ResourceRecords {
-		result[i] = aws.StringValue(record.Value)
+		result[i] = aws.ToString(record.Value)
 	}
 	return result
 }
 
 func (rrset ResourceRecordSet) Ttl() int64 {
-	return aws.Int64Value(rrset.impl.TTL)
+	return aws.ToInt64(rrset.impl.TTL)
 }
 
 func (rrset ResourceRecordSet) Type() rrstype.RrsType {
-	return rrstype.RrsType(aws.StringValue(rrset.impl.Type))
+	return rrstype.RrsType(aws.ToString(rrset.impl.Type))
 }
 
 // Route53ResourceRecordSet returns the route53 ResourceRecordSet object for the ResourceRecordSet

--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/rrsets.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/rrsets.go
@@ -17,7 +17,7 @@ limitations under the License.
 package route53
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider/rrstype"
@@ -60,7 +60,7 @@ func (rrsets ResourceRecordSets) Get(name string) ([]dnsprovider.ResourceRecordS
 	var list []dnsprovider.ResourceRecordSet
 	err := rrsets.zone.zones.interface_.service.ListResourceRecordSetsPages(&input, func(page *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
 		for _, rrset := range page.ResourceRecordSets {
-			if aws.StringValue(rrset.Name) != name {
+			if aws.ToString(rrset.Name) != name {
 				return false
 			}
 			list = append(list, &ResourceRecordSet{rrset, &rrsets})

--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/stubs/route53api.go
@@ -20,7 +20,7 @@ package stubs
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
@@ -107,7 +107,7 @@ func (r *Route53APIStub) ListHostedZonesPages(input *route53.ListHostedZonesInpu
 }
 
 func (r *Route53APIStub) CreateHostedZone(input *route53.CreateHostedZoneInput) (*route53.CreateHostedZoneOutput, error) {
-	name := aws.StringValue(input.Name)
+	name := aws.ToString(input.Name)
 	id := "/hostedzone/" + name
 	if _, ok := r.zones[id]; ok {
 		return nil, fmt.Errorf("error creating hosted DNS zone: %s already exists", id)

--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/zone.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/zone.go
@@ -19,7 +19,7 @@ package route53
 import (
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
 )
@@ -33,11 +33,11 @@ type Zone struct {
 }
 
 func (zone *Zone) Name() string {
-	return aws.StringValue(zone.impl.Name)
+	return aws.ToString(zone.impl.Name)
 }
 
 func (zone *Zone) ID() string {
-	id := aws.StringValue(zone.impl.Id)
+	id := aws.ToString(zone.impl.Id)
 	id = strings.TrimPrefix(id, "/hostedzone/")
 	return id
 }

--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kops/cloudmock/aws/mockec2"

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -19,7 +19,7 @@ package nodeup
 import (
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/util/pkg/architectures"

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"

--- a/pkg/resources/aws/aws_test.go
+++ b/pkg/resources/aws/aws_test.go
@@ -21,9 +21,9 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing/types"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/cloudmock/aws/mockec2"
 	"k8s.io/kops/cloudmock/aws/mockiam"

--- a/pkg/resources/aws/elasticip.go
+++ b/pkg/resources/aws/elasticip.go
@@ -17,24 +17,24 @@ limitations under the License.
 package aws
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"k8s.io/kops/pkg/resources"
 )
 
 func buildElasticIPResource(address *ec2.Address, forceShared bool, clusterName string) *resources.Resource {
-	name := aws.StringValue(address.PublicIp)
+	name := aws.ToString(address.PublicIp)
 	if name == "" {
-		name = aws.StringValue(address.PrivateIpAddress)
+		name = aws.ToString(address.PrivateIpAddress)
 	}
 	if name == "" {
-		name = aws.StringValue(address.AllocationId)
+		name = aws.ToString(address.AllocationId)
 	}
 
 	r := &resources.Resource{
 		Name:    name,
-		ID:      aws.StringValue(address.AllocationId),
+		ID:      aws.ToString(address.AllocationId),
 		Type:    TypeElasticIp,
 		Deleter: DeleteElasticIP,
 		Shared:  forceShared,

--- a/pkg/resources/aws/eni.go
+++ b/pkg/resources/aws/eni.go
@@ -19,7 +19,7 @@ package aws
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 
@@ -80,7 +80,7 @@ func DescribeENIs(cloud fi.Cloud, vpcID, clusterName string) (map[string]*ec2.Ne
 		}
 		err := c.EC2().DescribeNetworkInterfacesPages(request, func(dnio *ec2.DescribeNetworkInterfacesOutput, b bool) bool {
 			for _, eni := range dnio.NetworkInterfaces {
-				enis[aws.StringValue(eni.NetworkInterfaceId)] = eni
+				enis[aws.ToString(eni.NetworkInterfaceId)] = eni
 			}
 			return true
 		})
@@ -100,7 +100,7 @@ func ListENIs(cloud fi.Cloud, vpcID, clusterName string) ([]*resources.Resource,
 
 	var resourceTrackers []*resources.Resource
 	for _, v := range enis {
-		eniID := aws.StringValue(v.NetworkInterfaceId)
+		eniID := aws.ToString(v.NetworkInterfaceId)
 
 		resourceTracker := &resources.Resource{
 			ID:      eniID,
@@ -112,7 +112,7 @@ func ListENIs(cloud fi.Cloud, vpcID, clusterName string) ([]*resources.Resource,
 		}
 
 		var blocks []string
-		blocks = append(blocks, ec2.ResourceTypeVpc+":"+aws.StringValue(v.VpcId))
+		blocks = append(blocks, ec2.ResourceTypeVpc+":"+aws.ToString(v.VpcId))
 
 		resourceTracker.Blocks = blocks
 

--- a/pkg/resources/aws/filters.go
+++ b/pkg/resources/aws/filters.go
@@ -17,7 +17,7 @@ limitations under the License.
 package aws
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 )

--- a/pkg/resources/aws/natgateway.go
+++ b/pkg/resources/aws/natgateway.go
@@ -17,7 +17,7 @@ limitations under the License.
 package aws
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"k8s.io/kops/pkg/resources"
@@ -33,7 +33,7 @@ func DumpNatGateway(op *resources.DumpOperation, r *resources.Resource) error {
 }
 
 func buildNatGatewayResource(ngw *ec2.NatGateway, forceShared bool, clusterName string) *resources.Resource {
-	id := aws.StringValue(ngw.NatGatewayId)
+	id := aws.ToString(ngw.NatGatewayId)
 
 	r := &resources.Resource{
 		Name:    id,
@@ -52,7 +52,7 @@ func buildNatGatewayResource(ngw *ec2.NatGateway, forceShared bool, clusterName 
 	// The NAT gateway blocks deletion of any associated Elastic IPs
 	for _, address := range ngw.NatGatewayAddresses {
 		if address.AllocationId != nil {
-			r.Blocks = append(r.Blocks, TypeElasticIp+":"+aws.StringValue(address.AllocationId))
+			r.Blocks = append(r.Blocks, TypeElasticIp+":"+aws.ToString(address.AllocationId))
 		}
 	}
 

--- a/pkg/resources/aws/routetable.go
+++ b/pkg/resources/aws/routetable.go
@@ -19,7 +19,7 @@ package aws
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 
@@ -44,7 +44,7 @@ func DescribeRouteTables(cloud fi.Cloud, clusterName string) (map[string]*ec2.Ro
 		}
 
 		for _, rt := range response.RouteTables {
-			routeTables[aws.StringValue(rt.RouteTableId)] = rt
+			routeTables[aws.ToString(rt.RouteTableId)] = rt
 		}
 	}
 
@@ -79,7 +79,7 @@ func dumpRouteTable(op *resources.DumpOperation, r *resources.Resource) error {
 func buildTrackerForRouteTable(rt *ec2.RouteTable, clusterName string) *resources.Resource {
 	resourceTracker := &resources.Resource{
 		Name:    FindName(rt.Tags),
-		ID:      aws.StringValue(rt.RouteTableId),
+		ID:      aws.ToString(rt.RouteTableId),
 		Type:    ec2.ResourceTypeRouteTable,
 		Obj:     rt,
 		Dumper:  dumpRouteTable,
@@ -90,10 +90,10 @@ func buildTrackerForRouteTable(rt *ec2.RouteTable, clusterName string) *resource
 	var blocks []string
 	var blocked []string
 
-	blocks = append(blocks, "vpc:"+aws.StringValue(rt.VpcId))
+	blocks = append(blocks, "vpc:"+aws.ToString(rt.VpcId))
 
 	for _, a := range rt.Associations {
-		blocked = append(blocked, "subnet:"+aws.StringValue(a.SubnetId))
+		blocked = append(blocked, "subnet:"+aws.ToString(a.SubnetId))
 	}
 
 	resourceTracker.Blocks = blocks

--- a/pkg/resources/aws/securitygroup.go
+++ b/pkg/resources/aws/securitygroup.go
@@ -19,7 +19,7 @@ package aws
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 
@@ -112,7 +112,7 @@ func ListSecurityGroups(cloud fi.Cloud, vpcID, clusterName string) ([]*resources
 		}
 
 		var blocks []string
-		blocks = append(blocks, "vpc:"+aws.StringValue(sg.VpcId))
+		blocks = append(blocks, "vpc:"+aws.ToString(sg.VpcId))
 
 		resourceTracker.Blocks = blocks
 
@@ -137,7 +137,7 @@ func DescribeSecurityGroups(cloud fi.Cloud, clusterName string) (map[string]*ec2
 		}
 
 		for _, group := range response.SecurityGroups {
-			groups[aws.StringValue(group.GroupId)] = group
+			groups[aws.ToString(group.GroupId)] = group
 		}
 	}
 

--- a/pkg/resources/aws/subnet.go
+++ b/pkg/resources/aws/subnet.go
@@ -17,7 +17,7 @@ limitations under the License.
 package aws
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"k8s.io/kops/pkg/resources"
@@ -32,8 +32,8 @@ func DumpSubnet(op *resources.DumpOperation, r *resources.Resource) error {
 
 	ec2Subnet := r.Obj.(*ec2.Subnet)
 	s := &resources.Subnet{
-		ID:   aws.StringValue(ec2Subnet.SubnetId),
-		Zone: aws.StringValue(ec2Subnet.AvailabilityZone),
+		ID:   aws.ToString(ec2Subnet.SubnetId),
+		Zone: aws.ToString(ec2Subnet.AvailabilityZone),
 	}
 	op.Dump.Subnets = append(op.Dump.Subnets, s)
 

--- a/pkg/resources/aws/tags.go
+++ b/pkg/resources/aws/tags.go
@@ -17,7 +17,7 @@ limitations under the License.
 package aws
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
@@ -29,7 +29,7 @@ func HasOwnedTag(description string, tags []*ec2.Tag, clusterName string) bool {
 
 	var found *ec2.Tag
 	for _, tag := range tags {
-		if aws.StringValue(tag.Key) != tagKey {
+		if aws.ToString(tag.Key) != tagKey {
 			continue
 		}
 
@@ -37,7 +37,7 @@ func HasOwnedTag(description string, tags []*ec2.Tag, clusterName string) bool {
 	}
 
 	if found != nil {
-		tagValue := aws.StringValue(found.Value)
+		tagValue := aws.ToString(found.Value)
 		switch tagValue {
 		case "owned":
 			return true
@@ -52,7 +52,7 @@ func HasOwnedTag(description string, tags []*ec2.Tag, clusterName string) bool {
 
 	// Look for legacy tag - we assume that implies ownership
 	for _, tag := range tags {
-		if aws.StringValue(tag.Key) != awsup.TagClusterName {
+		if aws.ToString(tag.Key) != awsup.TagClusterName {
 			continue
 		}
 

--- a/pkg/resources/aws/vpc.go
+++ b/pkg/resources/aws/vpc.go
@@ -19,7 +19,7 @@ package aws
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/resources"
@@ -61,7 +61,7 @@ func DumpVPC(op *resources.DumpOperation, r *resources.Resource) error {
 
 	ec2VPC := r.Obj.(*ec2.Vpc)
 	vpc := &resources.VPC{
-		ID: aws.StringValue(ec2VPC.VpcId),
+		ID: aws.ToString(ec2VPC.VpcId),
 	}
 	op.Dump.VPC = vpc
 
@@ -83,7 +83,7 @@ func DescribeVPC(cloud fi.Cloud, clusterName string) (*ec2.Vpc, error) {
 		}
 
 		for _, vpc := range response.Vpcs {
-			vpcs[aws.StringValue(vpc.VpcId)] = vpc
+			vpcs[aws.ToString(vpc.VpcId)] = vpc
 		}
 	}
 
@@ -105,7 +105,7 @@ func ListVPCs(cloud fi.Cloud, clusterName string) ([]*resources.Resource, error)
 
 	var resourceTrackers []*resources.Resource
 	if vpc != nil {
-		vpcID := aws.StringValue(vpc.VpcId)
+		vpcID := aws.ToString(vpc.VpcId)
 
 		resourceTracker := &resources.Resource{
 			Name:    FindName(vpc.Tags),
@@ -118,7 +118,7 @@ func ListVPCs(cloud fi.Cloud, clusterName string) ([]*resources.Resource, error)
 		}
 
 		var blocks []string
-		blocks = append(blocks, "dhcp-options:"+aws.StringValue(vpc.DhcpOptionsId))
+		blocks = append(blocks, "dhcp-options:"+aws.ToString(vpc.DhcpOptionsId))
 
 		resourceTracker.Blocks = blocks
 

--- a/pkg/resources/aws/vpc_test.go
+++ b/pkg/resources/aws/vpc_test.go
@@ -19,7 +19,7 @@ package aws
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/cloudmock/aws/mockec2"
 	"k8s.io/kops/pkg/testutils"

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/kops/cloudmock/aws/mockeventbridge"
 	"k8s.io/kops/cloudmock/aws/mocksqs"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"

--- a/pkg/zones/wellknown.go
+++ b/pkg/zones/wellknown.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/scaleway/scaleway-sdk-go/scw"

--- a/protokube/pkg/gossip/aws/seeds.go
+++ b/protokube/pkg/gossip/aws/seeds.go
@@ -19,7 +19,7 @@ package aws
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"k8s.io/kops/protokube/pkg/gossip"
@@ -50,7 +50,7 @@ func (p *SeedProvider) GetSeeds() ([]string, error) {
 	err := p.ec2.DescribeInstancesPages(request, func(p *ec2.DescribeInstancesOutput, lastPage bool) (shouldContinue bool) {
 		for _, r := range p.Reservations {
 			for _, i := range r.Instances {
-				ip := aws.StringValue(i.PrivateIpAddress)
+				ip := aws.ToString(i.PrivateIpAddress)
 				if ip != "" {
 					seeds = append(seeds, ip)
 				}

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -68,7 +68,6 @@ require (
 	github.com/aliyun/credentials-go v1.2.3 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
-	github.com/aws/aws-sdk-go v1.51.10 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.26.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.1 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.27.9 // indirect

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kops/pkg/diff"
 	"k8s.io/kops/upup/pkg/fi"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"sigs.k8s.io/yaml"
 )

--- a/upup/pkg/fi/cloudup/awstasks/block_device_mappings.go
+++ b/upup/pkg/fi/cloudup/awstasks/block_device_mappings.go
@@ -19,7 +19,7 @@ package awstasks
 import (
 	"k8s.io/kops/upup/pkg/fi"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
@@ -62,7 +62,7 @@ func BlockDeviceMappingFromEC2(i *ec2.BlockDeviceMapping) (string, *BlockDeviceM
 		o.EbsVolumeType = i.Ebs.VolumeType
 	}
 
-	return aws.StringValue(i.DeviceName), o
+	return aws.ToString(i.DeviceName), o
 }
 
 // ToEC2 creates and returns an ec2 block mapping
@@ -110,7 +110,7 @@ func BlockDeviceMappingFromAutoscaling(i *autoscaling.BlockDeviceMapping) (strin
 		}
 	}
 
-	return aws.StringValue(i.DeviceName), o
+	return aws.ToString(i.DeviceName), o
 }
 
 // ToAutoscaling converts the internal block mapping to autoscaling
@@ -150,7 +150,7 @@ func BlockDeviceMappingFromLaunchTemplateBootDeviceRequest(i *ec2.LaunchTemplate
 		o.EbsKmsKey = i.Ebs.KmsKeyId
 	}
 
-	return aws.StringValue(i.DeviceName), o
+	return aws.ToString(i.DeviceName), o
 }
 
 // ToLaunchTemplateBootDeviceRequest coverts in the internal block device mapping to a launch template request

--- a/upup/pkg/fi/cloudup/awstasks/convenience.go
+++ b/upup/pkg/fi/cloudup/awstasks/convenience.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package awstasks
 
-import "github.com/aws/aws-sdk-go/aws"
+import "github.com/aws/aws-sdk-go-v2/aws"
 
 // s is a helper that builds a *string from a string value
 func s(v string) *string {

--- a/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi"
@@ -82,7 +82,7 @@ func (e *DHCPOptions) Find(c *fi.CloudupContext) (*DHCPOptions, error) {
 	}
 
 	for _, s := range o.DhcpConfigurations {
-		k := aws.StringValue(s.Key)
+		k := aws.ToString(s.Key)
 		v := ""
 		for _, av := range s.Values {
 			if v != "" {

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume_test.go
@@ -19,7 +19,7 @@ package awstasks
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/kops/pkg/diff"

--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/cloudmock/aws/mockec2"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -19,7 +19,7 @@ package awstasks
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
@@ -280,7 +280,7 @@ func (_ *ElasticIP) RenderTerraform(t *terraform.TerraformTarget, a, e, changes 
 		if e.ID == nil {
 			return fmt.Errorf("ID must be set, if ElasticIP is shared: %v", e)
 		}
-		klog.V(4).Infof("reusing existing ElasticIP with id %q", aws.StringValue(e.ID))
+		klog.V(4).Infof("reusing existing ElasticIP with id %q", aws.ToString(e.ID))
 		return nil
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/instance.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi"
@@ -125,7 +125,7 @@ func (e *Instance) Find(c *fi.CloudupContext) (*Instance, error) {
 			return nil, fmt.Errorf("error querying EC2 for user metadata for instance %q: %v", *i.InstanceId, err)
 		}
 		if response.UserData != nil {
-			b, err := base64.StdEncoding.DecodeString(aws.StringValue(response.UserData.Value))
+			b, err := base64.StdEncoding.DecodeString(aws.ToString(response.UserData.Value))
 			if err != nil {
 				return nil, fmt.Errorf("error decoding EC2 UserData: %v", err)
 			}
@@ -146,7 +146,7 @@ func (e *Instance) Find(c *fi.CloudupContext) (*Instance, error) {
 
 	associatePublicIpAddress := false
 	for _, ni := range i.NetworkInterfaces {
-		if aws.StringValue(ni.Association.PublicIp) != "" {
+		if aws.ToString(ni.Association.PublicIp) != "" {
 			associatePublicIpAddress = true
 		}
 	}
@@ -170,7 +170,7 @@ func (e *Instance) Find(c *fi.CloudupContext) (*Instance, error) {
 			klog.Warningf("unable to resolve image: %q: %v", *e.ImageID, err)
 		} else if image == nil {
 			klog.Warningf("unable to resolve image: %q: not found", *e.ImageID)
-		} else if aws.StringValue(image.ImageId) == *actual.ImageID {
+		} else if aws.ToString(image.ImageId) == *actual.ImageID {
 			klog.V(4).Infof("Returning matching ImageId as expected name: %q -> %q", *actual.ImageID, *e.ImageID)
 			actual.ImageID = e.ImageID
 		}

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/cloudmock/aws/mockec2"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 )
@@ -125,12 +125,12 @@ func (t *LaunchTemplate) buildRootDevice(cloud awsup.AWSCloud) (map[string]*Bloc
 		EbsVolumeThroughput:    t.RootVolumeThroughput,
 		EbsEncrypted:           t.RootVolumeEncryption,
 	}
-	if aws.BoolValue(t.RootVolumeEncryption) && aws.StringValue(t.RootVolumeKmsKey) != "" {
+	if aws.ToBool(t.RootVolumeEncryption) && aws.ToString(t.RootVolumeKmsKey) != "" {
 		b.EbsKmsKey = t.RootVolumeKmsKey
 	}
 
 	bm := map[string]*BlockDeviceMapping{
-		aws.StringValue(img.RootDeviceName): b,
+		aws.ToString(img.RootDeviceName): b,
 	}
 
 	return bm, nil
@@ -170,7 +170,7 @@ func (t *LaunchTemplate) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeleti
 	}
 
 	for _, lt := range list {
-		if aws.StringValue(lt.LaunchTemplateName) != aws.StringValue(t.Name) {
+		if aws.ToString(lt.LaunchTemplateName) != aws.ToString(t.Name) {
 			removals = append(removals, &deleteLaunchTemplate{lc: lt})
 		}
 	}

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -19,7 +19,7 @@ package awstasks
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
@@ -106,7 +106,7 @@ func (e *NatGateway) Find(c *fi.CloudupContext) (*NatGateway, error) {
 	} else if len(ngw.NatGatewayAddresses) == 1 {
 		actual.ElasticIP = &ElasticIP{ID: ngw.NatGatewayAddresses[0].AllocationId}
 	} else {
-		return nil, fmt.Errorf("found multiple elastic IPs attached to NatGateway %q", aws.StringValue(ngw.NatGatewayId))
+		return nil, fmt.Errorf("found multiple elastic IPs attached to NatGateway %q", aws.ToString(ngw.NatGatewayId))
 	}
 
 	// NATGateways now have names and tags so lets pull from there instead.
@@ -186,15 +186,15 @@ func findNatGatewayById(cloud awsup.AWSCloud, id *string) (*ec2.NatGateway, erro
 	request.NatGatewayIds = []*string{id}
 	response, err := cloud.EC2().DescribeNatGateways(request)
 	if err != nil {
-		return nil, fmt.Errorf("error listing NatGateway %q: %v", aws.StringValue(id), err)
+		return nil, fmt.Errorf("error listing NatGateway %q: %v", aws.ToString(id), err)
 	}
 
 	if response == nil || len(response.NatGateways) == 0 {
-		klog.V(2).Infof("Unable to find NatGateway %q", aws.StringValue(id))
+		klog.V(2).Infof("Unable to find NatGateway %q", aws.ToString(id))
 		return nil, nil
 	}
 	if len(response.NatGateways) != 1 {
-		return nil, fmt.Errorf("found multiple NatGateways with id %q", aws.StringValue(id))
+		return nil, fmt.Errorf("found multiple NatGateways with id %q", aws.ToString(id))
 	}
 	return response.NatGateways[0], nil
 }

--- a/upup/pkg/fi/cloudup/awstasks/routetable.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable.go
@@ -19,7 +19,7 @@ package awstasks
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
@@ -19,7 +19,7 @@ package awstasks
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi"
@@ -69,7 +69,7 @@ func (e *RouteTableAssociation) Find(c *fi.CloudupContext) (*RouteTableAssociati
 	}
 	rt := response.RouteTables[0]
 	for _, rta := range rt.Associations {
-		if aws.StringValue(rta.SubnetId) != *subnetID {
+		if aws.ToString(rta.SubnetId) != *subnetID {
 			continue
 		}
 		actual := &RouteTableAssociation{
@@ -154,7 +154,7 @@ func (_ *RouteTableAssociation) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *
 
 		if existing != nil {
 			for _, a := range existing.Associations {
-				if aws.StringValue(a.SubnetId) != aws.StringValue(e.Subnet.ID) {
+				if aws.ToString(a.SubnetId) != aws.ToString(e.Subnet.ID) {
 					continue
 				}
 				klog.V(2).Infof("Creating RouteTableAssociation")

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi"
@@ -244,7 +244,7 @@ func (d *deleteSecurityGroupRule) Delete(t fi.CloudupTarget) error {
 		return fmt.Errorf("unexpected target type for deletion: %T", t)
 	}
 
-	if aws.BoolValue(d.rule.IsEgress) {
+	if aws.ToBool(d.rule.IsEgress) {
 		request := &ec2.RevokeSecurityGroupEgressInput{
 			GroupId:              d.rule.GroupId,
 			SecurityGroupRuleIds: []*string{d.rule.SecurityGroupRuleId},
@@ -278,20 +278,20 @@ func (d *deleteSecurityGroupRule) TaskName() string {
 func (d *deleteSecurityGroupRule) Item() string {
 	s := fi.ValueOf(d.rule.GroupId) + ":"
 	p := d.rule
-	if aws.Int64Value(p.FromPort) != 0 {
-		s += fmt.Sprintf(" port=%d", aws.Int64Value(p.FromPort))
-		if aws.Int64Value(p.ToPort) != aws.Int64Value(p.FromPort) {
-			s += fmt.Sprintf("-%d", aws.Int64Value(p.ToPort))
+	if aws.ToInt64(p.FromPort) != 0 {
+		s += fmt.Sprintf(" port=%d", aws.ToInt64(p.FromPort))
+		if aws.ToInt64(p.ToPort) != aws.ToInt64(p.FromPort) {
+			s += fmt.Sprintf("-%d", aws.ToInt64(p.ToPort))
 		}
 	}
-	if aws.StringValue(p.IpProtocol) != "-1" {
-		s += fmt.Sprintf(" protocol=%s", aws.StringValue(p.IpProtocol))
+	if aws.ToString(p.IpProtocol) != "-1" {
+		s += fmt.Sprintf(" protocol=%s", aws.ToString(p.IpProtocol))
 	}
 	if p.ReferencedGroupInfo != nil {
-		s += fmt.Sprintf(" group=%s", aws.StringValue(p.ReferencedGroupInfo.GroupId))
+		s += fmt.Sprintf(" group=%s", aws.ToString(p.ReferencedGroupInfo.GroupId))
 	}
-	s += fmt.Sprintf(" ip=%s", aws.StringValue(p.CidrIpv4))
-	s += fmt.Sprintf(" ipv6=%s", aws.StringValue(p.CidrIpv6))
+	s += fmt.Sprintf(" ip=%s", aws.ToString(p.CidrIpv4))
+	s += fmt.Sprintf(" ipv6=%s", aws.ToString(p.CidrIpv6))
 	// permissionString := fi.DebugAsJsonString(d.permission)
 	// s += permissionString
 

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/cloudmock/aws/mockec2"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
@@ -103,7 +103,7 @@ func (e *SecurityGroupRule) Find(c *fi.CloudupContext) (*SecurityGroupRule, erro
 			Tags: intersectTags(foundRule.Tags, e.Tags),
 		}
 
-		if aws.StringValue(actual.Protocol) == "-1" {
+		if aws.ToString(actual.Protocol) == "-1" {
 			actual.Protocol = nil
 		}
 
@@ -154,7 +154,7 @@ func (e *SecurityGroupRule) matches(rule *ec2.SecurityGroupRule) bool {
 	if e.FromPort != nil {
 		matchFromPort = *e.FromPort
 	}
-	if aws.Int64Value(rule.FromPort) != matchFromPort {
+	if aws.ToInt64(rule.FromPort) != matchFromPort {
 		return false
 	}
 
@@ -162,7 +162,7 @@ func (e *SecurityGroupRule) matches(rule *ec2.SecurityGroupRule) bool {
 	if e.ToPort != nil {
 		matchToPort = *e.ToPort
 	}
-	if aws.Int64Value(rule.ToPort) != matchToPort {
+	if aws.ToInt64(rule.ToPort) != matchToPort {
 		return false
 	}
 
@@ -170,7 +170,7 @@ func (e *SecurityGroupRule) matches(rule *ec2.SecurityGroupRule) bool {
 	if e.Protocol != nil {
 		matchProtocol = *e.Protocol
 	}
-	if aws.StringValue(rule.IpProtocol) != matchProtocol {
+	if aws.ToString(rule.IpProtocol) != matchProtocol {
 		return false
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/subnet_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet_test.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/cloudmock/aws/mockec2"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/awstasks/tags.go
+++ b/upup/pkg/fi/cloudup/awstasks/tags.go
@@ -19,9 +19,9 @@ package awstasks
 import (
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	eventbridgetypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
@@ -31,10 +31,10 @@ func mapEC2TagsToMap(tags []*ec2.Tag) map[string]string {
 	}
 	m := make(map[string]string)
 	for _, t := range tags {
-		if strings.HasPrefix(aws.StringValue(t.Key), "aws:cloudformation:") {
+		if strings.HasPrefix(aws.ToString(t.Key), "aws:cloudformation:") {
 			continue
 		}
-		m[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		m[aws.ToString(t.Key)] = aws.ToString(t.Value)
 	}
 	return m
 }
@@ -45,10 +45,10 @@ func mapIAMTagsToMap(tags []iamtypes.Tag) map[string]string {
 	}
 	m := make(map[string]string)
 	for _, t := range tags {
-		if strings.HasPrefix(aws.StringValue(t.Key), "aws:cloudformation:") {
+		if strings.HasPrefix(aws.ToString(t.Key), "aws:cloudformation:") {
 			continue
 		}
-		m[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		m[aws.ToString(t.Key)] = aws.ToString(t.Value)
 	}
 	return m
 }
@@ -73,17 +73,17 @@ func mapEventBridgeTagsToMap(tags []eventbridgetypes.Tag) map[string]string {
 	}
 	m := make(map[string]string)
 	for _, t := range tags {
-		if strings.HasPrefix(aws.StringValue(t.Key), "aws:cloudformation:") {
+		if strings.HasPrefix(aws.ToString(t.Key), "aws:cloudformation:") {
 			continue
 		}
-		m[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		m[aws.ToString(t.Key)] = aws.ToString(t.Value)
 	}
 	return m
 }
 
 func findNameTag(tags []*ec2.Tag) *string {
 	for _, tag := range tags {
-		if aws.StringValue(tag.Key) == "Name" {
+		if aws.ToString(tag.Key) == "Name" {
 			return tag.Value
 		}
 	}
@@ -98,8 +98,8 @@ func intersectTags(tags []*ec2.Tag, desired map[string]string) map[string]string
 	}
 	actual := make(map[string]string)
 	for _, t := range tags {
-		k := aws.StringValue(t.Key)
-		v := aws.StringValue(t.Value)
+		k := aws.ToString(t.Key)
+		v := aws.ToString(t.Value)
 
 		if _, found := desired[k]; found {
 			actual[k] = v

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -19,7 +19,7 @@ package awstasks
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
@@ -104,12 +104,12 @@ func (e *VPC) Find(c *fi.CloudupContext) (*VPC, error) {
 			continue
 		}
 
-		state := aws.StringValue(association.Ipv6CidrBlockState.State)
+		state := aws.ToString(association.Ipv6CidrBlockState.State)
 		if state != ec2.VpcCidrBlockStateCodeAssociated && state != ec2.VpcCidrBlockStateCodeAssociating {
 			continue
 		}
 
-		pool := aws.StringValue(association.Ipv6Pool)
+		pool := aws.ToString(association.Ipv6Pool)
 		if pool == "Amazon" {
 			actual.AmazonIPv6 = aws.Bool(true)
 			actual.IPv6CIDR = association.Ipv6CidrBlock

--- a/upup/pkg/fi/cloudup/awstasks/vpc_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/cloudmock/aws/mockec2"
 	"k8s.io/kops/upup/pkg/fi"

--- a/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
@@ -19,7 +19,7 @@ package awstasks
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
@@ -84,7 +84,7 @@ func (s *VPCAmazonIPv6CIDRBlock) CheckChanges(a, e, changes *VPCAmazonIPv6CIDRBl
 }
 
 func (_ *VPCAmazonIPv6CIDRBlock) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPCAmazonIPv6CIDRBlock) error {
-	shared := aws.BoolValue(e.Shared)
+	shared := aws.ToBool(e.Shared)
 	if shared && a == nil {
 		// VPC not owned by kOps, no changes will be applied
 		// Verify that the Amazon IPv6 provided CIDR block was found.
@@ -111,7 +111,7 @@ func (_ *VPCAmazonIPv6CIDRBlock) RenderTerraform(t *terraform.TerraformTarget, a
 }
 
 func findVPCIPv6CIDR(cloud awsup.AWSCloud, vpcID *string) (*string, error) {
-	vpc, err := cloud.DescribeVPC(aws.StringValue(vpcID))
+	vpc, err := cloud.DescribeVPC(aws.ToString(vpcID))
 	if err != nil {
 		return nil, err
 	}
@@ -124,11 +124,11 @@ func findVPCIPv6CIDR(cloud awsup.AWSCloud, vpcID *string) (*string, error) {
 		}
 
 		// Ipv6CidrBlock is available only when state is "associated"
-		if aws.StringValue(association.Ipv6CidrBlockState.State) != ec2.VpcCidrBlockStateCodeAssociated {
+		if aws.ToString(association.Ipv6CidrBlockState.State) != ec2.VpcCidrBlockStateCodeAssociated {
 			continue
 		}
 
-		if aws.StringValue(association.Ipv6Pool) == "Amazon" {
+		if aws.ToString(association.Ipv6Pool) == "Amazon" {
 			return association.Ipv6CidrBlock, nil
 		}
 

--- a/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_apitarget.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"k8s.io/klog/v2"
 
 	"k8s.io/kops/upup/pkg/fi"
@@ -185,7 +185,7 @@ func (t *AWSAPITarget) WaitForInstanceRunning(instanceID string) error {
 
 		state := "?"
 		if instance.State != nil {
-			state = aws.StringValue(instance.State.Name)
+			state = aws.ToString(instance.State.Name)
 		}
 		if state == "running" {
 			return nil

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -32,7 +33,6 @@ import (
 	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing/types"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -118,8 +118,8 @@ func FindRegion(cluster *kops.Cluster) (string, error) {
 // FindEC2Tag find the value of the tag with the specified key
 func FindEC2Tag(tags []*ec2.Tag, key string) (string, bool) {
 	for _, tag := range tags {
-		if key == aws.StringValue(tag.Key) {
-			return aws.StringValue(tag.Value), true
+		if key == aws.ToString(tag.Key) {
+			return aws.ToString(tag.Value), true
 		}
 	}
 	return "", false
@@ -128,8 +128,8 @@ func FindEC2Tag(tags []*ec2.Tag, key string) (string, bool) {
 // FindASGTag find the value of the tag with the specified key
 func FindASGTag(tags []*autoscaling.TagDescription, key string) (string, bool) {
 	for _, tag := range tags {
-		if key == aws.StringValue(tag.Key) {
-			return aws.StringValue(tag.Value), true
+		if key == aws.ToString(tag.Key) {
+			return aws.ToString(tag.Value), true
 		}
 	}
 	return "", false
@@ -138,8 +138,8 @@ func FindASGTag(tags []*autoscaling.TagDescription, key string) (string, bool) {
 // FindELBTag find the value of the tag with the specified key
 func FindELBTag(tags []elbtypes.Tag, key string) (string, bool) {
 	for _, tag := range tags {
-		if key == aws.StringValue(tag.Key) {
-			return aws.StringValue(tag.Value), true
+		if key == aws.ToString(tag.Key) {
+			return aws.ToString(tag.Value), true
 		}
 	}
 	return "", false
@@ -148,8 +148,8 @@ func FindELBTag(tags []elbtypes.Tag, key string) (string, bool) {
 // FindELBV2Tag find the value of the tag with the specified key
 func FindELBV2Tag(tags []elbv2types.Tag, key string) (string, bool) {
 	for _, tag := range tags {
-		if key == aws.StringValue(tag.Key) {
-			return aws.StringValue(tag.Value), true
+		if key == aws.ToString(tag.Key) {
+			return aws.ToString(tag.Value), true
 		}
 	}
 	return "", false

--- a/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
@@ -21,8 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/pkg/apis/kops"
 )

--- a/upup/pkg/fi/cloudup/awsup/machine_types.go
+++ b/upup/pkg/fi/cloudup/awsup/machine_types.go
@@ -21,7 +21,7 @@ import (
 	"math"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"k8s.io/klog/v2"
 )
 
@@ -106,5 +106,5 @@ func GetMachineTypeInfo(c AWSCloud, machineType string) (*AWSMachineTypeInfo, er
 }
 
 func intValue(v *int64) int {
-	return int(aws.Int64Value(v))
+	return int(aws.ToInt64(v))
 }

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing/types"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2"

--- a/upup/pkg/fi/cloudup/awsup/status.go
+++ b/upup/pkg/fi/cloudup/awsup/status.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
@@ -75,14 +75,14 @@ func findEtcdStatus(c AWSCloud, cluster *kops.Cluster) ([]kops.EtcdClusterStatus
 	}
 
 	for _, volume := range volumes {
-		volumeID := aws.StringValue(volume.VolumeId)
+		volumeID := aws.ToString(volume.VolumeId)
 
 		etcdClusterName := ""
 		var etcdClusterSpec *etcd.EtcdClusterSpec
 		master := false
 		for _, tag := range volume.Tags {
-			k := aws.StringValue(tag.Key)
-			v := aws.StringValue(tag.Value)
+			k := aws.ToString(tag.Key)
+			v := aws.ToString(tag.Value)
 
 			if strings.HasPrefix(k, TagNameEtcdClusterPrefix) {
 				etcdClusterName = strings.TrimPrefix(k, TagNameEtcdClusterPrefix)
@@ -109,7 +109,7 @@ func findEtcdStatus(c AWSCloud, cluster *kops.Cluster) ([]kops.EtcdClusterStatus
 		memberName := etcdClusterSpec.NodeName
 		status.Members = append(status.Members, &kops.EtcdMemberStatus{
 			Name:     memberName,
-			VolumeID: aws.StringValue(volume.VolumeId),
+			VolumeID: aws.ToString(volume.VolumeId),
 		})
 	}
 

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/blang/semver/v4"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/upup/pkg/fi/cloudup/template_functions_test.go
+++ b/upup/pkg/fi/cloudup/template_functions_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/kops/cloudmock/aws/mockec2"
 	"k8s.io/kops/pkg/apis/kops"

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -31,10 +31,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"go.uber.org/multierr"


### PR DESCRIPTION
Ref: #16424

In an effort to reduce the diffs when migrating the last few largest services, this migrates most of the usage of `aws` pointer conversion methods to use the v2 SDK. 

I left files that still use v1's `aws.Config`