### PR TITLE
Use latest master build from k8s

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -27,7 +27,7 @@ fi
 echo "CLUSTER_NAME=${CLUSTER_NAME}"
 
 if [[ -z "${K8S_VERSION:-}" ]]; then
-  K8S_VERSION="$(curl -s -L https://dl.k8s.io/release/latest.txt)"
+  K8S_VERSION=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt
 fi
 
 # A temp patch for kubetest2 https://github.com/kubernetes-sigs/kubetest2/pull/256


### PR DESCRIPTION
We should be using tip of master for scalability tests
```
$ curl -L https://dl.k8s.io/release/latest.txt
v1.32.0-alpha.0

$ curl -L https://storage.googleapis.com/k8s-release-dev/ci/latest.txt
v1.32.0-alpha.0.16+dbc2b0a5c7acc3
```

I can see other jobs that are using it 🤞🏾 : 
https://cs.k8s.io/?q=--kubernetes-version.*k8s-release-dev&i=nope&files=&excludeFiles=&repos=kubernetes/test-infra