### PR TITLE
tests: Add test for dl.k8s.io kubernetes version parsing

### DIFF
--- a/pkg/apis/kops/util/versions_test.go
+++ b/pkg/apis/kops/util/versions_test.go
@@ -80,6 +80,14 @@ func Test_ParseKubernetesVersion(t *testing.T) {
 			},
 		},
 		{
+			version: "https://dl.k8s.io/release/v1.30.2",
+			expected: &semver.Version{
+				Major: 1,
+				Minor: 30,
+				Patch: 0,
+			},
+		},
+		{
 			version:       "",
 			expectedError: fmt.Errorf("unable to parse kubernetes version \"\""),
 		},


### PR DESCRIPTION
We saw an error with older kOps versions here, so add a test for this
case.
