### PR TITLE
Automated cherry pick of #16909: Use a different healthcheck port for AWS CSI controller

### DIFF
--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0f358b977cafae024aa70d0e97f8e1e9d3f8f2c359934d5f4fbea4d38371e9ab
+    manifestHash: a5b98b0e1567802e86a0acdf40915643d41f06db609e2f66a702b0cb3e2deb5f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,6 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9838f5a9f209b821bf3a81778e13a84c40ee76e1f958816c7e8f917994b147e8
+    manifestHash: 708673cced95a78d0fe1558035c0ecf42831c03909f5a5c87260b9a3152ba812
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 51ab8c8dc3403f0ed85796119f90eb17155cec61fe5008e379fdf3f3e1938e7d
+    manifestHash: 29e5d90b768b96358405830bfddefcbeb5021a5f61a9f5d7337a3ca9958c4e43
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 8af45b143af39fa63a161e4c918ff5a53adb8db08a8e0e3c24dd60fc1c250898
+    manifestHash: 39cef94908b236f6655a56e658a5c8ce7482e02a8f467f12889798838b7d9997
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6707680a1f273f492fa28c86ef6e7e4c32d004e4cffc7d440b368d00f7a1c2c1
+    manifestHash: 67fe4767a73c3d6991847705e6a4e108b845598a4e866b9c54a43cdd18ea6680
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 18ea1fb3998898c50cc4b029175ebed57f76a2813d70693b8dcb018e1c481a68
+    manifestHash: 17fd795c56753c4281d8df073380a638403e4aee10fd68dada5c356bf9488264
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 3171a819cfe7be27935b9d86528eb60ccf7366f549211880df20020f55094132
+    manifestHash: 698ef91047a24ebef2e35f01dc5da5cb8e0c066c956b7bc3da03b8b1b0916d34
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e439f0c4ed55b12da88dcfaddfc1929015042d53c7d20b529ea4f1635416fe84
+    manifestHash: b32426417f7de6a078379f6552c9c3a07a196f62a9b5452bafd8d0d476abe14a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e439f0c4ed55b12da88dcfaddfc1929015042d53c7d20b529ea4f1635416fe84
+    manifestHash: b32426417f7de6a078379f6552c9c3a07a196f62a9b5452bafd8d0d476abe14a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: db3946d46326378f5e433d055a65ab8b393a9c35ee5d325700a0c837e298f1ce
+    manifestHash: 4c9851cc0526e3121d831d8bdd93b40a84492b409f39e736baf902cfd49097c7
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 07b6b4ada11e5fc462104ef51aaaa435bffca9ed8f1f30bc28e2a1da179c0f6f
+    manifestHash: 5b97f53fb8cad34434eb9dd2c7b280c2e7d8e339dfeeaa9e146870bdfc9d9fe5
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 97f83992ed64cf4d43ac35326bb3e64b09a9ae441a635a60ad52fd506b294cfe
+    manifestHash: 89800bddb7b4cd673ccbb612a77c55ac8e41b5c84717adb634e42372c11384c4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,6 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9838f5a9f209b821bf3a81778e13a84c40ee76e1f958816c7e8f917994b147e8
+    manifestHash: 708673cced95a78d0fe1558035c0ecf42831c03909f5a5c87260b9a3152ba812
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bd552e66240106a7f5a0400c09c09eeb2eb8bd2ec7012d2be168d7600472935e
+    manifestHash: e12a90cfe11908aa8d48fb27562bf6242a3d13c1c7ade14304f43bcba73ceb74
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 72c581ea6b9f8e7a327c2a4fcca4fc628dfbb61a25833abe3780bbd4ff27b383
+    manifestHash: 3c639d6da7104f5e9f8d7b7eebb2e19b7d5b325447353f4eae05dae57592da7f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: baa00426a972730fc984b0dfe2a8a6a2fea57c8f204e9f286aa3a8f6d38d3cc0
+    manifestHash: 980c8d8add4062a91bfe4c3f22af939a7c501c99e7ab6ede5b047fc1ede6178a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,6 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9838f5a9f209b821bf3a81778e13a84c40ee76e1f958816c7e8f917994b147e8
+    manifestHash: 708673cced95a78d0fe1558035c0ecf42831c03909f5a5c87260b9a3152ba812
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1121,6 +1121,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -193,7 +193,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 36cafe1de69359b8ff8d4dd8772ded0837ab404e6b184f675518915ca30ed7e6
+    manifestHash: 1eb869764e6c608a046d589638dc389913c5a3428fb4ecdda7626b91550343d2
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1121,6 +1121,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -200,7 +200,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 36cafe1de69359b8ff8d4dd8772ded0837ab404e6b184f675518915ca30ed7e6
+    manifestHash: 1eb869764e6c608a046d589638dc389913c5a3428fb4ecdda7626b91550343d2
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1121,6 +1121,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -201,7 +201,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 36cafe1de69359b8ff8d4dd8772ded0837ab404e6b184f675518915ca30ed7e6
+    manifestHash: 1eb869764e6c608a046d589638dc389913c5a3428fb4ecdda7626b91550343d2
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -899,7 +899,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1081,6 +1081,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -193,7 +193,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 06a9b6cde944c4838b467849771f32657e60e0e6f8631e66a5bc8349a93cd4a7
+    manifestHash: 0cbdc7b57eccbde1cab112d2184c9503e1c955dec3e7fb9d3053f4ebbf385ed9
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1083,6 +1083,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -242,7 +242,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 42d982e2e4b754ef3dd055507ca5b5e8a5ac1610632f17233204a6deff0f0419
+    manifestHash: 9f986096669cb8c9a14f04bb6010506bea9cc81f1816b3549142e19b257e7013
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7efaf84918ff7c545fa639ea54b179839d3ccf77b61d19395f6ae6c3faffc2cf
+    manifestHash: ba71cbde24af4ef7fe7b2a96feb2839112780e3f89586e527c2cc98d54197c65
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bcf49fbdf2568c09e6c0f8fecf8c850c957c314a4c8cf0521c106b979922b08f
+    manifestHash: 6afb32b6f5ae929c5ec0d47ee7d3d4946d3987918cd648c03147dd08d3dc5933
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -905,7 +905,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1057,6 +1057,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -168,7 +168,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 3b3710900f6713f8076ad1a345cf409ecf39f536ff9e63ef00900a2716cb8ac7
+    manifestHash: de399ffc1c8a0803fd4442d1b4705af05063a459e6dab503cc0798eaa334dcb5
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -905,7 +905,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1057,6 +1057,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -121,7 +121,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 3b3710900f6713f8076ad1a345cf409ecf39f536ff9e63ef00900a2716cb8ac7
+    manifestHash: de399ffc1c8a0803fd4442d1b4705af05063a459e6dab503cc0798eaa334dcb5
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -905,7 +905,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1057,6 +1057,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 3b3710900f6713f8076ad1a345cf409ecf39f536ff9e63ef00900a2716cb8ac7
+    manifestHash: de399ffc1c8a0803fd4442d1b4705af05063a459e6dab503cc0798eaa334dcb5
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -905,7 +905,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1057,6 +1057,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 3b3710900f6713f8076ad1a345cf409ecf39f536ff9e63ef00900a2716cb8ac7
+    manifestHash: de399ffc1c8a0803fd4442d1b4705af05063a459e6dab503cc0798eaa334dcb5
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1ca448c816db001960176cda2c751f089bb497e4db6a0fc06d471e7a35138cb6
+    manifestHash: 2c037fd0dfcb4aab796bbbfd935b6cd766d1dd686547dfdd2fc6027669ee6769
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 230557f533c5f500e6349b50e4b62a38bff57f4d5bf590a377641d653cec2a10
+    manifestHash: 645d0938afbc9bc8cf14fb4ce2565b90eaa524046159d9090b883fc1582e1911
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9f3ae0789bae2a53882d6e849df7a1235a9f0c471ac16c5d0e5b9ddeebf4a1bd
+    manifestHash: 3bf6d5159feb604c7ac48508480b18040762b12db35af0075d2f1bee87807a10
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,6 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 07ba62c8931a7811d9c8f890ba007fd71c0d528e879f913b9bea1ad40856d7a7
+    manifestHash: a3ff813d36b15f0697c8d6454e7e075895c9ac6e3f931f1a819a57a48fd5e3b2
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 02fba23f0bf118f373b2392d1d2b012cab47ff0957d462b209f0f0d4ea323f5b
+    manifestHash: 953f7b54d0da96a955523210aac7151fd102447835de175a9dcc4e8f089e011a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 02fba23f0bf118f373b2392d1d2b012cab47ff0957d462b209f0f0d4ea323f5b
+    manifestHash: 953f7b54d0da96a955523210aac7151fd102447835de175a9dcc4e8f089e011a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,6 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -104,7 +104,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 5eb80d4a0452e499486949cbde34338f28fe63b0023c63c2eb6ccb646e6dc0d0
+    manifestHash: 53653dcc2ad09dbf1199f011770b821b7a0c8d08996b777c8da5fe5db7281252
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -104,7 +104,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: da77c1a21ee4b168ed63d59b3c404972d61e05192e4dadc8be60af54af6a5f0a
+    manifestHash: 6e38957d9f0df9e7ed6816d74f32644ba1744c099a9c7982f3489afddc5a4de0
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 14e26987f055b5c3d992aba41f24340d114b3c7479306a6b74177ecae66056a4
+    manifestHash: cb9d61e31f16c05f718131aa2408c68aef2fa4956feb02c71b2ba7569a27e3d1
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 099ace7aa9eea5504f98cec6a02fa2e7a7670a900d44ffdd9233dc1395740dc6
+    manifestHash: 0826603ac19bf719905db750280d18aaa28436da3227d92d1f873520622e415c
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -168,7 +168,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c6e42040133d5edf18610a3ca37fd81677fed236e90b1682cbc6de532640a7a6
+    manifestHash: 9c8a762c8db5c82dd367c5d7de0d90e11216fe86a1d1069171bb7a3423e6c694
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -168,7 +168,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a1559c6a80afbaf9edbce880ca232e59bb871555a90633241bd27e4de1c65303
+    manifestHash: edcb2f66a69b7da34dffc8a35412ba1106874eb601ab2748cc2dd570af833908
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 07b8668f63ccfa1587db48bbf86aa38c755243eedd7faf9e0735e9eda72de8df
+    manifestHash: 01ab3de240821688dd1532a496334dab16aa483386a38d1fbc8bc48776cfe847
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 07b8668f63ccfa1587db48bbf86aa38c755243eedd7faf9e0735e9eda72de8df
+    manifestHash: 01ab3de240821688dd1532a496334dab16aa483386a38d1fbc8bc48776cfe847
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -171,7 +171,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 07b8668f63ccfa1587db48bbf86aa38c755243eedd7faf9e0735e9eda72de8df
+    manifestHash: 01ab3de240821688dd1532a496334dab16aa483386a38d1fbc8bc48776cfe847
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: caf5bb44bf55a5c7907c8fbc8871910787b39d8fc04dd2d8e6e5e6340f49b387
+    manifestHash: 86bf1571fc243e7e79260d743e58a558cd8b0957fdb48446b5783380e9ca27fa
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 44ccb72c36c49bd2be0586dc2ab27a757b9ed94645491c4fde0beb09fe77b7b1
+    manifestHash: 7d0ccca0efb757cc1c8d68b84a5f44cf5eed10e12bbdf42b01282d7ce5469dc0
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 2fea612b75e1c6d2baad78e0c5ccbd29999249f7f586eefb103b8de41ffcc323
+    manifestHash: 583aea94faa01c10272612ab369b9219735f2cb574602ad412e18ffbbe88d652
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -164,7 +164,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 2253ab46a610ca01ea6eab6bed5dc477680dc38ba3aca64649c41330575c4dc8
+    manifestHash: 4d52310b3dcd33d3d4352d73aa74fff240dc5e41f1f073a6d776e014d506cd0e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -155,7 +155,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 46410aecf5f7897b460f7be7930415966d7f3da51b440a2a50d907423f22a77d
+    manifestHash: 7f015e0639c893075697428d2a3e8bf0bb62f5260a950e8cc3cd33bc013312ce
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,6 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9838f5a9f209b821bf3a81778e13a84c40ee76e1f958816c7e8f917994b147e8
+    manifestHash: 708673cced95a78d0fe1558035c0ecf42831c03909f5a5c87260b9a3152ba812
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 73668aca193df813fd164b262879623653f329ceed8c6b4739ea7edc837d67c3
+    manifestHash: 4cdc734018ea4d96008b291c9f8b66b1dfe829a5ea9e8cc74f919b6d9ffa4f69
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c4bf02dab50bbda5b505d69bc2f810df9e374290dd270fefcdb4707a8209ac4b
+    manifestHash: b9438dd3596adb168f5a439f47267f1264eab7a98311a89b18fc6d74525a909d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -905,7 +905,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1057,6 +1057,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 3b3710900f6713f8076ad1a345cf409ecf39f536ff9e63ef00900a2716cb8ac7
+    manifestHash: de399ffc1c8a0803fd4442d1b4705af05063a459e6dab503cc0798eaa334dcb5
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 5949cb5d18610da9642cf6c7df2ca74c81dbfceaa806bfd5c4be1c3f4d092d2a
+    manifestHash: 2957291e9d3919cb7b29396979eb46cbcf857f6e24aa5b38951fa82d3cdcad4d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9809
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,6 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c47461d072c7772cd3ba125f6c3480f451e79fdaa8e5c1dfe75539b6dc1d872
+    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -741,7 +741,7 @@ spec:
           mountPath: /var/lib/csi/sockets/pluginproxy/
         ports:
         - name: healthz
-          containerPort: 9808
+          containerPort: 9809
           protocol: TCP
         - name: metrics
           containerPort: 3301
@@ -932,6 +932,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --csi-address=/csi/csi.sock
+        - --http-endpoint=0.0.0.0:9809
         volumeMounts:
         - name: socket-dir
           mountPath: /csi

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c593ff221e831534d4d737cef416352a1b0e13d433554d3751c9ec7f92b26472
+    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c593ff221e831534d4d737cef416352a1b0e13d433554d3751c9ec7f92b26472
+    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c593ff221e831534d4d737cef416352a1b0e13d433554d3751c9ec7f92b26472
+    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c593ff221e831534d4d737cef416352a1b0e13d433554d3751c9ec7f92b26472
+    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c593ff221e831534d4d737cef416352a1b0e13d433554d3751c9ec7f92b26472
+    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c593ff221e831534d4d737cef416352a1b0e13d433554d3751c9ec7f92b26472
+    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c593ff221e831534d4d737cef416352a1b0e13d433554d3751c9ec7f92b26472
+    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -128,7 +128,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c593ff221e831534d4d737cef416352a1b0e13d433554d3751c9ec7f92b26472
+    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c593ff221e831534d4d737cef416352a1b0e13d433554d3751c9ec7f92b26472
+    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0a641fca7a974852b750a7aaf1dfe892466e9b4297f47a556a79ad079080fed3
+    manifestHash: d66a2070ecc72f8b94394d8ce7dc6f7165ec57ab65d8b82146391478e4ea02e3
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c593ff221e831534d4d737cef416352a1b0e13d433554d3751c9ec7f92b26472
+    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #16909 on release-1.30.

#16909: Use a different healthcheck port for AWS CSI controller

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```