### PR TITLE
Automated cherry pick of #16605: feat(components): permit to define kube-controller-manager

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2210,6 +2210,22 @@ spec:
                     items:
                       type: string
                     type: array
+                  cpuLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: CPULimit, cpu limit compute resource for kube-controler-manager
+                      e.g. "500m"
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  cpuRequest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: CPURequest, cpu request compute resource for kube-controler-manager.
+                      Defaults to "100m"
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   disableAttachDetachReconcileSync:
                     description: DisableAttachDetachReconcileSync disables the reconcile
                       sync loop in the attach-detach controller. This can cause volumes
@@ -2378,6 +2394,22 @@ spec:
                   master:
                     description: Master is the url for the kube api master
                     type: string
+                  memoryLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MemoryLimit, memory limit compute resource for kube-controler-manager
+                      e.g. "30Mi"
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  memoryRequest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MemoryRequest, memory request compute resource for
+                      kube-controler-manager e.g. "30Mi"
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   minResyncPeriod:
                     description: MinResyncPeriod indicates the resync period in reflectors.
                       The resync period will be random between MinResyncPeriod and
@@ -3773,6 +3805,22 @@ spec:
                       the burst quota is exhausted
                     format: int32
                     type: integer
+                  cpuLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: CPULimit, cpu limit compute resource for scheduler
+                      e.g. "500m"
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  cpuRequest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: CPURequest, cpu request compute resource for scheduler.
+                      Defaults to "100m"
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   enableContentionProfiling:
                     description: EnableContentionProfiling enables block profiling,
                       if profiling is enabled
@@ -3866,6 +3914,22 @@ spec:
                       on the version and the cloud provider as outlined: https://kubernetes.io/docs/concepts/storage/storage-limits/'
                     format: int32
                     type: integer
+                  memoryLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MemoryLimit, memory limit compute resource for scheduler
+                      e.g. "30Mi"
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  memoryRequest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MemoryRequest, memory request compute resource for
+                      scheduler e.g. "30Mi"
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   qps:
                     anyOf:
                     - type: integer

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -202,6 +202,27 @@ func (b *KubeControllerManagerBuilder) buildPod(kcm *kops.KubeControllerManagerC
 	// Add the volumePluginDir flag if provided in the kubelet spec, or set above based on the OS
 	flags = append(flags, "--flex-volume-plugin-dir="+volumePluginDir)
 
+	resourceRequests := v1.ResourceList{}
+	resourceLimits := v1.ResourceList{}
+
+	cpuRequest := resource.MustParse("100m")
+	if kcm.CPURequest != nil {
+		cpuRequest = *kcm.CPURequest
+	}
+	resourceRequests["cpu"] = cpuRequest
+
+	if kcm.CPULimit != nil {
+		resourceLimits["cpu"] = *kcm.CPULimit
+	}
+
+	if kcm.MemoryRequest != nil {
+		resourceRequests["memory"] = *kcm.MemoryRequest
+	}
+
+	if kcm.MemoryLimit != nil {
+		resourceLimits["memory"] = *kcm.MemoryLimit
+	}
+
 	image := b.RemapImage(kcm.Image)
 
 	container := &v1.Container{
@@ -221,9 +242,8 @@ func (b *KubeControllerManagerBuilder) buildPod(kcm *kops.KubeControllerManagerC
 			TimeoutSeconds:      15,
 		},
 		Resources: v1.ResourceRequirements{
-			Requests: v1.ResourceList{
-				v1.ResourceCPU: resource.MustParse("100m"),
-			},
+			Requests: resourceRequests,
+			Limits:   resourceLimits,
 		},
 	}
 

--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -213,6 +213,27 @@ func (b *KubeSchedulerBuilder) buildPod(kubeScheduler *kops.KubeSchedulerConfig)
 		},
 	}
 
+	resourceRequests := v1.ResourceList{}
+	resourceLimits := v1.ResourceList{}
+
+	cpuRequest := resource.MustParse("100m")
+	if kubeScheduler.CPURequest != nil {
+		cpuRequest = *kubeScheduler.CPURequest
+	}
+	resourceRequests["cpu"] = cpuRequest
+
+	if kubeScheduler.CPULimit != nil {
+		resourceLimits["cpu"] = *kubeScheduler.CPULimit
+	}
+
+	if kubeScheduler.MemoryRequest != nil {
+		resourceRequests["memory"] = *kubeScheduler.MemoryRequest
+	}
+
+	if kubeScheduler.MemoryLimit != nil {
+		resourceLimits["memory"] = *kubeScheduler.MemoryLimit
+	}
+
 	image := b.RemapImage(kubeScheduler.Image)
 
 	healthAction := &v1.HTTPGetAction{
@@ -232,9 +253,8 @@ func (b *KubeSchedulerBuilder) buildPod(kubeScheduler *kops.KubeSchedulerConfig)
 			TimeoutSeconds:      15,
 		},
 		Resources: v1.ResourceRequirements{
-			Requests: v1.ResourceList{
-				v1.ResourceCPU: resource.MustParse("100m"),
-			},
+			Requests: resourceRequests,
+			Limits:   resourceLimits,
 		},
 	}
 	kubemanifest.AddHostPathMapping(pod, container, "varlibkubescheduler", "/var/lib/kube-scheduler")

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -691,6 +691,15 @@ type KubeControllerManagerConfig struct {
 	EnableContentionProfiling *bool `json:"enableContentionProfiling,omitempty" flag:"contention-profiling"`
 	// EnableLeaderMigration enables controller leader migration.
 	EnableLeaderMigration *bool `json:"enableLeaderMigration,omitempty" flag:"enable-leader-migration"`
+
+	// CPURequest, cpu request compute resource for kube-controler-manager. Defaults to "100m"
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// CPULimit, cpu limit compute resource for kube-controler-manager e.g. "500m"
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// MemoryRequest, memory request compute resource for kube-controler-manager e.g. "30Mi"
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// MemoryLimit, memory limit compute resource for kube-controler-manager e.g. "30Mi"
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller
@@ -780,6 +789,15 @@ type KubeSchedulerConfig struct {
 	TLSCertFile *string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
 	// TLSPrivateKeyFile is the file containing the private key for the TLS server certificate.
 	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
+
+	// CPURequest, cpu request compute resource for scheduler. Defaults to "100m"
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// CPULimit, cpu limit compute resource for scheduler e.g. "500m"
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// MemoryRequest, memory request compute resource for scheduler e.g. "30Mi"
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// MemoryLimit, memory limit compute resource for scheduler e.g. "30Mi"
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -697,6 +697,15 @@ type KubeControllerManagerConfig struct {
 	EnableContentionProfiling *bool `json:"enableContentionProfiling,omitempty" flag:"contention-profiling"`
 	// EnableLeaderMigration enables controller leader migration.
 	EnableLeaderMigration *bool `json:"enableLeaderMigration,omitempty" flag:"enable-leader-migration"`
+
+	// CPURequest, cpu request compute resource for kube-controler-manager. Defaults to "100m"
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// CPULimit, cpu limit compute resource for kube-controler-manager e.g. "500m"
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// MemoryRequest, memory request compute resource for kube-controler-manager e.g. "30Mi"
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// MemoryLimit, memory limit compute resource for kube-controler-manager e.g. "30Mi"
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller
@@ -786,6 +795,15 @@ type KubeSchedulerConfig struct {
 	TLSCertFile *string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
 	// TLSPrivateKeyFile is the file containing the private key for the TLS server certificate.
 	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
+
+	// CPURequest, cpu request compute resource for scheduler. Defaults to "100m"
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// CPULimit, cpu limit compute resource for scheduler e.g. "500m"
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// MemoryRequest, memory request compute resource for scheduler e.g. "30Mi"
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// MemoryLimit, memory limit compute resource for scheduler e.g. "30Mi"
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5154,6 +5154,10 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.EnableProfiling = in.EnableProfiling
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.EnableLeaderMigration = in.EnableLeaderMigration
+	out.CPURequest = in.CPURequest
+	out.CPULimit = in.CPULimit
+	out.MemoryRequest = in.MemoryRequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 
@@ -5230,6 +5234,10 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.EnableProfiling = in.EnableProfiling
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.EnableLeaderMigration = in.EnableLeaderMigration
+	out.CPURequest = in.CPURequest
+	out.CPULimit = in.CPULimit
+	out.MemoryRequest = in.MemoryRequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 
@@ -5392,6 +5400,10 @@ func autoConvert_v1alpha2_KubeSchedulerConfig_To_kops_KubeSchedulerConfig(in *Ku
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
+	out.CPURequest = in.CPURequest
+	out.CPULimit = in.CPULimit
+	out.MemoryRequest = in.MemoryRequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 
@@ -5428,6 +5440,10 @@ func autoConvert_kops_KubeSchedulerConfig_To_v1alpha2_KubeSchedulerConfig(in *ko
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
+	out.CPURequest = in.CPURequest
+	out.CPULimit = in.CPULimit
+	out.MemoryRequest = in.MemoryRequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3643,6 +3643,26 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 
@@ -3871,6 +3891,26 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 		in, out := &in.TLSCertFile, &out.TLSCertFile
 		*out = new(string)
 		**out = **in
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -688,6 +688,15 @@ type KubeControllerManagerConfig struct {
 	EnableContentionProfiling *bool `json:"enableContentionProfiling,omitempty" flag:"contention-profiling"`
 	// EnableLeaderMigration enables controller leader migration.
 	EnableLeaderMigration *bool `json:"enableLeaderMigration,omitempty" flag:"enable-leader-migration"`
+
+	// CPURequest, cpu request compute resource for kube-controler-manager. Defaults to "100m"
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// CPULimit, cpu limit compute resource for kube-controler-manager e.g. "500m"
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// MemoryRequest, memory request compute resource for kube-controler-manager e.g. "30Mi"
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// MemoryLimit, memory limit compute resource for kube-controler-manager e.g. "30Mi"
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller
@@ -777,6 +786,15 @@ type KubeSchedulerConfig struct {
 	TLSCertFile *string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
 	// TLSPrivateKeyFile is the file containing the private key for the TLS server certificate.
 	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
+
+	// CPURequest, cpu request compute resource for scheduler. Defaults to "100m"
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// CPULimit, cpu limit compute resource for scheduler e.g. "500m"
+	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
+	// MemoryRequest, memory request compute resource for scheduler e.g. "30Mi"
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// MemoryLimit, memory limit compute resource for scheduler e.g. "30Mi"
+	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5549,6 +5549,10 @@ func autoConvert_v1alpha3_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.EnableProfiling = in.EnableProfiling
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.EnableLeaderMigration = in.EnableLeaderMigration
+	out.CPURequest = in.CPURequest
+	out.CPULimit = in.CPULimit
+	out.MemoryRequest = in.MemoryRequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 
@@ -5625,6 +5629,10 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha3_KubeControllerMana
 	out.EnableProfiling = in.EnableProfiling
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.EnableLeaderMigration = in.EnableLeaderMigration
+	out.CPURequest = in.CPURequest
+	out.CPULimit = in.CPULimit
+	out.MemoryRequest = in.MemoryRequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 
@@ -5785,6 +5793,10 @@ func autoConvert_v1alpha3_KubeSchedulerConfig_To_kops_KubeSchedulerConfig(in *Ku
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
+	out.CPURequest = in.CPURequest
+	out.CPULimit = in.CPULimit
+	out.MemoryRequest = in.MemoryRequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 
@@ -5821,6 +5833,10 @@ func autoConvert_kops_KubeSchedulerConfig_To_v1alpha3_KubeSchedulerConfig(in *ko
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
+	out.CPURequest = in.CPURequest
+	out.CPULimit = in.CPULimit
+	out.MemoryRequest = in.MemoryRequest
+	out.MemoryLimit = in.MemoryLimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3617,6 +3617,26 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 
@@ -3845,6 +3865,26 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 		in, out := &in.TLSCertFile, &out.TLSCertFile
 		*out = new(string)
 		**out = **in
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3720,6 +3720,26 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 
@@ -3948,6 +3968,26 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 		in, out := &in.TLSCertFile, &out.TLSCertFile
 		*out = new(string)
 		**out = **in
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPULimit != nil {
+		in, out := &in.CPULimit, &out.CPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -139,7 +139,7 @@ ClusterName: complex.example.com
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: TagVYsukF7ql0g7GpSE6Z1E3sQXC5hWT1Vf/OCgBHJU=
+NodeupConfigHash: MRD4Bp4bTN6/GAnqOQNJbR4iS2YzIgDqLGQfTdMolIw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -138,6 +138,8 @@ spec:
     concurrentHorizontalPodAustoscalerSyncs: 10
     concurrentJobSyncs: 10
     configureCloudRoutes: false
+    cpuLimit: 500m
+    cpuRequest: 200m
     featureGates:
       CSIMigrationAWS: "true"
       InTreePluginAWSUnregister: "true"
@@ -145,6 +147,8 @@ spec:
     leaderElection:
       leaderElect: true
     logLevel: 2
+    memoryLimit: 1000Mi
+    memoryRequest: 800Mi
     useServiceAccountCredentials: true
   kubeDNS:
     cacheMaxConcurrent: 150
@@ -166,6 +170,8 @@ spec:
     image: registry.k8s.io/kube-proxy:v1.24.0
     logLevel: 2
   kubeScheduler:
+    cpuLimit: 500m
+    cpuRequest: 200m
     featureGates:
       CSIMigrationAWS: "true"
       InTreePluginAWSUnregister: "true"
@@ -173,6 +179,8 @@ spec:
     leaderElection:
       leaderElect: true
     logLevel: 2
+    memoryLimit: 1000Mi
+    memoryRequest: 800Mi
   kubelet:
     anonymousAuth: false
     cgroupDriver: systemd

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -248,6 +248,8 @@ ControlPlaneConfig:
     concurrentHorizontalPodAustoscalerSyncs: 10
     concurrentJobSyncs: 10
     configureCloudRoutes: false
+    cpuLimit: 500m
+    cpuRequest: 200m
     featureGates:
       CSIMigrationAWS: "true"
       InTreePluginAWSUnregister: "true"
@@ -255,8 +257,12 @@ ControlPlaneConfig:
     leaderElection:
       leaderElect: true
     logLevel: 2
+    memoryLimit: 1000Mi
+    memoryRequest: 800Mi
     useServiceAccountCredentials: true
   KubeScheduler:
+    cpuLimit: 500m
+    cpuRequest: 200m
     featureGates:
       CSIMigrationAWS: "true"
       InTreePluginAWSUnregister: "true"
@@ -264,6 +270,8 @@ ControlPlaneConfig:
     leaderElection:
       leaderElect: true
     logLevel: 2
+    memoryLimit: 1000Mi
+    memoryRequest: 800Mi
 DNSZone: Z1AFAKE1ZON3YO
 EtcdClusterNames:
 - main

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -53,6 +53,15 @@ spec:
   kubeControllerManager:
     concurrentHorizontalPodAustoscalerSyncs: 10
     concurrentJobSyncs: 10
+    cpuRequest: 200m
+    cpuLimit: 500m
+    memoryRequest: 800Mi
+    memoryLimit: 1000Mi
+  kubeScheduler:
+    cpuRequest: 200m
+    cpuLimit: 500m
+    memoryRequest: 800Mi
+    memoryLimit: 1000Mi
   kubelet:
     anonymousAuth: false
   kubernetesVersion: v1.24.0

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -30,6 +30,10 @@ spec:
   kubeControllerManager:
     concurrentHorizontalPodAustoscalerSyncs: 10
     concurrentJobSyncs: 10
+    cpuRequest: 200m
+    cpuLimit: 500m
+    memoryRequest: 800Mi
+    memoryLimit: 1000Mi
   cloudProvider: aws
   cloudLabels:
     Owner: John Doe
@@ -49,6 +53,11 @@ spec:
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
     auditWebhookBatchThrottleQps: 3.14
+    cpuRequest: 200m
+    cpuLimit: 500m
+    memoryRequest: 800Mi
+    memoryLimit: 1000Mi
+  kubeScheduler:
     cpuRequest: 200m
     cpuLimit: 500m
     memoryRequest: 800Mi


### PR DESCRIPTION
Cherry pick of #16605 on release-1.29.

#16605: feat(components): permit to define kube-controller-manager

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```