### PR TITLE
Stop skipping protocol tests for future Cilium versions

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -75,11 +75,15 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|TCP.CLOSE_WAIT"
 		// https://github.com/cilium/cilium/issues/15361
 		skipRegex += "|external.IP.is.not.assigned.to.a.node"
-		// https://github.com/cilium/cilium/issues/14287
-		skipRegex += "|same.port.number.but.different.protocols"
-		skipRegex += "|same.hostPort.but.different.hostIP.and.protocol"
-		// https://github.com/cilium/cilium/issues/9207
-		skipRegex += "|serve.endpoints.on.same.port.and.different.protocols"
+
+		if networking.Cilium.Version < "v1.17" {
+			// https://github.com/cilium/cilium/issues/14287
+			skipRegex += "|same.port.number.but.different.protocols"
+			skipRegex += "|same.hostPort.but.different.hostIP.and.protocol"
+			// https://github.com/cilium/cilium/issues/9207
+			skipRegex += "|serve.endpoints.on.same.port.and.different.protocols"
+		}
+
 		// https://github.com/kubernetes/kubernetes/blob/418ae605ec1b788d43bff7ac44af66d8b669b833/test/e2e/network/networking.go#L135
 		skipRegex += "|should.check.kube-proxy.urls"
 


### PR DESCRIPTION
This was merged into cilium's main branch and will be a part of v1.17: https://github.com/cilium/cilium/pull/33434

Moving this skip regex into a condition as a reminder to confirm these tests pass once v1.17 is released and kops is upgraded to use v1.17.