### PR TITLE
Give each kops-controller controller unique names

### DIFF
--- a/cmd/kops-controller/controllers/awsipam.go
+++ b/cmd/kops-controller/controllers/awsipam.go
@@ -154,6 +154,7 @@ func (r *AWSIPAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 func (r *AWSIPAMReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("aws_ipam").
 		For(&corev1.Node{}).
 		Complete(r)
 }

--- a/cmd/kops-controller/controllers/gceipam.go
+++ b/cmd/kops-controller/controllers/gceipam.go
@@ -145,6 +145,7 @@ func (r *GCEIPAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 func (r *GCEIPAMReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("gce_ipam").
 		For(&corev1.Node{}).
 		Complete(r)
 }

--- a/cmd/kops-controller/controllers/legacy_node_controller.go
+++ b/cmd/kops-controller/controllers/legacy_node_controller.go
@@ -158,6 +158,7 @@ func (r *LegacyNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 func (r *LegacyNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("legacy_node").
 		For(&corev1.Node{}).
 		Complete(r)
 }

--- a/cmd/kops-controller/controllers/node_controller.go
+++ b/cmd/kops-controller/controllers/node_controller.go
@@ -126,6 +126,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("node").
 		For(&corev1.Node{}).
 		Complete(r)
 }


### PR DESCRIPTION
This makes progress on fixing ipv6 support.

For IPV6 clusters we enable an ipam controller in kops-controller:

https://github.com/kubernetes/kops/blob/423b640de6cd18c99fea5c43f938e029a8d8aad6/pkg/apis/kops/cluster.go#L949-L951

https://github.com/kubernetes/kops/blob/423b640de6cd18c99fea5c43f938e029a8d8aad6/upup/pkg/fi/cloudup/template_functions.go#L774-L776

https://github.com/kubernetes/kops/blob/423b640de6cd18c99fea5c43f938e029a8d8aad6/cmd/kops-controller/main.go#L221-L227

controller-runtime's manager picks "names" for each controller it manages, and defaults to the `kind` it watches:

https://github.com/kubernetes-sigs/controller-runtime/blob/38546806f2faf5973e3321a7bd5bb3afdbb5767d/pkg/builder/controller.go#L247-L257


This means that alongside the node bootstrap controller, there are multiple controllers watching nodes. This results in a conflict which causes kops-controller to crash loop:

```
I0906 00:17:26.074975       1 main.go:373] "msg"="enabling IPAM controller" "logger"="setup"
I0906 00:17:26.075026       1 awsipam.go:47] Starting aws ipam controller
E0906 00:17:26.077961       1 main.go:230] "msg"="unable to create controller" "error"="controller with name node already exists. Controller names must be unique to avoid multiple controllers reporting to the same metric" "controller"="NodeController" "logger"="setup"
```


This PR gives each controller a unique name to avoid the conflict.