### PR TITLE
Don't truncate the top level domains for GCP jobs

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -300,14 +300,17 @@ func defaultClusterName(cloudProvider string) (string, error) {
 		jobName = jobName[:79]
 	}
 	if jobType == "presubmit" {
-		jobName = fmt.Sprintf("e2e-pr%s.%s.%s", pullNumber, jobName, suffix)
+		jobName = fmt.Sprintf("e2e-pr%s.%s", pullNumber, jobName)
 	} else {
-		jobName = fmt.Sprintf("e2e-%s.%s", jobName, suffix)
+		jobName = fmt.Sprintf("e2e-%s", jobName)
 	}
-	if len(jobName) > 63 && cloudProvider == "gce" { // GCP has char limit of 64
-		jobName = jobName[:63]
+
+	// GCP has char limit of 64
+	gcpLimit := 63 - (len(suffix) + 1) // 1 for the dot
+	if len(jobName) > gcpLimit && cloudProvider == "gce" {
+		jobName = jobName[:gcpLimit]
 	}
-	return jobName, nil
+	return fmt.Sprintf("%v.%v", jobName, suffix), nil
 }
 
 // stateStore returns the kops state store to use


### PR DESCRIPTION
Followup to https://github.com/kubernetes/kops/pull/16787

[This test](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-disruptive-canary/1829626382510985216) run is using `e2e-pr127005.pull-kubernetes-e2e-gce-disruptive-canary.k8s.loca` where it would be more appropriate to keep `k8s.local` and trim `e2e-pr127005.pull-kubernetes-e2e-gce-disruptive-canary`.

This PR updates the trim logic to end up with `e2e-pr127005.pull-kubernetes-e2e-gce-disruptive-canar.k8s.local`

/cc @dims @hakman 