### PR TITLE
Implement SELinuxMount feature gate for GCE

### DIFF
--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -85,7 +85,7 @@ var (
 	ImageDigest = new("ImageDigest", Bool(true))
 	// Scaleway toggles the Scaleway Cloud support.
 	Scaleway = new("Scaleway", Bool(false))
-	// SELinuxMount configures AWS EBS CSI driver for SELinuxMount support.
+	// SELinuxMount configures AWS EBS and GCE PD CSI drivers for SELinuxMount support.
 	// It expects than Kubernetes feature gate SELinuxMountReadWriteOncePod is
 	// enabled or GA in the API server, KCM and kubelet.
 	// OS with SELinux support on all nodes is recommended, but not required

--- a/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
@@ -667,6 +667,10 @@ spec:
           name: udev-socket
         - mountPath: /sys
           name: sys
+{{ if KopsFeatureEnabled "SELinuxMount" }}
+        - name: etc-selinux
+          mountPath: /etc/selinux
+{{ end }}
       hostNetwork: true
       nodeSelector: null
       priorityClassName: csi-gce-pd-node
@@ -706,6 +710,12 @@ spec:
           path: /sys
           type: Directory
         name: sys
+{{ if KopsFeatureEnabled "SELinuxMount" }}
+      - name: etc-selinux
+        hostPath:
+          path: /etc/selinux
+          type: DirectoryOrCreate
+{{ end }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
@@ -714,3 +724,6 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+{{ if KopsFeatureEnabled "SELinuxMount" }}
+  seLinuxMount: true
+{{ end }}


### PR DESCRIPTION
Implement SELinuxMount feature gate for GCE.

I tested it on GCE + RockyLinux,

(for my future self: `KOPS_FEATURE_FLAGS=SELinuxMount kops create cluster ${DOMAIN} --zones us-central1-a --state ${KOPS_STATE_STORE}/ --project=${PROJECT}  --set=cluster.spec.cloudProvider.gce.useStartupScript=true  --image=rocky-linux-cloud/rocky-linux-9-optimized-gcp-v20240717 --yes --set=cluster.spec.containerd.selinuxEnabled=true`)