### PR TITLE
kube-router: bump version v2.1.0 -> v2.1.1

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -19,6 +19,7 @@ data:
              "type":"bridge",
              "bridge":"kube-bridge",
              "isDefaultGateway":true,
+             "hairpinMode":true,
              "ipam":{
                 "type":"host-local"
              }

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v2.1.0
+        image: docker.io/cloudnativelabs/kube-router:v2.1.1
         args:
         - --run-router=true
         - --run-firewall=true
@@ -117,7 +117,7 @@ spec:
           readOnly: true
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v2.1.0
+        image: docker.io/cloudnativelabs/kube-router:v2.1.1
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
@hakman 

Bump kube-router version from v2.1.0 -> v2.1.1 and enable hairpin mode in CNI configuration for the bridge plugin. This obviates the need for a hairpin controller inside kube-router which had a lot of unhandled edge cases.