### PR TITLE
Use addon versions for git repo clone in e2e scenarios

### DIFF
--- a/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
+++ b/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
@@ -33,7 +33,13 @@ REPORT_DIR="${ARTIFACTS:-$(pwd)/_artifacts}/aws-ebs-csi-driver/"
 cd "$(mktemp -dt kops.XXXXXXXXX)"
 go get github.com/onsi/ginkgo/ginkgo
 
-git clone --branch v1.4.0 https://github.com/kubernetes-sigs/aws-ebs-csi-driver.git .
+CSI_VERSION=$(kubectl get deployment -n kube-system ebs-csi-controller -o jsonpath='{.spec.template.spec.containers[?(@.name=="ebs-plugin")].image}' | cut -d':' -f2-)
+CLONE_ARGS=
+if [ -n "$CSI_VERSION" ]; then
+    CLONE_ARGS="-b ${CSI_VERSION}"
+fi
+# shellcheck disable=SC2086
+git clone ${CLONE_ARGS} https://github.com/kubernetes-sigs/aws-ebs-csi-driver.git .
 
 # shellcheck disable=SC2164
 cd tests/e2e-kubernetes/

--- a/tests/e2e/scenarios/metrics-server/run-test.sh
+++ b/tests/e2e/scenarios/metrics-server/run-test.sh
@@ -28,7 +28,13 @@ kops-up
 # shellcheck disable=SC2164
 cd "$(mktemp -dt kops.XXXXXXXXX)"
 
-git clone --branch v0.6.0 https://github.com/kubernetes-sigs/metrics-server.git .
+MS_VERSION=$(kubectl get deployment -n kube-system metrics-server -o jsonpath='{.spec.template.spec.containers[?(@.name=="metrics-server")].image}' | cut -d':' -f2-)
+CLONE_ARGS=
+if [ -n "$MS_VERSION" ]; then
+    CLONE_ARGS="-b ${MS_VERSION}"
+fi
+# shellcheck disable=SC2086
+git clone ${CLONE_ARGS} https://github.com/kubernetes-sigs/metrics-server.git .
 
 # some of the metrics only show when requested
 kubectl get --raw "/apis/metrics.k8s.io/v1beta1/pods"


### PR DESCRIPTION
This matches the aws-load-balancer-controller scenario script.

Should fix this metrics-server test that began to fail once it started using a kops version that includes metrics-server v0.7.1

https://testgrid.k8s.io/kops-misc#kops-aws-metrics-server