### PR TITLE
Update aws-iam-authenticator image

### DIFF
--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
@@ -164,7 +164,7 @@ spec:
         - --config=/etc/aws-iam-authenticator/config.yaml
         - --state-dir=/var/aws-iam-authenticator
         - --kubeconfig-pregenerated=true
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.27
+        image: public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.6.20-eks-1-30-7
         livenessProbe:
           httpGet:
             host: 127.0.0.1

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 904efad45a2ff29d5abc3357121317223e3d1b9256be90ba38178954fee50687
+    manifestHash: 4a72854108b5bf11c547c832153a13abc6b26952723ae7a9a9f8dd7126b8116c
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -164,7 +164,7 @@ spec:
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: aws-iam-authenticator
-        image: {{ or .Authentication.AWS.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.27" }}
+        image: {{ or .Authentication.AWS.Image "public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.6.20-eks-1-30-7" }}
         args:
         - server
         {{- if or (not .Authentication.AWS.BackendMode) (contains "MountedFile" .Authentication.AWS.BackendMode) }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
@@ -166,7 +166,7 @@ spec:
         - --state-dir=/var/aws-iam-authenticator
         - --kubeconfig-pregenerated=true
         - --backend-mode=CRD,MountedFile
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.27
+        image: public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.6.20-eks-1-30-7
         livenessProbe:
           httpGet:
             host: 127.0.0.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: e38c1aa72a3d40a7548fdd055f7baa1c24d9a63f0d336fe82aeffbcb6592610e
+    manifestHash: 4debe9956ffc92cd7c8da44e6fcc4c9705d51faa6640be9a59e8d86e0854c7ad
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
@@ -165,7 +165,7 @@ spec:
         - --state-dir=/var/aws-iam-authenticator
         - --kubeconfig-pregenerated=true
         - --backend-mode=CRD
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.27
+        image: public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.6.20-eks-1-30-7
         livenessProbe:
           httpGet:
             host: 127.0.0.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 76df887736bf7023f791eb8921ad0b1df8e55dcd1af7f24d138fe1176687d4f5
+    manifestHash: c8a71f31e741c1938991952cf16728801dc2e2f1b81f92aef39b0d9c250a3f94
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"


### PR DESCRIPTION
Temporary workaround for https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/723

Closes #16602

This should unblock the 1.30 beta release