### PR TITLE
Automated cherry pick of #16649: chore: update golang to 1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops
 
-go 1.22.3
+go 1.22.5
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/hack
 
-go 1.22.3
+go 1.22.5
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/tests/e2e
 
-go 1.22.3
+go 1.22.5
 
 replace k8s.io/kops => ../../.
 


### PR DESCRIPTION
Cherry pick of #16649 on release-1.28.

#16649: chore: update golang to 1.22.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```