### PR TITLE
fix: allow path-remapping in `set` commands

### DIFF
--- a/pkg/apis/kops/fieldmap.go
+++ b/pkg/apis/kops/fieldmap.go
@@ -27,6 +27,12 @@ func HumanPathForClusterField(fieldPath string) string {
 	return f.HumanPath()
 }
 
+// InternalPathForClusterField returns the path for a given cluster field, as it appears in the internal API.
+func InternalPathForClusterField(fieldPath string) string {
+	f := NewClusterField(fieldPath)
+	return f.InternalPath()
+}
+
 // ClusterField represents a field in the Cluster resource.
 // +k8s:deepcopy-gen=false
 type ClusterField struct {
@@ -41,6 +47,11 @@ func NewClusterField(path string) *ClusterField {
 // HumanPath returns the path for the field, as we should print it for users.
 func (f *ClusterField) HumanPath() string {
 	return f.PathInV1Alpha2()
+}
+
+// InternalPath returns the path for the field, as it appears in the internal API.
+func (f *ClusterField) InternalPath() string {
+	return f.PathInV1Alpha3()
 }
 
 // PathInV1Alpha2 returns the path for the field in the v1alpha2 API.

--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -35,6 +35,8 @@ func SetClusterFields(fields []string, cluster *api.Cluster) error {
 		key := kv[0]
 		key = strings.TrimPrefix(key, "cluster.")
 
+		key = api.InternalPathForClusterField(key)
+
 		if err := reflectutils.SetString(cluster, key, kv[1]); err != nil {
 			return err
 		}


### PR DESCRIPTION
We remap field paths to their internal forms, where the mapping is well-known.
