### PR TITLE
Automated cherry pick of #16556: cluster-autoscaler: Fix priority expander config

### DIFF
--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 41dc4453160d8f9ae80a1b9beb288252649912296ca56dc3f70dda6cf3cbfaa1
+    manifestHash: 8170c20f6d8184dff873231d153b5f6d93f5d8dd75f739963f6d091b6b7f2187
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -282,12 +282,12 @@ spec:
 apiVersion: v1
 data:
   priorities: |-
-    "0":
+    0:
     - .*
-    "50":
-    - .*low.*
-    "100":
+    100:
     - .*high.*
+    50:
+    - .*low.*
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 9b04006b3916dbc0e5fe22f2a23a1fa72d1665e12fe1b96f4cd7707cb823f7d7
+    manifestHash: f63778b4b540b89fff019defd1eec7e2320233b6eb54b46897a00589f3fceb92
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -282,12 +282,12 @@ spec:
 apiVersion: v1
 data:
   priorities: |-
-    "0":
+    0:
     - nodes.cas-priority-expander.example.com
-    "50":
-    - nodes-low-priority.cas-priority-expander.example.com
-    "100":
+    100:
     - nodes-high-priority.cas-priority-expander.example.com
+    50:
+    - nodes-low-priority.cas-priority-expander.example.com
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -270,8 +270,7 @@ metadata:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
 data:
-  priorities: |-
-    {{- ClusterAutoscalerPriorities | ToYAML | nindent 4 }}
+  priorities: |- {{ ClusterAutoscalerPriorities | nindent 4 }}
 {{ end }}
 ---
 # Source: cluster-autoscaler/templates/deployment.yaml

--- a/util/pkg/maps/maps.go
+++ b/util/pkg/maps/maps.go
@@ -17,28 +17,21 @@ limitations under the License.
 package maps
 
 import (
-	"reflect"
-	"sort"
+	"cmp"
+	"slices"
+
+	"golang.org/x/exp/maps"
 )
 
 // Keys returns the keys of a map
-func Keys(m interface{}) []string {
-	var list []string
-
-	v := reflect.ValueOf(m)
-	if v.Kind() == reflect.Map {
-		for _, x := range v.MapKeys() {
-			list = append(list, x.String())
-		}
-	}
-
-	return list
+func Keys[M ~map[K]V, K comparable, V any](m M) []K {
+	return maps.Keys(m)
 }
 
 // SortedKeys returns a list of sorted keys
-func SortedKeys(m interface{}) []string {
-	list := Keys(m)
-	sort.Strings(list)
+func SortedKeys[M ~map[K]V, K cmp.Ordered, V any](m M) []K {
+	list := maps.Keys(m)
+	slices.Sort(list)
 
 	return list
 }


### PR DESCRIPTION
Cherry pick of #16556 on release-1.28.

#16556: Use generics in util/pkg/maps

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```