### PR TITLE
Discover a bastion load balancer and use it for dumping artifacts

### DIFF
--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -211,10 +211,18 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 		}
 
 		// look for a bastion instance and use it if exists
+		// Prefer a bastion load balancer if exists
 		bastionAddress := ""
-		for _, instance := range d.Instances {
-			if strings.Contains(instance.Name, "bastion") {
-				bastionAddress = instance.PublicAddresses[0]
+		for _, lb := range d.LoadBalancers {
+			if strings.Contains(lb.Name, "bastion") && lb.DNSName != "" {
+				bastionAddress = lb.DNSName
+			}
+		}
+		if bastionAddress == "" {
+			for _, instance := range d.Instances {
+				if strings.Contains(instance.Name, "bastion") {
+					bastionAddress = instance.PublicAddresses[0]
+				}
 			}
 		}
 		dumper := dump.NewLogDumper(bastionAddress, sshConfig, keyRing, options.Dir)

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -1502,6 +1502,14 @@ func DumpELB(op *resources.DumpOperation, r *resources.Resource) error {
 	data["type"] = TypeLoadBalancer
 	data["raw"] = r.Obj
 	op.Dump.Resources = append(op.Dump.Resources, data)
+
+	if lb, ok := r.Obj.(elbv2types.LoadBalancer); ok {
+		op.Dump.LoadBalancers = append(op.Dump.LoadBalancers, &resources.LoadBalancer{
+			Name:    fi.ValueOf(lb.LoadBalancerName),
+			DNSName: fi.ValueOf(lb.DNSName),
+		})
+
+	}
 	return nil
 }
 

--- a/pkg/resources/dumpmodel.go
+++ b/pkg/resources/dumpmodel.go
@@ -25,6 +25,11 @@ type Instance struct {
 	SSHUser          string   `json:"sshUser,omitempty"`
 }
 
+type LoadBalancer struct {
+	Name    string `json:"name,omitempty"`
+	DNSName string `json:"dnsName,omitempty"`
+}
+
 // Subnet is the type for an subnetwork in a dump
 type Subnet struct {
 	ID   string `json:"id,omitempty"`
@@ -38,8 +43,9 @@ type VPC struct {
 
 // Dump is the type for a dump result
 type Dump struct {
-	Resources []interface{} `json:"resources,omitempty"`
-	Instances []*Instance   `json:"instances,omitempty"`
-	Subnets   []*Subnet     `json:"subnets,omitempty"`
-	VPC       *VPC          `json:"vpc,omitempty"`
+	Resources     []interface{}   `json:"resources,omitempty"`
+	Instances     []*Instance     `json:"instances,omitempty"`
+	LoadBalancers []*LoadBalancer `json:"loadBalancers,omitempty"`
+	Subnets       []*Subnet       `json:"subnets,omitempty"`
+	VPC           *VPC            `json:"vpc,omitempty"`
 }


### PR DESCRIPTION
Currently the e2e prow jobs for ipv6 clusters can't fetch artifacts:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-cni-cilium-ipv6/1832137312717246464#1:build-log.txt%3A1954

In my local testing, I can't reach the bastion host directly but can SSH through the bastion NLB that targets the instance. This adds support in `kops toolbox dump` to use the bastion NLB if it exists.