### PR TITLE
Use UTC for AWS token tests

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_authenticator_test.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_authenticator_test.go
@@ -120,7 +120,7 @@ func TestCreateTokenV1(t *testing.T) {
 	}
 	t.Logf("decoded: %+v", decoded)
 
-	signatureDate := time.Now().Format("20060102") // This might fail if we cross midnight, it seems very unlikely
+	signatureDate := time.Now().UTC().Format("20060102")
 
 	amzSignature := ""
 	amzSignedHeaders := ""
@@ -269,7 +269,7 @@ func TestCreateTokenV2(t *testing.T) {
 		t.Errorf("unexpected http method: got %q, want %q", decoded.Method, want)
 	}
 
-	signatureDate := time.Now().Format("20060102") // This might fail if we cross midnight, it seems very unlikely
+	signatureDate := time.Now().UTC().Format("20060102")
 
 	amzSignature := ""
 	amzSignedHeaders := ""


### PR DESCRIPTION
This ensures the unit tests pass when the current UTC date differs from the local timezone's date.

Example failure:

```
--- FAIL: TestCreateTokenV2 (0.00s)
    aws_authenticator_test.go:266: decoded: &{URL:https://sts.us-east-1.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=fakeaccesskey%2F20240718%2Fus-east-1%2Fsts%2Faws4_request&X-Amz-Date=20240718T012100Z&X-Amz-SignedHeaders=host%3Bx-kops-request-sha&X-Amz-Signature=7a851e423b5697c72a68286848c43ef68cfccbb01e46ab96a25cfb63d9e88c6d Method:GET SignedHeader:map[Host:[sts.us-east-1.amazonaws.com] X-Kops-Request-Sha:[2dhlzFTsYGePGxGQhK15rn+TV9HEUZxkV94zFLf7uoo]]}
    aws_authenticator_test.go:335: unexpected amzCredential: got "fakeaccesskey/20240718/us-east-1/sts/aws4_request", want "fakeaccesskey/20240717/us-east-1/sts/aws4_request"
    aws_authenticator_test.go:342: expected amz-date to have prefix "20240717T"; got "20240718T012100Z"

```