### PR TITLE
Automated cherry pick of #16550: tests: use version from go.mod in github actions
#16618: Update Go to v1.21.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,14 +16,14 @@ jobs:
   build-linux-amd64:
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
-        with:
-          go-version: '1.22.3'
-
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/kops
+
+      - name: Set up go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
+        with:
+          go-version-file: '${{ env.GOPATH }}/src/k8s.io/kops/go.mod'
 
       - name: make all examples test
         working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
@@ -33,14 +33,14 @@ jobs:
   build-macos-amd64:
     runs-on: macos-latest
     steps:
-    - name: Set up go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
-      with:
-        go-version: '1.22.3'
-
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       with:
         path: ${{ env.GOPATH }}/src/k8s.io/kops
+
+    - name: Set up go
+      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
+      with:
+        go-version-file: '${{ env.GOPATH }}/src/k8s.io/kops/go.mod'
 
     - name: make kops examples test
       working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
@@ -50,14 +50,14 @@ jobs:
   build-windows-amd64:
     runs-on: windows-2019
     steps:
-    - name: Set up go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
-      with:
-        go-version: '1.22.3'
-
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       with:
         path: ${{ env.GOPATH }}/src/k8s.io/kops
+
+    - name: Set up go
+      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
+      with:
+        go-version-file: '${{ env.GOPATH }}/src/k8s.io/kops/go.mod'
 
     - name: make kops examples test
       working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
@@ -67,14 +67,14 @@ jobs:
   verify:
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
-        with:
-          go-version: '1.22.3'
-
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/kops
+
+      - name: Set up go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
+        with:
+          go-version-file: '${{ env.GOPATH }}/src/k8s.io/kops/go.mod'
 
       - name: make quick-ci
         working-directory: ${{ env.GOPATH }}/src/k8s.io/kops

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -17,10 +17,10 @@ jobs:
     if: ${{ github.repository == 'kubernetes/kops' }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
         with:
-          go-version: '1.22.3'
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+          go-version-file: 'go.mod'
       - name: Update Dependencies
         id: update_deps
         run: |
@@ -30,7 +30,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
       - name: Create PR
         if: ${{ steps.update_deps.outputs.changes != '' }}
-        uses: peter-evans/create-pull-request@a4f52f8033a6168103c2538976c07b467e8163bc
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e
         with:
           title: 'Update dependencies'
           commit-message: Update dependencies

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # Push the images
-- name: 'docker.io/library/golang:1.22.3-bookworm'
+- name: 'docker.io/library/golang:1.22.4-bookworm'
   id: images
   entrypoint: make
   env:
@@ -21,7 +21,7 @@ steps:
   - dns-controller-push
   - kube-apiserver-healthcheck-push
 # Push the artifacts
-- name: 'docker.io/library/golang:1.22.3-bookworm'
+- name: 'docker.io/library/golang:1.22.4-bookworm'
   id: artifacts
   entrypoint: make
   env:
@@ -36,7 +36,7 @@ steps:
   args:
   - gcs-upload-and-tag
 # Build cloudbuild artifacts (for attestation)
-- name: 'docker.io/library/golang:1.22.3-bookworm'
+- name: 'docker.io/library/golang:1.22.4-bookworm'
   id: cloudbuild-artifacts
   entrypoint: make
   env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops
 
-go 1.22.3
+go 1.22.4
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/hack
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/tests/e2e
 
-go 1.22.3
+go 1.22.4
 
 replace k8s.io/kops => ../../.
 

--- a/tools/otel/traceserver/go.mod
+++ b/tools/otel/traceserver/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/tools/otel/traceserver
 
-go 1.22.3
+go 1.22.4
 
 require (
 	go.opentelemetry.io/proto/otlp v1.2.0


### PR DESCRIPTION
Cherry pick of #16550 #16618 on release-1.29.

#16550: tests: use version from go.mod in github actions
#16618: Update Go to v1.21.4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```