### PR TITLE
Automated cherry pick of #16467: k8s-1.12.yaml.template: update kube-router init container

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -72,6 +72,7 @@ spec:
         - --metrics-port=12013
         - --runtime-endpoint=unix:///run/containerd/containerd.sock
         - --hairpin-mode=true
+        - --service-cluster-ip-range="{{ .Networking.ServiceClusterIPRange }}"
         env:
         - name: NODE_NAME
           valueFrom:

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -115,7 +115,7 @@ spec:
           readOnly: true
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v1.6.0
+        image: docker.io/cloudnativelabs/kube-router:v2.1.0
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
Cherry pick of #16467 on release-1.29.

#16467: k8s-1.12.yaml.template: update kube-router init container

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```