### PR TITLE
[WIP] failure to specify featureGates from command line

### DIFF
--- a/pkg/commands/set_cluster_test.go
+++ b/pkg/commands/set_cluster_test.go
@@ -43,6 +43,25 @@ func TestSetClusterFields(t *testing.T) {
 	}{
 		{
 			Fields: []string{
+				"spec.kubeAPIserver.featureGates=ServiceTrafficDistribution=false",
+			},
+			Input: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					KubeAPIServer: &kops.KubeAPIServerConfig{},
+				},
+			},
+			Output: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					KubeAPIServer: &kops.KubeAPIServerConfig{
+						FeatureGates: map[string]string{
+							"ServiceTrafficDistribution": "false",
+						},
+					},
+				},
+			},
+		},
+		{
+			Fields: []string{
 				"spec.kubernetesVersion=1.8.2",
 				"spec.kubelet.authorizationMode=Webhook",
 				"spec.kubelet.authenticationTokenWebhook=true",


### PR DESCRIPTION
Why does this fail?
```
=== RUN   TestSetClusterFields
    set_cluster_test.go:295: unexpected error from setClusterFields [spec.kubeAPIserver.featureGates=]: field spec.kubeAPIserver.featureGates not found in *Cluster
--- FAIL: TestSetClusterFields (0.00s)

FAIL
```