### PR TITLE
refactor: allow access to S3 bucket region

### DIFF
--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -77,6 +77,15 @@ func newS3Path(s3Context *S3Context, scheme string, bucket string, key string, s
 	}
 }
 
+func (p *S3Path) Region(ctx context.Context) (string, error) {
+	bucketDetails, err := p.getBucketDetails(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return bucketDetails.region, nil
+}
+
 func (p *S3Path) Path() string {
 	return p.scheme + "://" + p.bucket + "/" + p.key
 }


### PR DESCRIPTION
This is useful if we want to build an AWSCloud instance for the S3
bucket, rather than where we are installing resources.
