### PR TITLE
Provide default region to route53 client

### DIFF
--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
@@ -46,7 +46,6 @@ func init() {
 // newRoute53 creates a new instance of an AWS Route53 DNS Interface.
 func newRoute53() (*Interface, error) {
 	ctx := context.TODO()
-	// Connect to AWS Route53 - TODO: Do more sophisticated auth
 
 	cfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithClientLogMode(aws.LogRetries),
@@ -56,6 +55,11 @@ func newRoute53() (*Interface, error) {
 		}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load default aws config: %w", err)
+	}
+
+	// AWS_REGION, IMDS, or config profiles can override this in LoadDefaultConfig above.
+	if cfg.Region == "" {
+		cfg.Region = "us-east-1"
 	}
 
 	svc := route53.NewFromConfig(cfg)


### PR DESCRIPTION
This has similar behavior to awsup.ValidateRegion where we dont have access to a kops.Cluster to determine its region.

This is only needed in the dnsprovider client initialized in the kops CLI for creating the placeholder records - it wont be used on control plane nodes because LoadDefaultConfig will query IMDS for the node's region.

This isn't needed for all other usage of awsconfig.LoadDefaultConfig() because the region is known, for example in awsup.NewAWSCloud().

In any other partitions where us-east-1 is not appropriate, the user will already be specifying a region in their ~/.aws/config or via env var.

Fixes a regression from https://github.com/kubernetes/kops/pull/16448

ref: https://github.com/kubernetes/kops/pull/16363#issuecomment-2031069155