### PR TITLE
Bump golang to 1.22.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
         with:
-          go-version: '1.22.0'
+          go-version: '1.22.3'
 
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
         with:
@@ -36,7 +36,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
       with:
-        go-version: '1.22.0'
+        go-version: '1.22.3'
 
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       with:
@@ -53,7 +53,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
       with:
-        go-version: '1.22.0'
+        go-version: '1.22.3'
 
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       with:
@@ -70,7 +70,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
         with:
-          go-version: '1.22.0'
+          go-version: '1.22.3'
 
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
         with:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
         with:
-          go-version: '1.22.0'
+          go-version: '1.22.3'
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Update Dependencies
         id: update_deps

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # Push the images
-- name: 'docker.io/library/golang:1.22.2-bookworm'
+- name: 'docker.io/library/golang:1.22.3-bookworm'
   id: images
   entrypoint: make
   env:
@@ -21,7 +21,7 @@ steps:
   - dns-controller-push
   - kube-apiserver-healthcheck-push
 # Push the artifacts
-- name: 'docker.io/library/golang:1.22.2-bookworm'
+- name: 'docker.io/library/golang:1.22.3-bookworm'
   id: artifacts
   entrypoint: make
   env:
@@ -36,7 +36,7 @@ steps:
   args:
   - gcs-upload-and-tag
 # Build cloudbuild artifacts (for attestation)
-- name: 'docker.io/library/golang:1.22.2-bookworm'
+- name: 'docker.io/library/golang:1.22.3-bookworm'
   id: cloudbuild-artifacts
   entrypoint: make
   env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops
 
-go 1.22.2
+go 1.22.3
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/hack
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/tests/e2e
 
-go 1.22.2
+go 1.22.3
 
 replace k8s.io/kops => ../../.
 

--- a/tools/otel/traceserver/go.mod
+++ b/tools/otel/traceserver/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/tools/otel/traceserver
 
-go 1.22.2
+go 1.22.3
 
 require (
 	go.opentelemetry.io/proto/otlp v1.2.0


### PR DESCRIPTION
Includes some security fixes, though they don't look likely to impact
us.
