### PR TITLE
test: Use latest K8s build for scale tests

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -27,7 +27,7 @@ fi
 echo "CLUSTER_NAME=${CLUSTER_NAME}"
 
 if [[ -z "${K8S_VERSION:-}" ]]; then
-  K8S_VERSION="$(curl -s -L https://dl.k8s.io/release/stable.txt)"
+  K8S_VERSION="$(curl -s -L https://dl.k8s.io/release/latest.txt)"
 fi
 
 # A temp patch for kubetest2 https://github.com/kubernetes-sigs/kubetest2/pull/256


### PR DESCRIPTION
Want to test 1.31.beta to see if it works on AWS.
