### PR TITLE
Allocate more resources to cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@
 timeout: 1800s
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'N1_HIGHCPU_32'
 steps:
 # Push the images
 - name: 'docker.io/library/golang:1.22.5-bookworm'


### PR DESCRIPTION
The most recent postsubmit job's cloudbuild job was killed:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/kops-postsubmit-push-to-staging/1822021656441262080

```
Step #0 - "images": 2024/08/09 21:36:20 Unexpected error running "go build": exit status 1
Step #0 - "images": github.com/aws/aws-sdk-go-v2/service/ec2: /usr/local/go/pkg/tool/linux_amd64/compile: signal: killed
Step #0 - "images": 2024/08/09 21:36:20 Unexpected error running "go build": signal: killed
Step #0 - "images": Error: failed to publish images: error building "ko://k8s.io/kops/cmd/kops-controller": build: go build: exit status 1
Step #0 - "images": exit status 1
Step #0 - "images": make: *** [Makefile:771: ko-kops-controller-push] Error 1 
```

Using the next largest machine type according to the docs: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#machinetype