### PR TITLE
Fix SSH Username on Google Cloud instances

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -154,9 +154,13 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 			}
 
 			if len(b.SSHPublicKeys) > 0 {
+				sshUsername := "admin"
+				if strings.Contains(ig.Spec.Image, "ubuntu") {
+					sshUsername = "ubuntu"
+				}
 				var gFmtKeys []string
 				for _, key := range b.SSHPublicKeys {
-					gFmtKeys = append(gFmtKeys, fmt.Sprintf("%s: %s", fi.SecretNameSSHPrimary, key))
+					gFmtKeys = append(gFmtKeys, fmt.Sprintf("%s: %s", sshUsername, key))
 				}
 
 				t.Metadata["ssh-keys"] = fi.NewStringResource(strings.Join(gFmtKeys, "\n"))


### PR DESCRIPTION
Currently on GKE, instances are created with an SSH key username of 'admin'. This fixes it by changing the username to ubuntu, if the image used is ubuntu. 

Closes #16642 