### PR TITLE
docs: Update release notes to reflect release of 1.29

### DIFF
--- a/docs/releases/1.29-NOTES.md
+++ b/docs/releases/1.29-NOTES.md
@@ -1,9 +1,5 @@
 ## Release notes for kOps 1.29 series
 
-**&#9888; kOps 1.29 has not been released yet! &#9888;**
-
-This is a document to gather the release notes prior to the release.
-
 # Significant changes
 
 ## Initial OpenTelemetry Support
@@ -38,8 +34,6 @@ instances.
 
 * As of Kubernetes version 1.29, credentials for private GCR/AR repositories will be handled by the out-of-tree credential provider. This is an additional binary that each instance downloads from the assets repository.
 
-## Openstack
-
 # Breaking changes
 
 ## Other breaking changes
@@ -60,4 +54,4 @@ instances.
 
 * Support for AWS Classic Load Balancer for API is deprecated and should not be used for newly created clusters.
 
-* All legacy addons are deprecated in favor of managed addons, including the [metrics server addon](https://github.com/kubernetes/kops/tree/master/addons/metrics-server) and the [autoscaler addon](https://github.com/kubernetes/kops/tree/master/addons/cluster-autoscaler).
+* All legacy addons (under `/addons`) are deprecated in favor of managed addons, including the [metrics server addon](https://github.com/kubernetes/kops/tree/master/addons/metrics-server) and the [autoscaler addon](https://github.com/kubernetes/kops/tree/master/addons/cluster-autoscaler).

--- a/docs/releases/1.30-NOTES.md
+++ b/docs/releases/1.30-NOTES.md
@@ -1,0 +1,40 @@
+## Release notes for kOps 1.30 series
+
+**&#9888; kOps 1.30 has not been released yet! &#9888;**
+
+This is a document to gather the release notes prior to the release.
+
+# Significant changes
+
+## Some Feature
+
+Lorem ipsum....
+
+## AWS
+
+* TODO
+
+## GCP
+
+* TODO
+
+## Openstack
+
+* TODO
+
+
+# Breaking changes
+
+## Other breaking changes
+
+* TODO
+
+# Known Issues
+
+* TODO
+
+# Deprecations
+
+* Support for Kubernetes version 1.24 is deprecated and will be removed in kOps 1.30.
+
+* Support for Kubernetes version 1.25 is deprecated and will be removed in kOps 1.31.


### PR DESCRIPTION
Remove the "not yet released" note from 1.29, create the 1.30 placeholder.
