### PR TITLE
Enforce GCP limit of 64 chars for cluster name in kubetest2 deployer

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -283,9 +283,14 @@ func defaultClusterName(cloudProvider string) (string, error) {
 		jobName = jobName[:79]
 	}
 	if jobType == "presubmit" {
-		return fmt.Sprintf("e2e-pr%s.%s.%s", pullNumber, jobName, suffix), nil
+		jobName = fmt.Sprintf("e2e-pr%s.%s.%s", pullNumber, jobName, suffix)
+	} else {
+		jobName = fmt.Sprintf("e2e-%s.%s", jobName, suffix)
 	}
-	return fmt.Sprintf("e2e-%s.%s", jobName, suffix), nil
+	if len(jobName) > 63 && cloudProvider == "gce" { // GCP has char limit of 64
+		jobName = jobName[:63]
+	}
+	return jobName, nil
 }
 
 // stateStore returns the kops state store to use


### PR DESCRIPTION
Ran into this https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/127005/pull-kubernetes-e2e-gce-disruptive-canary/1829211781348724736/build-log.txt

```
I0829 17:57:21.198213   74468 new_cluster.go:1454] Cloud Provider ID: "gce"
Error: error populating configuration: error fetching network "e2e-pr127005-pull-kubernetes-e2e-gce-disruptive-canary-k8s-local": googleapi: Error 400: Invalid value for field 'network': 'e2e-pr127005-pull-kubernetes-e2e-gce-disruptive-canary-k8s-local'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}', invalid
W0829 17:57:21.625216   15003 state.go:46] failed to run /home/prow/go/src/k8s.io/kubernetes/_rundir/d5760245-a280-4b20-9469-c66a140b00dc/kops get cluster e2e-pr127005.pull-kubernetes-e2e-gce-disruptive-canary.k8s.local -ojson; stderr=Error: cluster not found "e2e-pr127005.pull-kubernetes-e2e-gce-disruptive-canary.k8s.local"
Error: exit status 1
```