### PR TITLE
refactor: OptionsBuilder works on kops.Cluster

### DIFF
--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -34,11 +34,11 @@ type KubeAPIServerOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &KubeAPIServerOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &KubeAPIServerOptionsBuilder{}
 
 // BuildOptions is responsible for filling in the default settings for the kube apiserver
-func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *KubeAPIServerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	if clusterSpec.KubeAPIServer == nil {
 		clusterSpec.KubeAPIServer = &kops.KubeAPIServerConfig{}
 	}

--- a/pkg/model/components/aws.go
+++ b/pkg/model/components/aws.go
@@ -26,10 +26,10 @@ type AWSOptionsBuilder struct {
 	OptionsContext *OptionsContext
 }
 
-var _ loader.OptionsBuilder = &AWSOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &AWSOptionsBuilder{}
 
-func (b *AWSOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *AWSOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	aws := clusterSpec.CloudProvider.AWS
 	if aws == nil {
 		return nil

--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -29,11 +29,11 @@ type AWSCloudControllerManagerOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &AWSCloudControllerManagerOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &AWSCloudControllerManagerOptionsBuilder{}
 
 // BuildOptions generates the configurations used for the AWS cloud controller manager manifest
-func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 
 	if clusterSpec.GetCloudProvider() != kops.CloudProviderAWS {
 		return nil

--- a/pkg/model/components/awsebscsidriver.go
+++ b/pkg/model/components/awsebscsidriver.go
@@ -27,10 +27,10 @@ type AWSEBSCSIDriverOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &AWSEBSCSIDriverOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &AWSEBSCSIDriverOptionsBuilder{}
 
-func (b *AWSEBSCSIDriverOptionsBuilder) BuildOptions(o interface{}) error {
-	aws := o.(*kops.ClusterSpec).CloudProvider.AWS
+func (b *AWSEBSCSIDriverOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	aws := o.Spec.CloudProvider.AWS
 	if aws == nil {
 		return nil
 	}

--- a/pkg/model/components/calico.go
+++ b/pkg/model/components/calico.go
@@ -26,10 +26,10 @@ type CalicoOptionsBuilder struct {
 	Context *OptionsContext
 }
 
-var _ loader.OptionsBuilder = &CalicoOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &CalicoOptionsBuilder{}
 
-func (b *CalicoOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *CalicoOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	c := clusterSpec.Networking.Calico
 	if c == nil {
 		return nil

--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -30,10 +30,10 @@ type CiliumOptionsBuilder struct {
 	Context *OptionsContext
 }
 
-var _ loader.OptionsBuilder = &CiliumOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &CiliumOptionsBuilder{}
 
-func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *CiliumOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	c := clusterSpec.Networking.Cilium
 	if c == nil {
 		return nil

--- a/pkg/model/components/cloudconfiguration.go
+++ b/pkg/model/components/cloudconfiguration.go
@@ -27,10 +27,10 @@ type CloudConfigurationOptionsBuilder struct {
 	Context *OptionsContext
 }
 
-var _ loader.OptionsBuilder = &CloudConfigurationOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &CloudConfigurationOptionsBuilder{}
 
-func (b *CloudConfigurationOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *CloudConfigurationOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	c := clusterSpec.CloudConfig
 	if c == nil {
 		c = &kops.CloudConfiguration{}

--- a/pkg/model/components/cloudconfiguration_test.go
+++ b/pkg/model/components/cloudconfiguration_test.go
@@ -93,7 +93,8 @@ func TestCloudConfigurationOptionsBuilder(t *testing.T) {
 		},
 	} {
 		t.Run(test.description, func(t *testing.T) {
-			spec := kopsapi.ClusterSpec{
+			cluster := &kopsapi.Cluster{}
+			cluster.Spec = kopsapi.ClusterSpec{
 				CloudConfig: &kopsapi.CloudConfiguration{},
 				CloudProvider: kopsapi.CloudProviderSpec{
 					Openstack: &kopsapi.OpenstackSpec{
@@ -102,15 +103,15 @@ func TestCloudConfigurationOptionsBuilder(t *testing.T) {
 				},
 			}
 			if p := test.generalManageSCs; p != nil {
-				spec.CloudConfig.ManageStorageClasses = p
+				cluster.Spec.CloudConfig.ManageStorageClasses = p
 			}
 			if p := test.openStackManageSCs; p != nil {
-				spec.CloudProvider.Openstack.BlockStorage.CreateStorageClass = p
+				cluster.Spec.CloudProvider.Openstack.BlockStorage.CreateStorageClass = p
 			}
-			if err := ob.BuildOptions(&spec); err != nil {
+			if err := ob.BuildOptions(cluster); err != nil {
 				t.Fatalf("failed to build options: %v", err)
 			}
-			if want, got := test.expectedGeneralManageSCs, spec.CloudConfig.ManageStorageClasses; (want == nil) != (got == nil) || (got != nil && *got != *want) {
+			if want, got := test.expectedGeneralManageSCs, cluster.Spec.CloudConfig.ManageStorageClasses; (want == nil) != (got == nil) || (got != nil && *got != *want) {
 				switch {
 				case want == nil:
 					t.Errorf("spec.cloudConfig.manageStorageClasses: want nil, got %t", *got)

--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -28,10 +28,10 @@ type ClusterAutoscalerOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &ClusterAutoscalerOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &ClusterAutoscalerOptionsBuilder{}
 
-func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	cas := clusterSpec.ClusterAutoscaler
 	if cas == nil || !fi.ValueOf(cas.Enabled) {
 		return nil

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -27,11 +27,11 @@ type ContainerdOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &ContainerdOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &ContainerdOptionsBuilder{}
 
 // BuildOptions is responsible for filling in the default setting for containerd daemon
-func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *ContainerdOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 
 	if clusterSpec.Containerd == nil {
 		clusterSpec.Containerd = &kops.ContainerdConfig{}

--- a/pkg/model/components/containerd_test.go
+++ b/pkg/model/components/containerd_test.go
@@ -59,7 +59,7 @@ func Test_Build_Containerd_Supported_Version(t *testing.T) {
 			},
 		}
 
-		err = ob.BuildOptions(&c.Spec)
+		err = ob.BuildOptions(c)
 		if err != nil {
 			t.Fatalf("unexpected error from BuildOptions: %v", err)
 		}

--- a/pkg/model/components/defaults.go
+++ b/pkg/model/components/defaults.go
@@ -26,11 +26,11 @@ type DefaultsOptionsBuilder struct {
 	Context *OptionsContext
 }
 
-var _ loader.OptionsBuilder = &DefaultsOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &DefaultsOptionsBuilder{}
 
 // BuildOptions is responsible for cluster options
-func (b *DefaultsOptionsBuilder) BuildOptions(o interface{}) error {
-	options := o.(*kops.ClusterSpec)
+func (b *DefaultsOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	options := &o.Spec
 
 	if options.ClusterDNSDomain == "" {
 		options.ClusterDNSDomain = "cluster.local"

--- a/pkg/model/components/discovery.go
+++ b/pkg/model/components/discovery.go
@@ -31,10 +31,10 @@ type DiscoveryOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &DiscoveryOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &DiscoveryOptionsBuilder{}
 
-func (b *DiscoveryOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *DiscoveryOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 
 	if clusterSpec.KubeAPIServer == nil {
 		clusterSpec.KubeAPIServer = &kops.KubeAPIServerConfig{}

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -26,15 +26,15 @@ type EtcdOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &EtcdOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &EtcdOptionsBuilder{}
 
 const (
 	DefaultEtcd3Version_1_22 = "3.5.13"
 )
 
 // BuildOptions is responsible for filling in the defaults for the etcd cluster model
-func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
-	spec := o.(*kops.ClusterSpec)
+func (b *EtcdOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	spec := &o.Spec
 
 	for i := range spec.EtcdClusters {
 		c := &spec.EtcdClusters[i]

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -34,11 +34,11 @@ type EtcdManagerOptionsBuilder struct {
 	*components.OptionsContext
 }
 
-var _ loader.OptionsBuilder = &EtcdManagerOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &EtcdManagerOptionsBuilder{}
 
 // BuildOptions generates the configurations used to create etcd manager manifest
-func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *EtcdManagerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 
 	for i := range clusterSpec.EtcdClusters {
 		etcdCluster := &clusterSpec.EtcdClusters[i]

--- a/pkg/model/components/gcpcloudcontrollermanager.go
+++ b/pkg/model/components/gcpcloudcontrollermanager.go
@@ -27,10 +27,10 @@ type GCPCloudControllerManagerOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = (*GCPCloudControllerManagerOptionsBuilder)(nil)
+var _ loader.ClusterOptionsBuilder = (*GCPCloudControllerManagerOptionsBuilder)(nil)
 
-func (b *GCPCloudControllerManagerOptionsBuilder) BuildOptions(options interface{}) error {
-	clusterSpec := options.(*kops.ClusterSpec)
+func (b *GCPCloudControllerManagerOptionsBuilder) BuildOptions(options *kops.Cluster) error {
+	clusterSpec := &options.Spec
 
 	if clusterSpec.GetCloudProvider() != kops.CloudProviderGCE {
 		return nil

--- a/pkg/model/components/gcppdcsidriver.go
+++ b/pkg/model/components/gcppdcsidriver.go
@@ -27,10 +27,10 @@ type GCPPDCSIDriverOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &GCPPDCSIDriverOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &GCPPDCSIDriverOptionsBuilder{}
 
-func (b *GCPPDCSIDriverOptionsBuilder) BuildOptions(o interface{}) error {
-	gce := o.(*kops.ClusterSpec).CloudProvider.GCE
+func (b *GCPPDCSIDriverOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	gce := o.Spec.CloudProvider.GCE
 	if gce == nil {
 		return nil
 	}

--- a/pkg/model/components/hetznercloudcontrollermanager.go
+++ b/pkg/model/components/hetznercloudcontrollermanager.go
@@ -27,11 +27,11 @@ type HetznerCloudControllerManagerOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &HetznerCloudControllerManagerOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &HetznerCloudControllerManagerOptionsBuilder{}
 
 // BuildOptions generates the configurations used for the Hetzner cloud controller manager manifest
-func (b *HetznerCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *HetznerCloudControllerManagerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 
 	if clusterSpec.GetCloudProvider() != kops.CloudProviderHetzner {
 		return nil

--- a/pkg/model/components/karpenter.go
+++ b/pkg/model/components/karpenter.go
@@ -26,10 +26,10 @@ type KarpenterOptionsBuilder struct {
 	Context *OptionsContext
 }
 
-var _ loader.OptionsBuilder = &KarpenterOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &KarpenterOptionsBuilder{}
 
-func (b *KarpenterOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *KarpenterOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	c := clusterSpec.Karpenter
 	if c == nil {
 		return nil

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -38,11 +38,11 @@ type KubeControllerManagerOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &KubeControllerManagerOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &KubeControllerManagerOptionsBuilder{}
 
 // BuildOptions generates the configurations used to create kubernetes controller manager manifest
-func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	if clusterSpec.KubeControllerManager == nil {
 		clusterSpec.KubeControllerManager = &kops.KubeControllerManagerConfig{}
 	}

--- a/pkg/model/components/kubecontrollermanager_test.go
+++ b/pkg/model/components/kubecontrollermanager_test.go
@@ -55,7 +55,7 @@ func Test_Build_KCM_Builder(t *testing.T) {
 			},
 		}
 
-		err := kcm.BuildOptions(&c.Spec)
+		err := kcm.BuildOptions(c)
 		if err != nil {
 			t.Fatalf("unexpected error from BuildOptions %s", err)
 		}
@@ -82,7 +82,7 @@ func Test_Build_KCM_Builder_Change_Duration(t *testing.T) {
 
 	c.Spec.KubeControllerManager.AttachDetachReconcileSyncPeriod.Duration = time.Minute * 5
 
-	err := kcm.BuildOptions(&c.Spec)
+	err := kcm.BuildOptions(c)
 	if err != nil {
 		t.Fatalf("unexpected error from BuildOptions %s", err)
 	}
@@ -156,7 +156,7 @@ func Test_Build_KCM_Builder_CIDR_Mask_Size(t *testing.T) {
 				ClusterCIDR: tc.ClusterCIDR,
 			}
 
-			err := kcm.BuildOptions(&c.Spec)
+			err := kcm.BuildOptions(c)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.ExpectedMaskSize, c.Spec.KubeControllerManager.NodeCIDRMaskSize)

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -29,11 +29,11 @@ type KubeDnsOptionsBuilder struct {
 	Context *OptionsContext
 }
 
-var _ loader.OptionsBuilder = &KubeDnsOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &KubeDnsOptionsBuilder{}
 
 // BuildOptions fills in the kubedns model
-func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *KubeDnsOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 
 	if clusterSpec.KubeDNS == nil {
 		clusterSpec.KubeDNS = &kops.KubeDNSConfig{}

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -34,11 +34,11 @@ type KubeletOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &KubeletOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &KubeletOptionsBuilder{}
 
 // BuildOptions is responsible for filling the defaults for the kubelet
-func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *KubeletOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 
 	if clusterSpec.Kubelet == nil {
 		clusterSpec.Kubelet = &kops.KubeletConfigSpec{}

--- a/pkg/model/components/kubelet_test.go
+++ b/pkg/model/components/kubelet_test.go
@@ -52,7 +52,7 @@ func buildOptions(cluster *kops.Cluster) error {
 		},
 	}
 
-	err = builder.BuildOptions(&cluster.Spec)
+	err = builder.BuildOptions(cluster)
 	if err != nil {
 		return nil
 	}

--- a/pkg/model/components/kubeproxy.go
+++ b/pkg/model/components/kubeproxy.go
@@ -29,10 +29,10 @@ type KubeProxyOptionsBuilder struct {
 	Context *OptionsContext
 }
 
-var _ loader.OptionsBuilder = &KubeProxyOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &KubeProxyOptionsBuilder{}
 
-func (b *KubeProxyOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *KubeProxyOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	if clusterSpec.KubeProxy == nil {
 		clusterSpec.KubeProxy = &kops.KubeProxyConfig{}
 	}

--- a/pkg/model/components/kubescheduler.go
+++ b/pkg/model/components/kubescheduler.go
@@ -27,10 +27,10 @@ type KubeSchedulerOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &KubeSchedulerOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &KubeSchedulerOptionsBuilder{}
 
-func (b *KubeSchedulerOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *KubeSchedulerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	if clusterSpec.KubeScheduler == nil {
 		clusterSpec.KubeScheduler = &kops.KubeSchedulerConfig{}
 	}

--- a/pkg/model/components/kubescheduler_test.go
+++ b/pkg/model/components/kubescheduler_test.go
@@ -45,7 +45,7 @@ func Test_Build_Scheduler(t *testing.T) {
 			},
 		}
 
-		err = ks.BuildOptions(&c.Spec)
+		err = ks.BuildOptions(c)
 
 		if err != nil {
 			t.Fatalf("unexpected error from BuildOptions: %v", err)

--- a/pkg/model/components/networking.go
+++ b/pkg/model/components/networking.go
@@ -28,14 +28,12 @@ type NetworkingOptionsBuilder struct {
 	Context *OptionsContext
 }
 
-var _ loader.OptionsBuilder = &NetworkingOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &NetworkingOptionsBuilder{}
 
-func (b *NetworkingOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
-
-	options := o.(*kops.ClusterSpec)
-	if options.Kubelet == nil {
-		options.Kubelet = &kops.KubeletConfigSpec{}
+func (b *NetworkingOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
+	if clusterSpec.Kubelet == nil {
+		clusterSpec.Kubelet = &kops.KubeletConfigSpec{}
 	}
 
 	networking := &clusterSpec.Networking

--- a/pkg/model/components/nodeproblemdetector.go
+++ b/pkg/model/components/nodeproblemdetector.go
@@ -28,10 +28,10 @@ type NodeProblemDetectorOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &NodeProblemDetectorOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &NodeProblemDetectorOptionsBuilder{}
 
-func (b *NodeProblemDetectorOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *NodeProblemDetectorOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	if clusterSpec.NodeProblemDetector == nil {
 		return nil
 	}

--- a/pkg/model/components/nodeterminationhandler.go
+++ b/pkg/model/components/nodeterminationhandler.go
@@ -28,10 +28,10 @@ type NodeTerminationHandlerOptionsBuilder struct {
 	*OptionsContext
 }
 
-var _ loader.OptionsBuilder = &NodeTerminationHandlerOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &NodeTerminationHandlerOptionsBuilder{}
 
-func (b *NodeTerminationHandlerOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *NodeTerminationHandlerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	if clusterSpec.CloudProvider.AWS == nil {
 		return nil
 	}

--- a/pkg/model/components/openstack.go
+++ b/pkg/model/components/openstack.go
@@ -30,10 +30,10 @@ type OpenStackOptionsBuilder struct {
 	Context *OptionsContext
 }
 
-var _ loader.OptionsBuilder = &OpenStackOptionsBuilder{}
+var _ loader.ClusterOptionsBuilder = &OpenStackOptionsBuilder{}
 
-func (b *OpenStackOptionsBuilder) BuildOptions(o interface{}) error {
-	clusterSpec := o.(*kops.ClusterSpec)
+func (b *OpenStackOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+	clusterSpec := &o.Spec
 	openstack := clusterSpec.CloudProvider.Openstack
 
 	if openstack == nil {

--- a/upup/pkg/fi/cloudup/spec_builder.go
+++ b/upup/pkg/fi/cloudup/spec_builder.go
@@ -25,22 +25,22 @@ import (
 )
 
 type SpecBuilder struct {
-	OptionsLoader *loader.OptionsLoader
+	OptionsLoader *loader.OptionsLoader[*kopsapi.Cluster]
 }
 
-func (l *SpecBuilder) BuildCompleteSpec(clusterSpec *kopsapi.ClusterSpec) (*kopsapi.ClusterSpec, error) {
-	loaded, err := l.OptionsLoader.Build(clusterSpec)
+func (l *SpecBuilder) BuildCompleteSpec(cluster *kopsapi.Cluster) (*kopsapi.Cluster, error) {
+	loaded, err := l.OptionsLoader.Build(cluster)
 	if err != nil {
 		return nil, err
 	}
-	completed := &kopsapi.ClusterSpec{}
-	*completed = *(loaded.(*kopsapi.ClusterSpec))
+	completed := &kopsapi.Cluster{}
+	*completed = *loaded
 
 	// Control-plane kubelet config = (base kubelet config + control-plane kubelet config)
 	controlPlaneKubelet := &kopsapi.KubeletConfigSpec{}
-	reflectutils.JSONMergeStruct(controlPlaneKubelet, completed.Kubelet)
-	reflectutils.JSONMergeStruct(controlPlaneKubelet, completed.ControlPlaneKubelet)
-	completed.ControlPlaneKubelet = controlPlaneKubelet
+	reflectutils.JSONMergeStruct(controlPlaneKubelet, completed.Spec.Kubelet)
+	reflectutils.JSONMergeStruct(controlPlaneKubelet, completed.Spec.ControlPlaneKubelet)
+	completed.Spec.ControlPlaneKubelet = controlPlaneKubelet
 
 	klog.V(1).Infof("options: %s", fi.DebugAsJsonStringIndent(completed))
 	return completed, nil


### PR DESCRIPTION
Previously it worked on ClusterSpec, but that means we can't read the
labels or annotations.  We want to use those labels/annotations to
experiment with new cloud providers (e.g. bare metal) before adding
this to the API.

Introduce generics so we also get type-safety.
