### PR TITLE
docs: remove reference to old EnableExternalDNS feature flag

### DIFF
--- a/docs/advanced/experimental.md
+++ b/docs/advanced/experimental.md
@@ -6,7 +6,6 @@ Enable experimental features with:
 
 The following experimental features are currently available:
 
-* `+EnableExternalDNS` - Enable external-dns with default settings (ingress sources only).
 * `+VPCSkipEnableDNSSupport` - Enables creation of a VPC that does not need DNSSupport enabled.
 * `+EnableSeparateConfigBase` - Allow a config-base that is different from the state store.
 * `+ExperimentalClusterDNS` - Turns off validation of the kubelet cluster dns flag.


### PR DESCRIPTION
This was removed a while ago.
