### PR TITLE
chore: add a few more field mappings to our list

### DIFF
--- a/pkg/apis/kops/fieldmap.go
+++ b/pkg/apis/kops/fieldmap.go
@@ -80,4 +80,6 @@ var clusterFieldMappings = []struct {
 	V1Alpha3 string
 }{
 	{V1Alpha2: "spec.masterPublicName", V1Alpha3: "spec.api.publicName"},
+	{V1Alpha2: "spec.topology.dns.type", V1Alpha3: "spec.networking.topology.dns"},
+	{V1Alpha2: "spec.externalDns.provider", V1Alpha3: "spec.externalDNS.provider"},
 }


### PR DESCRIPTION
I encountered a few more that have changed between v1alpha2 and v1alpha3.
