### PR TITLE
Bump Github Actions jobs to latest distros

### DIFF
--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   dependency-review:
     if: ${{ github.repository == 'kubernetes/kops' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build-linux-amd64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -48,7 +48,7 @@ jobs:
         make kops examples test
 
   build-windows-amd64:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       with:
@@ -65,7 +65,7 @@ jobs:
         make kops examples test-windows
 
   verify:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   tag-release:
     if: ${{ github.repository == 'kubernetes/kops' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: write

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   update-deps:
     if: ${{ github.repository == 'kubernetes/kops' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
 


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#standard-github-hosted-runners-for-public-repositories