### PR TITLE
metal: copy static manifests to the control plane

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -80,6 +80,18 @@ type StaticManifest struct {
 
 	// The static manifest will only be applied to instances matching the specified role
 	Roles []kops.InstanceGroupRole
+
+	// Contents is the contents of the manifest, which may be easier than fetching it from Path
+	Contents []byte
+}
+
+func (m *StaticManifest) AppliesToRole(role kops.InstanceGroupRole) bool {
+	for _, r := range m.Roles {
+		if r == role {
+			return true
+		}
+	}
+	return false
 }
 
 // ImageAsset models an image's location.

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -62,9 +62,10 @@ func (b *KubeApiserverBuilder) Build(c *fi.CloudupModelBuilderContext) error {
 	})
 
 	b.AssetBuilder.StaticManifests = append(b.AssetBuilder.StaticManifests, &assets.StaticManifest{
-		Key:   key,
-		Path:  location,
-		Roles: []kops.InstanceGroupRole{kops.InstanceGroupRoleControlPlane, kops.InstanceGroupRoleAPIServer},
+		Key:      key,
+		Path:     location,
+		Contents: manifestYAML,
+		Roles:    []kops.InstanceGroupRole{kops.InstanceGroupRoleControlPlane, kops.InstanceGroupRoleAPIServer},
 	})
 	return nil
 }

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -399,14 +399,7 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 	}
 
 	for _, manifest := range n.assetBuilder.StaticManifests {
-		match := false
-		for _, r := range manifest.Roles {
-			if r == role {
-				match = true
-			}
-		}
-
-		if !match {
+		if !manifest.AppliesToRole(role) {
 			continue
 		}
 


### PR DESCRIPTION
Used by the kube-apiserver healthcheck.
