### PR TITLE
Fix tests skips for kube-router

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -83,9 +83,9 @@ func (t *Tester) setSkipRegexFlag() error {
 		// https://github.com/kubernetes/kubernetes/blob/418ae605ec1b788d43bff7ac44af66d8b669b833/test/e2e/network/networking.go#L135
 		skipRegex += "|should.check.kube-proxy.urls"
 
-		if k8sVersion.Minor < 32 {
+		if k8sVersion.Minor < 33 {
 			// This seems to be specific to the kube-proxy replacement
-			// < 32 so we look at this again
+			// < 33 so we look at this again
 			skipRegex += "|Services.should.support.externalTrafficPolicy.Local.for.type.NodePort"
 		}
 
@@ -171,7 +171,8 @@ func (t *Tester) setSkipRegexFlag() error {
 	// ref: https://github.com/kubernetes/kops/issues/16349
 	// ref: https://github.com/kubernetes/kubernetes/issues/123255
 	// ref: https://github.com/kubernetes/kubernetes/issues/121018
-	if k8sVersion.Minor < 32 {
+	// < 33 so we look at this again
+	if k8sVersion.Minor < 33 {
 		skipRegex += "|Services.should.function.for.service.endpoints.using.hostNetwork"
 	}
 


### PR DESCRIPTION
Ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/16768/pull-kops-e2e-cni-kuberouter/1827690671192936448

/cc @justinsb @rifelpet 