### PR TITLE
Drop InTreePluginAWSUnregister feature gate for k8s 1.31 and above

### DIFF
--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -185,6 +185,8 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 
 		if _, found := c.FeatureGates["InTreePluginAWSUnregister"]; !found {
 			c.FeatureGates["InTreePluginAWSUnregister"] = "true"
+		} else if b.IsKubernetesGTE("1.31") {
+			delete(c.FeatureGates, "InTreePluginAWSUnregister")
 		}
 
 		if _, found := c.FeatureGates["CSIMigrationAWS"]; !found && b.IsKubernetesLT("1.27") {

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -151,6 +151,8 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 
 		if _, found := kcm.FeatureGates["InTreePluginAWSUnregister"]; !found {
 			kcm.FeatureGates["InTreePluginAWSUnregister"] = "true"
+		} else if b.IsKubernetesGTE("1.31") {
+			delete(kcm.FeatureGates, "InTreePluginAWSUnregister")
 		}
 
 		if _, found := kcm.FeatureGates["CSIMigrationAWS"]; !found && b.IsKubernetesLT("1.27") {

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -178,6 +178,8 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 
 		if _, found := clusterSpec.Kubelet.FeatureGates["InTreePluginAWSUnregister"]; !found {
 			clusterSpec.Kubelet.FeatureGates["InTreePluginAWSUnregister"] = "true"
+		} else if b.IsKubernetesGTE("1.31") {
+			delete(clusterSpec.Kubelet.FeatureGates, "InTreePluginAWSUnregister")
 		}
 	}
 

--- a/pkg/model/components/kubescheduler.go
+++ b/pkg/model/components/kubescheduler.go
@@ -65,6 +65,8 @@ func (b *KubeSchedulerOptionsBuilder) BuildOptions(o interface{}) error {
 
 		if _, found := config.FeatureGates["InTreePluginAWSUnregister"]; !found {
 			config.FeatureGates["InTreePluginAWSUnregister"] = "true"
+		} else if b.IsKubernetesGTE("1.31") {
+			delete(clusterSpec.Kubelet.FeatureGates, "InTreePluginAWSUnregister")
 		}
 
 		if _, found := config.FeatureGates["CSIMigrationAWS"]; !found && b.IsKubernetesLT("1.27") {


### PR DESCRIPTION
possible Fix for CI job failures:
```
E0725 12:16:22.804670   27684 run.go:72] "command failed" err="failed to set feature gates from initial flags-based config: unrecognized feature gate: InTreePluginAWSUnregister"
```

k8s cleanup PR for some feature gates:
https://github.com/kubernetes/kubernetes/pull/124815/files