### PR TITLE
tests: use latest dev etcd-manager image in bare-metal test

### DIFF
--- a/tests/e2e/scenarios/bare-metal/dump-artifacts
+++ b/tests/e2e/scenarios/bare-metal/dump-artifacts
@@ -51,4 +51,5 @@ for vm in 0 1 2; do
   vm_name="vm${vm}"
   mkdir -p ${ARTIFACTS}/vms/${vm_name}/logs/
   scp -o StrictHostKeyChecking=accept-new -i ${REPO_ROOT}/.build/.ssh/id_ed25519 root@10.123.45.10:/var/log/etcd* ${ARTIFACTS}/vms/${vm_name}/logs/ || true
+  ssh -o StrictHostKeyChecking=accept-new -i ${REPO_ROOT}/.build/.ssh/id_ed25519 root@10.123.45.10 journalctl --no-pager -u kubelet 2>&1 > ${ARTIFACTS}/vms/${vm_name}/logs/journal-kubelet.service || true
 done

--- a/tests/e2e/scenarios/bare-metal/run-test
+++ b/tests/e2e/scenarios/bare-metal/run-test
@@ -81,6 +81,9 @@ ${KOPS} create cluster --cloud=metal metal.k8s.local --zones main
 # TODO: is this the best option?
 ${KOPS} edit cluster metal.k8s.local  --set spec.api.publicName=10.123.45.10
 
+# Use latest etcd-manager image (while we're adding features)
+${KOPS} edit cluster metal.k8s.local --set 'spec.etcdClusters[*].manager.image=us-central1-docker.pkg.dev/k8s-staging-images/etcd-manager/etcd-manager-static:latest'
+
 # List clusters
 ${KOPS} get cluster
 ${KOPS} get cluster -oyaml
@@ -99,5 +102,8 @@ ssh-add ${REPO_ROOT}/.build/.ssh/id_ed25519
 
 # Enroll the control-plane VM
 ${KOPS} toolbox enroll --cluster metal.k8s.local --instance-group control-plane-main --host 10.123.45.10 --v=8
+
+echo "Waiting 60 seconds for kube to start"
+sleep 60
 
 echo "Test successful"


### PR DESCRIPTION
At least while we are building out the static functionality.
