### PR TITLE
Automated cherry pick of #16879: Ignore blackhole NAT routes
#16868: aws: Update VPC CNI to v1.18.5

### DIFF
--- a/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
+++ b/nodeup/pkg/model/networking/amazon-vpc-routed-eni.go
@@ -65,10 +65,10 @@ ManageForeignRoutingPolicyRules=no
 		})
 	}
 
-	// Running Amazon VPC CNI on Ubuntu 22.04 and later or any version of al2023 requires
+	// Running Amazon VPC CNI on Ubuntu 22.04 or any version of al2023 requires
 	// setting MACAddressPolicy to `none` (ref: https://github.com/aws/amazon-vpc-cni-k8s/issues/2103
 	// & https://github.com/kubernetes/kops/issues/16255)
-	if (b.Distribution.IsUbuntu() && b.Distribution.Version() >= 22.04) ||
+	if (b.Distribution.IsUbuntu() && b.Distribution.Version() == 22.04) ||
 		b.Distribution == distributions.DistributionAmazonLinux2023 {
 		contents := `
 [Match]

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 516820e30ab3bc0817c018c36ffd1841d5e6c53b553a0ddd8ae98d7d3779c0fc
+    manifestHash: a60a3c1fc05a99c395f58df484510bc606cddb3b7131f71da76d2ca85c882384
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -19,6 +19,40 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ENIConfig is the Schema for the eniconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ENIConfigSpec defines the desired state of ENIConfig
+            properties:
+              securityGroups:
+                items:
+                  type: string
+                type: array
+              subnet:
+                type: string
+            required:
+            - subnet
+            type: object
+          status:
+            description: ENIConfigStatus defines the observed state of ENIConfig
+            type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true
     served: true
@@ -275,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -300,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -317,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -398,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -422,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -498,10 +532,16 @@ spec:
           value: "false"
         - name: ENABLE_PREFIX_DELEGATION
           value: "false"
+        - name: ENABLE_SUBNET_DISCOVERY
+          value: "true"
+        - name: NETWORK_POLICY_ENFORCING_MODE
+          value: standard
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_PREFIX_TARGET
           value: "1"
+        - name: VPC_CNI_VERSION
+          value: v1.18.5
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -514,7 +554,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
         livenessProbe:
           exec:
             command:
@@ -561,6 +601,7 @@ spec:
         - --enable-network-policy=false
         - --enable-cloudwatch-logs=false
         - --enable-policy-event-logs=false
+        - --log-file=/var/log/aws-routed-eni/network-policy-agent.log
         - --metrics-bind-addr=:8162
         - --health-probe-bind-addr=:8163
         - --conntrack-cache-cleanup-period=300
@@ -570,7 +611,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -596,7 +637,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -631,6 +672,7 @@ spec:
         name: run-dir
       - hostPath:
           path: /run/xtables.lock
+          type: FileOrCreate
         name: xtables-lock
   updateStrategy:
     rollingUpdate:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 516820e30ab3bc0817c018c36ffd1841d5e6c53b553a0ddd8ae98d7d3779c0fc
+    manifestHash: a60a3c1fc05a99c395f58df484510bc606cddb3b7131f71da76d2ca85c882384
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -19,6 +19,40 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ENIConfig is the Schema for the eniconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ENIConfigSpec defines the desired state of ENIConfig
+            properties:
+              securityGroups:
+                items:
+                  type: string
+                type: array
+              subnet:
+                type: string
+            required:
+            - subnet
+            type: object
+          status:
+            description: ENIConfigStatus defines the observed state of ENIConfig
+            type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true
     served: true
@@ -275,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -300,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -317,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -398,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -422,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -498,10 +532,16 @@ spec:
           value: "false"
         - name: ENABLE_PREFIX_DELEGATION
           value: "false"
+        - name: ENABLE_SUBNET_DISCOVERY
+          value: "true"
+        - name: NETWORK_POLICY_ENFORCING_MODE
+          value: standard
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_PREFIX_TARGET
           value: "1"
+        - name: VPC_CNI_VERSION
+          value: v1.18.5
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -514,7 +554,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
         livenessProbe:
           exec:
             command:
@@ -561,6 +601,7 @@ spec:
         - --enable-network-policy=false
         - --enable-cloudwatch-logs=false
         - --enable-policy-event-logs=false
+        - --log-file=/var/log/aws-routed-eni/network-policy-agent.log
         - --metrics-bind-addr=:8162
         - --health-probe-bind-addr=:8163
         - --conntrack-cache-cleanup-period=300
@@ -570,7 +611,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -596,7 +637,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -631,6 +672,7 @@ spec:
         name: run-dir
       - hostPath:
           path: /run/xtables.lock
+          type: FileOrCreate
         name: xtables-lock
   updateStrategy:
     rollingUpdate:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -186,7 +186,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 516820e30ab3bc0817c018c36ffd1841d5e6c53b553a0ddd8ae98d7d3779c0fc
+    manifestHash: a60a3c1fc05a99c395f58df484510bc606cddb3b7131f71da76d2ca85c882384
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -19,6 +19,40 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ENIConfig is the Schema for the eniconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ENIConfigSpec defines the desired state of ENIConfig
+            properties:
+              securityGroups:
+                items:
+                  type: string
+                type: array
+              subnet:
+                type: string
+            required:
+            - subnet
+            type: object
+          status:
+            description: ENIConfigStatus defines the observed state of ENIConfig
+            type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true
     served: true
@@ -275,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -300,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -317,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -398,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -422,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -498,10 +532,16 @@ spec:
           value: "false"
         - name: ENABLE_PREFIX_DELEGATION
           value: "false"
+        - name: ENABLE_SUBNET_DISCOVERY
+          value: "true"
+        - name: NETWORK_POLICY_ENFORCING_MODE
+          value: standard
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_PREFIX_TARGET
           value: "1"
+        - name: VPC_CNI_VERSION
+          value: v1.18.5
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -514,7 +554,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
         livenessProbe:
           exec:
             command:
@@ -561,6 +601,7 @@ spec:
         - --enable-network-policy=false
         - --enable-cloudwatch-logs=false
         - --enable-policy-event-logs=false
+        - --log-file=/var/log/aws-routed-eni/network-policy-agent.log
         - --metrics-bind-addr=:8162
         - --health-probe-bind-addr=:8163
         - --conntrack-cache-cleanup-period=300
@@ -570,7 +611,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -596,7 +637,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -631,6 +672,7 @@ spec:
         name: run-dir
       - hostPath:
           path: /run/xtables.lock
+          type: FileOrCreate
         name: xtables-lock
   updateStrategy:
     rollingUpdate:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 84642ad9b609d8e6ce59cbd1bd599e9410416c1619f4734112e1b338c4c4b469
+    manifestHash: ee77d3d72012e12d7a6de39684564a252fcae05edc4ad0cdc5b81fdf43b5424b
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -19,6 +19,40 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ENIConfig is the Schema for the eniconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ENIConfigSpec defines the desired state of ENIConfig
+            properties:
+              securityGroups:
+                items:
+                  type: string
+                type: array
+              subnet:
+                type: string
+            required:
+            - subnet
+            type: object
+          status:
+            description: ENIConfigStatus defines the observed state of ENIConfig
+            type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true
     served: true
@@ -275,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -300,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -317,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -398,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -422,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -498,10 +532,16 @@ spec:
           value: "false"
         - name: ENABLE_PREFIX_DELEGATION
           value: "false"
+        - name: ENABLE_SUBNET_DISCOVERY
+          value: "true"
+        - name: NETWORK_POLICY_ENFORCING_MODE
+          value: standard
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_PREFIX_TARGET
           value: "1"
+        - name: VPC_CNI_VERSION
+          value: v1.18.5
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -561,6 +601,7 @@ spec:
         - --enable-network-policy=false
         - --enable-cloudwatch-logs=false
         - --enable-policy-event-logs=false
+        - --log-file=/var/log/aws-routed-eni/network-policy-agent.log
         - --metrics-bind-addr=:8162
         - --health-probe-bind-addr=:8163
         - --conntrack-cache-cleanup-period=300
@@ -631,6 +672,7 @@ spec:
         name: run-dir
       - hostPath:
           path: /run/xtables.lock
+          type: FileOrCreate
         name: xtables-lock
   updateStrategy:
     rollingUpdate:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -227,7 +227,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 99cef59107f3517f28f5cb83b19066b9eac3a09491ba63628867298ce229cb10
+    manifestHash: ee9b99f490ec4f3bca1d8dc4bb14de9549621eddeb647a33655fcdebd18ff363
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -19,6 +19,40 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ENIConfig is the Schema for the eniconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ENIConfigSpec defines the desired state of ENIConfig
+            properties:
+              securityGroups:
+                items:
+                  type: string
+                type: array
+              subnet:
+                type: string
+            required:
+            - subnet
+            type: object
+          status:
+            description: ENIConfigStatus defines the observed state of ENIConfig
+            type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true
     served: true
@@ -275,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -300,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -317,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -398,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -422,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -498,10 +532,16 @@ spec:
           value: "false"
         - name: ENABLE_PREFIX_DELEGATION
           value: "false"
+        - name: ENABLE_SUBNET_DISCOVERY
+          value: "true"
+        - name: NETWORK_POLICY_ENFORCING_MODE
+          value: standard
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_PREFIX_TARGET
           value: "1"
+        - name: VPC_CNI_VERSION
+          value: v1.18.5
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -514,7 +554,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: many-addons.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
         livenessProbe:
           exec:
             command:
@@ -561,6 +601,7 @@ spec:
         - --enable-network-policy=false
         - --enable-cloudwatch-logs=false
         - --enable-policy-event-logs=false
+        - --log-file=/var/log/aws-routed-eni/network-policy-agent.log
         - --metrics-bind-addr=:8162
         - --health-probe-bind-addr=:8163
         - --conntrack-cache-cleanup-period=300
@@ -570,7 +611,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -596,7 +637,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -631,6 +672,7 @@ spec:
         name: run-dir
       - hostPath:
           path: /run/xtables.lock
+          type: FileOrCreate
         name: xtables-lock
   updateStrategy:
     rollingUpdate:

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,4 +1,4 @@
-# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.18.1/config/master/aws-k8s-cni.yaml
+# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.18.5/config/master/aws-k8s-cni.yaml
 ---
 # Source: aws-vpc-cni/crds/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -17,6 +17,40 @@ spec:
         openAPIV3Schema:
           type: object
           x-kubernetes-preserve-unknown-fields: true
+          description: ENIConfig is the Schema for the eniconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ENIConfigSpec defines the desired state of ENIConfig
+              properties:
+                securityGroups:
+                  items:
+                    type: string
+                  type: array
+                subnet:
+                  type: string
+              required:
+              - subnet
+              type: object
+            status:
+              description: ENIConfigStatus defines the observed state of ENIConfig
+              type: object
   names:
     plural: eniconfigs
     singular: eniconfig
@@ -267,7 +301,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.18.1"
+    app.kubernetes.io/version: "v1.18.5"
 ---
 # Source: aws-vpc-cni/templates/configmap.yaml
 apiVersion: v1
@@ -279,7 +313,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.18.1"
+    app.kubernetes.io/version: "v1.18.5"
 data:
   enable-windows-ipam: "false"
   enable-network-policy-controller: "false"
@@ -298,7 +332,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.18.1"
+    app.kubernetes.io/version: "v1.18.5"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -351,7 +385,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.18.1"
+    app.kubernetes.io/version: "v1.18.5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -371,7 +405,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.18.1"
+    app.kubernetes.io/version: "v1.18.5"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -392,7 +426,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.1" }}"
+        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5" }}"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -417,7 +451,7 @@ spec:
 {{ end }}
       containers:
         - name: aws-node
-          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.1" }}"
+          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5" }}"
           ports:
             - containerPort: 61678
               name: metrics
@@ -482,6 +516,12 @@ spec:
             #   value: "false"
             # - name: ENABLE_PREFIX_DELEGATION
             #   value: "false"
+            # - name: ENABLE_SUBNET_DISCOVERY
+            #   value: "true"
+            # - name: NETWORK_POLICY_ENFORCING_MODE
+            #   value: "standard"
+            - name: VPC_CNI_VERSION
+              value: "v1.18.5"
             # - name: WARM_ENI_TARGET
             #   value: "1"
             # - name: WARM_PREFIX_TARGET
@@ -518,7 +558,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: "{{- or .Networking.AmazonVPC.NetworkPolicyAgentImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.1" }}"
+          image: "{{- or .Networking.AmazonVPC.NetworkPolicyAgentImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3" }}"
           env:
             - name: MY_NODE_NAME
               valueFrom:
@@ -530,6 +570,7 @@ spec:
             - --enable-network-policy=false
             - --enable-cloudwatch-logs=false
             - --enable-policy-event-logs=false
+            - --log-file=/var/log/aws-routed-eni/network-policy-agent.log
             - --metrics-bind-addr=:8162
             - --health-probe-bind-addr=:8163
             - --conntrack-cache-cleanup-period=300
@@ -571,6 +612,7 @@ spec:
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
+          type: FileOrCreate
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -215,7 +215,7 @@ func findNatGatewayFromRouteTable(ctx context.Context, cloud awsup.AWSCloud, rou
 			var natGatewayIDs []*string
 			natGatewayIDsSeen := map[string]bool{}
 			for _, route := range rt.Routes {
-				if route.NatGatewayId != nil && !natGatewayIDsSeen[*route.NatGatewayId] {
+				if route.NatGatewayId != nil && route.State != ec2types.RouteStateBlackhole && !natGatewayIDsSeen[*route.NatGatewayId] {
 					natGatewayIDs = append(natGatewayIDs, route.NatGatewayId)
 					natGatewayIDsSeen[*route.NatGatewayId] = true
 				}

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -255,6 +255,8 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 				"DISABLE_METRICS":                       "false",
 				"ENABLE_POD_ENI":                        "false",
 				"ENABLE_PREFIX_DELEGATION":              "false",
+				"ENABLE_SUBNET_DISCOVERY":               "true",
+				"NETWORK_POLICY_ENFORCING_MODE":         "standard",
 				"WARM_ENI_TARGET":                       "1",
 				"WARM_PREFIX_TARGET":                    "1",
 				"DISABLE_NETWORK_RESOURCE_PROVISIONING": "false",

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: b7529091597956c7c6cd180a395ab5e53280ce112711f7c80f56fa2d626909ee
+    manifestHash: 3eb56f832b8994963d7cadfba8cb580838945c943b3d7852fab2720fca9e27e8
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -19,6 +19,40 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ENIConfig is the Schema for the eniconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ENIConfigSpec defines the desired state of ENIConfig
+            properties:
+              securityGroups:
+                items:
+                  type: string
+                type: array
+              subnet:
+                type: string
+            required:
+            - subnet
+            type: object
+          status:
+            description: ENIConfigStatus defines the observed state of ENIConfig
+            type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true
     served: true
@@ -275,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -300,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -317,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -398,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -422,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -498,12 +532,18 @@ spec:
           value: "false"
         - name: ENABLE_PREFIX_DELEGATION
           value: "false"
+        - name: ENABLE_SUBNET_DISCOVERY
+          value: "true"
+        - name: NETWORK_POLICY_ENFORCING_MODE
+          value: standard
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_IP_TARGET
           value: "10"
         - name: WARM_PREFIX_TARGET
           value: "1"
+        - name: VPC_CNI_VERSION
+          value: v1.18.5
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -516,7 +556,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
         livenessProbe:
           exec:
             command:
@@ -563,6 +603,7 @@ spec:
         - --enable-network-policy=false
         - --enable-cloudwatch-logs=false
         - --enable-policy-event-logs=false
+        - --log-file=/var/log/aws-routed-eni/network-policy-agent.log
         - --metrics-bind-addr=:8162
         - --health-probe-bind-addr=:8163
         - --conntrack-cache-cleanup-period=300
@@ -572,7 +613,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -598,7 +639,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -633,6 +674,7 @@ spec:
         name: run-dir
       - hostPath:
           path: /run/xtables.lock
+          type: FileOrCreate
         name: xtables-lock
   updateStrategy:
     rollingUpdate:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: b7529091597956c7c6cd180a395ab5e53280ce112711f7c80f56fa2d626909ee
+    manifestHash: 3eb56f832b8994963d7cadfba8cb580838945c943b3d7852fab2720fca9e27e8
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -19,6 +19,40 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ENIConfig is the Schema for the eniconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ENIConfigSpec defines the desired state of ENIConfig
+            properties:
+              securityGroups:
+                items:
+                  type: string
+                type: array
+              subnet:
+                type: string
+            required:
+            - subnet
+            type: object
+          status:
+            description: ENIConfigStatus defines the observed state of ENIConfig
+            type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true
     served: true
@@ -275,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -300,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -317,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -398,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -422,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.1
+    app.kubernetes.io/version: v1.18.5
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -498,12 +532,18 @@ spec:
           value: "false"
         - name: ENABLE_PREFIX_DELEGATION
           value: "false"
+        - name: ENABLE_SUBNET_DISCOVERY
+          value: "true"
+        - name: NETWORK_POLICY_ENFORCING_MODE
+          value: standard
         - name: WARM_ENI_TARGET
           value: "1"
         - name: WARM_IP_TARGET
           value: "10"
         - name: WARM_PREFIX_TARGET
           value: "1"
+        - name: VPC_CNI_VERSION
+          value: v1.18.5
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -516,7 +556,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
         livenessProbe:
           exec:
             command:
@@ -563,6 +603,7 @@ spec:
         - --enable-network-policy=false
         - --enable-cloudwatch-logs=false
         - --enable-policy-event-logs=false
+        - --log-file=/var/log/aws-routed-eni/network-policy-agent.log
         - --metrics-bind-addr=:8162
         - --health-probe-bind-addr=:8163
         - --conntrack-cache-cleanup-period=300
@@ -572,7 +613,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -598,7 +639,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
         name: aws-vpc-cni-init
         resources:
           requests:
@@ -633,6 +674,7 @@ spec:
         name: run-dir
       - hostPath:
           path: /run/xtables.lock
+          type: FileOrCreate
         name: xtables-lock
   updateStrategy:
     rollingUpdate:


### PR DESCRIPTION
Cherry pick of #16879 #16868 on release-1.30.

#16879: Ignore blackhole NAT routes
#16868: aws: Update VPC CNI to v1.18.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```