### PR TITLE
Dont fail resource dump if not all APIs can be discovered

### DIFF
--- a/pkg/dump/resourcedumper.go
+++ b/pkg/dump/resourcedumper.go
@@ -111,7 +111,10 @@ func (d *resourceDumper) DumpResources(ctx context.Context) error {
 	}
 
 	resourceLists, err := discoveryClient.ServerPreferredResources()
-	if err != nil {
+	var discoveryErr *discovery.ErrGroupDiscoveryFailed
+	if errors.As(err, &discoveryErr) {
+		klog.Warningf("using incomplete list of API groups: %v", discoveryErr)
+	} else if err != nil {
 		return fmt.Errorf("listing server preferred resources: %w", err)
 	}
 


### PR DESCRIPTION
Some addons install their own APIServices:

https://github.com/kubernetes/kops/blob/7a43629a8e434c1b378c9160846bb98d3fff0e61/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template#L217-L237

These are recognized by `kops toolbox dump` to dump the resources served by this APIService.

If there is an issue with the pods behind the APIService, client-go will be unable to query the service for its resources.

When that happens, we should skip the API and continue.

Client-go makes this scenario easy to recognize:

https://github.com/kubernetes/kops/blob/3b5fa6fc3513102862eb7e6e698db16c9bd784f7/vendor/k8s.io/client-go/discovery/discovery_client.go#L512-L516


Example failure, there are no resources in [this job's](https://gcsweb.k8s.io/gcs/kubernetes-jenkins/pr-logs/pull/kops/16868/pull-kops-e2e-aws-upgrade-k129-ko129-to-klatest-kolatest-many-addons/1842523658468200448/artifacts/cluster-info/) artifacts and [the log](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/16868/pull-kops-e2e-aws-upgrade-k129-ko129-to-klatest-kolatest-many-addons/1842523658468200448#1:build-log.txt%3A4645) reports:

`W1005 11:46:53.962526   50016 toolbox_dump.go:244] error dumping resources: listing server preferred resources: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: stale GroupVersion discovery: metrics.k8s.io/v1beta1`