### PR TITLE
Fix InTreePluginAWSUnregister feature gate removal in 1.31

### DIFF
--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -183,10 +183,8 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 
 	if clusterSpec.CloudProvider.AWS != nil {
 
-		if _, found := c.FeatureGates["InTreePluginAWSUnregister"]; !found {
+		if _, found := c.FeatureGates["InTreePluginAWSUnregister"]; !found && b.IsKubernetesLT("1.31") {
 			c.FeatureGates["InTreePluginAWSUnregister"] = "true"
-		} else if b.IsKubernetesGTE("1.31") {
-			delete(c.FeatureGates, "InTreePluginAWSUnregister")
 		}
 
 		if _, found := c.FeatureGates["CSIMigrationAWS"]; !found && b.IsKubernetesLT("1.27") {

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -149,10 +149,8 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 			kcm.FeatureGates = make(map[string]string)
 		}
 
-		if _, found := kcm.FeatureGates["InTreePluginAWSUnregister"]; !found {
+		if _, found := kcm.FeatureGates["InTreePluginAWSUnregister"]; !found && b.IsKubernetesLT("1.31") {
 			kcm.FeatureGates["InTreePluginAWSUnregister"] = "true"
-		} else if b.IsKubernetesGTE("1.31") {
-			delete(kcm.FeatureGates, "InTreePluginAWSUnregister")
 		}
 
 		if _, found := kcm.FeatureGates["CSIMigrationAWS"]; !found && b.IsKubernetesLT("1.27") {

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -172,14 +172,12 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if clusterSpec.CloudProvider.AWS != nil {
-		if _, found := clusterSpec.Kubelet.FeatureGates["CSIMigrationAWS"]; !found && b.IsKubernetesLT("1.27") {
-			clusterSpec.Kubelet.FeatureGates["CSIMigrationAWS"] = "true"
+		if _, found := clusterSpec.Kubelet.FeatureGates["InTreePluginAWSUnregister"]; !found && b.IsKubernetesLT("1.31") {
+			clusterSpec.Kubelet.FeatureGates["InTreePluginAWSUnregister"] = "true"
 		}
 
-		if _, found := clusterSpec.Kubelet.FeatureGates["InTreePluginAWSUnregister"]; !found {
-			clusterSpec.Kubelet.FeatureGates["InTreePluginAWSUnregister"] = "true"
-		} else if b.IsKubernetesGTE("1.31") {
-			delete(clusterSpec.Kubelet.FeatureGates, "InTreePluginAWSUnregister")
+		if _, found := clusterSpec.Kubelet.FeatureGates["CSIMigrationAWS"]; !found && b.IsKubernetesLT("1.27") {
+			clusterSpec.Kubelet.FeatureGates["CSIMigrationAWS"] = "true"
 		}
 	}
 

--- a/pkg/model/components/kubescheduler.go
+++ b/pkg/model/components/kubescheduler.go
@@ -63,10 +63,8 @@ func (b *KubeSchedulerOptionsBuilder) BuildOptions(o interface{}) error {
 			config.FeatureGates = make(map[string]string)
 		}
 
-		if _, found := config.FeatureGates["InTreePluginAWSUnregister"]; !found {
+		if _, found := config.FeatureGates["InTreePluginAWSUnregister"]; !found && b.IsKubernetesLT("1.31") {
 			config.FeatureGates["InTreePluginAWSUnregister"] = "true"
-		} else if b.IsKubernetesGTE("1.31") {
-			delete(clusterSpec.Kubelet.FeatureGates, "InTreePluginAWSUnregister")
 		}
 
 		if _, found := config.FeatureGates["CSIMigrationAWS"]; !found && b.IsKubernetesLT("1.27") {


### PR DESCRIPTION
These BuildOptions methods are ran repeatedly, and the old `else` condition caused the contents of the map to alternate between the feature gate being present and removed.

[Example failure](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/16701/presubmit-kops-aws-scale-amazonvpc-using-cl2/1817026530975420416)

```
I0727 02:47:00.991757   52038 up.go:219] /home/prow/go/src/k8s.io/kops/_rundir/9d9f923e-e44a-48ab-9cfd-aa28cfd2e9e2/kops create cluster --name e2e-ff02749ef8-a423a.test-cncf-aws.k8s.io --cloud aws --kubernetes-version v1.31.0-beta.0 --ssh-public-key /tmp/kops/e2e-ff02749ef8-a423a.test-cncf-aws.k8s.io/id_ed25519.pub --set cluster.spec.nodePortAccess=0.0.0.0/0 --set spec.containerd.configAdditions=plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.runtime_type=io.containerd.runc.v2 --network-cidr=10.0.0.0/16,10.1.0.0/16,10.2.0.0/16,10.3.0.0/16,10.4.0.0/16,10.5.0.0/16,10.6.0.0/16,10.7.0.0/16,10.8.0.0/16,10.9.0.0/16,10.10.0.0/16,10.11.0.0/16,10.12.0.0/16 --node-size=t3a.medium,t3.medium,t2.medium,t3a.large,c5a.large,t3.large,c5.large,m5a.large,m6a.large,m5.large,c4.large,c7a.large,r5a.large,r6a.large,m7a.large --node-volume-size=20 --zones=us-east-2a,us-east-2b,us-east-2c --image=ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id --networking=amazonvpc --set spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set spec.etcdClusters[0].manager.listenMetricsURLs=http://localhost:2382/ --set spec.etcdClusters[0].manager.env=ETCD_QUOTA_BACKEND_BYTES=8589934592 --set spec.etcdClusters[1].manager.env=ETCD_QUOTA_BACKEND_BYTES=8589934592 --set spec.cloudControllerManager.concurrentNodeSyncs=10 --set spec.kubelet.maxPods=96 --set spec.kubeScheduler.authorizationAlwaysAllowPaths=/healthz --set spec.kubeScheduler.authorizationAlwaysAllowPaths=/metrics --set spec.kubeScheduler.kubeAPIQPS=500 --set spec.kubeScheduler.kubeAPIBurst=500 --set spec.kubeScheduler.enableProfiling=true --set spec.kubeScheduler.enableContentionProfiling=true --set spec.kubeControllerManager.endpointUpdatesBatchPeriod=500ms --set spec.kubeControllerManager.endpointSliceUpdatesBatchPeriod=500ms --set spec.kubeControllerManager.kubeAPIQPS=500 --set spec.kubeControllerManager.kubeAPIBurst=500 --set spec.kubeControllerManager.enableProfiling=true --set spec.kubeControllerManager.enableContentionProfiling=true --set spec.kubeAPIServer.maxRequestsInflight=800 --set spec.kubeAPIServer.maxMutatingRequestsInflight=400 --set spec.kubeAPIServer.enableProfiling=true --set spec.kubeAPIServer.enableContentionProfiling=true --set spec.kubeAPIServer.logLevel=2 --set spec.kubeAPIServer.anonymousAuth=true --set spec.kubeProxy.metricsBindAddress=0.0.0.0:10249 --node-count=5000 --dns=none --control-plane-count=3 --master-size=c5.18xlarge --admin-access 0.0.0.0/0 --master-volume-size 48
I0727 02:47:01.001824   52100 featureflag.go:168] FeatureFlag "AWSSingleNodesInstanceGroup"=true
Flag --master-size has been deprecated, use --control-plane-size instead
Flag --master-volume-size has been deprecated, use --control-plane-volume-size instead
I0727 02:47:01.073577   52100 create_cluster.go:880] Using SSH public key: /tmp/kops/e2e-ff02749ef8-a423a.test-cncf-aws.k8s.io/id_ed25519.pub
I0727 02:47:01.161823   52100 new_cluster.go:1454] Cloud Provider ID: "aws"
I0727 02:47:01.345340   52100 subnets.go:224] Assigned CIDR 10.0.0.0/18 to subnet us-east-2a
I0727 02:47:01.345380   52100 subnets.go:224] Assigned CIDR 10.0.64.0/18 to subnet us-east-2b
I0727 02:47:01.345390   52100 subnets.go:224] Assigned CIDR 10.0.128.0/18 to subnet us-east-2c
Error: error building complete spec: options did not converge after 10 iterations
```

This fix matches the pattern used for the `CSIMigrationAWS` feature gate below.


/cc @hakman @dims
