### PR TITLE
Resolve golangci-lint warnings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,6 @@
 run:
   timeout: 30m
-  skip-files:
-  - "^zz_generated.*"
+  go: "1.22"
 
 issues:
   max-same-issues: 0
@@ -11,6 +10,8 @@ issues:
   - path: conversion\.go
     linters:
     - ineffassign
+  exclude-files:
+  - "^zz_generated.*"
 
 linters:
   disable-all: true
@@ -22,7 +23,6 @@ linters:
 
 linters-settings: # please keep this alphabetized
   staticcheck:
-    go: "1.20"
     checks: [
       "all",
       "-ST1000",  # Incorrect or missing package comment


### PR DESCRIPTION
```
WARN [config_reader] The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`. 
WARN [config_reader] The configuration option `linters.staticcheck.go` is deprecated, please use global `run.go`. 
```

Also bumping the go version 1.20 -> 1.22