### PR TITLE
refactor: Move GetCloudProvider to cluster

### DIFF
--- a/clusterapi/bootstrap/controllers/kopsconfig_controller.go
+++ b/clusterapi/bootstrap/controllers/kopsconfig_controller.go
@@ -305,7 +305,7 @@ func (r *KopsConfigReconciler) buildBootstrapData(ctx context.Context) ([]byte, 
 	// See https://github.com/kubernetes/kops/issues/10206 for details.
 	// TODO: nodeupScript.SetSysctls = setSysctls()
 
-	nodeupScript.CloudProvider = string(cluster.Spec.GetCloudProvider())
+	nodeupScript.CloudProvider = string(cluster.GetCloudProvider())
 
 	nodeupScriptResource, err := nodeupScript.Build()
 	if err != nil {

--- a/cmd/kops/create_instancegroup.go
+++ b/cmd/kops/create_instancegroup.go
@@ -199,7 +199,7 @@ func RunCreateInstanceGroup(ctx context.Context, f *util.Factory, out io.Writer,
 	}
 
 	ig.AddInstanceGroupNodeLabel()
-	if cluster.Spec.GetCloudProvider() == kopsapi.CloudProviderGCE {
+	if cluster.GetCloudProvider() == kopsapi.CloudProviderGCE {
 		fmt.Println("detected a GCE cluster; labeling nodes to receive metadata-proxy.")
 		ig.Spec.NodeLabels["cloud.google.com/metadata-proxy-ready"] = "true"
 	}

--- a/cmd/kops/get_cluster.go
+++ b/cmd/kops/get_cluster.go
@@ -219,7 +219,7 @@ func clusterOutputTable(clusters []*kopsapi.Cluster, out io.Writer) error {
 		return c.ObjectMeta.Name
 	})
 	t.AddColumn("CLOUD", func(c *kopsapi.Cluster) string {
-		return string(c.Spec.GetCloudProvider())
+		return string(c.GetCloudProvider())
 	})
 	t.AddColumn("ZONES", func(c *kopsapi.Cluster) string {
 		zones := sets.NewString()

--- a/cmd/kops/toolbox_instance-selector.go
+++ b/cmd/kops/toolbox_instance-selector.go
@@ -238,7 +238,7 @@ func RunToolboxInstanceSelector(ctx context.Context, f commandutils.Factory, out
 		return err
 	}
 
-	if cluster.Spec.GetCloudProvider() != kops.CloudProviderAWS {
+	if cluster.GetCloudProvider() != kops.CloudProviderAWS {
 		return fmt.Errorf("cannot select instance types from non-aws cluster")
 	}
 

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -493,7 +493,7 @@ func completeUpdateClusterTarget(f commandutils.Factory, options *UpdateClusterO
 			cloudup.TargetDryRun,
 		}
 		for _, cp := range cloudup.TerraformCloudProviders {
-			if cluster.Spec.GetCloudProvider() == cp {
+			if cluster.GetCloudProvider() == cp {
 				completions = append(completions, cloudup.TargetTerraform)
 			}
 		}

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -240,7 +240,7 @@ func BuildNodeupModelContext(model *testutils.Model) (*NodeupModelContext, error
 	nodeupModelContext := &NodeupModelContext{
 		Architecture: "amd64",
 		BootConfig: &nodeup.BootConfig{
-			CloudProvider: model.Cluster.Spec.GetCloudProvider(),
+			CloudProvider: model.Cluster.GetCloudProvider(),
 		},
 	}
 

--- a/pkg/acls/gce/storage.go
+++ b/pkg/acls/gce/storage.go
@@ -36,7 +36,7 @@ var _ acls.ACLStrategy = &gcsAclStrategy{}
 
 // GetACL returns the ACL to use if this is a google cloud storage path
 func (s *gcsAclStrategy) GetACL(ctx context.Context, p vfs.Path, cluster *kops.Cluster) (vfs.ACL, error) {
-	if cluster.Spec.GetCloudProvider() != kops.CloudProviderGCE {
+	if cluster.GetCloudProvider() != kops.CloudProviderGCE {
 		return nil, nil
 	}
 	gcsPath, ok := p.(*vfs.GSPath)

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -293,6 +293,14 @@ const (
 	CloudProviderOpenstack CloudProviderID = "openstack"
 	CloudProviderAzure     CloudProviderID = "azure"
 	CloudProviderScaleway  CloudProviderID = "scaleway"
+
+	// Experimental cloud providers
+	CloudProviderMetal CloudProviderID = "metal"
+
+	// If you add any cloud providers here, you must add them to:
+	// * Convert_kops_ClusterSpec_To_v1alpha2_ClusterSpec
+	// * cluster.GetCloudProvider()
+	// * type CloudProviderSpec
 )
 
 // FindImage returns the image for the cloudprovider, or nil if none found

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -28,6 +28,10 @@ import (
 	"k8s.io/kops/upup/pkg/fi/utils"
 )
 
+// AlphaLabelCloudProvider lets us experiment with a cloud provider,
+// before adding it to the API.
+const AlphaLabelCloudProvider = "alpha.kops.k8s.io/cloud"
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -946,20 +950,25 @@ func (c *ClusterSpec) IsKopsControllerIPAM() bool {
 	return c.IsIPv6Only()
 }
 
-func (c *ClusterSpec) GetCloudProvider() CloudProviderID {
-	if c.CloudProvider.AWS != nil {
+func (c *Cluster) GetCloudProvider() CloudProviderID {
+	if c.Labels[AlphaLabelCloudProvider] == "metal" {
+		return CloudProviderMetal
+	}
+
+	spec := c.Spec
+	if spec.CloudProvider.AWS != nil {
 		return CloudProviderAWS
-	} else if c.CloudProvider.Azure != nil {
+	} else if spec.CloudProvider.Azure != nil {
 		return CloudProviderAzure
-	} else if c.CloudProvider.DO != nil {
+	} else if spec.CloudProvider.DO != nil {
 		return CloudProviderDO
-	} else if c.CloudProvider.GCE != nil {
+	} else if spec.CloudProvider.GCE != nil {
 		return CloudProviderGCE
-	} else if c.CloudProvider.Hetzner != nil {
+	} else if spec.CloudProvider.Hetzner != nil {
 		return CloudProviderHetzner
-	} else if c.CloudProvider.Openstack != nil {
+	} else if spec.CloudProvider.Openstack != nil {
 		return CloudProviderOpenstack
-	} else if c.CloudProvider.Scaleway != nil {
+	} else if spec.CloudProvider.Scaleway != nil {
 		return CloudProviderScaleway
 	}
 	return ""

--- a/pkg/apis/kops/model/features.go
+++ b/pkg/apis/kops/model/features.go
@@ -41,7 +41,7 @@ func UseChallengeCallback(cloudProvider kops.CloudProviderID) bool {
 // UseKopsControllerForNodeConfig checks if nodeup should use kops-controller to get nodeup.Config.
 func UseKopsControllerForNodeConfig(cluster *kops.Cluster) bool {
 	if cluster.UsesLegacyGossip() {
-		switch cluster.Spec.GetCloudProvider() {
+		switch cluster.GetCloudProvider() {
 		case kops.CloudProviderGCE:
 			// We can use cloud-discovery here.
 		case kops.CloudProviderHetzner, kops.CloudProviderScaleway, kops.CloudProviderDO:

--- a/pkg/apis/kops/v1alpha2/conversion.go
+++ b/pkg/apis/kops/v1alpha2/conversion.go
@@ -419,7 +419,27 @@ func Convert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, out 
 	if out.API.IsEmpty() {
 		out.LegacyAPI = nil
 	}
-	out.LegacyCloudProvider = string(in.GetCloudProvider())
+	if in.CloudProvider.AWS != nil {
+		out.LegacyCloudProvider = string(kops.CloudProviderAWS)
+	}
+	if in.CloudProvider.Azure != nil {
+		out.LegacyCloudProvider = string(kops.CloudProviderAzure)
+	}
+	if in.CloudProvider.DO != nil {
+		out.LegacyCloudProvider = string(kops.CloudProviderDO)
+	}
+	if in.CloudProvider.GCE != nil {
+		out.LegacyCloudProvider = string(kops.CloudProviderGCE)
+	}
+	if in.CloudProvider.Hetzner != nil {
+		out.LegacyCloudProvider = string(kops.CloudProviderHetzner)
+	}
+	if in.CloudProvider.Openstack != nil {
+		out.LegacyCloudProvider = string(kops.CloudProviderOpenstack)
+	}
+	if in.CloudProvider.Scaleway != nil {
+		out.LegacyCloudProvider = string(kops.CloudProviderScaleway)
+	}
 	switch kops.CloudProviderID(out.LegacyCloudProvider) {
 	case kops.CloudProviderAWS:
 		aws := in.CloudProvider.AWS

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -239,7 +239,7 @@ func CrossValidateInstanceGroup(g *kops.InstanceGroup, cluster *kops.Cluster, cl
 	}
 
 	if g.Spec.Role == kops.InstanceGroupRoleAPIServer {
-		if cluster.Spec.GetCloudProvider() != kops.CloudProviderAWS {
+		if cluster.GetCloudProvider() != kops.CloudProviderAWS {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "role"), "APIServer role only supported on AWS"))
 		}
 		if cluster.UsesNoneDNS() {
@@ -262,7 +262,7 @@ func CrossValidateInstanceGroup(g *kops.InstanceGroup, cluster *kops.Cluster, cl
 		}
 	}
 
-	if cluster.Spec.GetCloudProvider() == kops.CloudProviderAWS {
+	if cluster.GetCloudProvider() == kops.CloudProviderAWS {
 		if g.Spec.RootVolume != nil && g.Spec.RootVolume.Type != nil {
 			allErrs = append(allErrs, IsValidValue(field.NewPath("spec", "rootVolume", "type"), g.Spec.RootVolume.Type, []string{"standard", "gp3", "gp2", "io1", "io2"})...)
 		}
@@ -292,7 +292,7 @@ func CrossValidateInstanceGroup(g *kops.InstanceGroup, cluster *kops.Cluster, cl
 	}
 
 	if g.Spec.Containerd != nil {
-		allErrs = append(allErrs, validateContainerdConfig(&cluster.Spec, g.Spec.Containerd, field.NewPath("spec", "containerd"), false)...)
+		allErrs = append(allErrs, validateContainerdConfig(cluster, g.Spec.Containerd, field.NewPath("spec", "containerd"), false)...)
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -150,7 +150,7 @@ func ValidateCluster(c *kops.Cluster, strict bool, vfsContext *vfs.VFSContext) f
 	{
 
 		var k8sCloudProvider string
-		switch c.Spec.GetCloudProvider() {
+		switch c.GetCloudProvider() {
 		case kops.CloudProviderAWS:
 			k8sCloudProvider = "aws"
 		case kops.CloudProviderGCE:
@@ -275,7 +275,7 @@ func DeepValidate(c *kops.Cluster, groups []*kops.InstanceGroup, strict bool, vf
 		errs := CrossValidateInstanceGroup(g, c, cloud, strict)
 
 		// Additional cloud-specific validation rules
-		if c.Spec.GetCloudProvider() != kops.CloudProviderAWS && len(g.Spec.Volumes) > 0 {
+		if c.GetCloudProvider() != kops.CloudProviderAWS && len(g.Spec.Volumes) > 0 {
 			errs = append(errs, field.Forbidden(field.NewPath("spec", "volumes"), "instancegroup volumes are only available with aws at present"))
 		}
 

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -189,7 +189,8 @@ func TestValidateSubnets(t *testing.T) {
 		},
 	}
 	for _, g := range grid {
-		cluster := &kops.ClusterSpec{
+		cluster := &kops.Cluster{}
+		cluster.Spec = kops.ClusterSpec{
 			CloudProvider: kops.CloudProviderSpec{
 				AWS: &kops.AWSSpec{},
 			},
@@ -198,8 +199,8 @@ func TestValidateSubnets(t *testing.T) {
 				Subnets:     g.Input,
 			},
 		}
-		_, ipNet, _ := net.ParseCIDR(cluster.Networking.NetworkCIDR)
-		errs := validateSubnets(cluster, cluster.Networking.Subnets, field.NewPath("subnets"), true, &cloudProviderConstraints{}, []*net.IPNet{ipNet}, nil, nil)
+		_, ipNet, _ := net.ParseCIDR(cluster.Spec.Networking.NetworkCIDR)
+		errs := validateSubnets(cluster, cluster.Spec.Networking.Subnets, field.NewPath("subnets"), true, &cloudProviderConstraints{}, []*net.IPNet{ipNet}, nil, nil)
 
 		testErrors(t, g.Input, errs, g.ExpectedErrors)
 	}
@@ -1652,7 +1653,9 @@ func Test_Validate_Nvidia_Cluster(t *testing.T) {
 		},
 	}
 	for _, g := range grid {
-		errs := validateNvidiaConfig(&g.Input, g.Input.Containerd.NvidiaGPU, field.NewPath("containerd", "nvidiaGPU"), true)
+		cluster := &kops.Cluster{}
+		cluster.Spec = g.Input
+		errs := validateNvidiaConfig(cluster, g.Input.Containerd.NvidiaGPU, field.NewPath("containerd", "nvidiaGPU"), true)
 		testErrors(t, g.Input, errs, g.ExpectedErrors)
 	}
 }
@@ -1701,7 +1704,9 @@ func Test_Validate_Nvidia_Ig(t *testing.T) {
 		},
 	}
 	for _, g := range grid {
-		errs := validateNvidiaConfig(&g.Input, g.Input.Containerd.NvidiaGPU, field.NewPath("containerd", "nvidiaGPU"), false)
+		cluster := &kops.Cluster{}
+		cluster.Spec = g.Input
+		errs := validateNvidiaConfig(cluster, g.Input.Containerd.NvidiaGPU, field.NewPath("containerd", "nvidiaGPU"), false)
 		testErrors(t, g.Input, errs, g.ExpectedErrors)
 	}
 }

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -237,7 +237,7 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 	}
 
 	bootConfig := BootConfig{
-		CloudProvider:     cluster.Spec.GetCloudProvider(),
+		CloudProvider:     cluster.GetCloudProvider(),
 		ClusterName:       cluster.ObjectMeta.Name,
 		InstanceGroupName: instanceGroup.ObjectMeta.Name,
 		InstanceGroupRole: role,

--- a/pkg/cloudinstances/cloud_instance_group.go
+++ b/pkg/cloudinstances/cloud_instance_group.go
@@ -100,7 +100,7 @@ func (group *CloudInstanceGroup) AdjustNeedUpdate() {
 func GetNodeMap(nodes []v1.Node, cluster *kopsapi.Cluster) map[string]*v1.Node {
 	nodeMap := make(map[string]*v1.Node)
 
-	if cluster.Spec.GetCloudProvider() == kopsapi.CloudProviderAzure {
+	if cluster.GetCloudProvider() == kopsapi.CloudProviderAzure {
 		for i := range nodes {
 			node := &nodes[i]
 			vmName, err := toAzureVMName(node.Spec.ProviderID)

--- a/pkg/commands/toolbox_enroll.go
+++ b/pkg/commands/toolbox_enroll.go
@@ -513,7 +513,7 @@ func buildBootstrapData(ctx context.Context, clientset simple.Clientset, cluster
 	// See https://github.com/kubernetes/kops/issues/10206 for details.
 	// nodeupScript.SetSysctls = setSysctls()
 
-	nodeupScript.CloudProvider = string(cluster.Spec.GetCloudProvider())
+	nodeupScript.CloudProvider = string(cluster.GetCloudProvider())
 
 	nodeupScriptResource, err := nodeupScript.Build()
 	if err != nil {

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -443,7 +443,7 @@ func (c *RollingUpdateCluster) drainTerminateAndWait(u *cloudinstances.CloudInst
 
 	// GCE often re-uses names, so we delete the node object to prevent the new instance from using the cordoned Node object
 	// Scaleway has the same behavior
-	if (c.Cluster.Spec.GetCloudProvider() == api.CloudProviderGCE || c.Cluster.Spec.GetCloudProvider() == api.CloudProviderScaleway) &&
+	if (c.Cluster.GetCloudProvider() == api.CloudProviderGCE || c.Cluster.GetCloudProvider() == api.CloudProviderScaleway) &&
 		!isBastion && !c.CloudOnly {
 		if u.Node == nil {
 			klog.Warningf("no kubernetes Node associated with %s, skipping node deletion", instanceID)
@@ -473,11 +473,11 @@ func (c *RollingUpdateCluster) drainTerminateAndWait(u *cloudinstances.CloudInst
 }
 
 func (c *RollingUpdateCluster) reconcileInstanceGroup() error {
-	if c.Cluster.Spec.GetCloudProvider() != api.CloudProviderOpenstack &&
-		c.Cluster.Spec.GetCloudProvider() != api.CloudProviderHetzner &&
-		c.Cluster.Spec.GetCloudProvider() != api.CloudProviderScaleway &&
-		c.Cluster.Spec.GetCloudProvider() != api.CloudProviderDO &&
-		c.Cluster.Spec.GetCloudProvider() != api.CloudProviderAzure {
+	if c.Cluster.GetCloudProvider() != api.CloudProviderOpenstack &&
+		c.Cluster.GetCloudProvider() != api.CloudProviderHetzner &&
+		c.Cluster.GetCloudProvider() != api.CloudProviderScaleway &&
+		c.Cluster.GetCloudProvider() != api.CloudProviderDO &&
+		c.Cluster.GetCloudProvider() != api.CloudProviderAzure {
 		return nil
 	}
 	rto := fi.RunTasksOptions{}

--- a/pkg/instancegroups/settings.go
+++ b/pkg/instancegroups/settings.go
@@ -48,7 +48,7 @@ func resolveSettings(cluster *kops.Cluster, group *kops.InstanceGroup, numInstan
 
 	if rollingUpdate.MaxSurge == nil {
 		val := intstr.FromInt(0)
-		if cluster.Spec.GetCloudProvider() == kops.CloudProviderAWS && !featureflag.Spotinst.Enabled() && group.Spec.Manager != kops.InstanceManagerKarpenter {
+		if cluster.GetCloudProvider() == kops.CloudProviderAWS && !featureflag.Spotinst.Enabled() && group.Spec.Manager != kops.InstanceManagerKarpenter {
 			val = intstr.FromInt(1)
 		}
 		rollingUpdate.MaxSurge = &val

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -148,7 +148,7 @@ func (b *BootstrapScript) buildEnvironmentVariables() (map[string]string, error)
 		}
 	}
 
-	if cluster.Spec.GetCloudProvider() == kops.CloudProviderOpenstack {
+	if cluster.GetCloudProvider() == kops.CloudProviderOpenstack {
 
 		osEnvs := []string{
 			"OS_TENANT_ID", "OS_TENANT_NAME", "OS_PROJECT_ID", "OS_PROJECT_NAME",
@@ -185,7 +185,7 @@ func (b *BootstrapScript) buildEnvironmentVariables() (map[string]string, error)
 		}
 	}
 
-	if cluster.Spec.GetCloudProvider() == kops.CloudProviderDO {
+	if cluster.GetCloudProvider() == kops.CloudProviderDO {
 		if b.ig.IsControlPlane() {
 			doToken := os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
 			if doToken != "" {
@@ -194,14 +194,14 @@ func (b *BootstrapScript) buildEnvironmentVariables() (map[string]string, error)
 		}
 	}
 
-	if cluster.Spec.GetCloudProvider() == kops.CloudProviderHetzner && (b.ig.IsControlPlane() || cluster.UsesLegacyGossip()) {
+	if cluster.GetCloudProvider() == kops.CloudProviderHetzner && (b.ig.IsControlPlane() || cluster.UsesLegacyGossip()) {
 		hcloudToken := os.Getenv("HCLOUD_TOKEN")
 		if hcloudToken != "" {
 			env["HCLOUD_TOKEN"] = hcloudToken
 		}
 	}
 
-	if cluster.Spec.GetCloudProvider() == kops.CloudProviderAWS {
+	if cluster.GetCloudProvider() == kops.CloudProviderAWS {
 		region, err := awsup.FindRegion(cluster)
 		if err != nil {
 			return nil, err
@@ -213,7 +213,7 @@ func (b *BootstrapScript) buildEnvironmentVariables() (map[string]string, error)
 		}
 	}
 
-	if cluster.Spec.GetCloudProvider() == kops.CloudProviderAzure {
+	if cluster.GetCloudProvider() == kops.CloudProviderAzure {
 		env["AZURE_STORAGE_ACCOUNT"] = os.Getenv("AZURE_STORAGE_ACCOUNT")
 		azureEnv := os.Getenv("AZURE_ENVIRONMENT")
 		if azureEnv != "" {
@@ -221,7 +221,7 @@ func (b *BootstrapScript) buildEnvironmentVariables() (map[string]string, error)
 		}
 	}
 
-	if cluster.Spec.GetCloudProvider() == kops.CloudProviderScaleway && (b.ig.IsControlPlane() || cluster.UsesLegacyGossip()) {
+	if cluster.GetCloudProvider() == kops.CloudProviderScaleway && (b.ig.IsControlPlane() || cluster.UsesLegacyGossip()) {
 		profile, err := scaleway.CreateValidScalewayProfile()
 		if err != nil {
 			return nil, err
@@ -356,7 +356,7 @@ func (b *BootstrapScript) Run(c *fi.CloudupContext) error {
 	// See https://github.com/kubernetes/kops/issues/10206 for details.
 	nodeupScript.SetSysctls = setSysctls()
 
-	nodeupScript.CloudProvider = string(c.T.Cluster.Spec.GetCloudProvider())
+	nodeupScript.CloudProvider = string(c.T.Cluster.GetCloudProvider())
 
 	nodeupScriptResource, err := nodeupScript.Build()
 	if err != nil {

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -37,8 +37,8 @@ type KubeAPIServerOptionsBuilder struct {
 var _ loader.ClusterOptionsBuilder = &KubeAPIServerOptionsBuilder{}
 
 // BuildOptions is responsible for filling in the default settings for the kube apiserver
-func (b *KubeAPIServerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
-	clusterSpec := &o.Spec
+func (b *KubeAPIServerOptionsBuilder) BuildOptions(cluster *kops.Cluster) error {
+	clusterSpec := &cluster.Spec
 	if clusterSpec.KubeAPIServer == nil {
 		clusterSpec.KubeAPIServer = &kops.KubeAPIServerConfig{}
 	}
@@ -97,7 +97,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 	}
 	c.Image = image
 
-	switch clusterSpec.GetCloudProvider() {
+	switch cluster.GetCloudProvider() {
 	case kops.CloudProviderAWS:
 		c.CloudProvider = "aws"
 	case kops.CloudProviderGCE:
@@ -113,7 +113,7 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 	case kops.CloudProviderScaleway:
 		c.CloudProvider = "external"
 	default:
-		return fmt.Errorf("unknown cloudprovider %q", clusterSpec.GetCloudProvider())
+		return fmt.Errorf("unknown cloudprovider %q", cluster.GetCloudProvider())
 	}
 
 	if clusterSpec.ExternalCloudControllerManager != nil {

--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -32,10 +32,10 @@ type AWSCloudControllerManagerOptionsBuilder struct {
 var _ loader.ClusterOptionsBuilder = &AWSCloudControllerManagerOptionsBuilder{}
 
 // BuildOptions generates the configurations used for the AWS cloud controller manager manifest
-func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
-	clusterSpec := &o.Spec
+func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(cluster *kops.Cluster) error {
+	clusterSpec := &cluster.Spec
 
-	if clusterSpec.GetCloudProvider() != kops.CloudProviderAWS {
+	if cluster.GetCloudProvider() != kops.CloudProviderAWS {
 		return nil
 	}
 

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -450,7 +450,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 	}
 
 	{
-		switch b.Cluster.Spec.GetCloudProvider() {
+		switch b.Cluster.GetCloudProvider() {
 		case kops.CloudProviderAWS:
 			config.VolumeProvider = "aws"
 
@@ -526,7 +526,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 			}
 			config.VolumeNameTag = fmt.Sprintf("%s=%s", scaleway.TagInstanceGroup, instanceGroupName)
 		default:
-			return nil, fmt.Errorf("CloudProvider %q not supported with etcd-manager", b.Cluster.Spec.GetCloudProvider())
+			return nil, fmt.Errorf("CloudProvider %q not supported with etcd-manager", b.Cluster.GetCloudProvider())
 		}
 	}
 

--- a/pkg/model/components/gcpcloudcontrollermanager.go
+++ b/pkg/model/components/gcpcloudcontrollermanager.go
@@ -29,10 +29,10 @@ type GCPCloudControllerManagerOptionsBuilder struct {
 
 var _ loader.ClusterOptionsBuilder = (*GCPCloudControllerManagerOptionsBuilder)(nil)
 
-func (b *GCPCloudControllerManagerOptionsBuilder) BuildOptions(options *kops.Cluster) error {
-	clusterSpec := &options.Spec
+func (b *GCPCloudControllerManagerOptionsBuilder) BuildOptions(cluster *kops.Cluster) error {
+	clusterSpec := &cluster.Spec
 
-	if clusterSpec.GetCloudProvider() != kops.CloudProviderGCE {
+	if cluster.GetCloudProvider() != kops.CloudProviderGCE {
 		return nil
 	}
 

--- a/pkg/model/components/hetznercloudcontrollermanager.go
+++ b/pkg/model/components/hetznercloudcontrollermanager.go
@@ -30,10 +30,10 @@ type HetznerCloudControllerManagerOptionsBuilder struct {
 var _ loader.ClusterOptionsBuilder = &HetznerCloudControllerManagerOptionsBuilder{}
 
 // BuildOptions generates the configurations used for the Hetzner cloud controller manager manifest
-func (b *HetznerCloudControllerManagerOptionsBuilder) BuildOptions(o *kops.Cluster) error {
-	clusterSpec := &o.Spec
+func (b *HetznerCloudControllerManagerOptionsBuilder) BuildOptions(cluster *kops.Cluster) error {
+	clusterSpec := &cluster.Spec
 
-	if clusterSpec.GetCloudProvider() != kops.CloudProviderHetzner {
+	if cluster.GetCloudProvider() != kops.CloudProviderHetzner {
 		return nil
 	}
 

--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -32,8 +32,8 @@ type KubeDnsOptionsBuilder struct {
 var _ loader.ClusterOptionsBuilder = &KubeDnsOptionsBuilder{}
 
 // BuildOptions fills in the kubedns model
-func (b *KubeDnsOptionsBuilder) BuildOptions(o *kops.Cluster) error {
-	clusterSpec := &o.Spec
+func (b *KubeDnsOptionsBuilder) BuildOptions(cluster *kops.Cluster) error {
+	clusterSpec := &cluster.Spec
 
 	if clusterSpec.KubeDNS == nil {
 		clusterSpec.KubeDNS = &kops.KubeDNSConfig{}
@@ -74,7 +74,7 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 		clusterSpec.KubeDNS.MemoryLimit = &defaultMemoryLimit
 	}
 
-	if clusterSpec.IsIPv6Only() && clusterSpec.GetCloudProvider() == kops.CloudProviderAWS {
+	if clusterSpec.IsIPv6Only() && cluster.GetCloudProvider() == kops.CloudProviderAWS {
 		if len(clusterSpec.KubeDNS.UpstreamNameservers) == 0 {
 			clusterSpec.KubeDNS.UpstreamNameservers = []string{"fd00:ec2::253"}
 		}

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -37,8 +37,8 @@ type KubeletOptionsBuilder struct {
 var _ loader.ClusterOptionsBuilder = &KubeletOptionsBuilder{}
 
 // BuildOptions is responsible for filling the defaults for the kubelet
-func (b *KubeletOptionsBuilder) BuildOptions(o *kops.Cluster) error {
-	clusterSpec := &o.Spec
+func (b *KubeletOptionsBuilder) BuildOptions(cluster *kops.Cluster) error {
+	clusterSpec := &cluster.Spec
 
 	if clusterSpec.Kubelet == nil {
 		clusterSpec.Kubelet = &kops.KubeletConfigSpec{}
@@ -113,7 +113,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 		clusterSpec.ControlPlaneKubelet.HairpinMode = "none"
 	}
 
-	cloudProvider := clusterSpec.GetCloudProvider()
+	cloudProvider := cluster.GetCloudProvider()
 
 	clusterSpec.Kubelet.CgroupRoot = "/"
 

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -208,7 +208,7 @@ func (b *KopsModelContext) CloudTagsForServiceAccount(name string, sa types.Name
 func (b *KopsModelContext) CloudTags(name string, shared bool) map[string]string {
 	tags := make(map[string]string)
 
-	switch b.Cluster.Spec.GetCloudProvider() {
+	switch b.Cluster.GetCloudProvider() {
 	case kops.CloudProviderAWS:
 		if shared {
 			// If the resource is shared, we don't try to set the Name - we presume that is managed externally

--- a/pkg/model/iam/subject.go
+++ b/pkg/model/iam/subject.go
@@ -107,7 +107,7 @@ func BuildNodeRoleSubject(igRole kops.InstanceGroupRole, enableLifecycleHookPerm
 
 // AddServiceAccountRole adds the appropriate mounts / env vars to enable a pod to use a service-account role
 func AddServiceAccountRole(context *IAMModelContext, podSpec *corev1.PodSpec, serviceAccountRole Subject) error {
-	cloudProvider := context.Cluster.Spec.GetCloudProvider()
+	cloudProvider := context.Cluster.GetCloudProvider()
 
 	switch cloudProvider {
 	case kops.CloudProviderAWS:

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -98,7 +98,7 @@ func (b *MasterVolumeBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			}
 			sort.Strings(allMembers)
 
-			switch b.Cluster.Spec.GetCloudProvider() {
+			switch b.Cluster.GetCloudProvider() {
 			case kops.CloudProviderAWS:
 				err = b.addAWSVolume(c, name, volumeSize, zone, etcd, m, allMembers)
 				if err != nil {
@@ -123,7 +123,7 @@ func (b *MasterVolumeBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 			case kops.CloudProviderScaleway:
 				b.addScalewayVolume(c, name, volumeSize, zone, etcd, m, allMembers)
 			default:
-				return fmt.Errorf("unknown cloudprovider %q", b.Cluster.Spec.GetCloudProvider())
+				return fmt.Errorf("unknown cloudprovider %q", b.Cluster.GetCloudProvider())
 			}
 		}
 	}

--- a/pkg/nodemodel/fileassets.go
+++ b/pkg/nodemodel/fileassets.go
@@ -84,7 +84,7 @@ func (c *FileAssets) AddFileAssets(assetBuilder *assets.AssetBuilder) error {
 
 		kubernetesVersion, _ := util.ParseKubernetesVersion(c.Cluster.Spec.KubernetesVersion)
 
-		cloudProvider := c.Cluster.Spec.GetCloudProvider()
+		cloudProvider := c.Cluster.GetCloudProvider()
 		if ok := model.UseExternalKubeletCredentialProvider(*kubernetesVersion, cloudProvider); ok {
 			switch cloudProvider {
 			case kops.CloudProviderGCE:
@@ -186,7 +186,7 @@ func (c *FileAssets) AddFileAssets(assetBuilder *assets.AssetBuilder) error {
 // This is only needed currently on ContainerOS i.e. GCE, but we don't have a nice way to detect it yet
 func needsMounterAsset(c *kops.Cluster) bool {
 	// TODO: Do real detection of ContainerOS (but this has to work with image names, and maybe even forked images)
-	switch c.Spec.GetCloudProvider() {
+	switch c.GetCloudProvider() {
 	case kops.CloudProviderGCE:
 		return true
 	default:

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -316,7 +316,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 
 	// Set API server address to an IP from the cluster network CIDR
 	var controlPlaneIPs []string
-	switch cluster.Spec.GetCloudProvider() {
+	switch cluster.GetCloudProvider() {
 	case kops.CloudProviderAWS, kops.CloudProviderHetzner, kops.CloudProviderOpenstack:
 		// Use a private IP address that belongs to the cluster network CIDR (some additional addresses may be FQDNs or public IPs)
 		for _, additionalIP := range wellKnownAddresses[wellknownservices.KubeAPIServer] {
@@ -359,7 +359,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 		// If we do have a fixed IP, we use it (on some clouds, initially)
 		// This covers the clouds in UseKopsControllerForNodeConfig which use kops-controller for node config,
 		// but don't have a specialized discovery mechanism for finding kops-controller etc.
-		switch cluster.Spec.GetCloudProvider() {
+		switch cluster.GetCloudProvider() {
 		case kops.CloudProviderHetzner, kops.CloudProviderScaleway, kops.CloudProviderDO:
 			bootConfig.APIServerIPs = controlPlaneIPs
 		}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -406,7 +406,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 		AdditionalObjects: c.AdditionalObjects,
 	}
 
-	switch cluster.Spec.GetCloudProvider() {
+	switch cluster.GetCloudProvider() {
 	case kops.CloudProviderGCE:
 		{
 			gceCloud := cloud.(gce.GCECloud)
@@ -483,7 +483,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 		}
 
 	default:
-		return nil, fmt.Errorf("unknown CloudProvider %q", cluster.Spec.GetCloudProvider())
+		return nil, fmt.Errorf("unknown CloudProvider %q", cluster.GetCloudProvider())
 	}
 
 	modelContext.SSHPublicKeys = sshPublicKeys
@@ -562,7 +562,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 			&model.ConfigBuilder{KopsModelContext: modelContext, Lifecycle: clusterLifecycle},
 		)
 
-		switch cluster.Spec.GetCloudProvider() {
+		switch cluster.GetCloudProvider() {
 		case kops.CloudProviderAWS:
 			awsModelContext := &awsmodel.AWSModelContext{
 				KopsModelContext: modelContext,
@@ -687,7 +687,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 			)
 
 		default:
-			return nil, fmt.Errorf("unknown cloudprovider %q", cluster.Spec.GetCloudProvider())
+			return nil, fmt.Errorf("unknown cloudprovider %q", cluster.GetCloudProvider())
 		}
 	}
 	c.TaskMap, err = l.BuildTasks(ctx, c.LifecycleOverrides)
@@ -701,7 +701,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 	deletionProcessingMode := c.DeletionProcessing
 	switch c.TargetName {
 	case TargetDirect:
-		switch cluster.Spec.GetCloudProvider() {
+		switch cluster.GetCloudProvider() {
 		case kops.CloudProviderGCE:
 			target = gce.NewGCEAPITarget(cloud.(gce.GCECloud))
 		case kops.CloudProviderAWS:
@@ -717,7 +717,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 		case kops.CloudProviderScaleway:
 			target = scaleway.NewScwAPITarget(cloud.(scaleway.ScwCloud))
 		default:
-			return nil, fmt.Errorf("direct configuration not supported with CloudProvider:%q", cluster.Spec.GetCloudProvider())
+			return nil, fmt.Errorf("direct configuration not supported with CloudProvider:%q", cluster.GetCloudProvider())
 		}
 
 	case TargetTerraform:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -427,8 +427,8 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 	}
 
 	if b.IsKubernetesLT("1.26") &&
-		(b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderAWS ||
-			b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderGCE) {
+		(b.Cluster.GetCloudProvider() == kops.CloudProviderAWS ||
+			b.Cluster.GetCloudProvider() == kops.CloudProviderGCE) {
 		// AWS and GCE KCM-to-CCM leader migration
 		key := "leader-migration.rbac.addons.k8s.io"
 
@@ -701,7 +701,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 	}
 
 	if fi.ValueOf(b.Cluster.Spec.CloudConfig.ManageStorageClasses) {
-		if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderAWS {
+		if b.Cluster.GetCloudProvider() == kops.CloudProviderAWS {
 			key := "storage-aws.addons.k8s.io"
 
 			{
@@ -718,7 +718,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 		}
 	}
 
-	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderDO {
+	if b.Cluster.GetCloudProvider() == kops.CloudProviderDO {
 		key := "digitalocean-cloud-controller.addons.k8s.io"
 
 		{
@@ -748,7 +748,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 		}
 	}
 
-	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderHetzner {
+	if b.Cluster.GetCloudProvider() == kops.CloudProviderHetzner {
 		{
 			key := "hcloud-cloud-controller.addons.k8s.io"
 			id := "k8s-1.22"
@@ -775,7 +775,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 		}
 	}
 
-	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderGCE {
+	if b.Cluster.GetCloudProvider() == kops.CloudProviderGCE {
 		if fi.ValueOf(b.Cluster.Spec.CloudConfig.ManageStorageClasses) {
 			key := "storage-gce.addons.k8s.io"
 
@@ -806,7 +806,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 		}
 	}
 
-	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderScaleway {
+	if b.Cluster.GetCloudProvider() == kops.CloudProviderScaleway {
 		{
 			key := "scaleway-cloud-controller.addons.k8s.io"
 			id := "k8s-1.24"
@@ -852,7 +852,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 
 	// The metadata-proxy daemonset conceals node metadata endpoints in GCE.
 	// It will land on nodes labeled cloud.google.com/metadata-proxy-ready=true
-	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderGCE && b.Cluster.IsKubernetesLT("1.29") {
+	if b.Cluster.GetCloudProvider() == kops.CloudProviderGCE && b.Cluster.IsKubernetesLT("1.29") {
 		key := "metadata-proxy.addons.k8s.io"
 
 		{
@@ -868,7 +868,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 		}
 	}
 
-	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderGCE {
+	if b.Cluster.GetCloudProvider() == kops.CloudProviderGCE {
 		{
 			key := "gcp-cloud-controller.addons.k8s.io"
 			useBuiltin := !b.hasExternalAddon(key)
@@ -1110,7 +1110,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 		}
 	}
 
-	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderOpenstack {
+	if b.Cluster.GetCloudProvider() == kops.CloudProviderOpenstack {
 		{
 			key := "storage-openstack.addons.k8s.io"
 
@@ -1142,7 +1142,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 		}
 	}
 
-	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderAWS {
+	if b.Cluster.GetCloudProvider() == kops.CloudProviderAWS {
 
 		{
 			key := "aws-cloud-controller.addons.k8s.io"
@@ -1217,7 +1217,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.CloudupModelBuilderContext) 
 
 	serviceAccounts := make(map[types.NamespacedName]iam.Subject)
 
-	if b.Cluster.Spec.GetCloudProvider() == kops.CloudProviderAWS && b.Cluster.Spec.KubeAPIServer.ServiceAccountIssuer != nil {
+	if b.Cluster.GetCloudProvider() == kops.CloudProviderAWS && b.Cluster.Spec.KubeAPIServer.ServiceAccountIssuer != nil {
 		awsModelContext := &awsmodel.AWSModelContext{
 			KopsModelContext: b.KopsModelContext,
 		}

--- a/upup/pkg/fi/cloudup/defaults.go
+++ b/upup/pkg/fi/cloudup/defaults.go
@@ -236,7 +236,7 @@ func assignProxy(cluster *kops.Cluster) (*kops.EgressProxySpec, error) {
 
 		awsNoProxy := "169.254.169.254"
 
-		if cluster.Spec.GetCloudProvider() == kops.CloudProviderAWS && !strings.Contains(cluster.Spec.Networking.EgressProxy.ProxyExcludes, awsNoProxy) {
+		if cluster.GetCloudProvider() == kops.CloudProviderAWS && !strings.Contains(cluster.Spec.Networking.EgressProxy.ProxyExcludes, awsNoProxy) {
 			egressSlice = append(egressSlice, awsNoProxy)
 		}
 

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -144,7 +144,7 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 	}
 
 	if ig.Spec.Tenancy != "" && ig.Spec.Tenancy != "default" {
-		switch cluster.Spec.GetCloudProvider() {
+		switch cluster.GetCloudProvider() {
 		case kops.CloudProviderAWS:
 			if _, ok := awsDedicatedInstanceExceptions[ig.Spec.MachineType]; ok {
 				return nil, fmt.Errorf("invalid dedicated instance type: %s", ig.Spec.MachineType)
@@ -198,7 +198,7 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 		igNvidia = true
 	}
 
-	switch cluster.Spec.GetCloudProvider() {
+	switch cluster.GetCloudProvider() {
 	case kops.CloudProviderAWS:
 		if clusterNvidia || igNvidia {
 			mt, err := awsup.GetMachineTypeInfo(cloud.(awsup.AWSCloud), ec2types.InstanceType(ig.Spec.MachineType))
@@ -304,7 +304,7 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 
 // defaultMachineType returns the default MachineType for the instance group, based on the cloudprovider
 func defaultMachineType(cloud fi.Cloud, cluster *kops.Cluster, ig *kops.InstanceGroup) (string, error) {
-	switch cluster.Spec.GetCloudProvider() {
+	switch cluster.GetCloudProvider() {
 	case kops.CloudProviderAWS:
 		if ig.Spec.Manager == kops.InstanceManagerKarpenter {
 			return "", nil
@@ -379,6 +379,6 @@ func defaultMachineType(cloud fi.Cloud, cluster *kops.Cluster, ig *kops.Instance
 		}
 	}
 
-	klog.V(2).Infof("Cannot set default MachineType for CloudProvider=%q, Role=%q", cluster.Spec.GetCloudProvider(), ig.Spec.Role)
+	klog.V(2).Infof("Cannot set default MachineType for CloudProvider=%q, Role=%q", cluster.GetCloudProvider(), ig.Spec.Role)
 	return "", nil
 }

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -116,7 +116,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 		return defaultValue
 	}
 
-	dest["GetCloudProvider"] = cluster.Spec.GetCloudProvider
+	dest["GetCloudProvider"] = cluster.GetCloudProvider
 	dest["GetInstanceGroup"] = tf.GetInstanceGroup
 	dest["GetNodeInstanceGroups"] = tf.GetNodeInstanceGroups
 	dest["GetClusterAutoscalerNodeGroups"] = tf.GetClusterAutoscalerNodeGroups
@@ -287,7 +287,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			if c.IPIPMode != "" {
 				return c.IPIPMode
 			}
-			if cluster.Spec.GetCloudProvider() == kops.CloudProviderOpenstack {
+			if cluster.GetCloudProvider() == kops.CloudProviderOpenstack {
 				return "Always"
 			}
 			return "CrossSubnet"
@@ -520,8 +520,8 @@ func (tf *TemplateFunctions) CloudControllerConfigArgv() ([]string, error) {
 
 	// take the cloud provider value from clusterSpec if unset
 	if cluster.Spec.ExternalCloudControllerManager.CloudProvider == "" {
-		if cluster.Spec.GetCloudProvider() != "" {
-			argv = append(argv, fmt.Sprintf("--cloud-provider=%s", cluster.Spec.GetCloudProvider()))
+		if cluster.GetCloudProvider() != "" {
+			argv = append(argv, fmt.Sprintf("--cloud-provider=%s", cluster.GetCloudProvider()))
 		} else {
 			return nil, fmt.Errorf("Cloud Provider is not set")
 		}
@@ -532,7 +532,7 @@ func (tf *TemplateFunctions) CloudControllerConfigArgv() ([]string, error) {
 		argv = append(argv, fmt.Sprintf("--use-service-account-credentials=%t", true))
 	}
 
-	if cluster.Spec.GetCloudProvider() != kops.CloudProviderHetzner {
+	if cluster.GetCloudProvider() != kops.CloudProviderHetzner {
 		argv = append(argv, "--cloud-config=/etc/kubernetes/cloud.config")
 	}
 
@@ -614,7 +614,7 @@ func (tf *TemplateFunctions) DNSControllerArgv() ([]string, error) {
 			argv = append(argv, fmt.Sprintf("--gossip-seed-secondary=127.0.0.1:%d", wellknownports.ProtokubeGossipMemberlist))
 		}
 	} else {
-		switch cluster.Spec.GetCloudProvider() {
+		switch cluster.GetCloudProvider() {
 		case kops.CloudProviderAWS:
 			if strings.HasPrefix(os.Getenv("AWS_REGION"), "cn-") {
 				argv = append(argv, "--dns=gossip")
@@ -631,7 +631,7 @@ func (tf *TemplateFunctions) DNSControllerArgv() ([]string, error) {
 			argv = append(argv, "--dns=scaleway")
 
 		default:
-			return nil, fmt.Errorf("unhandled cloudprovider %q", cluster.Spec.GetCloudProvider())
+			return nil, fmt.Errorf("unhandled cloudprovider %q", cluster.GetCloudProvider())
 		}
 	}
 
@@ -666,7 +666,7 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 
 	config := &kopscontrollerconfig.Options{
 		ClusterName: cluster.Name,
-		Cloud:       string(cluster.Spec.GetCloudProvider()),
+		Cloud:       string(cluster.GetCloudProvider()),
 		ConfigBase:  cluster.Spec.ConfigStore.Base,
 		SecretStore: cluster.Spec.ConfigStore.Secrets,
 	}
@@ -703,7 +703,7 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 			config.Server.PKI = &pkibootstrap.Options{}
 		}
 
-		switch cluster.Spec.GetCloudProvider() {
+		switch cluster.GetCloudProvider() {
 		case kops.CloudProviderAWS:
 			nodesRoles := sets.String{}
 			for _, ig := range tf.InstanceGroups {
@@ -763,7 +763,7 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 			}
 
 		default:
-			return "", fmt.Errorf("unsupported cloud provider %s", cluster.Spec.GetCloudProvider())
+			return "", fmt.Errorf("unsupported cloud provider %s", cluster.GetCloudProvider())
 		}
 	}
 
@@ -804,7 +804,7 @@ func (tf *TemplateFunctions) ExternalDNSArgv() ([]string, error) {
 
 	var argv []string
 
-	cloudProvider := cluster.Spec.GetCloudProvider()
+	cloudProvider := cluster.GetCloudProvider()
 
 	switch cloudProvider {
 	case kops.CloudProviderAWS:
@@ -814,7 +814,7 @@ func (tf *TemplateFunctions) ExternalDNSArgv() ([]string, error) {
 		argv = append(argv, "--provider=google")
 		argv = append(argv, "--google-project="+project)
 	default:
-		return nil, fmt.Errorf("unhandled cloudprovider %q", cluster.Spec.GetCloudProvider())
+		return nil, fmt.Errorf("unhandled cloudprovider %q", cluster.GetCloudProvider())
 	}
 
 	argv = append(argv, "--events")
@@ -835,7 +835,7 @@ func (tf *TemplateFunctions) ExternalDNSArgv() ([]string, error) {
 }
 
 func (tf *TemplateFunctions) DNSControllerEnvs() map[string]string {
-	if tf.Cluster.Spec.GetCloudProvider() != kops.CloudProviderOpenstack {
+	if tf.Cluster.GetCloudProvider() != kops.CloudProviderOpenstack {
 		return nil
 	}
 	envs := env.BuildSystemComponentEnvVars(&tf.Cluster.Spec)
@@ -955,7 +955,7 @@ func (tf *TemplateFunctions) GetClusterAutoscalerNodeGroups() map[string]Cluster
 				MinSize:   fi.ValueOf(ig.Spec.MinSize),
 				MaxSize:   fi.ValueOf(ig.Spec.MaxSize),
 			}
-			if cluster.Spec.GetCloudProvider() == kops.CloudProviderGCE {
+			if cluster.GetCloudProvider() == kops.CloudProviderGCE {
 				cloud := tf.cloud.(gce.GCECloud)
 				format := "https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instanceGroups/%s"
 				group.Other = fmt.Sprintf(format, cloud.Project(), ig.Spec.Zones[0], gce.NameForInstanceGroupManager(cluster.ObjectMeta.Name, ig.ObjectMeta.Name, ig.Spec.Zones[0]))

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -42,7 +42,7 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 	region := ""
 	project := ""
 
-	switch cluster.Spec.GetCloudProvider() {
+	switch cluster.GetCloudProvider() {
 	case kops.CloudProviderGCE:
 		{
 			for _, subnet := range cluster.Spec.Networking.Subnets {
@@ -194,7 +194,7 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 			cloud = scwCloud
 		}
 	default:
-		return nil, fmt.Errorf("unknown CloudProvider %q", cluster.Spec.GetCloudProvider())
+		return nil, fmt.Errorf("unknown CloudProvider %q", cluster.GetCloudProvider())
 	}
 	return cloud, nil
 }


### PR DESCRIPTION
This lets us use labels (or annotations), meaning we can experiment
with different clouds without changing the API.

We also add initial (experimental/undocumented) support for exposing a "Metal" provider.
