### PR TITLE
Automated cherry pick of #16670: Fix cluster-autoscaler priority expander config

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -345,7 +345,9 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			if cluster.Spec.ClusterAutoscaler.CustomPriorityExpanderConfig != nil {
 				priorities = cluster.Spec.ClusterAutoscaler.CustomPriorityExpanderConfig
 			} else {
-				for name, spec := range tf.GetNodeInstanceGroups() {
+				igNames := maps.SortedKeys(tf.GetNodeInstanceGroups())
+				for _, name := range igNames {
+					spec := tf.GetNodeInstanceGroups()[name]
 					if spec.Autoscale != nil {
 						priorities[strconv.Itoa(int(spec.AutoscalePriority))] = append(priorities[strconv.Itoa(int(spec.AutoscalePriority))], fmt.Sprintf("%s.%s", name, tf.ClusterName()))
 					}


### PR DESCRIPTION
Cherry pick of #16670 on release-1.29.

#16670: Fix cluster-autoscaler priority expander config

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```