### PR TITLE
Automated cherry pick of #16542: Initial support for Ubuntu 24.04 (Noble Numbat)

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -53,6 +53,7 @@ The following table provides the support status for various distros with regards
 | Ubuntu 18.04                            |         1.10 |   1.16 |       1.26 |    1.28 |
 | [Ubuntu 20.04](#ubuntu-2004-focal)      |       1.16.2 |   1.18 |          - |       - |
 | [Ubuntu 22.04](#ubuntu-2204-jammy)      |         1.23 |   1.24 |          - |       - |
+| [Ubuntu 24.04](#ubuntu-2404-noble)      |         1.29 |      - |          - |       - |
 
 ## Supported Distros
 
@@ -240,6 +241,18 @@ gcloud compute images list --filter ubuntu-2204-jammy-v
 # Microsoft Azure
 az vm image list --all --output table \
   --publisher Canonical --offer 0001-com-ubuntu-server-jammy --sku 22_04-lts-gen2
+```
+
+### Ubuntu 24.04 (Noble)
+
+Support for Ubuntu 24.04 is **experimental**.
+
+```bash
+# Amazon Web Services (AWS)
+aws ec2 describe-images --region us-east-1 --output table \
+  --owners 099720109477 \
+  --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
+  --filters "Name=name,Values=ubuntu/images/hvm-ssd-gp3/ubuntu-jammy-22.04-*-*"
 ```
 
 ## Owner aliases

--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -42,10 +42,8 @@ var (
 	DistributionDebian11        = Distribution{packageFormat: "deb", project: "debian", id: "bullseye", version: 11}
 	DistributionDebian12        = Distribution{packageFormat: "deb", project: "debian", id: "bookworm", version: 12}
 	DistributionUbuntu2004      = Distribution{packageFormat: "deb", project: "ubuntu", id: "focal", version: 20.04}
-	DistributionUbuntu2010      = Distribution{packageFormat: "deb", project: "ubuntu", id: "groovy", version: 20.10}
-	DistributionUbuntu2104      = Distribution{packageFormat: "deb", project: "ubuntu", id: "hirsute", version: 21.04}
-	DistributionUbuntu2110      = Distribution{packageFormat: "deb", project: "ubuntu", id: "impish", version: 21.10}
 	DistributionUbuntu2204      = Distribution{packageFormat: "deb", project: "ubuntu", id: "jammy", version: 22.04}
+	DistributionUbuntu2404      = Distribution{packageFormat: "deb", project: "ubuntu", id: "noble", version: 24.04}
 	DistributionAmazonLinux2    = Distribution{packageFormat: "rpm", project: "amazonlinux2", id: "amazonlinux2", version: 0}
 	DistributionAmazonLinux2023 = Distribution{packageFormat: "rpm", project: "amazonlinux2023", id: "amzn", version: 2023}
 	DistributionRhel8           = Distribution{packageFormat: "rpm", project: "rhel", id: "rhel8", version: 8}
@@ -99,9 +97,7 @@ func (d *Distribution) DefaultUsers() ([]string, error) {
 // See https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting-loops-in-kubernetes-clusters
 func (d *Distribution) HasLoopbackEtcResolvConf() bool {
 	switch d.project {
-	case "ubuntu":
-		return d.version >= 18.04
-	case "flatcar":
+	case "ubuntu", "flatcar":
 		return true
 	default:
 		if _, err := os.Stat("/run/systemd/resolve/resolv.conf"); err == nil {

--- a/util/pkg/distributions/identify.go
+++ b/util/pkg/distributions/identify.go
@@ -60,14 +60,10 @@ func FindDistribution(rootfs string) (Distribution, error) {
 		return DistributionDebian12, nil
 	case "ubuntu-20.04":
 		return DistributionUbuntu2004, nil
-	case "ubuntu-20.10":
-		return DistributionUbuntu2010, nil
-	case "ubuntu-21.04":
-		return DistributionUbuntu2104, nil
-	case "ubuntu-21.10":
-		return DistributionUbuntu2110, nil
 	case "ubuntu-22.04":
 		return DistributionUbuntu2204, nil
+	case "ubuntu-24.04":
+		return DistributionUbuntu2404, nil
 	}
 
 	// Some distros have a more verbose VERSION_ID

--- a/util/pkg/distributions/identify_test.go
+++ b/util/pkg/distributions/identify_test.go
@@ -120,24 +120,14 @@ func TestFindDistribution(t *testing.T) {
 			expected: DistributionUbuntu2004,
 		},
 		{
-			rootfs:   "ubuntu2010",
-			err:      nil,
-			expected: DistributionUbuntu2010,
-		},
-		{
-			rootfs:   "ubuntu2104",
-			err:      nil,
-			expected: DistributionUbuntu2104,
-		},
-		{
-			rootfs:   "ubuntu2110",
-			err:      nil,
-			expected: DistributionUbuntu2110,
-		},
-		{
 			rootfs:   "ubuntu2204",
 			err:      nil,
 			expected: DistributionUbuntu2204,
+		},
+		{
+			rootfs:   "ubuntu2404",
+			err:      nil,
+			expected: DistributionUbuntu2404,
 		},
 		{
 			rootfs:   "notfound",

--- a/util/pkg/distributions/tests/ubuntu2404/etc/os-release
+++ b/util/pkg/distributions/tests/ubuntu2404/etc/os-release
@@ -1,0 +1,13 @@
+PRETTY_NAME="Ubuntu 24.04 LTS"
+NAME="Ubuntu"
+VERSION_ID="24.04"
+VERSION="24.04 LTS (Noble Numbat)"
+VERSION_CODENAME=noble
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=noble
+LOGO=ubuntu-logo


### PR DESCRIPTION
Cherry pick of #16542 on release-1.29.

#16542: Initial support for Ubuntu 24.04 (Noble Numbat)

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```