### PR TITLE
doc:fix broken link

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5360,7 +5360,7 @@ spec:
                           metrics:
                             description: |-
                               Metrics is a list of metrics to collect. If empty or null, metrics are disabled.
-                              See https://docs.cilium.io/en/stable/configuration/metrics/#hubble-exported-metrics
+                              See https://docs.cilium.io/en/stable/observability/metrics/#hubble-exported-metrics
                             items:
                               type: string
                             type: array

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -536,7 +536,7 @@ type HubbleSpec struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Metrics is a list of metrics to collect. If empty or null, metrics are disabled.
-	// See https://docs.cilium.io/en/stable/configuration/metrics/#hubble-exported-metrics
+	// See https://docs.cilium.io/en/stable/observability/metrics/#hubble-exported-metrics
 	Metrics []string `json:"metrics,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -657,7 +657,7 @@ type HubbleSpec struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Metrics is a list of metrics to collect. If empty or null, metrics are disabled.
-	// See https://docs.cilium.io/en/stable/configuration/metrics/#hubble-exported-metrics
+	// See https://docs.cilium.io/en/stable/observability/metrics/#hubble-exported-metrics
 	Metrics []string `json:"metrics,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -499,7 +499,7 @@ type HubbleSpec struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Metrics is a list of metrics to collect. If empty or null, metrics are disabled.
-	// See https://docs.cilium.io/en/stable/configuration/metrics/#hubble-exported-metrics
+	// See https://docs.cilium.io/en/stable/observability/metrics/#hubble-exported-metrics
 	Metrics []string `json:"metrics,omitempty"`
 }
 


### PR DESCRIPTION
## Context

The image below shows the broken link that has been updated: ![image](https://github.com/user-attachments/assets/c3ecc00a-5bf8-46df-a9ab-58b01f5efd47)
And the correct link is:  https://docs.cilium.io/en/stable/observability/metrics/#hubble-exported-metrics

Example of the change in code: [networking.go#L539](https://github.com/kubernetes/kops/blob/master/pkg/apis/kops/networking.go#L539).

Other references that were verified:

[clusters.yaml#L5363](https://github.com/kubernetes/kops/blob/master/k8s/crds/kops.k8s.io_clusters.yaml#L5363)
[v1alpha2/networking.go#L660](https://github.com/kubernetes/kops/blob/master/pkg/apis/kops/v1alpha2/networking.go#L660)
[v1alpha3/networking.go#L502](https://github.com/kubernetes/kops/blob/master/pkg/apis/kops/v1alpha3/networking.go#L502)
