### PR TITLE
Automated cherry pick of #16887: Fix awsup default and DescribeTag max retries

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -63,7 +63,7 @@ import (
 	"k8s.io/kops/util/pkg/awsinterfaces"
 )
 
-// By default, aws-sdk-go only retries 3 times, which doesn't give
+// By default, aws-sdk-go-v2 only retries 3 times, which doesn't give
 // much time for exponential backoff to work for serious issues. At 13
 // retries, we'll try a given request for up to ~6m with exponential
 // backoff along the way.
@@ -268,7 +268,11 @@ func loadAWSConfig(ctx context.Context, region string) (aws.Config, error) {
 		awsconfig.WithClientLogMode(aws.LogRetries),
 		awsconfig.WithLogger(awsLogger{}),
 		awsconfig.WithRetryer(func() aws.Retryer {
-			return retry.NewAdaptiveMode()
+			return retry.NewAdaptiveMode(func(ao *retry.AdaptiveModeOptions) {
+				ao.StandardOptions = append(ao.StandardOptions, func(so *retry.StandardOptions) {
+					so.MaxAttempts = ClientMaxRetries
+				})
+			})
 		}),
 	}
 
@@ -1260,7 +1264,9 @@ func getTags(c AWSCloud, resourceID string) (map[string]string, error) {
 	for {
 		attempt++
 
-		response, err := c.EC2().DescribeTags(ctx, request)
+		response, err := c.EC2().DescribeTags(ctx, request, func(o *ec2.Options) {
+			o.RetryMaxAttempts = DescribeTagsMaxAttempts
+		})
 		if err != nil {
 			if isTagsEventualConsistencyError(err) {
 				if attempt > DescribeTagsMaxAttempts {


### PR DESCRIPTION
Cherry pick of #16887 on release-1.30.

#16887: Fix awsup default and DescribeTag max retries

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```