### PR TITLE
refactor: support multiple podCIDRs in the node patch

### DIFF
--- a/cmd/kops-controller/controllers/gceipam.go
+++ b/cmd/kops-controller/controllers/gceipam.go
@@ -134,7 +134,8 @@ func (r *GCEIPAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 
 		ipv6Address := ipv6Addresses[0]
-		if err := patchNodePodCIDRs(r.coreV1Client, ctx, node, ipv6Address); err != nil {
+		podCIDRs := []string{ipv6Address}
+		if err := patchNodePodCIDRs(r.coreV1Client, ctx, node, podCIDRs); err != nil {
 			return ctrl.Result{}, err
 		}
 	}


### PR DESCRIPTION
Breaking down the metal support into bite-sized chunks.
