### PR TITLE
Automated cherry pick of #16556: cluster-autoscaler: Fix priority expander config

### DIFF
--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: b0c764405add27350d8642bbb30352457acd9b7f223cff119a62bb18773fe2e3
+    manifestHash: 963767d82e85200787e166f3cc6e7b3b9e60d2383c9fef71a562d9e4eedd7086
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -282,12 +282,12 @@ spec:
 apiVersion: v1
 data:
   priorities: |-
-    "0":
+    0:
     - .*
-    "50":
-    - .*low.*
-    "100":
+    100:
     - .*high.*
+    50:
+    - .*low.*
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: c4557839138e0ff31d1f98ed22223c98cb99170cf838929e4141ac924758314a
+    manifestHash: d28605db2e6ade6fee371d462c0e9893871ea73a35ad598fa616a2657290d319
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -282,12 +282,12 @@ spec:
 apiVersion: v1
 data:
   priorities: |-
-    "0":
+    0:
     - nodes.cas-priority-expander.example.com
-    "50":
-    - nodes-low-priority.cas-priority-expander.example.com
-    "100":
+    100:
     - nodes-high-priority.cas-priority-expander.example.com
+    50:
+    - nodes-low-priority.cas-priority-expander.example.com
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -266,8 +266,7 @@ metadata:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
 data:
-  priorities: |-
-    {{- ClusterAutoscalerPriorities | ToYAML | nindent 4 }}
+  priorities: |- {{ ClusterAutoscalerPriorities | nindent 4 }}
 {{ end }}
 ---
 # Source: cluster-autoscaler/templates/deployment.yaml

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -69,6 +69,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/upup/pkg/fi/cloudup/scaleway"
 	"k8s.io/kops/util/pkg/env"
+	"k8s.io/kops/util/pkg/maps"
 	"sigs.k8s.io/yaml"
 )
 
@@ -339,19 +340,26 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["UseServiceAccountExternalPermissions"] = tf.UseServiceAccountExternalPermissions
 
 	if cluster.Spec.ClusterAutoscaler != nil {
-		dest["ClusterAutoscalerPriorities"] = func() map[string][]string {
+		dest["ClusterAutoscalerPriorities"] = func() string {
 			priorities := make(map[string][]string)
 			if cluster.Spec.ClusterAutoscaler.CustomPriorityExpanderConfig != nil {
 				priorities = cluster.Spec.ClusterAutoscaler.CustomPriorityExpanderConfig
 			} else {
 				for name, spec := range tf.GetNodeInstanceGroups() {
-
 					if spec.Autoscale != nil {
-						priorities[fmt.Sprint(spec.AutoscalePriority)] = append(priorities[fmt.Sprint(spec.AutoscalePriority)], fmt.Sprintf("%s.%s", name, tf.ClusterName()))
+						priorities[strconv.Itoa(int(spec.AutoscalePriority))] = append(priorities[strconv.Itoa(int(spec.AutoscalePriority))], fmt.Sprintf("%s.%s", name, tf.ClusterName()))
 					}
 				}
 			}
-			return priorities
+
+			var prioritiesStr []string
+			for _, prio := range maps.SortedKeys(priorities) {
+				prioritiesStr = append(prioritiesStr, fmt.Sprintf("%s:", prio))
+				for _, value := range priorities[prio] {
+					prioritiesStr = append(prioritiesStr, fmt.Sprintf("- %s", value))
+				}
+			}
+			return strings.Join(prioritiesStr, "\n")
 		}
 		dest["CreateClusterAutoscalerPriorityConfig"] = func() bool {
 			return fi.ValueOf(cluster.Spec.ClusterAutoscaler.CreatePriorityExpenderConfig)

--- a/util/pkg/maps/maps.go
+++ b/util/pkg/maps/maps.go
@@ -17,28 +17,21 @@ limitations under the License.
 package maps
 
 import (
-	"reflect"
-	"sort"
+	"cmp"
+	"slices"
+
+	"golang.org/x/exp/maps"
 )
 
 // Keys returns the keys of a map
-func Keys(m interface{}) []string {
-	var list []string
-
-	v := reflect.ValueOf(m)
-	if v.Kind() == reflect.Map {
-		for _, x := range v.MapKeys() {
-			list = append(list, x.String())
-		}
-	}
-
-	return list
+func Keys[M ~map[K]V, K comparable, V any](m M) []K {
+	return maps.Keys(m)
 }
 
 // SortedKeys returns a list of sorted keys
-func SortedKeys(m interface{}) []string {
-	list := Keys(m)
-	sort.Strings(list)
+func SortedKeys[M ~map[K]V, K cmp.Ordered, V any](m M) []K {
+	list := maps.Keys(m)
+	slices.Sort(list)
 
 	return list
 }


### PR DESCRIPTION
Cherry pick of #16556 on release-1.29.

#16556: Use generics in util/pkg/maps

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```