### PR TITLE
Use a different bucket for pod-identity-webhook discovery store

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -331,6 +331,18 @@ func (d *deployer) stateStore() string {
 	return ss
 }
 
+// discoveryStore returns the VFS path to use for public OIDC documents
+func (d *deployer) discoveryStore() string {
+	discovery := os.Getenv("KOPS_DISCOVERY_STORE")
+	if discovery == "" {
+		switch d.CloudProvider {
+		case "aws":
+			discovery = "s3://k8s-kops-ci-prow"
+		}
+	}
+	return discovery
+}
+
 func (d *deployer) stagingStore() string {
 	sb := os.Getenv("KOPS_STAGING_BUCKET")
 	if sb == "" {

--- a/tests/e2e/kubetest2-kops/deployer/template.go
+++ b/tests/e2e/kubetest2-kops/deployer/template.go
@@ -79,6 +79,7 @@ func (d *deployer) templateValues(zones []string, publicIP string) (map[string]i
 		"kubernetesVersion": d.KubernetesVersion,
 		"publicIP":          publicIP,
 		"stateStore":        d.stateStore(),
+		"discoveryStore":    d.discoveryStore(),
 		"zones":             zones,
 		"sshPublicKey":      string(publicKey),
 	}, nil

--- a/tests/e2e/scenarios/podidentitywebhook/cluster.yaml.tmpl
+++ b/tests/e2e/scenarios/podidentitywebhook/cluster.yaml.tmpl
@@ -40,7 +40,7 @@ spec:
   podIdentityWebhook:
     enabled: true
   serviceAccountIssuerDiscovery:
-    discoveryStore: "{{.stateStore}}/{{.clusterName}}"
+    discoveryStore: "{{.discoveryStore}}/{{.clusterName}}"
     enableAWSOIDCProvider: true
   sshAccess:
     - {{.publicIP}}


### PR DESCRIPTION
This job is currently failing because its trying to reuse the kops state store for discovery documents and the state store s3 bucket doesn't support ACLs

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-pod-identity-webhook/1841974219194241024

`W1003 22:59:03.893406   14665 executor.go:141] error running task "ManagedFile/keys.json" (9m33s remaining to succeed): error creating ManagedFile "openid/v1/jwks": error writing s3://k8s-kops-ci-prow-state-store/e2e-49d63c55eb-ac683.tests-kops-aws.k8s.io/openid/v1/jwks (with ACL="public-read"): operation error S3: PutObject, https response error StatusCode: 400, RequestID: S4Q35EVQAWC6XCSQ, HostID: qwNOSCxjfBeio8cM845/Od/jn/d83NGKVOO8igAOXzUbe3fUUA4/ow51TSY9EBzBXEy2w8XXLnfTT97wRXocGg==, api error AccessControlListNotSupported: The bucket does not allow ACLs`

We have a separate bucket for public-read ACLs:

https://github.com/kubernetes/k8s.io/blob/35e7931e4042a437ec719bd56991fe46467e5f20/infra/aws/terraform/kops-infra-ci/main.tf#L49-L78

This updates the e2e job to use that new bucket.


---


As an aside, other e2e jobs use a different s3 bucket and I'm not sure which account it lives in but it seems to work:

https://github.com/kubernetes/test-infra/blob/9bd543de4b91a940ebe23b3e56fcc64c2aca1651/config/jobs/kubernetes/kops/build_jobs.py#L130-L133

If this pod identity webhook job is fixed by this change, I'll update the remaining e2e jobs to use this new bucket as well.