### PR TITLE
Migrate AWS Verifier to aws-sdk-go-v2

### DIFF
--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -130,7 +130,7 @@ func main() {
 		var verifiers []bootstrap.Verifier
 		var err error
 		if opt.Server.Provider.AWS != nil {
-			verifier, err := awsup.NewAWSVerifier(opt.Server.Provider.AWS)
+			verifier, err := awsup.NewAWSVerifier(ctx, opt.Server.Provider.AWS)
 			if err != nil {
 				setupLog.Error(err, "unable to create verifier")
 				os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/amazon-ec2-instance-selector/v2 v2.4.2-0.20231216170552-14d4dfcbaadf
-	github.com/aws/aws-sdk-go v1.52.1
 	github.com/aws/aws-sdk-go-v2 v1.26.1
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11
@@ -111,6 +110,7 @@ require (
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aws/aws-sdk-go v1.52.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.5 // indirect

--- a/nodeup/pkg/model/bootstrap_client.go
+++ b/nodeup/pkg/model/bootstrap_client.go
@@ -52,7 +52,7 @@ func (b BootstrapClientBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 
 	switch b.CloudProvider() {
 	case kops.CloudProviderAWS:
-		a, err := awsup.NewAWSAuthenticator(b.Cloud.Region())
+		a, err := awsup.NewAWSAuthenticator(c.Context(), b.Cloud.Region())
 		if err != nil {
 			return err
 		}

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -46,7 +46,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	ec2v1 "github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
@@ -2358,7 +2357,7 @@ func GetRolesInInstanceProfile(c AWSCloud, profileName string) ([]string, error)
 
 // GetInstanceCertificateNames returns the instance hostname and addresses that should go into certificates.
 // The first value is the node name and any additional values are the DNS name and IP addresses.
-func GetInstanceCertificateNames(instances *ec2v1.DescribeInstancesOutput) (addrs []string, err error) {
+func GetInstanceCertificateNames(instances *ec2.DescribeInstancesOutput) (addrs []string, err error) {
 	if len(instances.Reservations) != 1 {
 		return nil, fmt.Errorf("too many reservations returned for the single instance-id")
 	}

--- a/upup/pkg/fi/cloudup/awsup/aws_verifier.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_verifier.go
@@ -36,6 +36,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kops/pkg/bootstrap"
 	nodeidentityaws "k8s.io/kops/pkg/nodeidentity/aws"
 	"k8s.io/kops/pkg/wellknownports"
@@ -54,8 +55,9 @@ type awsVerifier struct {
 	opt       AWSVerifierOptions
 
 	ec2    *ec2.Client
-	sts    *sts.PresignClient
 	client http.Client
+
+	stsRequestValidator *stsRequestValidator
 }
 
 var _ bootstrap.Verifier = &awsVerifier{}
@@ -79,12 +81,17 @@ func NewAWSVerifier(ctx context.Context, opt *AWSVerifierOptions) (bootstrap.Ver
 
 	ec2Client := ec2.NewFromConfig(config)
 
+	stsRequestValidator, err := buildSTSRequestValidator(ctx, stsClient)
+	if err != nil {
+		return nil, err
+	}
+
 	return &awsVerifier{
-		accountId: aws.ToString(identity.Account),
-		partition: partition,
-		opt:       *opt,
-		ec2:       ec2Client,
-		sts:       sts.NewPresignClient(stsClient),
+		accountId:           aws.ToString(identity.Account),
+		partition:           partition,
+		opt:                 *opt,
+		ec2:                 ec2Client,
+		stsRequestValidator: stsRequestValidator,
 		client: http.Client{
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,
@@ -126,59 +133,38 @@ func (a awsVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request, 
 	}
 	token = strings.TrimPrefix(token, AWSAuthenticationTokenPrefix)
 
-	// We rely on the client and server using the same version of the same STS library.
-	stsRequest, err := a.sts.PresignGetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-	if err != nil {
-		return nil, fmt.Errorf("creating identity request: %v", err)
-	}
-
-	stsRequest.SignedHeader = nil
 	tokenBytes, err := base64.StdEncoding.DecodeString(token)
 	if err != nil {
 		return nil, fmt.Errorf("decoding authorization token: %v", err)
 	}
-	err = json.Unmarshal(tokenBytes, &stsRequest.SignedHeader)
-	if err != nil {
+	var decoded awsV2Token
+	if err := json.Unmarshal(tokenBytes, &decoded); err != nil {
 		return nil, fmt.Errorf("unmarshalling authorization token: %v", err)
 	}
 
 	// Verify the token has signed the body content.
 	sha := sha256.Sum256(body)
-	if stsRequest.SignedHeader.Get("X-Kops-Request-SHA") != base64.RawStdEncoding.EncodeToString(sha[:]) {
+	if decoded.SignedHeader.Get("X-Kops-Request-SHA") != base64.RawStdEncoding.EncodeToString(sha[:]) {
 		return nil, fmt.Errorf("incorrect SHA")
 	}
 
-	reqURL, err := url.Parse(stsRequest.URL)
+	reqURL, err := url.Parse(decoded.URL)
 	if err != nil {
 		return nil, fmt.Errorf("parsing STS request URL: %v", err)
 	}
-	req := &http.Request{
-		URL:    reqURL,
-		Method: stsRequest.Method,
-		Header: stsRequest.SignedHeader,
-	}
-	response, err := a.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("sending STS request: %v", err)
-	}
-	if response != nil {
-		defer response.Body.Close()
+	signedHeaders := sets.New(strings.Split(reqURL.Query().Get("X-Amz-SignedHeaders"), ";")...)
+	if !signedHeaders.Has("x-kops-request-sha") {
+		return nil, fmt.Errorf("unexpected signed headers value")
 	}
 
-	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading STS response: %v", err)
-	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("received status code %d from STS: %s", response.StatusCode, string(responseBody))
+	if !a.stsRequestValidator.IsValid(reqURL) {
+		return nil, fmt.Errorf("invalid STS url: host=%q, path=%q", reqURL.Host, reqURL.Path)
 	}
 
-	callerIdentity := GetCallerIdentityResponse{}
-	err = xml.NewDecoder(bytes.NewReader(responseBody)).Decode(&callerIdentity)
+	callerIdentity, err := a.stsRequestValidator.GetCallerIdentity(ctx, &a.client, &decoded)
 	if err != nil {
-		return nil, fmt.Errorf("decoding STS response: %v", err)
+		return nil, err
 	}
-
 	if callerIdentity.GetCallerIdentityResult[0].Account != a.accountId {
 		return nil, fmt.Errorf("incorrect account %s", callerIdentity.GetCallerIdentityResult[0].Account)
 	}
@@ -275,4 +261,82 @@ func (a awsVerifier) VerifyToken(ctx context.Context, rawRequest *http.Request, 
 	}
 
 	return result, nil
+}
+
+// stsRequestValidator describes valid STS Presigned URLs, and is used to validate client authentication requests.
+type stsRequestValidator struct {
+	Host string
+}
+
+// IsValid performs some basic pre-validation of the request URL.
+func (s *stsRequestValidator) IsValid(u *url.URL) bool {
+	if u.Host != s.Host {
+		return false
+	}
+	if u.Path != "/" {
+		return false
+	}
+	if u.Query().Get("Action") != "GetCallerIdentity" {
+		return false
+	}
+	if len(u.Query()["Action"]) != 1 {
+		return false
+	}
+
+	return true
+}
+
+// GetCallerIdentity will request the presigned token URL, and decode the returned identity.
+func (s *stsRequestValidator) GetCallerIdentity(ctx context.Context, httpClient *http.Client, decoded *awsV2Token) (*GetCallerIdentityResponse, error) {
+	reqURL, err := url.Parse(decoded.URL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing STS request URL: %w", err)
+	}
+
+	if !s.IsValid(reqURL) {
+		return nil, fmt.Errorf("url not valid for STS request")
+	}
+
+	req := &http.Request{
+		URL:    reqURL,
+		Method: decoded.Method,
+		Header: decoded.SignedHeader,
+	}
+	response, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending STS request: %v", err)
+	}
+	if response != nil {
+		defer response.Body.Close()
+	}
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading STS response: %v", err)
+	}
+	if response.StatusCode != 200 {
+		return nil, fmt.Errorf("received status code %d from STS: %s", response.StatusCode, string(responseBody))
+	}
+
+	callerIdentity := &GetCallerIdentityResponse{}
+	err = xml.NewDecoder(bytes.NewReader(responseBody)).Decode(callerIdentity)
+	if err != nil {
+		return nil, fmt.Errorf("decoding STS response: %v", err)
+	}
+
+	return callerIdentity, nil
+}
+
+// buildSTSRequestValidator determines the form of a valid STS presigned URL.
+func buildSTSRequestValidator(ctx context.Context, stsClient *sts.Client) (*stsRequestValidator, error) {
+	// We build a presigned token ourselves, primarily to get the expected hostname for the endpoint.
+	signed, err := sts.NewPresignClient(stsClient).PresignGetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return nil, fmt.Errorf("building presigned request: %w", err)
+	}
+	u, err := url.Parse(signed.URL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing presigned url: %w", err)
+	}
+	return &stsRequestValidator{Host: u.Host}, nil
 }

--- a/upup/pkg/fi/cloudup/awsup/aws_verifier_test.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_verifier_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsup
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+func TestGetSTSRequestInfo(t *testing.T) {
+	ctx := context.TODO()
+
+	awsConfig := aws.Config{}
+	awsConfig.Region = "us-east-1"
+	awsConfig.Credentials = credentials.NewStaticCredentialsProvider("fakeaccesskey", "fakesecretkey", "")
+	sts := sts.NewFromConfig(awsConfig)
+
+	stsRequestInfo, err := buildSTSRequestValidator(ctx, sts)
+	if err != nil {
+		t.Fatalf("error from getSTSRequestInfo: %v", err)
+	}
+
+	if got, want := stsRequestInfo.Host, "sts.us-east-1.amazonaws.com"; got != want {
+		t.Errorf("unexpected host in sts request info; got %q, want %q", got, want)
+	}
+
+	grid := []struct {
+		URL     string
+		IsValid bool
+	}{
+		{
+			URL:     "https://sts.us-east-1.amazonaws.com/",
+			IsValid: false,
+		},
+		{
+			URL:     "https://sts.us-east-1.amazonaws.com/Foo",
+			IsValid: false,
+		},
+		{
+			URL:     "https://sts.us-east-1.amazonaws.com/?Action=GetCallerIdentity",
+			IsValid: true,
+		},
+		{
+			URL:     "https://sts.us-east-1.amazonaws.com/Foo?Action=GetCallerIdentity",
+			IsValid: false,
+		},
+		{
+			URL:     "https://sts.us-east-1.amazonaws.com/?Action=GetCallerIdentity&Action=GetCallerIdentity",
+			IsValid: false,
+		},
+	}
+
+	for _, g := range grid {
+		u, err := url.Parse(g.URL)
+		if err != nil {
+			t.Fatalf("parsing url %q: %v", g.URL, err)
+		}
+		got := stsRequestInfo.IsValid(u)
+		if got != g.IsValid {
+			t.Errorf("unexpected result for IsValid(%v); got %v, want %v", g.URL, got, g.IsValid)
+		}
+	}
+
+}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -625,7 +625,7 @@ func getNodeConfigFromServers(ctx context.Context, bootConfig *nodeup.BootConfig
 
 	switch bootConfig.CloudProvider {
 	case api.CloudProviderAWS:
-		a, err := awsup.NewAWSAuthenticator(region)
+		a, err := awsup.NewAWSAuthenticator(ctx, region)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Closes https://github.com/kubernetes/kops/issues/16424

From [this comment](https://github.com/kubernetes/kops/issues/16424#issuecomment-2046489720):

[While presigned requests are still supported in V2](https://aws.github.io/aws-sdk-go-v2/docs/migrating/#presigned-requests), the [presign methods and types](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/sts#PresignClient) no longer provide access to the request body, only their url and headers. See https://github.com/aws/aws-sdk-go-v2/issues/1137. Kops-controller currently reads the request body to perform some validation:
https://github.com/kubernetes/kops/blob/1c24423d9be20396e62755f6952b415567a56ced/upup/pkg/fi/cloudup/awsup/aws_verifier.go#L153-L157

In V1 the presigned request is a POST however in V2 it is converted to a GET request and the normal  `Action=GetCallerIdentity&Version=2011-06-15` body is moved to URL query parameters:
https://github.com/aws/aws-sdk-go-v2/blob/bc2a669d3241023e20194cdfe042b8c275887e51/service/sts/api_client.go#L641-L645

I've removed the validation that checks the Content-Length signed header matches the size of the request body, given the request body is now empty.


[This thread](https://github.com/kubernetes/kops/pull/9653#discussion_r463585666) on the original kops-controller PR discusses potential upgrade challenges. In this case I believe we'll have the normal race with this type of change:

1. Old node is launched
2. New `kops update cluster --yes` and `kops rolling-update --yes` is ran
3. New control plane node is launched, new kops-controller is running
4. Old node attempts to join and fails because the GetCallerIdentity requests dont match.

In reality I dont anticipate this being a problem because the old node would have needed to not join the cluster in the time it took the control plane to bootstrap and launch the kops-controller daemonset pod (a significantly longer process than normal k8s node bootstrap). Eventually the failed node will be cleaned up by cluster-autoscaler or karpenter.

My only concern would be disruption to `kops rolling-update` if the node never joins which causes cluster validation to fail until it is cleaned up.