### PR TITLE
Automated cherry pick of #16627: Upgrade cilium to v1.15.6

### DIFF
--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.15.4"
+		c.Version = "v1.15.6"
 	}
 
 	if c.EnableEndpointHealthChecking == nil {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -226,7 +226,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.15.4
+      version: v1.15.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 6b8c194f2e4b5c13c5adf56111305077a641fbddff4fb999d2a0e817a820cf53
+    manifestHash: b9879c934ae3fc644e07f15629981bb9bf0162335a4ef5be413182fcfc66897a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -550,7 +550,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -647,7 +647,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -666,7 +666,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -687,7 +687,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -717,7 +717,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -734,7 +734,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -889,7 +889,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.15.4
+        image: quay.io/cilium/operator:v1.15.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -153,7 +153,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal-warmpool.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 2pekI4BdRgjut5UcgcI8QZVszjluZGVgnBmPbmfvIl4=
+NodeupConfigHash: Qk29AY0f5+WYSZtngVmowAvt0IFItqN2mBDATTa1yqU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -218,7 +218,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.15.4
+      version: v1.15.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 421c780d3ecd73290adddfc80e7f16fc46e7908483653b723aee415f43a68004
+    manifestHash: a1a193f3b5a7e4978166141793abd91ca31da43c5d22ccac28cbe8a9e971620e
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -551,7 +551,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -648,7 +648,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -667,7 +667,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -688,7 +688,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -718,7 +718,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -735,7 +735,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -890,7 +890,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.15.4
+        image: quay.io/cilium/operator:v1.15.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
@@ -64,7 +64,7 @@ containerdConfig:
 usesLegacyGossip: false
 usesNoneDNS: false
 warmPoolImages:
-- quay.io/cilium/cilium:v1.15.4
-- quay.io/cilium/operator:v1.15.4
+- quay.io/cilium/cilium:v1.15.6
+- quay.io/cilium/operator:v1.15.6
 - registry.k8s.io/kube-proxy:v1.26.0
 - registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.11

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
@@ -199,7 +199,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.15.4
+      version: v1.15.6
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://tests/scw-minimal.k8s.local/secrets

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 4652a3f140f42408f62a64d19bd71fabf901ca4330b8a70dc0a7e7880097cc9e
+    manifestHash: 7b74c26eba86a08e584e9621b100ef63a3aedca452958210ae67304f84d40542
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
@@ -551,7 +551,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -648,7 +648,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -667,7 +667,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -688,7 +688,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -718,7 +718,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -735,7 +735,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -890,7 +890,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.15.4
+        image: quay.io/cilium/operator:v1.15.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -220,7 +220,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.15.4
+      version: v1.15.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 4232331188e8053a0643160ae0776de5de4b083482fd0e86ca7744efc5f90923
+    manifestHash: 73bb75823f5a80f87197e6fcb8dc72a63ee1c24883175dac77300e6902681161
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -553,7 +553,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -675,7 +675,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -694,7 +694,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -715,7 +715,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -745,7 +745,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -762,7 +762,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -917,7 +917,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.15.4
+        image: quay.io/cilium/operator:v1.15.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -228,7 +228,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.15.4
+      version: v1.15.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 7c8b359e91e1a74eb5040f6fb03aff7e1ce3b2ba3398687a905658b7e80bb1be
+    manifestHash: 12325ce4b4f85d7aa094ccd86197641ff7aff6a90c32da34b64678aa9454a18e
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -555,7 +555,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -652,7 +652,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -671,7 +671,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -692,7 +692,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -722,7 +722,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -739,7 +739,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -898,7 +898,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.15.4
+        image: quay.io/cilium/operator:v1.15.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -229,7 +229,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.15.4
+      version: v1.15.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -162,7 +162,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: ed7e873a9c5134c5e664e52ed90f62e962ce700edccf82991ae4b6522840abb9
+    manifestHash: 45ecd4b0c81a42b7fe61b223bc4fc869f89c9aae2a1863235782134e346c7151
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -774,7 +774,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -878,7 +878,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -897,7 +897,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -918,7 +918,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -948,7 +948,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -965,7 +965,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1127,7 +1127,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.15.4
+        image: quay.io/cilium/operator:v1.15.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1221,7 +1221,7 @@ spec:
         - serve
         command:
         - hubble-relay
-        image: quay.io/cilium/hubble-relay:v1.15.4
+        image: quay.io/cilium/hubble-relay:v1.15.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           tcpSocket:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -232,7 +232,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.15.4
+      version: v1.15.6
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 5839de48e04312f39fecbbace74a8fdc269ef6b6248409c1dc34b3e3ce5580c9
+    manifestHash: be09a607c2a87737bee2f1fbf38420f09ae2ff560e021fab080a98f3225f0c51
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -563,7 +563,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -691,7 +691,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -710,7 +710,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -731,7 +731,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -761,7 +761,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -778,7 +778,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.15.4
+        image: quay.io/cilium/cilium:v1.15.6
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -944,7 +944,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.15.4
+        image: quay.io/cilium/operator:v1.15.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 7efc3c6bdacb904b61a4b88e15897b789bbffd65e2f943de57bc1fb3144f708d
+    manifestHash: 3cd28effb6499670f52244fa0fe1814c2a6921a3e7eaac43b0064dab804127d7
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 7efc3c6bdacb904b61a4b88e15897b789bbffd65e2f943de57bc1fb3144f708d
+    manifestHash: 3cd28effb6499670f52244fa0fe1814c2a6921a3e7eaac43b0064dab804127d7
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 7efc3c6bdacb904b61a4b88e15897b789bbffd65e2f943de57bc1fb3144f708d
+    manifestHash: 3cd28effb6499670f52244fa0fe1814c2a6921a3e7eaac43b0064dab804127d7
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #16627 on release-1.29.

#16627: Upgrade cilium to v1.15.6

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```