### PR TITLE
refactor: create awsup.GetCloud helper method

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -144,7 +144,7 @@ func (e *AutoscalingGroup) GetDependencies(tasks map[string]fi.CloudupTask) []fi
 func (e *AutoscalingGroup) Find(c *fi.CloudupContext) (*AutoscalingGroup, error) {
 	ctx := c.Context()
 
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	g, err := findAutoscalingGroup(ctx, cloud, fi.ValueOf(e.Name))
 	if err != nil {
@@ -199,7 +199,7 @@ func (e *AutoscalingGroup) Find(c *fi.CloudupContext) (*AutoscalingGroup, error)
 			}
 		}
 		if apiLBTask != nil && len(actual.LoadBalancers) > 0 {
-			apiLBDesc, err := c.T.Cloud.(awsup.AWSCloud).FindELBByNameTag(fi.ValueOf(apiLBTask.Name))
+			apiLBDesc, err := awsup.GetCloud(c).FindELBByNameTag(fi.ValueOf(apiLBTask.Name))
 			if err != nil {
 				return nil, err
 			}
@@ -360,7 +360,7 @@ func findAutoscalingGroup(ctx context.Context, cloud awsup.AWSCloud, name string
 
 func (e *AutoscalingGroup) Normalize(c *fi.CloudupContext) error {
 	sort.Strings(e.Metrics)
-	c.T.Cloud.(awsup.AWSCloud).AddTags(e.Name, e.Tags)
+	awsup.GetCloud(c).AddTags(e.Name, e.Tags)
 
 	return nil
 }

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
@@ -56,7 +56,7 @@ func (h *AutoscalingLifecycleHook) CompareWithID() *string {
 
 func (h *AutoscalingLifecycleHook) Find(c *fi.CloudupContext) (*AutoscalingLifecycleHook, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	request := &autoscaling.DescribeLifecycleHooksInput{
 		AutoScalingGroupName: h.AutoscalingGroup.Name,

--- a/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
@@ -215,7 +215,7 @@ func (e *ClassicLoadBalancer) getHostedZoneId() *string {
 
 func (e *ClassicLoadBalancer) Find(c *fi.CloudupContext) (*ClassicLoadBalancer, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	lb, err := cloud.FindELBByNameTag(fi.ValueOf(e.Name))
 	if err != nil {

--- a/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
@@ -54,7 +54,7 @@ func (e *DHCPOptions) CompareWithID() *string {
 }
 
 func (e *DHCPOptions) Find(c *fi.CloudupContext) (*DHCPOptions, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	request := &ec2.DescribeDhcpOptionsInput{}
 	if e.ID != nil {

--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -53,7 +53,7 @@ type DNSTarget interface {
 
 func (e *DNSName) Find(c *fi.CloudupContext) (*DNSName, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	if e.Zone == nil || e.Zone.ZoneID == nil {
 		klog.V(4).Infof("Zone / ZoneID not found for %s, skipping Find", fi.ValueOf(e.ResourceName))

--- a/upup/pkg/fi/cloudup/awstasks/dnszone.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnszone.go
@@ -54,7 +54,7 @@ func (e *DNSZone) CompareWithID() *string {
 }
 
 func (e *DNSZone) Find(c *fi.CloudupContext) (*DNSZone, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	z, err := e.findExisting(c.Context(), cloud)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
@@ -56,7 +56,7 @@ func (e *EBSVolume) CompareWithID() *string {
 
 func (e *EBSVolume) Find(c *fi.CloudupContext) (*EBSVolume, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	filters := cloud.BuildFilters(e.Name)
 	request := &ec2.DescribeVolumesInput{
@@ -102,7 +102,7 @@ func (e *EBSVolume) Find(c *fi.CloudupContext) (*EBSVolume, error) {
 }
 
 func (e *EBSVolume) Normalize(c *fi.CloudupContext) error {
-	c.T.Cloud.(awsup.AWSCloud).AddTags(e.Name, e.Tags)
+	awsup.GetCloud(c).AddTags(e.Name, e.Tags)
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/egressonlyinternetgateway.go
@@ -67,7 +67,7 @@ func findEgressOnlyInternetGateway(ctx context.Context, cloud awsup.AWSCloud, re
 
 func (e *EgressOnlyInternetGateway) Find(c *fi.CloudupContext) (*EgressOnlyInternetGateway, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	request := &ec2.DescribeEgressOnlyInternetGatewaysInput{}
 

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -62,7 +62,7 @@ func (e *ElasticIP) CompareWithID() *string {
 
 // Find returns the actual ElasticIP state, or nil if not found
 func (e *ElasticIP) Find(c *fi.CloudupContext) (*ElasticIP, error) {
-	return e.find(c.Context(), c.T.Cloud.(awsup.AWSCloud))
+	return e.find(c.Context(), awsup.GetCloud(c))
 }
 
 // find will attempt to look up the elastic IP from AWS

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
@@ -50,7 +50,7 @@ func (eb *EventBridgeRule) CompareWithID() *string {
 }
 
 func (eb *EventBridgeRule) Find(c *fi.CloudupContext) (*EventBridgeRule, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	if eb.Name == nil {
 		return nil, nil

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
@@ -48,7 +48,7 @@ func (eb *EventBridgeTarget) CompareWithID() *string {
 }
 
 func (eb *EventBridgeTarget) Find(c *fi.CloudupContext) (*EventBridgeTarget, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	if eb.Rule == nil || eb.SQSQueue == nil {
 		return nil, nil

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
@@ -67,7 +67,7 @@ func findIAMInstanceProfile(ctx context.Context, cloud awsup.AWSCloud, name stri
 
 func (e *IAMInstanceProfile) Find(c *fi.CloudupContext) (*IAMInstanceProfile, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	p, err := findIAMInstanceProfile(ctx, cloud, *e.Name)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
@@ -40,7 +40,7 @@ type IAMInstanceProfileRole struct {
 
 func (e *IAMInstanceProfileRole) Find(c *fi.CloudupContext) (*IAMInstanceProfileRole, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	if e.Role == nil || e.Role.ID == nil {
 		klog.V(2).Infof("Role/RoleID not set")

--- a/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
@@ -53,7 +53,7 @@ func (e *IAMOIDCProvider) CompareWithID() *string {
 
 func (e *IAMOIDCProvider) Find(c *fi.CloudupContext) (*IAMOIDCProvider, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	response, err := cloud.IAM().ListOpenIDConnectProviders(ctx, &iam.ListOpenIDConnectProvidersInput{})
 	if err != nil {

--- a/upup/pkg/fi/cloudup/awstasks/iamrole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole.go
@@ -63,7 +63,7 @@ func (e *IAMRole) CompareWithID() *string {
 
 func (e *IAMRole) Find(c *fi.CloudupContext) (*IAMRole, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	request := &iam.GetRoleInput{RoleName: e.Name}
 

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -56,7 +56,7 @@ func (e *IAMRolePolicy) Find(c *fi.CloudupContext) (*IAMRolePolicy, error) {
 	ctx := c.Context()
 	var actual IAMRolePolicy
 
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	// Handle policy overrides
 	if e.ExternalPolicies != nil {

--- a/upup/pkg/fi/cloudup/awstasks/instance.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance.go
@@ -66,7 +66,7 @@ func (s *Instance) CompareWithID() *string {
 
 func (e *Instance) Find(c *fi.CloudupContext) (*Instance, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 	var request *ec2.DescribeInstancesInput
 
 	if fi.ValueOf(e.Shared) {

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway.go
@@ -67,7 +67,7 @@ func findInternetGateway(ctx context.Context, cloud awsup.AWSCloud, request *ec2
 
 func (e *InternetGateway) Find(c *fi.CloudupContext) (*InternetGateway, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	request := &ec2.DescribeInternetGatewaysInput{}
 

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -198,10 +198,7 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchT
 
 // Find is responsible for finding the launch template for us
 func (t *LaunchTemplate) Find(c *fi.CloudupContext) (*LaunchTemplate, error) {
-	cloud, ok := c.T.Cloud.(awsup.AWSCloud)
-	if !ok {
-		return nil, fmt.Errorf("invalid cloud provider: %v, expected: %s", c.T.Cloud, "awsup.AWSCloud")
-	}
+	cloud := awsup.GetCloud(c)
 
 	// @step: get the latest launch template version
 	lt, err := t.findLatestLaunchTemplateVersion(c)
@@ -357,10 +354,7 @@ func (t *LaunchTemplate) Find(c *fi.CloudupContext) (*LaunchTemplate, error) {
 func (t *LaunchTemplate) findAllLaunchTemplates(c *fi.CloudupContext) ([]ec2types.LaunchTemplate, error) {
 	ctx := c.Context()
 
-	cloud, ok := c.T.Cloud.(awsup.AWSCloud)
-	if !ok {
-		return nil, fmt.Errorf("invalid cloud provider: %v, expected: %s", c.T.Cloud, "awsup.AWSCloud")
-	}
+	cloud := awsup.GetCloud(c)
 
 	input := &ec2.DescribeLaunchTemplatesInput{
 		Filters: []ec2types.Filter{
@@ -388,10 +382,7 @@ func (t *LaunchTemplate) findAllLaunchTemplates(c *fi.CloudupContext) ([]ec2type
 func (t *LaunchTemplate) findLatestLaunchTemplateVersion(c *fi.CloudupContext) (*ec2types.LaunchTemplateVersion, error) {
 	ctx := c.Context()
 
-	cloud, ok := c.T.Cloud.(awsup.AWSCloud)
-	if !ok {
-		return nil, fmt.Errorf("invalid cloud provider: %v, expected: awsup.AWSCloud", c.T.Cloud)
-	}
+	cloud := awsup.GetCloud(c)
 
 	input := &ec2.DescribeLaunchTemplateVersionsInput{
 		LaunchTemplateName: t.Name,

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -62,7 +62,7 @@ func (e *NatGateway) CompareWithID() *string {
 
 func (e *NatGateway) Find(c *fi.CloudupContext) (*NatGateway, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 	var ngw *ec2types.NatGateway
 	actual := &NatGateway{}
 
@@ -130,7 +130,7 @@ func (e *NatGateway) Find(c *fi.CloudupContext) (*NatGateway, error) {
 
 func (e *NatGateway) findNatGateway(c *fi.CloudupContext) (*ec2types.NatGateway, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	id := e.ID
 

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -171,7 +171,7 @@ func (e *NetworkLoadBalancer) getHostedZoneId() *string {
 
 func (e *NetworkLoadBalancer) Find(c *fi.CloudupContext) (*NetworkLoadBalancer, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	allLoadBalancers, err := awsup.ListELBV2LoadBalancers(ctx, cloud)
 	if err != nil {
@@ -354,7 +354,7 @@ func (e *NetworkLoadBalancer) FindAddresses(c *fi.CloudupContext) ([]string, err
 
 	var addresses []string
 
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 	cluster := c.T.Cluster
 
 	{

--- a/upup/pkg/fi/cloudup/awstasks/networkloadbalancerlistener.go
+++ b/upup/pkg/fi/cloudup/awstasks/networkloadbalancerlistener.go
@@ -57,7 +57,7 @@ func (e *NetworkLoadBalancerListener) CompareWithID() *string {
 func (e *NetworkLoadBalancerListener) Find(c *fi.CloudupContext) (*NetworkLoadBalancerListener, error) {
 	ctx := c.Context()
 
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	if e.NetworkLoadBalancer == nil {
 		return nil, fi.RequiredField("NetworkLoadBalancer")

--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -51,7 +51,7 @@ type Route struct {
 
 func (e *Route) Find(c *fi.CloudupContext) (*Route, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	if e.RouteTable == nil || (e.CIDR == nil && e.IPv6CIDR == nil) {
 		// TODO: Move to validate?

--- a/upup/pkg/fi/cloudup/awstasks/routetable.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable.go
@@ -52,7 +52,7 @@ func (e *RouteTable) CompareWithID() *string {
 
 func (e *RouteTable) Find(c *fi.CloudupContext) (*RouteTable, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	var rt *ec2types.RouteTable
 	var err error

--- a/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
@@ -46,7 +46,7 @@ func (s *RouteTableAssociation) CompareWithID() *string {
 
 func (e *RouteTableAssociation) Find(c *fi.CloudupContext) (*RouteTableAssociation, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	routeTableID := e.RouteTable.ID
 	subnetID := e.Subnet.ID

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -100,7 +100,7 @@ func (e *SecurityGroup) Find(c *fi.CloudupContext) (*SecurityGroup, error) {
 
 func (e *SecurityGroup) findEc2(c *fi.CloudupContext) (*ec2types.SecurityGroup, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 	request := &ec2.DescribeSecurityGroupsInput{}
 
 	if fi.ValueOf(e.ID) != "" {
@@ -332,7 +332,7 @@ func (e *SecurityGroup) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletio
 		return nil, nil
 	}
 
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	request := &ec2.DescribeSecurityGroupRulesInput{
 		Filters: []ec2types.Filter{

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
@@ -58,7 +58,7 @@ type SecurityGroupRule struct {
 
 func (e *SecurityGroupRule) Find(c *fi.CloudupContext) (*SecurityGroupRule, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	if e.SecurityGroup == nil || e.SecurityGroup.ID == nil {
 		return nil, nil

--- a/upup/pkg/fi/cloudup/awstasks/sqs.go
+++ b/upup/pkg/fi/cloudup/awstasks/sqs.go
@@ -56,7 +56,7 @@ func (q *SQS) CompareWithID() *string {
 
 func (q *SQS) Find(c *fi.CloudupContext) (*SQS, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	if q.Name == nil {
 		return nil, nil

--- a/upup/pkg/fi/cloudup/awstasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey.go
@@ -54,7 +54,7 @@ func (e *SSHKey) CompareWithID() *string {
 }
 
 func (e *SSHKey) Find(c *fi.CloudupContext) (*SSHKey, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	return e.find(c.Context(), cloud)
 }

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -145,7 +145,7 @@ func (e *Subnet) Find(c *fi.CloudupContext) (*Subnet, error) {
 }
 
 func (e *Subnet) findEc2Subnet(c *fi.CloudupContext) (*ec2types.Subnet, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	request := &ec2.DescribeSubnetsInput{}
 	if e.ID != nil {

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -212,7 +212,7 @@ func (e *TargetGroup) findTargetGroupByARN(ctx context.Context, cloud awsup.AWSC
 
 func (e *TargetGroup) Find(c *fi.CloudupContext) (*TargetGroup, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	var targetGroupInfo *awsup.TargetGroupInfo
 

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -70,7 +70,7 @@ func (e *VPC) CompareWithID() *string {
 
 func (e *VPC) Find(c *fi.CloudupContext) (*VPC, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	request := &ec2.DescribeVpcsInput{}
 
@@ -245,7 +245,7 @@ func (e *VPC) FindDeletions(c *fi.CloudupContext) ([]fi.CloudupDeletion, error) 
 	request := &ec2.DescribeVpcsInput{
 		VpcIds: []string{aws.ToString(e.ID)},
 	}
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 	response, err := cloud.EC2().DescribeVpcs(c.Context(), request)
 	if err != nil {
 		return nil, err

--- a/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
@@ -38,7 +38,7 @@ type VPCDHCPOptionsAssociation struct {
 }
 
 func (e *VPCDHCPOptionsAssociation) Find(c *fi.CloudupContext) (*VPCDHCPOptionsAssociation, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	vpcID := e.VPC.ID
 	dhcpOptionsID := e.DHCPOptions.ID

--- a/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
@@ -40,7 +40,7 @@ type VPCAmazonIPv6CIDRBlock struct {
 }
 
 func (e *VPCAmazonIPv6CIDRBlock) Find(c *fi.CloudupContext) (*VPCAmazonIPv6CIDRBlock, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	// If the VPC doesn't (yet) exist, there is no association
 	if e.VPC.ID == nil {

--- a/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
@@ -42,7 +42,7 @@ type VPCCIDRBlock struct {
 }
 
 func (e *VPCCIDRBlock) Find(c *fi.CloudupContext) (*VPCCIDRBlock, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	vpcID := aws.ToString(e.VPC.ID)
 

--- a/upup/pkg/fi/cloudup/awstasks/warmpool.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool.go
@@ -69,7 +69,7 @@ func (e *WarmPool) GetDependencies(tasks map[string]fi.CloudupTask) []fi.Cloudup
 // Find is used to discover the ASG in the cloud provider.
 func (e *WarmPool) Find(c *fi.CloudupContext) (*WarmPool, error) {
 	ctx := c.Context()
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 	svc := cloud.Autoscaling()
 	warmPool, err := svc.DescribeWarmPool(ctx, &autoscaling.DescribeWarmPoolInput{
 		AutoScalingGroupName: e.AutoscalingGroup.Name,

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -188,6 +188,17 @@ type AWSCloud interface {
 	AccountInfo(ctx context.Context) (string, string, error)
 }
 
+// GetCloud returns the AWSCloud in the CloudupContext.
+// It panics if the CloudupContext has not been initialized with an AWSCloud.
+func GetCloud(c *fi.CloudupContext) AWSCloud {
+	awsCloud, ok := c.T.Cloud.(AWSCloud)
+	if ok {
+		return awsCloud
+	}
+	klog.Fatalf("cannot find instance of AWSCloud in context")
+	return nil
+}
+
 type awsCloudImplementation struct {
 	ec2         *ec2.Client
 	iam         *iam.Client

--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -196,7 +196,7 @@ func (e *Elastigroup) find(svc spotinst.InstanceGroupService) (*aws.Group, error
 var _ fi.CloudupHasCheckExisting = &Elastigroup{}
 
 func (e *Elastigroup) Find(c *fi.CloudupContext) (*Elastigroup, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	group, err := e.find(cloud.Spotinst().Elastigroup())
 	if err != nil {
@@ -494,7 +494,7 @@ func (e *Elastigroup) Find(c *fi.CloudupContext) (*Elastigroup, error) {
 }
 
 func (e *Elastigroup) CheckExisting(c *fi.CloudupContext) bool {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 	group, err := e.find(cloud.Spotinst().Elastigroup())
 	return err == nil && group != nil
 }

--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -130,7 +130,7 @@ func (o *LaunchSpec) find(svc spotinst.LaunchSpecService, oceanID string) (*aws.
 var _ fi.CloudupHasCheckExisting = &LaunchSpec{}
 
 func (o *LaunchSpec) Find(c *fi.CloudupContext) (*LaunchSpec, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	ocean, err := o.Ocean.find(cloud.Spotinst().Ocean())
 	if err != nil {

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -135,7 +135,7 @@ func (o *Ocean) find(svc spotinst.InstanceGroupService) (*aws.Cluster, error) {
 var _ fi.CloudupHasCheckExisting = &Ocean{}
 
 func (o *Ocean) Find(c *fi.CloudupContext) (*Ocean, error) {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 
 	ocean, err := o.find(cloud.Spotinst().Ocean())
 	if err != nil {
@@ -347,7 +347,7 @@ func (o *Ocean) Find(c *fi.CloudupContext) (*Ocean, error) {
 }
 
 func (o *Ocean) CheckExisting(c *fi.CloudupContext) bool {
-	cloud := c.T.Cloud.(awsup.AWSCloud)
+	cloud := awsup.GetCloud(c)
 	ocean, err := o.find(cloud.Spotinst().Ocean())
 	return err == nil && ocean != nil
 }


### PR DESCRIPTION
This is a little clearer than casting the instance, but also sets us
up to have multiple clouds in the context, and have tasks that run
against multiple clouds.

We will need this if (for example) if we want a GCP or Metal cluster
to use an AWS state-store via OIDC.
