### PR TITLE
fix KOPS_AWS_ROLE_ARN assume behaviour

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	autoscalingtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -57,7 +56,7 @@ func ValidateRegion(ctx context.Context, region string) error {
 		if awsRegion == "" {
 			awsRegion = "us-east-1"
 		}
-		cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(awsRegion))
+		cfg, err := loadAWSConfig(ctx, awsRegion)
 		if err != nil {
 			return fmt.Errorf("error loading AWS config: %v", err)
 		}


### PR DESCRIPTION
without this change we got error:

(we have KOPS_AWS_ROLE_ARN=arn:aws:iam::xx:role/yy env defined`

```
% ./kops export kubecfg --admin=87600h
Error: got an error while querying for valid regions (verify your AWS credentials?): operation error EC2: DescribeRegions, https response error StatusCode: 403, RequestID: bee08acb-624f-460d-9a9d-5da92325b6d1, api error UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:iam::xx:user/xx is not authorized to perform: ec2:DescribeRegions because no identity-based policy allows the ec2:DescribeRegions action
```

after this change it works fine

```
% ./kops export kubecfg --admin=87600h     
kOps has set your kubectl context to yyy.k8s.local
```

