### PR TITLE
Prioritize dumping nodes that are not ready

### DIFF
--- a/cmd/kops/toolbox_dump_test.go
+++ b/cmd/kops/toolbox_dump_test.go
@@ -64,6 +64,19 @@ func TestTruncateNodeList(t *testing.T) {
 			},
 		},
 		{
+			name: "truncate-with-failed-node",
+			input: []corev1.Node{
+				makeNode(),
+				makeNode(),
+				makeNode(),
+				makeFailedNode(),
+			},
+			max: 1,
+			expected: []corev1.Node{
+				makeFailedNode(),
+			},
+		},
+		{
 			name: "less than zero",
 			input: []corev1.Node{
 				makeNode(),
@@ -92,6 +105,14 @@ func TestTruncateNodeList(t *testing.T) {
 
 func makeControlPlaneNode() corev1.Node {
 	return corev1.Node{
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				"node-role.kubernetes.io/control-plane": "",
@@ -102,6 +123,32 @@ func makeControlPlaneNode() corev1.Node {
 
 func makeNode() corev1.Node {
 	return corev1.Node{
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"node-role.kubernetes.io/node": "",
+			},
+		},
+	}
+}
+
+func makeFailedNode() corev1.Node {
+	return corev1.Node{
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				"node-role.kubernetes.io/node": "",

--- a/pkg/validation/node_conditions.go
+++ b/pkg/validation/node_conditions.go
@@ -39,11 +39,11 @@ func findNodeCondition(node *v1.Node, conditionType v1.NodeConditionType) *v1.No
 	return nil
 }
 
-// isNodeReady returns if a Node is considered ready.
+// IsNodeReady returns if a Node is considered ready.
 // It is considered ready if:
 // 1) its Ready condition is set to true
 // 2) doesn't have NetworkUnavailable condition set to true
-func isNodeReady(node *v1.Node) bool {
+func IsNodeReady(node *v1.Node) bool {
 	nodeReadyCondition := findNodeCondition(node, v1.NodeReady)
 	if nodeReadyCondition == nil {
 		klog.Warningf("v1.NodeReady condition not set on node %s", node.Name)

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -346,7 +346,7 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 				Status:   getNodeReadyStatus(node),
 			}
 
-			ready := isNodeReady(node)
+			ready := IsNodeReady(node)
 			if ready {
 				readyNodes = append(readyNodes, *node)
 			}


### PR DESCRIPTION
In the recent 5K/aws CI job, one node failed:
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-scale-amazonvpc-using-cl2/1819992126977478656/build-log.txt

```
VALIDATION ERRORS
KIND	NAME			MESSAGE
Machine	i-0818da8f0156bf045	machine "i-0818da8f0156bf045" has not yet joined cluster
```

But since we truncate using `--max-nodes-to-dump` we did not capture logs from this node. Looks like we already prioritize dumping control-plane/apiserver nodes, let's do the same for failed nodes as well. 