### PR TITLE
refactor: give clear error message if challenge endpoint cannot be found

### DIFF
--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -210,6 +210,12 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if model.UseChallengeCallback(kops.CloudProviderID(s.opt.Cloud)) {
+		if id.ChallengeEndpoint == "" {
+			klog.Infof("cannot determine endpoint for bootstrap callback challenge from %q", r.RemoteAddr)
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("callback failed"))
+			return
+		}
 		if err := s.challengeClient.DoCallbackChallenge(ctx, s.opt.ClusterName, id.ChallengeEndpoint, req); err != nil {
 			klog.Infof("bootstrap %s callback challenge failed: %v", r.RemoteAddr, err)
 			w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
We were not handling this particularly clearly before, although it should only happen in development.
