### PR TITLE
Fix ipv6 prefix detection with aws-sdk-go-v2

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/prefix.go
+++ b/upup/pkg/fi/nodeup/nodetasks/prefix.go
@@ -25,10 +25,10 @@ import (
 	"path"
 	"strings"
 
-	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
@@ -128,7 +128,7 @@ func getInstanceMetadataList(ctx context.Context, category string) ([]string, er
 	metadata := imds.NewFromConfig(cfg)
 	resp, err := metadata.GetMetadata(ctx, &imds.GetMetadataInput{Path: category})
 	if err != nil {
-		var awsErr *awshttp.ResponseError
+		var awsErr *smithyhttp.ResponseError
 		if errors.As(err, &awsErr) && awsErr.HTTPStatusCode() == http.StatusNotFound {
 			return nil, nil
 		} else {


### PR DESCRIPTION
AWS ipv6 jobs have been failing with this nodeup error:

```
Sep 05 03:58:28 i-002abc28507b7ab4f nodeup[4374]: I0905 03:58:28.588344    4374 executor.go:171] Continuing to run 1 task(s)
Sep 05 03:58:38 i-002abc28507b7ab4f nodeup[4374]: I0905 03:58:38.589379    4374 executor.go:113] Tasks: 182 done / 199 total; 1 can run
Sep 05 03:58:38 i-002abc28507b7ab4f nodeup[4374]: I0905 03:58:38.589427    4374 executor.go:214] Executing task "Prefix/prefix": Prefix: prefix
Sep 05 03:58:38 i-002abc28507b7ab4f nodeup[4374]: W0905 03:58:38.592417    4374 executor.go:141] error running task "Prefix/prefix" (6m1s remaining to succeed): failed to get "network/interfaces/macs/06:05:2f:0e:c6:eb/ipv6-prefix" from ec2 meta-data: operation error ec2imds: GetMetadata, http response error StatusCode: 404, request to EC2 IMDS failed
Sep 05 03:58:38 i-002abc28507b7ab4f nodeup[4374]: I0905 03:58:38.592440    4374 executor.go:171] Continuing to run 1 task(s)
Sep 05 03:58:48 i-002abc28507b7ab4f nodeup[4374]: I0905 03:58:48.593316    4374 executor.go:113] Tasks: 182 done / 199 total; 1 can run
Sep 05 03:58:48 i-002abc28507b7ab4f nodeup[4374]: I0905 03:58:48.593367    4374 executor.go:214] Executing task "Prefix/prefix": Prefix: prefix
Sep 05 03:58:48 i-002abc28507b7ab4f nodeup[4374]: W0905 03:58:48.596224    4374 executor.go:141] error running task "Prefix/prefix" (5m51s remaining to succeed): failed to get "network/interfaces/macs/06:05:2f:0e:c6:eb/ipv6-prefix" from ec2 meta-data: operation error ec2imds: GetMetadata, http response error StatusCode: 404, request to EC2 IMDS failed
```

This occurs in the task's Find method. We should just return nil (indicating the resource doesn't exist yet and needs to be created) but there was a bug in the error handling in aws-sdk-go-v2 and we weren't identifying the request as a 404.

The SDK's IMDS client uses different error types from normal services, so we have to unwrap the error differently:

https://github.com/aws/aws-sdk-go-v2/blob/f1d71c59a1499981873f70db8c92d07242779670/feature/ec2/imds/request_middleware.go#L185-L191

Once we confirm this fixes all of the [failing ipv6 jobs](https://testgrid.k8s.io/kops-ipv6) then we should cherrypick this to 1.30

