### PR TITLE
correct hubble tls file names as mapped from secret hubble-server-certs

### DIFF
--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -155,7 +155,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 0a96b2e9786d0cc7e87eff42a6b38e011a45cb6c485825aaa491034e2c7d631b
+    manifestHash: 8ddc25c69cac51e23be319400370ec6047fd919e9affce367e90f39214a9ac05
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -80,9 +80,9 @@ data:
   hubble-metrics: drop
   hubble-metrics-server: :9091
   hubble-socket-path: /var/run/cilium/hubble.sock
-  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/tls.crt
-  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/ca.crt
-  hubble-tls-key-file: /var/lib/cilium/tls/hubble/tls.key
+  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/server.crt
+  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/client-ca.crt
+  hubble-tls-key-file: /var/lib/cilium/tls/hubble/server.key
   identity-allocation-mode: crd
   identity-change-grace-period: 5s
   ingress-default-lb-mode: dedicated

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -328,9 +328,9 @@ data:
   # An additional address for Hubble server to listen to (e.g. ":4244").
   hubble-listen-address: ":4244"
   hubble-disable-tls: "false"
-  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/tls.crt
-  hubble-tls-key-file: /var/lib/cilium/tls/hubble/tls.key
-  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/ca.crt
+  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/server.crt
+  hubble-tls-key-file: /var/lib/cilium/tls/hubble/server.key
+  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/client-ca.crt
   {{ if .Hubble.Metrics }}
   hubble-metrics-server: ":9091"
   hubble-metrics:


### PR DESCRIPTION
I realized, that after upgrading to Kops master branch, the cilium-relay deployment was not ok.

Further analyzing brought me to https://github.com/cilium/cilium/issues/31516 where people say, there is a problem with dns, but not for me.

`hubble-relay` connects though `hubble-peer`-service to the hubble processes on port 4244.

But the problem was, that Hubble server inside cilium pods did not start, because the files mounted from `hubble-server-certs` have gotten a new name after upgrade to cilium 1.16.

`cilium status` inside cilium pod reported:
```
Hubble:                  Warning Server not initialized
```

while `hubble status` reported
```
Healthcheck (via unix:///var/run/cilium/hubble.sock): Ok
```
