### PR TITLE
Use latest ubuntu jammy 22.04 to match GCE

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -64,7 +64,7 @@ if [[ "${CLOUD_PROVIDER}" == "aws" ]]; then
   create_args+=("--node-size=t3a.medium,t3.medium,t2.medium,t3a.large,c5a.large,t3.large,c5.large,m5a.large,m6a.large,m5.large,c4.large,c7a.large,r5a.large,r6a.large,m7a.large")
   create_args+=("--node-volume-size=20")
   create_args+=("--zones=us-east-2a,us-east-2b,us-east-2c")
-  create_args+=("--image=${INSTANCE_IMAGE:-ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id}")
+  create_args+=("--image=${INSTANCE_IMAGE:-ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id}")
 fi
 if [[ "${CLOUD_PROVIDER}" == "gce" ]]; then
   create_args+=("--zones=us-east1-b,us-east1-c,us-east1-d")


### PR DESCRIPTION
Ensure we test with same image as GCE

https://github.com/kubernetes/kops/blob/4e57ea751401ee1a1076792945dc6c40a165e5dd/tests/e2e/scenarios/scalability/run-test.sh#L75