### PR TITLE
Automated cherry pick of #16803: chore: update aws pod identity webhook

### DIFF
--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -148,7 +148,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db1d4b48d5be1590d1462766363498c165fa6c5ecec2be931c166b3d3697745d
+    manifestHash: 79c41f59887ce9fa60e8bd509c9b43d0c0aa8c2ebecc3bbb78c570485d55b8c2
     name: eks-pod-identity-webhook.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
@@ -130,14 +130,14 @@ spec:
         - --sts-regional-endpoint
         - --aws-default-region=us-test-1
         - --v=5
-        image: amazon/amazon-eks-pod-identity-webhook:v0.4.0
+        image: amazon/amazon-eks-pod-identity-webhook:v0.5.7
         name: pod-identity-webhook
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 9999
-            scheme: HTTP
+            port: 443
+            scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 5
           successThreshold: 1

--- a/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
@@ -80,7 +80,7 @@ spec:
       serviceAccountName: pod-identity-webhook
       containers:
       - name: pod-identity-webhook
-        image: amazon/amazon-eks-pod-identity-webhook:v0.4.0
+        image: amazon/amazon-eks-pod-identity-webhook:v0.5.7
         command:
         - /webhook
         - --in-cluster=false
@@ -96,8 +96,8 @@ spec:
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 9999
-            scheme: HTTP
+            port: 443
+            scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 5
           timeoutSeconds: 1


### PR DESCRIPTION
Cherry pick of #16803 on release-1.30.

#16803: chore: update aws pod identity webhook

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```