### PR TITLE
Fix 2 broken links in the docs

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -59,7 +59,7 @@ If you think you have found a bug please follow the instructions below.
 - Note the version of kOps you are running (from `kops version`), and the command line options you are using.
 - Open a [new issue](https://github.com/kubernetes/kops/issues/new).
 - Remember users might be searching for your issue in the future, so please give it a meaningful title to helps others.
-- Feel free to reach out to the kOps community on [kubernetes slack](https://github.com/kubernetes/community/blob/master/communication.md#social-media).
+- Feel free to reach out to the kOps community on [kubernetes slack](https://kubernetes.slack.com/messages/kops-dev/).
 
 
 ### Features

--- a/docs/operations/etcd_backup_restore_encryption.md
+++ b/docs/operations/etcd_backup_restore_encryption.md
@@ -96,7 +96,7 @@ Because the state on each of the Nodes may differ from the state in etcd, it is 
 kops rolling-update cluster --force --yes
 ```
 
-For more information and troubleshooting, please check the [etcd-manager documentation](https://github.com/kubernetes-sigs/etcdadm/etcd-manager).
+For more information and troubleshooting, please check the [etcd-manager documentation](https://github.com/kubernetes-sigs/etcdadm/tree/master/etcd-manager).
 
 ## Etcd Volume Encryption
 


### PR DESCRIPTION
There is 2 link is broken(404) in the docs.

> https://github.com/kubernetes/community/blob/master/communication.md#social-media
> https://github.com/kubernetes-sigs/etcdadm/etcd-manager

update to:

> https://github.com/kubernetes/community/tree/master/communication#slack
> https://github.com/kubernetes-sigs/etcdadm/tree/master/etcd-manager