### PR TITLE
Skip some GCP in-tree e2e tests

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -137,15 +137,20 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|should.be.mountable.when.non-attachable"
 		// The in-tree driver and its E2E tests use `topology.kubernetes.io/zone` but the CSI driver uses `topology.gke.io/zone`
 		skipRegex += "|In-tree.Volumes.\\[Driver:.gcepd\\].*topology.should.provision.a.volume.and.schedule.a.pod.with.AllowedTopologies"
-	}
 
-	if cluster.Spec.LegacyCloudProvider == "gce" {
 		// this tests assumes a custom config for containerd:
 		// https://github.com/kubernetes/test-infra/blob/578d86a7be187214be6ccd60e6ea7317b51aeb15/jobs/e2e_node/containerd/config.toml#L19-L21
 		// ref: https://github.com/kubernetes/kubernetes/pull/104803
 		skipRegex += "|RuntimeClass.should.run"
 		// https://github.com/kubernetes/kubernetes/pull/108694
 		skipRegex += "|Metadata.Concealment"
+
+		if k8sVersion.Minor >= 31 {
+			// Most e2e framework code for the in-tree provider has been removed but some test cases remain
+			// https://github.com/kubernetes/kubernetes/pull/124519
+			// https://github.com/kubernetes/test-infra/pull/33222
+			skipRegex += "\\[sig-cloud-provider-gcp\\]"
+		}
 	}
 
 	if k8sVersion.Minor >= 22 {


### PR DESCRIPTION
Most GCP in-tree e2e code has been removed, see https://github.com/kubernetes/kubernetes/pull/124519/files#diff-dea92b851e7b09eb22ffa0bcb0e7ccf58684dbc6a4dc0e06be0fb25d9967002c
`test/e2e/framework/providers/gce/gce.go`

However there are still a few test cases that only run on GCP and fail because the e2e framework no longer implements the in-tree functionality. 

```
   I0909 22:43:44.814983 15305 resize_nodes.go:152] Unexpected error: 
      <*errors.errorString | 0xc0011db630>: 
      Provider does not support InstanceGroups
      {
          s: "Provider does not support InstanceGroups",
      } 
```

https://github.com/kubernetes/kubernetes/blob/0aea469b96a1c0fed48dd2d4a0af96d36e24968c/test/e2e/cloud/gcp/resize_nodes.go#L68-L79

https://github.com/kubernetes/kubernetes/blob/7f9a0ef5d2b0ae5e27d008a9225fb04b3a86b694/test/e2e/framework/providers/gce/gce.go#L27-L29

https://github.com/kubernetes/kubernetes/blob/7f9a0ef5d2b0ae5e27d008a9225fb04b3a86b694/test/e2e/framework/provider.go#L124-L127

Fixes these failing jobs:

https://testgrid.k8s.io/kops-gce#ci-kubernetes-e2e-cos-gce-disruptive-canary
https://testgrid.k8s.io/kops-gce#ci-kubernetes-e2e-cos-gce-reboot-canary

/cc @hakman @dims

@dims the second job above only runs tests that will now be skipped, can we delete that job altogether?