### PR TITLE
chore: optimize the method for obtaining gopath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ UPLOAD_DEST?=$(S3_BUCKET)
 GCS_LOCATION?=gs://must-override
 GCS_URL=$(GCS_LOCATION:gs://%=https://storage.googleapis.com/%)
 LATEST_FILE?=latest-ci.txt
-GOPATH_1ST:=$(shell go env | grep GOPATH | cut -f 2 -d '"' | sed 's/ /\\ /g')
+GOPATH_1ST:=$(shell go env GOPATH)
 UNIQUE:=$(shell date +%s)
 BUILD=$(KOPS_ROOT)/.build
 LOCAL=$(BUILD)/local


### PR DESCRIPTION
```bash
$ time(go env | grep GOPATH | cut -f 2 -d '"' | sed 's/ /\\ /g')
/root/go

real    0m0.004s
user    0m0.003s
sys     0m0.004s
$ time(go env GOPATH)
/root/go

real    0m0.003s
user    0m0.003s
sys     0m0.000s

```