### PR TITLE
Dont install libcgroup on Rocky 9

### DIFF
--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -76,8 +76,8 @@ func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 			c.AddTask(&nodetasks.Package{Name: "container-selinux"})
 			c.AddTask(&nodetasks.Package{Name: "pigz"})
 		}
-		// RHEL9 does not have libcgroup
-		if b.Distribution != distributions.DistributionRhel9 {
+		// RHEL9 and Rocky 9 do not have libcgroup
+		if b.Distribution != distributions.DistributionRhel9 && b.Distribution != distributions.DistributionRocky9 {
 			c.AddTask(&nodetasks.Package{Name: "libcgroup"})
 		}
 		// Additional packages


### PR DESCRIPTION
Fixes this nodeup error:

https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-distro-rocky9/1802047093284540416/artifacts/3.26.188.59/journal.log

```
Jun 15 18:47:13.329504 i-02b399f4c3616e238.ap-southeast-2.compute.internal nodeup[966]: I0615 18:47:13.329292     966 executor.go:113] Tasks: 178 done / 195 total; 1 can run
Jun 15 18:47:13.329504 i-02b399f4c3616e238.ap-southeast-2.compute.internal nodeup[966]: I0615 18:47:13.329345     966 executor.go:214] Executing task "Package/libcgroup": Package: libcgroup
Jun 15 18:47:13.329504 i-02b399f4c3616e238.ap-southeast-2.compute.internal nodeup[966]: I0615 18:47:13.329449     966 package.go:216] Listing installed packages: /usr/bin/rpm -q libcgroup --queryformat %{NAME} %{VERSION}
Jun 15 18:47:13.336257 i-02b399f4c3616e238.ap-southeast-2.compute.internal nodeup[966]: I0615 18:47:13.336229     966 package.go:282] Installing package "libcgroup" (dependencies: [])
Jun 15 18:47:13.336257 i-02b399f4c3616e238.ap-southeast-2.compute.internal nodeup[966]: I0615 18:47:13.336255     966 package.go:344] running command [/usr/bin/dnf install -y --setopt=install_weak_deps=False libcgroup]
Jun 15 18:47:13.672476 i-02b399f4c3616e238.ap-southeast-2.compute.internal nodeup[966]: W0615 18:47:13.672394     966 executor.go:141] error running task "Package/libcgroup" (8m39s remaining to succeed): error installing package "libcgroup": exit status 1: Last metadata expiration check: 0:01:21 ago on Sat 15 Jun 2024 06:45:52 PM UTC.
Jun 15 18:47:13.672476 i-02b399f4c3616e238.ap-southeast-2.compute.internal nodeup[966]: No match for argument: libcgroup
Jun 15 18:47:13.672476 i-02b399f4c3616e238.ap-southeast-2.compute.internal nodeup[966]: Error: Unable to find a match: libcgroup
```