### PR TITLE
WIP: Try not installing cgroupfs-mount

### DIFF
--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -40,7 +40,6 @@ func (b *PackagesBuilder) Build(c *fi.NodeupModelBuilderContext) error {
 	if b.Distribution.IsDebianFamily() {
 		// From containerd: https://github.com/containerd/cri/blob/master/contrib/ansible/tasks/bootstrap_ubuntu.yaml
 		c.AddTask(&nodetasks.Package{Name: "bridge-utils"})
-		c.AddTask(&nodetasks.Package{Name: "cgroupfs-mount"})
 		c.AddTask(&nodetasks.Package{Name: "conntrack"})
 		c.AddTask(&nodetasks.Package{Name: "ebtables"})
 		c.AddTask(&nodetasks.Package{Name: "ethtool"})


### PR DESCRIPTION
It seems to cause a restart of kops-configuration, right in the middle of an apt-get install
