### PR TITLE
Upgrade Cilium to v1.16.3

### DIFF
--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.16.2"
+		c.Version = "v1.16.3"
 	}
 
 	if c.EnableEndpointHealthChecking == nil {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -226,7 +226,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.16.2
+      version: v1.16.3
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: bb7751360889bc5bc3963dbe393b3c18674bc212cf4a8fed6e47ca5758cf8158
+    manifestHash: 0c83f79dd943a154662cf1734b14afd5b3f57f945e26f5805ea263fc9cd7c733
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -219,6 +219,14 @@ rules:
   - delete
 - apiGroups:
   - ""
+  resourceNames:
+  - cilium-config
+  resources:
+  - configmaps
+  verbs:
+  - patch
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -573,7 +581,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -691,7 +699,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -710,7 +718,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -737,7 +745,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -761,7 +769,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -796,7 +804,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -821,7 +829,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -984,7 +992,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.2
+        image: quay.io/cilium/operator:v1.16.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -153,7 +153,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal-warmpool.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 53DAgmSgxkT5LHbVOaS+ALQ9vJKa22trQltoyBX2Vho=
+NodeupConfigHash: hDw7GDccItBvn+jlc6WzJY9fsp/mwxeXHtMTGK8EWnY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -218,7 +218,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.2
+      version: v1.16.3
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: a6ae74358c641db5a5283506a053e73cbb4e4008036e4fb9274e8978d8f34317
+    manifestHash: e20102c57059c105762a9e526913d54064345c7a6f462bb194481df9491b9e09
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -220,6 +220,14 @@ rules:
   - delete
 - apiGroups:
   - ""
+  resourceNames:
+  - cilium-config
+  resources:
+  - configmaps
+  verbs:
+  - patch
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -574,7 +582,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -692,7 +700,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -711,7 +719,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -738,7 +746,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -762,7 +770,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -797,7 +805,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -822,7 +830,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -985,7 +993,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.2
+        image: quay.io/cilium/operator:v1.16.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
@@ -64,7 +64,7 @@ containerdConfig:
 usesLegacyGossip: false
 usesNoneDNS: false
 warmPoolImages:
-- quay.io/cilium/cilium:v1.16.2
-- quay.io/cilium/operator:v1.16.2
+- quay.io/cilium/cilium:v1.16.3
+- quay.io/cilium/operator:v1.16.3
 - registry.k8s.io/kube-proxy:v1.26.0
 - registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.12

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
@@ -199,7 +199,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.2
+      version: v1.16.3
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://tests/scw-minimal.k8s.local/secrets

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: b69c067f22f597071237cf1fe1f3c0ebca9f76da1f3546b5e8e7fcc13e6f0c6b
+    manifestHash: 54bfa4260f0111b78afdae9dd0cded3f0cbb815b3f3104cbfbf71347edd96a4a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
@@ -220,6 +220,14 @@ rules:
   - delete
 - apiGroups:
   - ""
+  resourceNames:
+  - cilium-config
+  resources:
+  - configmaps
+  verbs:
+  - patch
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -574,7 +582,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -692,7 +700,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -711,7 +719,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -738,7 +746,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -762,7 +770,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -797,7 +805,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -822,7 +830,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -985,7 +993,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.2
+        image: quay.io/cilium/operator:v1.16.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -220,7 +220,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.16.2
+      version: v1.16.3
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: eacf36b5df00f8e7b3244ef7eb019b0f73365645f5da5ffcd6f5a372b8624811
+    manifestHash: cee3b0b1d69ab6822b004ccada95ae75a9964e5edab73b7b9ad7cec349e7313b
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -222,6 +222,14 @@ rules:
   - delete
 - apiGroups:
   - ""
+  resourceNames:
+  - cilium-config
+  resources:
+  - configmaps
+  verbs:
+  - patch
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -576,7 +584,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -719,7 +727,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -738,7 +746,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -765,7 +773,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -789,7 +797,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -824,7 +832,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -849,7 +857,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1012,7 +1020,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.2
+        image: quay.io/cilium/operator:v1.16.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -228,7 +228,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.2
+      version: v1.16.3
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: fbb9faf48eb988d099b42abacf6e6e42cd7b9406801acd24da68b00e95bdc099
+    manifestHash: e406ff605e0421c49f3fe01fa04f07928c341bc79a7d5fe71305a035d5f1d076
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -220,6 +220,14 @@ rules:
   - delete
 - apiGroups:
   - ""
+  resourceNames:
+  - cilium-config
+  resources:
+  - configmaps
+  verbs:
+  - patch
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -577,7 +585,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -695,7 +703,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -714,7 +722,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -741,7 +749,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -765,7 +773,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -800,7 +808,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -825,7 +833,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -992,7 +1000,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.2
+        image: quay.io/cilium/operator:v1.16.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -225,7 +225,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.2
+      version: v1.16.3
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -155,7 +155,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 4bcad9db74c02ba2eb263f0db9b5de89909c21a0da60ac61a67311c8880bf973
+    manifestHash: 9c423eebef5ac27defdcdff9c7024b33861adcbd62928c6a0c8a3db4b897cb69
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -301,6 +301,14 @@ rules:
   - delete
 - apiGroups:
   - ""
+  resourceNames:
+  - cilium-config
+  resources:
+  - configmaps
+  verbs:
+  - patch
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -828,7 +836,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -957,7 +965,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -976,7 +984,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -1003,7 +1011,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -1027,7 +1035,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -1062,7 +1070,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -1087,7 +1095,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1264,7 +1272,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.2
+        image: quay.io/cilium/operator:v1.16.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1368,7 +1376,7 @@ spec:
         - serve
         command:
         - hubble-relay
-        image: quay.io/cilium/hubble-relay:v1.16.2
+        image: quay.io/cilium/hubble-relay:v1.16.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 12
@@ -1462,10 +1470,16 @@ metadata:
 spec:
   dnsNames:
   - '*.privatecilium-example-com.hubble-grpc.cilium.io'
+  isCA: false
   issuerRef:
     kind: Issuer
     name: networking.cilium.io
   secretName: hubble-server-certs
+  usages:
+  - signing
+  - key encipherment
+  - server auth
+  - client auth
 
 ---
 
@@ -1484,11 +1498,14 @@ metadata:
 spec:
   dnsNames:
   - hubble-relay-client
+  isCA: false
   issuerRef:
     kind: Issuer
     name: networking.cilium.io
   secretName: hubble-relay-client-certs
   usages:
+  - signing
+  - key encipherment
   - client auth
 
 ---

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -232,7 +232,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.16.2
+      version: v1.16.3
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 0a6d718cca2c76fba60e1a5283e9486d713d3091c17a6c50b46021b9ed6ac2d1
+    manifestHash: 59dd2dba26c98808b12efde637d423130af3020d865de67b56bd9066c87c765f
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -232,6 +232,14 @@ rules:
   - delete
 - apiGroups:
   - ""
+  resourceNames:
+  - cilium-config
+  resources:
+  - configmaps
+  verbs:
+  - patch
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -586,7 +594,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -735,7 +743,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -754,7 +762,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -781,7 +789,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -805,7 +813,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -840,7 +848,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -865,7 +873,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.2
+        image: quay.io/cilium/cilium:v1.16.3
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1039,7 +1047,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.2
+        image: quay.io/cilium/operator:v1.16.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -508,6 +508,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  resourceNames:
+  - cilium-config
+  verbs:
+  # allow patching of the configmap to set annotations
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - list
@@ -1834,6 +1843,12 @@ spec:
     kind: Issuer
     name: networking.cilium.io
   secretName: hubble-server-certs
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - server auth
+    - client auth
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -1849,8 +1864,11 @@ spec:
   issuerRef:
     kind: Issuer
     name: networking.cilium.io
+  isCA: false
   usages:
-  - client auth
+    - signing
+    - key encipherment
+    - client auth
   secretName: hubble-relay-client-certs
 {{ end }}
 {{ end }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 91b14b96c511318fdd55d2fbb021209dd6bcd13882f081feb9bea7646769e60a
+    manifestHash: e36f5ab6a807e2ab12f741978b535f59927bf9618d3239ca9ed65af010838468
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 91b14b96c511318fdd55d2fbb021209dd6bcd13882f081feb9bea7646769e60a
+    manifestHash: e36f5ab6a807e2ab12f741978b535f59927bf9618d3239ca9ed65af010838468
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 91b14b96c511318fdd55d2fbb021209dd6bcd13882f081feb9bea7646769e60a
+    manifestHash: e36f5ab6a807e2ab12f741978b535f59927bf9618d3239ca9ed65af010838468
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
/hold
for https://github.com/kubernetes/test-infra/pull/33718 to land first. We'll use this PR to ensure latest-ci and latest-ci-updown-green are in a good state.