### PR TITLE
Automated cherry pick of #16776: aws: Fix conversion for instance-selector flags

### DIFF
--- a/cmd/kops/toolbox_instance-selector.go
+++ b/cmd/kops/toolbox_instance-selector.go
@@ -398,11 +398,11 @@ func getFilters(commandline *cli.CommandLineInterface, region string, zones []st
 	flags := commandline.Flags
 	var cpuArch ec2types.ArchitectureType
 	if v, ok := flags[cpuArchitecture]; ok {
-		cpuArch = ec2types.ArchitectureType(v.(string))
+		cpuArch = ec2types.ArchitectureType(*commandline.StringMe(v))
 	}
 	var uc ec2types.UsageClassType
 	if v, ok := flags[usageClass]; ok {
-		uc = ec2types.UsageClassType(v.(string))
+		uc = ec2types.UsageClassType(*commandline.StringMe(v))
 	}
 	return selector.Filters{
 		VCpusRange:             commandline.Int32RangeMe(flags[vcpus]),


### PR DESCRIPTION
Cherry pick of #16776 on release-1.30.

#16776: aws: Fix conversion for instance-selector flags

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```