### PR TITLE
kube-router: fix version and cluster ip range

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -72,6 +72,7 @@ spec:
         - --metrics-port=12013
         - --runtime-endpoint=unix:///run/containerd/containerd.sock
         - --hairpin-mode=true
+        - --service-cluster-ip-range="{{ .Networking.ServiceClusterIPRange }}"
         env:
         - name: NODE_NAME
           valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -115,7 +115,7 @@ spec:
           readOnly: true
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v1.6.0
+        image: docker.io/cloudnativelabs/kube-router:v2.1.0
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
FYI @hakman 

* Updates the kube-router init container to also be v2.1.0 which is latest at this point
* Adds the service Cluster IP range from the kops configuration so that cluster IPs can be ingressed to the node and then later be processed by NetworkPolicy