### PR TITLE
Automated cherry pick of #16661: Bump cloudbuild to go 1.22.5

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # Push the images
-- name: 'docker.io/library/golang:1.22.4-bookworm'
+- name: 'docker.io/library/golang:1.22.5-bookworm'
   id: images
   entrypoint: make
   env:
@@ -21,7 +21,7 @@ steps:
   - dns-controller-push
   - kube-apiserver-healthcheck-push
 # Push the artifacts
-- name: 'docker.io/library/golang:1.22.4-bookworm'
+- name: 'docker.io/library/golang:1.22.5-bookworm'
   id: artifacts
   entrypoint: make
   env:
@@ -36,7 +36,7 @@ steps:
   args:
   - gcs-upload-and-tag
 # Build cloudbuild artifacts (for attestation)
-- name: 'docker.io/library/golang:1.22.4-bookworm'
+- name: 'docker.io/library/golang:1.22.5-bookworm'
   id: cloudbuild-artifacts
   entrypoint: make
   env:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module k8s.io/kops
 
+// This should be kept in sync with cloudbuild.yaml and the other go.mod files
 go 1.22.5
 
 require (


### PR DESCRIPTION
Cherry pick of #16661 on release-1.30.

#16661: Bump cloudbuild to go 1.22.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```