### PR TITLE
Support AuthenticationConfig in APIserver

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1750,6 +1750,11 @@ spec:
                       Batch causes the backend to buffer and write events asynchronously.
                       Known modes are batch,blocking. (default "batch")
                     type: string
+                  authenticationConfigFile:
+                    description: |-
+                      AuthenticationConfigFile is the location of the authentication-config
+                      this option is mutually exclusive with all OIDC options
+                    type: string
                   authenticationTokenWebhookCacheTtl:
                     description: The duration to cache responses from the webhook
                       token authenticator. Default is 2m. (default 2m0s)

--- a/nodeup/pkg/model/tests/golden/audit/cluster.yaml
+++ b/nodeup/pkg/model/tests/golden/audit/cluster.yaml
@@ -65,6 +65,7 @@ spec:
     auditPolicyFile: /etc/kubernetes/audit/policy-config.yaml
     auditWebhookBatchMaxWait: 5s
     auditWebhookConfigFile: /etc/kubernetes/audit/webhook-config.yaml
+    authenticationConfigFile: /etc/kubernetes/authentication-config.yaml
   kubelet:
     anonymousAuth: false
   kubernetesVersion: v1.28.0

--- a/nodeup/pkg/model/tests/golden/audit/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/audit/tasks-kube-apiserver.yaml
@@ -28,6 +28,7 @@ contents: |
       - --audit-policy-file=/etc/kubernetes/audit/policy-config.yaml
       - --audit-webhook-batch-max-wait=5s
       - --audit-webhook-config-file=/etc/kubernetes/audit/webhook-config.yaml
+      - --authentication-config=/etc/kubernetes/authentication-config.yaml
       - --authorization-mode=AlwaysAllow
       - --bind-address=0.0.0.0
       - --client-ca-file=/srv/kubernetes/ca.crt

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -401,6 +401,9 @@ type KubeAPIServerConfig struct {
 	// OIDCCAFile if set, the OpenID server's certificate will be verified by one
 	// of the authorities in the oidc-ca-file
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
+	// AuthenticationConfigFile is the location of the authentication-config
+	// this option is mutually exclusive with all OIDC options
+	AuthenticationConfigFile string `json:"authenticationConfigFile,omitempty" flag:"authentication-config"`
 	// The apiserver's client certificate used for outbound requests.
 	ProxyClientCertFile *string `json:"proxyClientCertFile,omitempty" flag:"proxy-client-cert-file"`
 	// The apiserver's client key used for outbound requests.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -408,6 +408,9 @@ type KubeAPIServerConfig struct {
 	// OIDCCAFile if set, the OpenID server's certificate will be verified by one
 	// of the authorities in the oidc-ca-file
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
+	// AuthenticationConfigFile is the location of the authentication-config
+	// this option is mutually exclusive with all OIDC options
+	AuthenticationConfigFile string `json:"authenticationConfigFile,omitempty" flag:"authentication-config"`
 	// The apiserver's client certificate used for outbound requests.
 	ProxyClientCertFile *string `json:"proxyClientCertFile,omitempty" flag:"proxy-client-cert-file"`
 	// The apiserver's client key used for outbound requests.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4906,6 +4906,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	// INFO: in.OIDCClientID opted out of conversion generation
 	// INFO: in.OIDCRequiredClaim opted out of conversion generation
 	out.OIDCCAFile = in.OIDCCAFile
+	out.AuthenticationConfigFile = in.AuthenticationConfigFile
 	out.ProxyClientCertFile = in.ProxyClientCertFile
 	out.ProxyClientKeyFile = in.ProxyClientKeyFile
 	out.AuditLogFormat = in.AuditLogFormat
@@ -5020,6 +5021,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.OIDCClientID = in.OIDCClientID
 	out.OIDCRequiredClaim = in.OIDCRequiredClaim
 	out.OIDCCAFile = in.OIDCCAFile
+	out.AuthenticationConfigFile = in.AuthenticationConfigFile
 	out.ProxyClientCertFile = in.ProxyClientCertFile
 	out.ProxyClientKeyFile = in.ProxyClientKeyFile
 	out.AuditLogFormat = in.AuditLogFormat

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -399,6 +399,9 @@ type KubeAPIServerConfig struct {
 	// OIDCCAFile if set, the OpenID server's certificate will be verified by one
 	// of the authorities in the oidc-ca-file
 	OIDCCAFile *string `json:"oidcCAFile,omitempty" flag:"oidc-ca-file"`
+	// AuthenticationConfigFile is the location of the authentication-config
+	// this option is mutually exclusive with all OIDC options
+	AuthenticationConfigFile string `json:"authenticationConfigFile,omitempty" flag:"authentication-config"`
 	// ProxyClientCertFile is not admin-configurable.
 	ProxyClientCertFile *string `json:"-"`
 	// ProxyClientKeyFile is not admin-configurable.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5301,6 +5301,7 @@ func autoConvert_v1alpha3_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.OIDCClientID = in.OIDCClientID
 	out.OIDCRequiredClaim = in.OIDCRequiredClaim
 	out.OIDCCAFile = in.OIDCCAFile
+	out.AuthenticationConfigFile = in.AuthenticationConfigFile
 	out.ProxyClientCertFile = in.ProxyClientCertFile
 	out.ProxyClientKeyFile = in.ProxyClientKeyFile
 	out.AuditLogFormat = in.AuditLogFormat
@@ -5415,6 +5416,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha3_KubeAPIServerConfig(in *ko
 	out.OIDCClientID = in.OIDCClientID
 	out.OIDCRequiredClaim = in.OIDCRequiredClaim
 	out.OIDCCAFile = in.OIDCCAFile
+	out.AuthenticationConfigFile = in.AuthenticationConfigFile
 	out.ProxyClientCertFile = in.ProxyClientCertFile
 	out.ProxyClientKeyFile = in.ProxyClientKeyFile
 	out.AuditLogFormat = in.AuditLogFormat

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -732,6 +732,13 @@ func validateExecContainerAction(v *kops.ExecContainerAction, fldPath *field.Pat
 func validateKubeAPIServer(v *kops.KubeAPIServerConfig, c *kops.Cluster, fldPath *field.Path, strict bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	if v.AuthenticationConfigFile != "" && c.Spec.Authentication != nil && c.Spec.Authentication.OIDC != nil {
+		o := c.Spec.Authentication.OIDC
+		if o.UsernameClaim != nil || o.UsernamePrefix != nil || o.GroupsClaims != nil || o.GroupsPrefix != nil || o.IssuerURL != nil || o.ClientID != nil || o.RequiredClaims != nil {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("authenticationConfigFile"), "authenticationConfigFile is mutually exclusive with OIDC options, remove all existing OIDC options to use authenticationConfigFile"))
+		}
+	}
+
 	if fi.ValueOf(v.EnableBootstrapAuthToken) {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableBootstrapTokenAuth"), "bootstrap tokens are not supported"))
 	}

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -310,6 +310,21 @@ func TestValidateKubeAPIServer(t *testing.T) {
 			},
 			ExpectedErrors: []string{"Unsupported value::KubeAPIServer.logFormat"},
 		},
+		{
+			Input: kops.KubeAPIServerConfig{
+				AuthenticationConfigFile: "/foo/bar",
+			},
+			Cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					Authentication: &kops.AuthenticationSpec{
+						OIDC: &kops.OIDCAuthenticationSpec{
+							ClientID: fi.PtrTo("foo"),
+						},
+					},
+				},
+			},
+			ExpectedErrors: []string{"Forbidden::KubeAPIServer.authenticationConfigFile"},
+		},
 	}
 	for _, g := range grid {
 		if g.Cluster == nil {


### PR DESCRIPTION
this PR will add possibility to use `--authentication-config` flag for apiserver

https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3331-structured-authentication-configuration

