### PR TITLE
Automated cherry pick of #16681: Add new API field for VPC CNI's network policy agent

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -4905,6 +4905,10 @@ spec:
                         description: InitImageName is the init container image name
                           to use.
                         type: string
+                      networkPolicyAgentImage:
+                        description: NetworkPolicyAgentImage is the container image
+                          to use for the network policy agent
+                        type: string
                     type: object
                   calico:
                     description: CalicoNetworkingSpec declares that we want Calico

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -316,6 +316,8 @@ type AmazonVPCNetworkingSpec struct {
 	Image string `json:"image,omitempty"`
 	// InitImage is the init container image name to use.
 	InitImage string `json:"initImage,omitempty"`
+	// NetworkPolicyAgentImage is the container image to use for the network policy agent
+	NetworkPolicyAgentImage string `json:"networkPolicyAgentImage,omitempty"`
 	// Env is a list of environment variables to set in the container.
 	Env []EnvVar `json:"env,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -281,6 +281,8 @@ type AmazonVPCNetworkingSpec struct {
 	Image string `json:"imageName,omitempty"`
 	// InitImageName is the init container image name to use.
 	InitImage string `json:"initImageName,omitempty"`
+	// NetworkPolicyAgentImage is the container image to use for the network policy agent
+	NetworkPolicyAgentImage string `json:"networkPolicyAgentImage,omitempty"`
 	// Env is a list of environment variables to set in the container.
 	Env []EnvVar `json:"env,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1504,6 +1504,7 @@ func Convert_kops_AlwaysAllowAuthorizationSpec_To_v1alpha2_AlwaysAllowAuthorizat
 func autoConvert_v1alpha2_AmazonVPCNetworkingSpec_To_kops_AmazonVPCNetworkingSpec(in *AmazonVPCNetworkingSpec, out *kops.AmazonVPCNetworkingSpec, s conversion.Scope) error {
 	out.Image = in.Image
 	out.InitImage = in.InitImage
+	out.NetworkPolicyAgentImage = in.NetworkPolicyAgentImage
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]kops.EnvVar, len(*in))
@@ -1526,6 +1527,7 @@ func Convert_v1alpha2_AmazonVPCNetworkingSpec_To_kops_AmazonVPCNetworkingSpec(in
 func autoConvert_kops_AmazonVPCNetworkingSpec_To_v1alpha2_AmazonVPCNetworkingSpec(in *kops.AmazonVPCNetworkingSpec, out *AmazonVPCNetworkingSpec, s conversion.Scope) error {
 	out.Image = in.Image
 	out.InitImage = in.InitImage
+	out.NetworkPolicyAgentImage = in.NetworkPolicyAgentImage
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]EnvVar, len(*in))

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -286,6 +286,8 @@ type AmazonVPCNetworkingSpec struct {
 	Image string `json:"image,omitempty"`
 	// InitImage is the init container image name to use.
 	InitImage string `json:"initImage,omitempty"`
+	// NetworkPolicyAgentImage is the container image to use for the network policy agent
+	NetworkPolicyAgentImage string `json:"networkPolicyAgentImage,omitempty"`
 	// Env is a list of environment variables to set in the container.
 	Env []EnvVar `json:"env,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1664,6 +1664,7 @@ func Convert_kops_AlwaysAllowAuthorizationSpec_To_v1alpha3_AlwaysAllowAuthorizat
 func autoConvert_v1alpha3_AmazonVPCNetworkingSpec_To_kops_AmazonVPCNetworkingSpec(in *AmazonVPCNetworkingSpec, out *kops.AmazonVPCNetworkingSpec, s conversion.Scope) error {
 	out.Image = in.Image
 	out.InitImage = in.InitImage
+	out.NetworkPolicyAgentImage = in.NetworkPolicyAgentImage
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]kops.EnvVar, len(*in))
@@ -1686,6 +1687,7 @@ func Convert_v1alpha3_AmazonVPCNetworkingSpec_To_kops_AmazonVPCNetworkingSpec(in
 func autoConvert_kops_AmazonVPCNetworkingSpec_To_v1alpha3_AmazonVPCNetworkingSpec(in *kops.AmazonVPCNetworkingSpec, out *AmazonVPCNetworkingSpec, s conversion.Scope) error {
 	out.Image = in.Image
 	out.InitImage = in.InitImage
+	out.NetworkPolicyAgentImage = in.NetworkPolicyAgentImage
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]EnvVar, len(*in))

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -211,7 +211,10 @@ spec:
     enabled: true
   networkCIDR: 172.20.0.0/16
   networking:
-    amazonvpc: {}
+    amazonvpc:
+      imageName: image:123
+      initImageName: initimage:123
+      networkPolicyAgentImage: networkpolicyagentimage:123
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 516820e30ab3bc0817c018c36ffd1841d5e6c53b553a0ddd8ae98d7d3779c0fc
+    manifestHash: 84642ad9b609d8e6ce59cbd1bd599e9410416c1619f4734112e1b338c4c4b469
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -514,7 +514,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.1
+        image: image:123
         livenessProbe:
           exec:
             command:
@@ -570,7 +570,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.1
+        image: networkpolicyagentimage:123
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -596,7 +596,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.1
+        image: initimage:123
         name: aws-vpc-cni-init
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/many-addons-ccm/in-v1alpha2.yaml
@@ -39,7 +39,10 @@ spec:
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:
-    amazonvpc: {}
+    amazonvpc:
+      imageName: image:123
+      initImageName: initimage:123
+      networkPolicyAgentImage: networkpolicyagentimage:123
   nodeTerminationHandler:
     enabled: true
     enableRebalanceDraining: true

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -518,7 +518,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.1
+          image: "{{- or .Networking.AmazonVPC.NetworkPolicyAgentImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.1" }}"
           env:
             - name: MY_NODE_NAME
               valueFrom:


### PR DESCRIPTION
Cherry pick of #16681 on release-1.29.

#16681: Add new API field for VPC CNI's network policy agent

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```