### PR TITLE
Set Ubuntu 24.04 as default in k8s 1.31

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -69,11 +69,19 @@ spec:
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240607
       providerID: aws
       architectureID: amd64
-      kubernetesVersion: ">=1.27.0"
+      kubernetesVersion: ">=1.27.0 <1.31.0"
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20240607
       providerID: aws
       architectureID: arm64
-      kubernetesVersion: ">=1.27.0"
+      kubernetesVersion: ">=1.27.0 <1.31.0"
+    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20240701.1
+      providerID: aws
+      architectureID: amd64
+      kubernetesVersion: ">=1.31.0"
+    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20240701.1
+      providerID: aws
+      architectureID: arm64
+      kubernetesVersion: ">=1.31.0"
     - name: cos-cloud/cos-stable-65-10323-99-0
       providerID: gce
       architectureID: amd64
@@ -89,7 +97,11 @@ spec:
     - name: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
       providerID: gce
       architectureID: amd64
-      kubernetesVersion: ">=1.27.0"
+      kubernetesVersion: ">=1.27.0 <1.31.0"
+    - name: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
+      providerID: gce
+      architectureID: amd64
+      kubernetesVersion: ">=1.31.0"
     - name: Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202406060
       providerID: azure
       architectureID: amd64
@@ -97,7 +109,11 @@ spec:
     - name: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202405140
       providerID: azure
       architectureID: amd64
-      kubernetesVersion: ">=1.27.0"
+      kubernetesVersion: ">=1.27.0 <1.31.0"
+    - name: Canonical:ubuntu-24_04-lts:server-gen1:24.04.202407011
+      providerID: azure
+      architectureID: amd64
+      kubernetesVersion: ">=1.31.0"
   cluster:
     kubernetesVersion: v1.5.8
     networking:

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -358,13 +358,16 @@ func RecommendedKubernetesVersion(c *Channel, kopsVersionString string) *semver.
 // Returns true if the given image name has the stable or alpha channel images prefix. Otherwise false.
 func (c *Channel) HasUpstreamImagePrefix(image string) bool {
 	return strings.HasPrefix(image, "kope.io/k8s-") ||
+		strings.HasPrefix(image, "099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-") ||
 		strings.HasPrefix(image, "099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-") ||
 		strings.HasPrefix(image, "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-") ||
 		strings.HasPrefix(image, "cos-cloud/cos-stable-") ||
 		strings.HasPrefix(image, "ubuntu-os-cloud/ubuntu-2004-focal-") ||
 		strings.HasPrefix(image, "ubuntu-os-cloud/ubuntu-2204-jammy-") ||
+		strings.HasPrefix(image, "ubuntu-os-cloud/ubuntu-2404-noble-") ||
 		strings.HasPrefix(image, "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:") ||
-		strings.HasPrefix(image, "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:")
+		strings.HasPrefix(image, "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:") ||
+		strings.HasPrefix(image, "Canonical:ubuntu-24_04-lts:server-gen1:")
 }
 
 // GetPackageVersion returns the version for the package, or an error if could not be found.


### PR DESCRIPTION
kops 1.30 is already far enough into the release cycle that I think it makes sense to wait for 1.31 for this. The 24.04 e2e testing has been fine so far.