### PR TITLE
protokube: remove unused internal IP discovery, add metal support

### DIFF
--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -149,14 +149,10 @@ func run() error {
 		}
 		cloudProvider = scwCloudProvider
 
+	} else if cloud == "metal" {
+		cloudProvider = nil
 	} else {
 		klog.Errorf("Unknown cloud %q", cloud)
-		os.Exit(1)
-	}
-
-	internalIP := cloudProvider.InstanceInternalIP()
-	if internalIP == nil {
-		klog.Errorf("Cannot determine internal IP")
 		os.Exit(1)
 	}
 
@@ -182,6 +178,10 @@ func run() error {
 	protokube.RootFS = rootfs
 
 	if gossip {
+		if cloudProvider == nil {
+			return fmt.Errorf("gossip not supported with cloudprovider %q", cloud)
+		}
+
 		dnsTarget := &gossipdns.HostsFile{
 			Path: path.Join(rootfs, "etc/hosts"),
 		}
@@ -244,7 +244,6 @@ func run() error {
 		NodeName:                  nodeName,
 		Channels:                  channels,
 		InternalDNSSuffix:         dnsInternalSuffix,
-		InternalIP:                internalIP,
 		Kubernetes:                protokube.NewKubernetesContext(),
 		Master:                    master,
 	}

--- a/protokube/pkg/gossip/azure/client.go
+++ b/protokube/pkg/gossip/azure/client.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"strings"
 
@@ -128,22 +127,6 @@ func (c *Client) GetName() string {
 // GetTags returns the tags of the VM queried from Instance Metadata Service.
 func (c *Client) GetTags() (map[string]string, error) {
 	return c.metadata.Compute.GetTags()
-}
-
-// GetInternalIP returns the internal IP of the VM queried from Instance Metadata Service.
-// This function returns nil if no internal IP is found.
-func (c *Client) GetInternalIP() net.IP {
-	for _, iface := range c.metadata.Network.Interfaces {
-		if iface.IPv4 == nil {
-			continue
-		}
-		for _, ipAddr := range iface.IPv4.IPAddresses {
-			if a := ipAddr.PrivateIPAddress; a != "" {
-				return net.ParseIP(a)
-			}
-		}
-	}
-	return nil
 }
 
 // ListVMScaleSets returns VM ScaleSets in the resource group.

--- a/protokube/pkg/gossip/azure/client_test.go
+++ b/protokube/pkg/gossip/azure/client_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"net"
 	"os"
 	"reflect"
 	"testing"
@@ -64,23 +63,5 @@ func TestUnmarshalMetadata(t *testing.T) {
 	}
 	if a, e := ipAddrs[0].PublicIPAddress, "52.136.124.5"; a != e {
 		t.Errorf("expected public IP address %s, but got %s", e, a)
-	}
-}
-
-func TestGetInternalIP(t *testing.T) {
-	data, err := os.ReadFile("testdata/metadata.json")
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	metadata, err := unmarshalInstanceMetadata(data)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	c := Client{
-		metadata: metadata,
-	}
-
-	if a, e := c.GetInternalIP(), net.ParseIP("172.16.32.8"); !a.Equal(e) {
-		t.Errorf("expected internal address %s, but got %s", e, a)
 	}
 }

--- a/protokube/pkg/protokube/aws_volume.go
+++ b/protokube/pkg/protokube/aws_volume.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -42,7 +41,6 @@ type AWSCloudProvider struct {
 	deviceMap  map[string]string
 	ec2        ec2.DescribeInstancesAPIClient
 	instanceId string
-	internalIP net.IP
 	imdsClient *imds.Client
 	zone       string
 }
@@ -98,10 +96,6 @@ func NewAWSCloudProvider() (*AWSCloudProvider, error) {
 	return a, nil
 }
 
-func (a *AWSCloudProvider) InstanceInternalIP() net.IP {
-	return a.internalIP
-}
-
 func (a *AWSCloudProvider) discoverTags(ctx context.Context) error {
 	instance, err := a.describeInstance(ctx)
 	if err != nil {
@@ -119,14 +113,6 @@ func (a *AWSCloudProvider) discoverTags(ctx context.Context) error {
 	}
 
 	a.clusterTag = clusterID
-
-	a.internalIP = net.ParseIP(aws.ToString(instance.Ipv6Address))
-	if a.internalIP == nil {
-		a.internalIP = net.ParseIP(aws.ToString(instance.PrivateIpAddress))
-	}
-	if a.internalIP == nil {
-		return fmt.Errorf("Internal IP not found on this instance (%q)", a.instanceId)
-	}
 
 	return nil
 }

--- a/protokube/pkg/protokube/azure_volume.go
+++ b/protokube/pkg/protokube/azure_volume.go
@@ -19,7 +19,6 @@ package protokube
 import (
 	"context"
 	"fmt"
-	"net"
 
 	compute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
@@ -33,7 +32,6 @@ type client interface {
 	ListVMSSNetworkInterfaces(ctx context.Context, vmScaleSetName string) ([]*network.Interface, error)
 	GetName() string
 	GetTags() (map[string]string, error)
-	GetInternalIP() net.IP
 }
 
 var _ client = &gossipazure.Client{}
@@ -44,7 +42,6 @@ type AzureCloudProvider struct {
 
 	clusterTag string
 	instanceID string
-	internalIP net.IP
 }
 
 var _ CloudProvider = &AzureCloudProvider{}
@@ -68,26 +65,16 @@ func NewAzureCloudProvider() (*AzureCloudProvider, error) {
 	if instanceID == "" {
 		return nil, fmt.Errorf("empty name")
 	}
-	internalIP := client.GetInternalIP()
-	if internalIP == nil {
-		return nil, fmt.Errorf("error querying internal IP")
-	}
 	return &AzureCloudProvider{
 		client:     client,
 		clusterTag: clusterTag,
 		instanceID: instanceID,
-		internalIP: internalIP,
 	}, nil
 }
 
 // InstanceID implements CloudProvider InstanceID.
 func (a *AzureCloudProvider) InstanceID() string {
 	return a.instanceID
-}
-
-// InstanceInternalIP implements CloudProvider InstanceInternalIP.
-func (a *AzureCloudProvider) InstanceInternalIP() net.IP {
-	return a.internalIP
 }
 
 // GossipSeeds implements CloudProvider GossipSeeds.

--- a/protokube/pkg/protokube/do_volume.go
+++ b/protokube/pkg/protokube/do_volume.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -55,7 +54,6 @@ type DOCloudProvider struct {
 	region      string
 	dropletName string
 	dropletID   int
-	dropletIP   net.IP
 	dropletTags []string
 }
 
@@ -102,12 +100,6 @@ func NewDOCloudProvider() (*DOCloudProvider, error) {
 		return nil, fmt.Errorf("failed to convert droplet ID to int: %s", err)
 	}
 
-	dropletIPStr, err := getMetadata(dropletInternalIPMetadataURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get droplet ip: %s", err)
-	}
-	dropletIP := net.ParseIP(dropletIPStr)
-
 	dropletName, err := getMetadataDropletName()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get droplet name: %s", err)
@@ -132,7 +124,6 @@ func NewDOCloudProvider() (*DOCloudProvider, error) {
 		godoClient:  godoClient,
 		ClusterID:   clusterID,
 		dropletID:   dropletID,
-		dropletIP:   dropletIP,
 		dropletName: dropletName,
 		region:      region,
 		dropletTags: dropletTags,
@@ -200,10 +191,6 @@ func (d *DOCloudProvider) GossipSeeds() (gossip.SeedProvider, error) {
 
 func (d *DOCloudProvider) InstanceID() string {
 	return d.dropletName
-}
-
-func (d *DOCloudProvider) InstanceInternalIP() net.IP {
-	return d.dropletIP
 }
 
 func getMetadataRegion() (string, error) {

--- a/protokube/pkg/protokube/gce_volume.go
+++ b/protokube/pkg/protokube/gce_volume.go
@@ -18,7 +18,6 @@ package protokube
 
 import (
 	"fmt"
-	"net"
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
@@ -38,7 +37,6 @@ type GCECloudProvider struct {
 	region       string
 	clusterName  string
 	instanceName string
-	internalIP   net.IP
 }
 
 var _ CloudProvider = &GCECloudProvider{}
@@ -66,11 +64,6 @@ func NewGCECloudProvider() (*GCECloudProvider, error) {
 // Project returns the current GCE project
 func (a *GCECloudProvider) Project() string {
 	return a.project
-}
-
-// InstanceInternalIP implements CloudProvider InstanceInternalIP
-func (a *GCECloudProvider) InstanceInternalIP() net.IP {
-	return a.internalIP
 }
 
 func (a *GCECloudProvider) discoverTags() error {
@@ -114,22 +107,6 @@ func (a *GCECloudProvider) discoverTags() error {
 			return fmt.Errorf("instance name metadata was empty")
 		}
 		klog.Infof("Found instanceName=%q", a.instanceName)
-	}
-
-	// Internal IP
-	{
-		internalIP, err := metadata.InternalIP()
-		if err != nil {
-			return fmt.Errorf("error querying InternalIP from GCE: %v", err)
-		}
-		if internalIP == "" {
-			return fmt.Errorf("InternalIP from metadata was empty")
-		}
-		a.internalIP = net.ParseIP(internalIP)
-		if a.internalIP == nil {
-			return fmt.Errorf("InternalIP from metadata was not parseable(%q)", internalIP)
-		}
-		klog.Infof("Found internalIP=%q", a.internalIP)
 	}
 
 	return nil

--- a/protokube/pkg/protokube/hetzner_volume.go
+++ b/protokube/pkg/protokube/hetzner_volume.go
@@ -19,7 +19,6 @@ package protokube
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
@@ -34,7 +33,6 @@ import (
 type HetznerCloudProvider struct {
 	hcloudClient *hcloud.Client
 	server       *hcloud.Server
-	serverIP     net.IP
 }
 
 var _ CloudProvider = &HetznerCloudProvider{}
@@ -77,14 +75,9 @@ func NewHetznerCloudProvider() (*HetznerCloudProvider, error) {
 	h := &HetznerCloudProvider{
 		hcloudClient: hcloudClient,
 		server:       server,
-		serverIP:     server.PrivateNet[0].IP,
 	}
 
 	return h, nil
-}
-
-func (h HetznerCloudProvider) InstanceInternalIP() net.IP {
-	return h.serverIP
 }
 
 func (h *HetznerCloudProvider) GossipSeeds() (gossip.SeedProvider, error) {

--- a/protokube/pkg/protokube/kube_boot.go
+++ b/protokube/pkg/protokube/kube_boot.go
@@ -19,7 +19,6 @@ package protokube
 import (
 	"context"
 	"fmt"
-	"net"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,8 +34,6 @@ type KubeBoot struct {
 	Channels []string
 	// InternalDNSSuffix is the dns zone we are living in
 	InternalDNSSuffix string
-	// InternalIP is the internal ip address of the node
-	InternalIP net.IP
 	// Kubernetes holds a kubernetes client
 	Kubernetes *KubernetesContext
 	// Master indicates we are a master node

--- a/protokube/pkg/protokube/volumes.go
+++ b/protokube/pkg/protokube/volumes.go
@@ -17,13 +17,10 @@ limitations under the License.
 package protokube
 
 import (
-	"net"
-
 	"k8s.io/kops/protokube/pkg/gossip"
 )
 
 type CloudProvider interface {
 	InstanceID() string
-	InstanceInternalIP() net.IP
 	GossipSeeds() (gossip.SeedProvider, error)
 }


### PR DESCRIPTION
Metal support is basically a stub, but should be sufficient as we are
now only using the cloud provider in gossip mode (and metal does not
use gossip).
