### PR TITLE
refactor: remove unused keystore parameter

### DIFF
--- a/pkg/model/awsmodel/oidc_provider.go
+++ b/pkg/model/awsmodel/oidc_provider.go
@@ -24,7 +24,6 @@ import (
 // OIDCProviderBuilder configures IAM OIDC Provider
 type OIDCProviderBuilder struct {
 	*AWSModelContext
-	KeyStore  fi.Keystore
 	Lifecycle fi.Lifecycle
 }
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -581,7 +581,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 				&awsmodel.SSHKeyModelBuilder{AWSModelContext: awsModelContext, Lifecycle: securityLifecycle},
 				&awsmodel.NetworkModelBuilder{AWSModelContext: awsModelContext, Lifecycle: networkLifecycle},
 				&awsmodel.IAMModelBuilder{AWSModelContext: awsModelContext, Lifecycle: securityLifecycle, Cluster: cluster},
-				&awsmodel.OIDCProviderBuilder{AWSModelContext: awsModelContext, Lifecycle: securityLifecycle, KeyStore: keyStore},
+				&awsmodel.OIDCProviderBuilder{AWSModelContext: awsModelContext, Lifecycle: securityLifecycle},
 			)
 
 			awsModelBuilder := &awsmodel.AutoscalingGroupModelBuilder{


### PR DESCRIPTION
This keystore field was not used.  Refactor for clarity/simplicity.
