### PR TITLE
Prefix resource dump filenames with group

### DIFF
--- a/pkg/dump/resourcedumper.go
+++ b/pkg/dump/resourcedumper.go
@@ -58,7 +58,13 @@ type gvrNamespace struct {
 }
 
 func (d *gvrNamespace) String() string {
-	return path.Join(d.namespace, d.gvr.Resource)
+	var gr string
+	if d.gvr.Group == "" {
+		gr = d.gvr.Resource
+	} else {
+		gr = fmt.Sprintf("%v.%v", d.gvr.Group, d.gvr.Resource)
+	}
+	return path.Join(d.namespace, gr)
 }
 
 type resourceDumper struct {


### PR DESCRIPTION
Certain api services have conflicting Resource types, causing resource dumps to overwrite eachother. This ensures filenames remain unique by prefixing them with the api group.

Example: metrics-server installs an api service that as a `kind` of `NodeMetrics` but the resource name is `nodes`, causing the e2e resource dumps to not include node information:

https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-metrics-server/1841911807569039360/artifacts/cluster-info/nodes.yaml

https://github.com/kubernetes-sigs/metrics-server/blob/5a7a444dc27c0061e8c67417779aa344e1342c8f/pkg/api/install.go#L44-L54