### PR TITLE
Conditionally set TF aws_s3_object SSE and ACLs

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -131,7 +131,7 @@ func (d *deployer) initialize() error {
 	klog.V(1).Infof("Using SSH user: [%s]", d.SSHUser)
 
 	if d.TerraformVersion != "" {
-		t, err := target.NewTerraform(d.TerraformVersion)
+		t, err := target.NewTerraform(d.TerraformVersion, d.ArtifactsDir)
 		if err != nil {
 			return err
 		}

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -752,9 +752,13 @@ func (p *S3Path) RenderTerraform(w *terraformWriter.TerraformWriter, name string
 			Bucket:   p.Bucket(),
 			Key:      p.Key(),
 			Content:  content,
-			SSE:      &sseVal,
-			Acl:      &aclVal,
 			Provider: terraformWriter.LiteralTokens("aws", "files"),
+		}
+		if sseVal != "" {
+			tf.SSE = &sseVal
+		}
+		if aclVal != "" {
+			tf.Acl = &aclVal
 		}
 		return w.RenderResource("aws_s3_object", name, tf)
 	}


### PR DESCRIPTION
We used to set SSE to an empty string, now we leave it unset. This should fix [this failing job](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-scenario-ipv6-terraform/1831834061656559616). 

```
[31m│ [31mError: expected server_side_encryption to be one of ["AES256" "aws:kms" "aws:kms:dsse"], got 
[31m│ 
[31m│   with aws_s3_object.cluster-completed-spec,
[31m│   on kubernetes.tf line 1104, in resource "aws_s3_object" "cluster-completed-spec":
[31m│ 1104:   server_side_encryption = ""
[31m│ 
[31m╵
[31m│ [31mError: expected acl to be one of ["private" "public-read" "public-read-write" "authenticated-read" "aws-exec-read" "bucket-owner-read" "bucket-owner-full-control"], got 
[31m│ 
[31m│   with aws_s3_object.e2e-e2e-kops-scenario-ipv6-terraform-test-cncf-aws-k8s-io-addons-bootstrap,
[31m│   on kubernetes.tf line 1135, in resource "aws_s3_object" "e2e-e2e-kops-scenario-ipv6-terraform-test-cncf-aws-k8s-io-addons-bootstrap":
[31m│ 1135:   acl                    = ""
[31m│  
```

Also attempting to keep the generated terraform files in job artifacts for easier troubleshooting.