### PR TITLE
Automated cherry pick of #16531: Update containerd to v1.7.16

### DIFF
--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -59,12 +59,12 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 					Version: fi.PtrTo("1.1.5"),
 				}
 			case b.IsKubernetesGTE("1.27.2"):
-				containerd.Version = fi.PtrTo("1.7.13")
+				containerd.Version = fi.PtrTo("1.7.16")
 				containerd.Runc = &kops.Runc{
 					Version: fi.PtrTo("1.1.12"),
 				}
 			default:
-				containerd.Version = fi.PtrTo("1.6.28")
+				containerd.Version = fi.PtrTo("1.6.31")
 				containerd.Runc = &kops.Runc{
 					Version: fi.PtrTo("1.1.12"),
 				}

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -128,7 +128,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: PYm5BYFmYy5ptdy9KmulViNCxelEfRFYqVyxDpPF+so=
+NodeupConfigHash: /Bb9dUaOfbl2JBMEflXryNjgGqQaBYLV4dmRJ/CzWMg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -151,7 +151,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: u0Pkmi2KyYCdYvFCsJo+42JLkmA90RkuJVkHpsoxyXg=
+NodeupConfigHash: 4/FsIb8rIwtBYWazLy/gF5FU+POrD5BeJhmPXeZmQaU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_cluster-completed.spec_content
@@ -30,7 +30,7 @@ spec:
     logLevel: info
     runc:
       version: 1.1.12
-    version: 1.7.13
+    version: 1.7.16
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -62,7 +62,7 @@ Assets:
   - 4f38ee903f35b300d3b005a9c6bfb9a46a57f92e89ae602ef9c129b91dc6c5a5@https://dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl,https://cdn.dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl
   - 5035d7814c95cd3cedbc5efb447ef25a4942ef05caab2159746d55ce1698c74a@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/amd64/ecr-credential-provider-linux-amd64
   - f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz
-  - c2371c009dd8b7738663333d91e5ab50d204f8bcae24201f45d59060d12c3a23@https://github.com/containerd/containerd/releases/download/v1.7.13/containerd-1.7.13-linux-amd64.tar.gz
+  - 4f4f2c3c7d14fd59a404961a3a3341303c2fdeeba0e78808c209f606e828f99c@https://github.com/containerd/containerd/releases/download/v1.7.16/containerd-1.7.16-linux-amd64.tar.gz
   - aadeef400b8f05645768c1476d1023f7875b78f52c7ff1967a6dbce236b8cbd8@https://github.com/opencontainers/runc/releases/download/v1.1.12/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -71,7 +71,7 @@ Assets:
   - 1b0966692e398efe71fe59f913eaec44ffd4468cc1acd00bf91c29fa8ff8f578@https://dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubectl,https://cdn.dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubectl
   - b3d567bda9e2996fc1fbd9d13506bd16763d3865b5c7b0b3c4b48c6088c04481@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/arm64/ecr-credential-provider-linux-arm64
   - 525e2b62ba92a1b6f3dc9612449a84aa61652e680f7ebf4eff579795fe464b57@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-arm64-v1.2.0.tgz
-  - 118759e398f35337109592b4d237538872dc12a207d38832b9d04515d0acbc4d@https://github.com/containerd/containerd/releases/download/v1.7.13/containerd-1.7.13-linux-arm64.tar.gz
+  - 2d4373de40a6f58cd0f29377c0257b35697a987248e6268520586996771d7a75@https://github.com/containerd/containerd/releases/download/v1.7.16/containerd-1.7.16-linux-arm64.tar.gz
   - 879f910a05c95c10c64ad8eb7d5e3aa8e4b30e65587b3d68e009a3565aed5bb8@https://github.com/opencontainers/runc/releases/download/v1.1.12/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -319,7 +319,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.12
-  version: 1.7.13
+  version: 1.7.16
 docker:
   skipInstall: true
 etcdManifests:

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_nodeupconfig-nodes_content
@@ -4,14 +4,14 @@ Assets:
   - 4f38ee903f35b300d3b005a9c6bfb9a46a57f92e89ae602ef9c129b91dc6c5a5@https://dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl,https://cdn.dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl
   - 5035d7814c95cd3cedbc5efb447ef25a4942ef05caab2159746d55ce1698c74a@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/amd64/ecr-credential-provider-linux-amd64
   - f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz
-  - c2371c009dd8b7738663333d91e5ab50d204f8bcae24201f45d59060d12c3a23@https://github.com/containerd/containerd/releases/download/v1.7.13/containerd-1.7.13-linux-amd64.tar.gz
+  - 4f4f2c3c7d14fd59a404961a3a3341303c2fdeeba0e78808c209f606e828f99c@https://github.com/containerd/containerd/releases/download/v1.7.16/containerd-1.7.16-linux-amd64.tar.gz
   - aadeef400b8f05645768c1476d1023f7875b78f52c7ff1967a6dbce236b8cbd8@https://github.com/opencontainers/runc/releases/download/v1.1.12/runc.amd64
   arm64:
   - 810cd9a611e9f084e57c9ee466e33c324b2228d4249ff38c2588a0cc3224f10d@https://dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubelet,https://cdn.dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubelet
   - 1b0966692e398efe71fe59f913eaec44ffd4468cc1acd00bf91c29fa8ff8f578@https://dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubectl,https://cdn.dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubectl
   - b3d567bda9e2996fc1fbd9d13506bd16763d3865b5c7b0b3c4b48c6088c04481@https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.27.1/linux/arm64/ecr-credential-provider-linux-arm64
   - 525e2b62ba92a1b6f3dc9612449a84aa61652e680f7ebf4eff579795fe464b57@https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-arm64-v1.2.0.tgz
-  - 118759e398f35337109592b4d237538872dc12a207d38832b9d04515d0acbc4d@https://github.com/containerd/containerd/releases/download/v1.7.13/containerd-1.7.13-linux-arm64.tar.gz
+  - 2d4373de40a6f58cd0f29377c0257b35697a987248e6268520586996771d7a75@https://github.com/containerd/containerd/releases/download/v1.7.16/containerd-1.7.16-linux-arm64.tar.gz
   - 879f910a05c95c10c64ad8eb7d5e3aa8e4b30e65587b3d68e009a3565aed5bb8@https://github.com/opencontainers/runc/releases/download/v1.1.12/runc.arm64
 CAs: {}
 ClusterName: minimal.example.com
@@ -57,7 +57,7 @@ containerdConfig:
   logLevel: info
   runc:
     version: 1.1.12
-  version: 1.7.13
+  version: 1.7.16
 docker:
   skipInstall: true
 useInstanceIDForNodeName: true


### PR DESCRIPTION
Cherry pick of #16531 on release-1.28.

#16531: Update containerd to v1.7.16

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```