### PR TITLE
Skip all us-west-1 zones

### DIFF
--- a/tests/e2e/kubetest2-kops/aws/zones.go
+++ b/tests/e2e/kubetest2-kops/aws/zones.go
@@ -77,9 +77,10 @@ var allZones = []string{
 	"us-east-2a",
 	"us-east-2b",
 	"us-east-2c",
-	"us-west-1a",
-	"us-west-1b",
-	//"us-west-1c", AZ does not exist, so we're breaking the 3 AZs per region target here
+	// Newer accounts don't have us-west-1c and one other zone is constrained so we ignore the entire region
+	//"us-west-1a",
+	//"us-west-1b",
+	//"us-west-1c",
 	"us-west-2a",
 	"us-west-2b",
 	"us-west-2c",


### PR DESCRIPTION
Before the migration to community-owned accounts we were skipping the one constrained zone in the old AWS account. Now we run in multiple accounts depending on the prow cluster, and they have different zone mappings. Rather than identify the problematic zone by API call we just skip the us-west-1 zones altogether.

Should prevent this flake: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-k129-ko129-to-k130-kolatest/1844488150970273792

```
W1010 21:23:23.992379   14719 aws_cloud.go:2384] cannot find suitable instance type
W1010 21:23:23.992399   14719 aws_cloud.go:2386]   *  instance type "t3.medium" is not available in all zones (available in zones map[:{} us-west-1a:{} us-west-1c:{}], need [us-west-1b])
W1010 21:23:23.992403   14719 aws_cloud.go:2386]   *  instance type "c5.large" is not available in all zones (available in zones map[:{} us-west-1a:{} us-west-1c:{}], need [us-west-1b])
W1010 21:23:23.992405   14719 aws_cloud.go:2386]   *  instance type "c4.large" is not available in all zones (available in zones map[:{} us-west-1a:{} us-west-1c:{}], need [us-west-1b])
W1010 21:23:23.992407   14719 aws_cloud.go:2386]   *  instance type "t4g.medium" does not match image architecture "x86_64"
Error: error assigning default machine type for nodes: error finding default machine type: could not find a suitable supported instance type for the instance group "nodes-us-west-1b" (type "Node") in region "us-west-1"
Error: exit status 1 
```