### PR TITLE
tests: use version from go.mod in github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,14 +16,14 @@ jobs:
   build-linux-amd64:
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
-        with:
-          go-version: '1.22.3'
-
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/kops
+
+      - name: Set up go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
+        with:
+          go-version-file: '${{ env.GOPATH }}/src/k8s.io/kops/go.mod'
 
       - name: make all examples test
         working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
@@ -33,14 +33,14 @@ jobs:
   build-macos-amd64:
     runs-on: macos-latest
     steps:
-    - name: Set up go
-      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
-      with:
-        go-version: '1.22.3'
-
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       with:
         path: ${{ env.GOPATH }}/src/k8s.io/kops
+
+    - name: Set up go
+      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
+      with:
+        go-version-file: '${{ env.GOPATH }}/src/k8s.io/kops/go.mod'
 
     - name: make kops examples test
       working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
@@ -50,14 +50,14 @@ jobs:
   build-windows-amd64:
     runs-on: windows-2019
     steps:
-    - name: Set up go
-      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
-      with:
-        go-version: '1.22.3'
-
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       with:
         path: ${{ env.GOPATH }}/src/k8s.io/kops
+
+    - name: Set up go
+      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
+      with:
+        go-version-file: '${{ env.GOPATH }}/src/k8s.io/kops/go.mod'
 
     - name: make kops examples test
       working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
@@ -67,14 +67,14 @@ jobs:
   verify:
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
-        with:
-          go-version: '1.22.3'
-
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/kops
+
+      - name: Set up go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
+        with:
+          go-version-file: '${{ env.GOPATH }}/src/k8s.io/kops/go.mod'
 
       - name: make quick-ci
         working-directory: ${{ env.GOPATH }}/src/k8s.io/kops

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -17,10 +17,12 @@ jobs:
     if: ${{ github.repository == 'kubernetes/kops' }}
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
         with:
-          go-version: '1.22.3'
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+          go-version-file: 'go.mod'
+
       - name: Update Dependencies
         id: update_deps
         run: |


### PR DESCRIPTION
- Bump golang to 1.22.3
- tests: use version from go.mod in github actions
