### PR TITLE
tests: skip kube-proxy metric tests with cilium

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -97,6 +97,14 @@ func (t *Tester) setSkipRegexFlag() error {
 			// Ref: https://github.com/kubernetes/kubernetes/pull/113335
 			skipRegex += "|should.create.a.Pod.with.SCTP.HostPort"
 		}
+
+		if k8sVersion.Minor < 34 {
+			// < 34 so we revisit this in future
+			// This test checks for kube-proxy on port 10249 (`127.0.0.1:10249/proxyMode`)
+			// It appears that the cilium kube-proxy replacement does not implement this.
+			// Ref: https://github.com/kubernetes/kubernetes/issues/126903
+			skipRegex += "|KubeProxy.should.update.metric.for.tracking.accepted.packets.destined.for.localhost.nodeports"
+		}
 	} else if networking.KubeRouter != nil {
 		skipRegex += "|should set TCP CLOSE_WAIT timeout|should check kube-proxy urls"
 	} else if networking.Kubenet != nil {


### PR DESCRIPTION
This test tries to query kube-proxy on port 10249, but it appears that the cilium kube-proxy replacement does not implement this.

Upstream issue: https://github.com/kubernetes/kubernetes/issues/126903
