### PR TITLE
Skip installing crictl if old format containerd package is specified 

### DIFF
--- a/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
@@ -130,7 +130,7 @@ ClusterName: containerd.example.com
 ConfigBase: memfs://clusters.example.com/containerd.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: kp0kUXaxFgVddQpmP05mfszMPPHSV248hXXpQdcd2jw=
+NodeupConfigHash: VzyQCK9tv7L9svuLdh6adFRFmfeiwSIotD7Cyue6dCw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_nodes.containerd.example.com_user_data
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_nodes.containerd.example.com_user_data
@@ -153,7 +153,7 @@ ConfigServer:
   - https://kops-controller.internal.containerd.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: tcBm/XrPXdSV8TkWdzOgCRPlTj0W4kwvFC3WTgkC8rA=
+NodeupConfigHash: aApUXGvs7zCbaHeqsIoG4CmXDsPzFf03tvUPTi3m/xQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -62,7 +62,6 @@ Assets:
   - b64949fe696c77565edbe4100a315b6bf8f0e2325daeb762f7e865f16a6e54b5@https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubelet,https://cdn.dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubelet
   - b6769d8ac6a0ed0f13b307d289dc092ad86180b08f5b5044af152808c04950ae@https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl,https://cdn.dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - d16a1ffb3938f5a19d5c8f45d363bd091ef89c0bc4d44ad16b933eede32fdcbb@https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.29.0/crictl-v1.29.0-linux-amd64.tar.gz
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
   arm64:

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-nodes_content
@@ -3,7 +3,6 @@ Assets:
   - b64949fe696c77565edbe4100a315b6bf8f0e2325daeb762f7e865f16a6e54b5@https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubelet,https://cdn.dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubelet
   - b6769d8ac6a0ed0f13b307d289dc092ad86180b08f5b5044af152808c04950ae@https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl,https://cdn.dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - d16a1ffb3938f5a19d5c8f45d363bd091ef89c0bc4d44ad16b933eede32fdcbb@https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.29.0/crictl-v1.29.0-linux-amd64.tar.gz
   arm64:
   - fb033c1d079cac8babb04a25abecbc6cc1a2afb53f56ef1d73f8dc3b15b3c09e@https://dl.k8s.io/release/v1.26.0/bin/linux/arm64/kubelet,https://cdn.dl.k8s.io/release/v1.26.0/bin/linux/arm64/kubelet
   - 79b14e4ddada9e81d2989f36a89faa9e56f8abe6e0246e7bdc305c93c3731ea4@https://dl.k8s.io/release/v1.26.0/bin/linux/arm64/kubectl,https://cdn.dl.k8s.io/release/v1.26.0/bin/linux/arm64/kubectl


### PR DESCRIPTION
Fix #16425 
Because the old format containerd contains crictl binary.
If we don't skip it, it will conflict.