### PR TITLE
Fix verify-golangci-lint

### DIFF
--- a/cmd/kops/create_cluster_test.go
+++ b/cmd/kops/create_cluster_test.go
@@ -37,7 +37,7 @@ func checkParse(t *testing.T, s string, expect map[string]string, shouldErr bool
 		if shouldErr {
 			return
 		}
-		t.Errorf(err.Error())
+		t.Errorf("%s", err.Error())
 	}
 
 	for k, v := range expect {

--- a/pkg/k8scodecs/codecs_test.go
+++ b/pkg/k8scodecs/codecs_test.go
@@ -74,7 +74,7 @@ func TestToVersionedYaml(t *testing.T) {
 		actual = strings.TrimSpace(actual)
 		expected := strings.TrimSpace(g.expected)
 		if actual != expected {
-			t.Logf(diff.FormatDiff(actual, expected))
+			t.Log(diff.FormatDiff(actual, expected))
 			t.Errorf("actual != expected")
 			continue
 		}

--- a/pkg/kopscodecs/codecs_test.go
+++ b/pkg/kopscodecs/codecs_test.go
@@ -68,7 +68,7 @@ func TestToVersionedYaml(t *testing.T) {
 		actual = strings.TrimSpace(actual)
 		expected := strings.TrimSpace(g.expected)
 		if actual != expected {
-			t.Logf(diff.FormatDiff(actual, expected))
+			t.Log(diff.FormatDiff(actual, expected))
 			t.Errorf("actual != expected")
 			continue
 		}
@@ -102,7 +102,7 @@ func TestToVersionedJSON(t *testing.T) {
 		actual := string(actualBytes)
 		actual = strings.TrimSpace(actual)
 		if actual != g.expected {
-			t.Logf(diff.FormatDiff(actual, g.expected))
+			t.Log(diff.FormatDiff(actual, g.expected))
 			t.Errorf("actual != expected")
 			continue
 		}

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -441,8 +441,8 @@ func matches(l, r *compute.InstanceTemplate) bool {
 		if klog.V(10).Enabled() {
 			ls := fi.DebugAsJsonStringIndent(normalizedL)
 			rs := fi.DebugAsJsonStringIndent(normalizedR)
-			klog.V(10).Infof("Not equal")
-			klog.V(10).Infof(diff.FormatDiff(ls, rs))
+			klog.V(10).Info("Not equal")
+			klog.V(10).Info(diff.FormatDiff(ls, rs))
 		}
 		return false
 	}

--- a/upup/pkg/fi/cloudup/scaleway/utils.go
+++ b/upup/pkg/fi/cloudup/scaleway/utils.go
@@ -165,7 +165,7 @@ func CreateValidScalewayProfile() (*scw.Profile, error) {
 		} else {
 			errMsg += " in a Scaleway profile or as an environment variable"
 		}
-		return nil, fmt.Errorf(errMsg)
+		return nil, fmt.Errorf("%s", errMsg)
 	}
 
 	return &profile, nil

--- a/upup/pkg/fi/executor.go
+++ b/upup/pkg/fi/executor.go
@@ -127,7 +127,7 @@ func (e *executor[T]) RunTasks(ctx context.Context, taskMap map[string]Task[T]) 
 			if err != nil {
 				//  print warning message and continue like the task succeeded
 				if _, ok := err.(*ExistsAndWarnIfChangesError); ok {
-					klog.Warningf(err.Error())
+					klog.Warning(err.Error())
 					ts.done = true
 					ts.lastError = nil
 					progress = true


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kops/pull/16744
```
running golangci-lint 
level=warning msg="[config_reader] The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`."
cmd/kops/create_cluster_test.go:40:12: printf: non-constant format string in call to (*testing.common).Errorf (govet)
		t.Errorf(err.Error())
		         ^
pkg/k8scodecs/codecs_test.go:77:11: printf: non-constant format string in call to (*testing.common).Logf (govet)
			t.Logf(diff.FormatDiff(actual, expected))
			       ^
pkg/kopscodecs/codecs_test.go:71:11: printf: non-constant format string in call to (*testing.common).Logf (govet)
			t.Logf(diff.FormatDiff(actual, expected))
			       ^
pkg/kopscodecs/codecs_test.go:105:11: printf: non-constant format string in call to (*testing.common).Logf (govet)
			t.Logf(diff.FormatDiff(actual, g.expected))
			       ^
upup/pkg/fi/executor.go:130:20: printf: non-constant format string in call to k8s.io/klog/v2.Warningf (govet)
					klog.Warningf(err.Error())
					              ^
upup/pkg/fi/cloudup/gcetasks/instancetemplate.go:445:21: printf: non-constant format string in call to (k8s.io/klog/v2.Verbose).Infof (govet)
			klog.V(10).Infof(diff.FormatDiff(ls, rs))
			                 ^
upup/pkg/fi/cloudup/scaleway/utils.go:168:26: printf: non-constant format string in call to fmt.Errorf (govet)
		return nil, fmt.Errorf(errMsg)
```