### PR TITLE
Include all APIserver addresses for nodeup config

### DIFF
--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -319,7 +319,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 	var controlPlaneIPs []string
 	switch cluster.GetCloudProvider() {
 	case kops.CloudProviderAWS, kops.CloudProviderHetzner, kops.CloudProviderOpenstack:
-		// Use a private IP address that belongs to the cluster network CIDR (some additional addresses may be FQDNs or public IPs)
+		// Use a private IP address that belongs to the cluster network CIDR, or any IPv6 addresses (some additional addresses may be FQDNs or public IPs)
 		for _, additionalIP := range wellKnownAddresses[wellknownservices.KubeAPIServer] {
 			for _, networkCIDR := range append(cluster.Spec.Networking.AdditionalNetworkCIDRs, cluster.Spec.Networking.NetworkCIDR) {
 				cidr, err := netip.ParsePrefix(networkCIDR)
@@ -330,7 +330,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 				if err != nil {
 					continue
 				}
-				if cidr.Contains(ip) {
+				if cidr.Contains(ip) || ip.Is6() {
 					controlPlaneIPs = append(controlPlaneIPs, additionalIP)
 				}
 			}

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -19,6 +19,7 @@ package nodemodel
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"net/url"
 	"os"
 	"path"
@@ -321,11 +322,15 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 		// Use a private IP address that belongs to the cluster network CIDR (some additional addresses may be FQDNs or public IPs)
 		for _, additionalIP := range wellKnownAddresses[wellknownservices.KubeAPIServer] {
 			for _, networkCIDR := range append(cluster.Spec.Networking.AdditionalNetworkCIDRs, cluster.Spec.Networking.NetworkCIDR) {
-				_, cidr, err := net.ParseCIDR(networkCIDR)
+				cidr, err := netip.ParsePrefix(networkCIDR)
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to parse network CIDR %q: %w", networkCIDR, err)
 				}
-				if cidr.Contains(net.ParseIP(additionalIP)) {
+				ip, err := netip.ParseAddr(additionalIP)
+				if err != nil {
+					continue
+				}
+				if cidr.Contains(ip) {
 					controlPlaneIPs = append(controlPlaneIPs, additionalIP)
 				}
 			}
@@ -336,11 +341,15 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 		// Note that on GCE subnets have IP ranges, networks do not
 		for _, apiserverIP := range wellKnownAddresses[wellknownservices.KubeAPIServer] {
 			for _, subnet := range cluster.Spec.Networking.Subnets {
-				_, cidr, err := net.ParseCIDR(subnet.CIDR)
+				cidr, err := netip.ParsePrefix(subnet.CIDR)
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to parse subnet CIDR %q: %w", subnet.CIDR, err)
 				}
-				if cidr.Contains(net.ParseIP(apiserverIP)) {
+				ip, err := netip.ParseAddr(apiserverIP)
+				if err != nil {
+					continue
+				}
+				if cidr.Contains(ip) {
 					controlPlaneIPs = append(controlPlaneIPs, apiserverIP)
 				}
 			}

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -379,6 +379,9 @@ func (e *NetworkLoadBalancer) FindAddresses(c *fi.CloudupContext) ([]string, err
 					if fi.ValueOf(ni.PrivateIpAddress) != "" {
 						addresses = append(addresses, fi.ValueOf(ni.PrivateIpAddress))
 					}
+					for _, v6 := range ni.Ipv6Addresses {
+						addresses = append(addresses, fi.ValueOf(v6.Ipv6Address))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
With this plus https://github.com/kubernetes/kops/pull/16812 i'm able to get an ipv6 dns=none cluster to pass validation.

Before we were only including ipv4 addresses because those are the only CIDRs included in the cluster spec - ipv6 CIDRs are provided by AWS. This resulted in nodes failing to bootstrap because they couldn't reach the kops-controller endpoint:

`Sep 06 01:23:11 i-0250853b64092f19d nodeup[1323]: W0906 01:23:11.157536    1323 main.go:133] got error running nodeup (will retry in 30s): failed to get node config from server: Post "https://172.20.5.248:3988/bootstrap": dial tcp 172.20.5.248:3988: connect: network is unreachable`

Even though the ipv6 address and load balancer DNS name both work:

```
$ curl -6 -k  'https://[2600:1f14:1800:ab02:ba1a:4b60:b424:d3f3]:3988/bootstrap'
failed to verify token

curl -k https://api-peter-ipv6-k8s--k283sk-ef9b199ef8b93ba4.elb.us-west-2.amazonaws.com:3988/bootstrap
failed to verify token
```

With this change, the nodeup config userdata changes as such:

```
Will modify resources:
  LaunchTemplate/control-plane-us-west-2a.masters.peter-rifel-ipv6.k8s.local
  	UserData
  	                    	...
  	                    	  APIServerIPs:
  	                    	  - 172.20.5.248
  	                    	+ - 2600:1f14:1800:ab02:ba1a:4b60:b424:d3f3
  	                    	+ - api-peter-ipv6-k8s--k283sk-ef9b199ef8b93ba4.elb.us-west-2.amazonaws.com
  	                    	  CloudProvider: aws
  	                    	  ClusterName: peter-ipv6.k8s.local
  	                    	...


  LaunchTemplate/nodes-us-west-2a.peter-rifel-ipv6.k8s.local
  	UserData
  	                    	...
  	                    	  APIServerIPs:
  	                    	  - 172.20.5.248
  	                    	+ - 2600:1f14:1800:ab02:ba1a:4b60:b424:d3f3
  	                    	+ - api-peter-ipv6-k8s--k283sk-ef9b199ef8b93ba4.elb.us-west-2.amazonaws.com
  	                    	  CloudProvider: aws
  	                    	  ClusterName: peter-ipv6.k8s.local
  	                    	...
  	                    	    servers:
  	                    	    - https://172.20.5.248:3988/
  	                    	+   - https://[2600:1f14:1800:ab02:ba1a:4b60:b424:d3f3]:3988/
  	                    	+   - https://api-peter-ipv6-k8s--k283sk-ef9b199ef8b93ba4.elb.us-west-2.amazonaws.com:3988/
  	                    	  InstanceGroupName: nodes-us-west-2a
  	                    	  InstanceGroupRole: Node
  	                    	...


Must specify --yes to apply changes
```

Marking this as draft because its possible we could find a better approach, and because this may break other cluster configurations
