### PR TITLE
Ignore blackhole NAT routes

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -215,7 +215,7 @@ func findNatGatewayFromRouteTable(ctx context.Context, cloud awsup.AWSCloud, rou
 			var natGatewayIDs []*string
 			natGatewayIDsSeen := map[string]bool{}
 			for _, route := range rt.Routes {
-				if route.NatGatewayId != nil && !natGatewayIDsSeen[*route.NatGatewayId] {
+				if route.NatGatewayId != nil && route.State != ec2types.RouteStateBlackhole && !natGatewayIDsSeen[*route.NatGatewayId] {
 					natGatewayIDs = append(natGatewayIDs, route.NatGatewayId)
 					natGatewayIDsSeen[*route.NatGatewayId] = true
 				}


### PR DESCRIPTION
This should improve kops' handling of NAT gateways being deleted. If a NAT gateway is present in a route table and it is deleted, the route remains but with a state of `blackhole`. When kops discovers NAT gateways it discovers them via route table. This means a deleted NAT Gateway could still be recognized by kops, leading to 404s in subsequent API calls.

Now kops will ignore such NAT Gateways and should report needing to create a replacement. route.go will also correctly handle replacing the blackhole'd route in the route table.