### PR TITLE
Allow additional network tags to be set for GCP instances

### DIFF
--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -63,6 +63,11 @@ spec:
           spec:
             description: InstanceGroupSpec is the specification for an InstanceGroup
             properties:
+              additionalNetworkTags:
+                description: AdditionalNetworkTags adds network tags to the GCP Instance.
+                items:
+                  type: string
+                type: array
               additionalSecurityGroups:
                 description: AdditionalSecurityGroups attaches additional security
                   groups (e.g. i-123456)

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -198,6 +198,8 @@ type InstanceGroupSpec struct {
 	//   'STANDARD': (default) standard provisioning with user controlled run time, no discounts
 	//   'SPOT': heavily discounted, no guaranteed run time.
 	GCPProvisioningModel *string `json:"gcpProvisioningModel,omitempty"`
+	// AdditionalNetworkTags adds network tags to the GCP Instance.
+	AdditionalNetworkTags []string `json:"additionalNetworkTags,omitempty"`
 }
 
 const (

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -184,6 +184,8 @@ type InstanceGroupSpec struct {
 	//   'STANDARD': (default) standard provisioning with user controlled run time, no discounts
 	//   'SPOT': heavily discounted, no guaranteed run time.
 	GCPProvisioningModel *string `json:"gcpProvisioningModel,omitempty"`
+	// AdditionalNetworkTags adds network tags to the GCP Instance.
+	AdditionalNetworkTags []string `json:"additionalNetworkTags,omitempty"`
 }
 
 // InstanceMetadataOptions defines the EC2 instance metadata service options (AWS Only)

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4393,6 +4393,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	}
 	out.MaxInstanceLifetime = in.MaxInstanceLifetime
 	out.GCPProvisioningModel = in.GCPProvisioningModel
+	out.AdditionalNetworkTags = in.AdditionalNetworkTags
 	return nil
 }
 
@@ -4569,6 +4570,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	}
 	out.MaxInstanceLifetime = in.MaxInstanceLifetime
 	out.GCPProvisioningModel = in.GCPProvisioningModel
+	out.AdditionalNetworkTags = in.AdditionalNetworkTags
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2787,6 +2787,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.AdditionalNetworkTags != nil {
+		in, out := &in.AdditionalNetworkTags, &out.AdditionalNetworkTags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/instancegroup.go
+++ b/pkg/apis/kops/v1alpha3/instancegroup.go
@@ -159,6 +159,8 @@ type InstanceGroupSpec struct {
 	//   'STANDARD': (default) standard provisioning with user controlled run time, no discounts
 	//   'SPOT': heavily discounted, no guaranteed run time.
 	GCPProvisioningModel *string `json:"gcpProvisioningModel,omitempty"`
+	// AdditionalNetworkTags adds network tags to the GCP Instance.
+	AdditionalNetworkTags []string `json:"additionalNetworkTags,omitempty"`
 }
 
 // InstanceRootVolumeSpec specifies options for an instance's root volume.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -4738,6 +4738,7 @@ func autoConvert_v1alpha3_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	}
 	out.MaxInstanceLifetime = in.MaxInstanceLifetime
 	out.GCPProvisioningModel = in.GCPProvisioningModel
+	out.AdditionalNetworkTags = in.AdditionalNetworkTags
 	return nil
 }
 
@@ -4927,6 +4928,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha3_InstanceGroupSpec(in *kops.I
 	}
 	out.MaxInstanceLifetime = in.MaxInstanceLifetime
 	out.GCPProvisioningModel = in.GCPProvisioningModel
+	out.AdditionalNetworkTags = in.AdditionalNetworkTags
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -2710,6 +2710,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.AdditionalNetworkTags != nil {
+		in, out := &in.AdditionalNetworkTags, &out.AdditionalNetworkTags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2797,6 +2797,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.AdditionalNetworkTags != nil {
+		in, out := &in.AdditionalNetworkTags, &out.AdditionalNetworkTags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -176,6 +176,7 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.CloudupModelB
 			case kops.InstanceGroupRoleBastion:
 				t.Tags = append(t.Tags, b.GCETagForRole(kops.InstanceGroupRoleBastion))
 			}
+			t.Tags = append(t.Tags, ig.Spec.AdditionalNetworkTags...)
 			clusterLabel := gce.LabelForCluster(b.ClusterName())
 			roleLabel := gce.GceLabelNameRolePrefix + ig.Spec.Role.ToLowerString()
 			t.Labels = map[string]string{

--- a/tests/integration/update_cluster/minimal_gce/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal_gce/in-v1alpha2.yaml
@@ -79,6 +79,8 @@ metadata:
     kops.k8s.io/cluster: minimal-gce.example.com
   name: nodes
 spec:
+  additionalNetworkTags:
+  - testTag
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20221018
   machineType: e2-medium
   maxSize: 2

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -527,7 +527,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
     email  = google_service_account.node.email
     scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/cloud-platform", "https://www.googleapis.com/auth/devstorage.read_only"]
   }
-  tags = ["minimal-gce-example-com-k8s-io-role-node"]
+  tags = ["minimal-gce-example-com-k8s-io-role-node", "testTag"]
 }
 
 resource "google_compute_network" "minimal-gce-example-com" {


### PR DESCRIPTION
Allow additional network tags to be passed to GCP Instances.  

This addresses https://github.com/kubernetes/kops/issues/15687