### PR TITLE
Automated cherry pick of #16682: Add the hubble-metrics service for cilium

### DIFF
--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -208,6 +208,8 @@ spec:
       enableUnreachableRoutes: false
       hubble:
         enabled: true
+        metrics:
+        - drop
       identityAllocationMode: crd
       identityChangeGracePeriod: 5s
       ingress:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -155,7 +155,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 45ecd4b0c81a42b7fe61b223bc4fc869f89c9aae2a1863235782134e346c7151
+    manifestHash: 3fdb869ea26ce50ae6db32e1b997749f18cbb30ebf31468f2c5da2c692681a54
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -77,6 +77,8 @@ data:
   external-envoy-proxy: "false"
   hubble-disable-tls: "false"
   hubble-listen-address: :4244
+  hubble-metrics: drop
+  hubble-metrics-server: :9091
   hubble-socket-path: /var/run/cilium/hubble.sock
   hubble-tls-cert-file: /var/lib/cilium/tls/hubble/tls.crt
   hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/ca.crt
@@ -681,6 +683,35 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "9965"
+    prometheus.io/scrape: "true"
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.cilium.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: hubble
+    app.kubernetes.io/part-of: cilium
+    k8s-app: hubble
+    role.kubernetes.io/networking: "1"
+  name: hubble-metrics
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: hubble-metrics
+    port: 9965
+    protocol: TCP
+    targetPort: hubble-metrics
+  selector:
+    k8s-app: cilium
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.cilium.io
@@ -799,6 +830,10 @@ spec:
         - containerPort: 4244
           hostPort: 4244
           name: peer-service
+          protocol: TCP
+        - containerPort: 9091
+          hostPort: 9091
+          name: hubble-metrics
           protocol: TCP
         readinessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/privatecilium2/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatecilium2/in-v1alpha2.yaml
@@ -39,6 +39,8 @@ spec:
         sharedLoadBalancerServiceName: private-ingress
       hubble:
         enabled: true
+        metrics:
+        - drop
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
   - 0.0.0.0/0

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -886,6 +886,32 @@ subsets:
 {{ end }}
 {{ end }}
 {{ if WithDefaultBool .Hubble.Enabled false }}
+{{ if .Hubble.Metrics }}
+---
+# Source: cilium/templates/hubble/metrics-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-metrics
+  namespace: kube-system
+  labels:
+    k8s-app: hubble
+    app.kubernetes.io/name: hubble
+    app.kubernetes.io/part-of: cilium
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9965"
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: hubble-metrics
+    port: 9965
+    protocol: TCP
+    targetPort: hubble-metrics
+  selector:
+    k8s-app: cilium
+{{ end }}
 ---
 # Source: cilium/templates/hubble-relay-service.yaml
 kind: Service


### PR DESCRIPTION
Cherry pick of #16682 on release-1.30.

#16682: Add the hubble-metrics service for cilium

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```