### PR TITLE
Automated cherry pick of #16879: Ignore blackhole NAT routes

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -212,7 +212,7 @@ func findNatGatewayFromRouteTable(cloud awsup.AWSCloud, routeTable *RouteTable) 
 			var natGatewayIDs []*string
 			natGatewayIDsSeen := map[string]bool{}
 			for _, route := range rt.Routes {
-				if route.NatGatewayId != nil && !natGatewayIDsSeen[*route.NatGatewayId] {
+				if route.NatGatewayId != nil && route.State != ec2types.RouteStateBlackhole && !natGatewayIDsSeen[*route.NatGatewayId] {
 					natGatewayIDs = append(natGatewayIDs, route.NatGatewayId)
 					natGatewayIDsSeen[*route.NatGatewayId] = true
 				}

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -212,7 +212,7 @@ func findNatGatewayFromRouteTable(cloud awsup.AWSCloud, routeTable *RouteTable) 
 			var natGatewayIDs []*string
 			natGatewayIDsSeen := map[string]bool{}
 			for _, route := range rt.Routes {
-				if route.NatGatewayId != nil && route.State != ec2types.RouteStateBlackhole && !natGatewayIDsSeen[*route.NatGatewayId] {
+				if route.NatGatewayId != nil && (route.State == nil || *route.State != ec2.LocalGatewayRouteStateBlackhole) && !natGatewayIDsSeen[*route.NatGatewayId] {
 					natGatewayIDs = append(natGatewayIDs, route.NatGatewayId)
 					natGatewayIDsSeen[*route.NatGatewayId] = true
 				}


### PR DESCRIPTION
Cherry pick of #16879 on release-1.29.

#16879: Ignore blackhole NAT routes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```