### PR TITLE
aws: Experiment with Adaptive retry mode

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -268,7 +268,7 @@ func loadAWSConfig(ctx context.Context, region string) (aws.Config, error) {
 		awsconfig.WithClientLogMode(aws.LogRetries),
 		awsconfig.WithLogger(awsLogger{}),
 		awsconfig.WithRetryer(func() aws.Retryer {
-			return retry.NewStandard()
+			return retry.NewAdaptiveMode()
 		}),
 	}
 


### PR DESCRIPTION
https://github.com/aws/aws-sdk-go-v2/pull/1576 introduced support for the experimental Adaptive retry mode to the SDK.
> The adaptive retryer expands on the exponential backoff retry strategies of the Standard mode, adding client attempt rate limiting based on throttle responses received from an API.

This may help fix the Scalability tests that are now failing:
https://testgrid.k8s.io/sig-scalability-aws#ec2-master-scale-performance
> instance:i-06b9c1de0b89a3499	error deleting resources, will retry: error terminating instances: operation error EC2: TerminateInstances, failed to get rate limit token, retry quota exceeded, 0 available, 5 requested

/cc @dims @hakuna-matatah @rifelpet @zetaab 