### PR TITLE
Fix getting crictl assets

### DIFF
--- a/nodeup/pkg/model/crictl.go
+++ b/nodeup/pkg/model/crictl.go
@@ -17,10 +17,10 @@ limitations under the License.
 package model
 
 import (
-	"fmt"
 	"path/filepath"
 	"regexp"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 	"k8s.io/kops/util/pkg/distributions"
@@ -35,10 +35,12 @@ var _ fi.NodeupModelBuilder = &CrictlBuilder{}
 func (b *CrictlBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	assets := b.Assets.FindMatches(regexp.MustCompile(`^crictl$`))
 	if len(assets) == 0 {
-		return fmt.Errorf("unable to find any crictl binaries in assets")
+		klog.Warning("unable to find any crictl binaries in assets")
+		return nil
 	}
 	if len(assets) > 1 {
-		return fmt.Errorf("multiple crictl binaries are found")
+		klog.Warning("multiple crictl binaries are found")
+		return nil
 	}
 
 	for k, v := range assets {

--- a/nodeup/pkg/model/nerdctl.go
+++ b/nodeup/pkg/model/nerdctl.go
@@ -17,7 +17,6 @@ limitations under the License.
 package model
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"k8s.io/klog/v2"
@@ -42,7 +41,8 @@ func (b *NerdctlBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	assetPath := ""
 	asset, err := b.Assets.Find(assetName, assetPath)
 	if err != nil {
-		return fmt.Errorf("unable to locate asset %q: %w", assetName, err)
+		klog.Warningf("unable to locate asset %q: %v", assetName, err)
+		return nil
 	}
 
 	c.AddTask(&nodetasks.File{


### PR DESCRIPTION
because multiple crictl binaries are found when you specify containerd packages. The old format containerd packages contain crictl binary.

Fix #16425 