### PR TITLE
Automated cherry pick of #16469: azure: Use lowercase for node names

### DIFF
--- a/upup/pkg/fi/cloudup/azure/verifier.go
+++ b/upup/pkg/fi/cloudup/azure/verifier.go
@@ -89,7 +89,7 @@ func (a azureVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request
 	if vm.Properties.OSProfile == nil || vm.Properties.OSProfile.ComputerName == nil || *vm.Properties.OSProfile.ComputerName == "" {
 		return nil, fmt.Errorf("determining ComputerName for VMSS %q virtual machine #%s", vmssName, vmssIndex)
 	}
-	nodeName := *vm.Properties.OSProfile.ComputerName
+	nodeName := strings.ToLower(*vm.Properties.OSProfile.ComputerName)
 
 	ni, err := a.client.nisClient.GetVirtualMachineScaleSetNetworkInterface(ctx, a.client.resourceGroup, vmssName, vmssIndex, vmssName+"-netconfig", nil)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #16469 on release-1.29.

#16469: azure: Use lowercase for node names

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```