### PR TITLE
Fix postsubmit jobs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # Push the images
-- name: 'docker.io/library/golang:1.22.0-bookworm'
+- name: 'docker.io/library/golang:1.22.2-bookworm'
   id: images
   entrypoint: make
   env:
@@ -21,7 +21,7 @@ steps:
   - dns-controller-push
   - kube-apiserver-healthcheck-push
 # Push the artifacts
-- name: 'docker.io/library/golang:1.22.0-bookworm'
+- name: 'docker.io/library/golang:1.22.2-bookworm'
   id: artifacts
   entrypoint: make
   env:
@@ -36,7 +36,7 @@ steps:
   args:
   - gcs-upload-and-tag
 # Build cloudbuild artifacts (for attestation)
-- name: 'docker.io/library/golang:1.22.0-bookworm'
+- name: 'docker.io/library/golang:1.22.2-bookworm'
   id: cloudbuild-artifacts
   entrypoint: make
   env:


### PR DESCRIPTION
ref: #16533

These were still running on go 1.22.0 and failing because the go.mod version directive now includes patch versions:

https://github.com/kubernetes/kops/blob/02f6b921e1cd03af61e5a0e56ffd3a2c7b4a0d04/go.mod#L3

Should fix these post-submit jobs
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/kops-postsubmit-push-to-staging/1787502731934568448

In the future we'll need to make sure patch updates to the go version also update this file.