### PR TITLE
Automated cherry pick of #16737: fix bootstrap already exists handling

### DIFF
--- a/pkg/bootstrap/chain.go
+++ b/pkg/bootstrap/chain.go
@@ -44,6 +44,9 @@ func (v *ChainVerifier) VerifyToken(ctx context.Context, rawRequest *http.Reques
 		if err == ErrNotThisVerifier {
 			continue
 		}
+		if err == ErrAlreadyExists {
+			return nil, ErrAlreadyExists
+		}
 		klog.Infof("failed to verify token: %v", err)
 	}
 	return nil, fmt.Errorf("unable to verify token")

--- a/pkg/kopscontrollerclient/client.go
+++ b/pkg/kopscontrollerclient/client.go
@@ -125,3 +125,9 @@ func (b *Client) Query(ctx context.Context, req any, resp any) error {
 
 	return json.NewDecoder(response.Body).Decode(resp)
 }
+
+func (b *Client) Close() {
+	if b.httpClient != nil {
+		b.httpClient.CloseIdleConnections()
+	}
+}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -699,6 +699,7 @@ func getNodeConfigFromServers(ctx context.Context, bootConfig *nodeup.BootConfig
 		Authenticator: authenticator,
 		CAs:           []byte(bootConfig.ConfigServer.CACertificates),
 	}
+	defer client.Close()
 
 	var merr error
 	for _, server := range bootConfig.ConfigServer.Servers {


### PR DESCRIPTION
Cherry pick of #16737 on release-1.30.

#16737: fix bootstrap already exists handling

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```