### PR TITLE
Automated cherry pick of #16560: Bump nvidia-driver-535-server

### DIFF
--- a/pkg/apis/kops/containerdconfig.go
+++ b/pkg/apis/kops/containerdconfig.go
@@ -22,7 +22,7 @@ import (
 )
 
 // NvidiaDefaultDriverPackage is the nvidia driver default version
-const NvidiaDefaultDriverPackage = "nvidia-headless-515-server"
+const NvidiaDefaultDriverPackage = "nvidia-driver-535-server"
 
 // ContainerdConfig is the configuration for containerd
 type ContainerdConfig struct {

--- a/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: l4FtWUtTLWOE+t6ihnjNQFlZ8dJgS72jriF14VKhZbM=
+NodeupConfigHash: cwyqCCFnssIV1nXXDLtK3tVr3SnKIehU+WPKtYlR4F0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nvidia/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/nvidia/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -153,7 +153,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: rM8udZ4cIZlKX3TKdddF0VCg76jbOn/ND8Nw81juaaU=
+NodeupConfigHash: hLayQK1LsL3zJl0yv83AKXFuUSkb7geBp0jtZbhHD/U=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
@@ -28,7 +28,7 @@ spec:
     logLevel: info
     nvidiaGPU:
       enabled: true
-      package: nvidia-headless-515-server
+      package: nvidia-driver-535-server
     runc:
       version: 1.1.5
     version: 1.6.20

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -315,7 +315,7 @@ Networking:
   serviceClusterIPRange: 100.64.0.0/13
 NvidiaGPU:
   enabled: true
-  package: nvidia-headless-515-server
+  package: nvidia-driver-535-server
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
@@ -326,7 +326,7 @@ containerdConfig:
   logLevel: info
   nvidiaGPU:
     enabled: true
-    package: nvidia-headless-515-server
+    package: nvidia-driver-535-server
   runc:
     version: 1.1.5
   version: 1.6.20

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-nodes_content
@@ -58,13 +58,13 @@ Networking:
   serviceClusterIPRange: 100.64.0.0/13
 NvidiaGPU:
   enabled: true
-  package: nvidia-headless-515-server
+  package: nvidia-driver-535-server
 UpdatePolicy: automatic
 containerdConfig:
   logLevel: info
   nvidiaGPU:
     enabled: true
-    package: nvidia-headless-515-server
+    package: nvidia-driver-535-server
   runc:
     version: 1.1.5
   version: 1.6.20


### PR DESCRIPTION
Cherry pick of #16560 on release-1.30.

#16560: Bump nvidia-driver-535-server

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```