### PR TITLE
tests: skip NodePort tests with cilium

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -83,6 +83,12 @@ func (t *Tester) setSkipRegexFlag() error {
 		// https://github.com/kubernetes/kubernetes/blob/418ae605ec1b788d43bff7ac44af66d8b669b833/test/e2e/network/networking.go#L135
 		skipRegex += "|should.check.kube-proxy.urls"
 
+		if k8sVersion.Minor < 32 {
+			// This seems to be specific to the kube-proxy replacement
+			// < 32 so we look at this again
+			skipRegex += "|Services.should.support.externalTrafficPolicy.Local.for.type.NodePort"
+		}
+
 		if isPre28 {
 			// These may be fixed in Cilium 1.13 but skipping for now
 			skipRegex += "|Service.with.multiple.ports.specified.in.multiple.EndpointSlices"


### PR DESCRIPTION
Seems to be specific to kube-proxy replacement, but that is our default for newer clusters.
