### PR TITLE
Automated cherry pick of #16918: API Server: memory management related flags

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -586,14 +586,27 @@ spec:
     disableBasicAuth: true
 ```
 
-### targetRamMb
-
-Memory limit for apiserver in MB (used to configure sizes of caches, etc.)
+### watchCache
+Used to disable watch caching in the apiserver, defaults to enabling caching by omission
 
 ```yaml
 spec:
   kubeAPIServer:
-    targetRamMb: 4096
+    watchCache: false
+```
+
+### watchCacheSizes
+
+Set the watch-cache-sizes parameter for the apiserver
+The only currently useful value is setting to 0, which disable caches for specific object types.
+Setting any values other than 0 for a resource will yield no effect since the caches are dynamic
+
+```yaml
+spec:
+  kubeAPIServer:
+    watchCacheSizes: 
+      - secrets#0
+      - pods#0
 ```
 
 ### eventTTL
@@ -1585,7 +1598,6 @@ the removal of fields no longer in use.
 | kubeAPIServer.oidcRequiredClaim (list)                 | authentication.oidc.oidcRequiredClaims (map)                   |
 | kubeAPIServer.oidcUsernameClaim                        | authentication.oidc.usernameClaim                              |
 | kubeAPIServer.oidcUsernamePrefix                       | authentication.oidc.usernamePrefix                             |
-| kubeAPIServer.targetRamMb                              | kubeAPIServer.targetRamMB                                      |
 | kubeControllerManager.concurrentRcSyncs                | kubeControllerManager.concurrentRCSyncs                        |
 | kubelet.authenticationTokenWebhookCacheTtl             | kubelet.authenticationTokenWebhookCacheTTL                     |
 | kubelet.clientCaFile                                   | kubelet.clientCAFile                                           |

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2129,11 +2129,6 @@ spec:
                   storageBackend:
                     description: StorageBackend is the backend storage
                     type: string
-                  targetRamMb:
-                    description: Memory limit for apiserver in MB (used to configure
-                      sizes of caches, etc.)
-                    format: int32
-                    type: integer
                   tlsCertFile:
                     description: 'TODO: Remove unused TLSCertFile'
                     type: string
@@ -2152,6 +2147,18 @@ spec:
                   tokenAuthFile:
                     description: 'TODO: Remove unused TokenAuthFile'
                     type: string
+                  watchCache:
+                    description: Used to disable watch caching in the apiserver, defaults
+                      to enabling caching by omission
+                    type: boolean
+                  watchCacheSizes:
+                    description: |-
+                      Set the watch-cache-sizes parameter for the apiserver
+                      The only meaningful value is setting to 0, which disable caches for specific object types.
+                      Setting any values other than 0 for a resource will yield no effect since the caches are dynamic
+                    items:
+                      type: string
+                    type: array
                 type: object
               kubeControllerManager:
                 description: KubeControllerManagerConfig is the configuration for

--- a/nodeup/pkg/model/kube_apiserver_test.go
+++ b/nodeup/pkg/model/kube_apiserver_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/util/pkg/architectures"
+	"k8s.io/utils/pointer"
 )
 
 func Test_KubeAPIServer_BuildFlags(t *testing.T) {
@@ -92,9 +93,15 @@ func Test_KubeAPIServer_BuildFlags(t *testing.T) {
 		},
 		{
 			kops.KubeAPIServerConfig{
-				TargetRamMB: 320,
+				WatchCache: pointer.Bool(false),
 			},
-			"--secure-port=0 --target-ram-mb=320",
+			"--secure-port=0 --watch-cache=false",
+		},
+		{
+			kops.KubeAPIServerConfig{
+				WatchCacheSizes: []string{"secrets#0", "pods#0"},
+			},
+			"--secure-port=0 --watch-cache-sizes=secrets#0,pods#0",
 		},
 		{
 			kops.KubeAPIServerConfig{

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -487,8 +487,13 @@ type KubeAPIServerConfig struct {
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`
 
-	// Memory limit for apiserver in MB (used to configure sizes of caches, etc.)
-	TargetRamMB int32 `json:"targetRamMB,omitempty" flag:"target-ram-mb" flag-empty:"0"`
+	// Used to disable watch caching in the apiserver, defaults to enabling caching by omission
+	WatchCache *bool `json:"watchCache,omitempty" flag:"watch-cache"`
+
+	// Set the watch-cache-sizes parameter for the apiserver
+	// The only meaningful value is setting to 0, which disable caches for specific object types.
+	// Setting any values other than 0 for a resource will yield no effect since the caches are dynamic
+	WatchCacheSizes []string `json:"watchCacheSizes,omitempty" flag:"watch-cache-sizes" flag-empty:"0"`
 
 	// File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens.
 	// The specified file can contain multiple keys, and the flag can be specified multiple times with different files.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -494,8 +494,13 @@ type KubeAPIServerConfig struct {
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`
 
-	// Memory limit for apiserver in MB (used to configure sizes of caches, etc.)
-	TargetRamMB int32 `json:"targetRamMb,omitempty" flag:"target-ram-mb" flag-empty:"0"`
+	// Used to disable watch caching in the apiserver, defaults to enabling caching by omission
+	WatchCache *bool `json:"watchCache,omitempty" flag:"watch-cache"`
+
+	// Set the watch-cache-sizes parameter for the apiserver
+	// The only meaningful value is setting to 0, which disable caches for specific object types.
+	// Setting any values other than 0 for a resource will yield no effect since the caches are dynamic
+	WatchCacheSizes []string `json:"watchCacheSizes,omitempty" flag:"watch-cache-sizes" flag-empty:"0"`
 
 	// File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens.
 	// The specified file can contain multiple keys, and the flag can be specified multiple times with different files.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4953,7 +4953,8 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
-	out.TargetRamMB = in.TargetRamMB
+	out.WatchCache = in.WatchCache
+	out.WatchCacheSizes = in.WatchCacheSizes
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
 	out.ServiceAccountSigningKeyFile = in.ServiceAccountSigningKeyFile
 	out.ServiceAccountIssuer = in.ServiceAccountIssuer
@@ -5068,7 +5069,8 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
-	out.TargetRamMB = in.TargetRamMB
+	out.WatchCache = in.WatchCache
+	out.WatchCacheSizes = in.WatchCacheSizes
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
 	out.ServiceAccountSigningKeyFile = in.ServiceAccountSigningKeyFile
 	out.ServiceAccountIssuer = in.ServiceAccountIssuer

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3325,6 +3325,16 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.WatchCache != nil {
+		in, out := &in.WatchCache, &out.WatchCache
+		*out = new(bool)
+		**out = **in
+	}
+	if in.WatchCacheSizes != nil {
+		in, out := &in.WatchCacheSizes, &out.WatchCacheSizes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ServiceAccountKeyFile != nil {
 		in, out := &in.ServiceAccountKeyFile, &out.ServiceAccountKeyFile
 		*out = make([]string, len(*in))

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -485,8 +485,13 @@ type KubeAPIServerConfig struct {
 	// Currently only honored by the watch request handler
 	MinRequestTimeout *int32 `json:"minRequestTimeout,omitempty" flag:"min-request-timeout"`
 
-	// Memory limit for apiserver in MB (used to configure sizes of caches, etc.)
-	TargetRamMB int32 `json:"targetRamMB,omitempty" flag:"target-ram-mb" flag-empty:"0"`
+	// Used to disable watch caching in the apiserver, defaults to enabling caching by omission
+	WatchCache *bool `json:"watchCache,omitempty" flag:"watch-cache"`
+
+	// Set the watch-cache-sizes parameter for the apiserver
+	// The only meaningful value is setting to 0, which disable caches for specific object types.
+	// Setting any values other than 0 for a resource will yield no effect since the caches are dynamic
+	WatchCacheSizes []string `json:"watchCacheSizes,omitempty" flag:"watch-cache-sizes" flag-empty:"0"`
 
 	// File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens.
 	// The specified file can contain multiple keys, and the flag can be specified multiple times with different files.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5348,7 +5348,8 @@ func autoConvert_v1alpha3_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
-	out.TargetRamMB = in.TargetRamMB
+	out.WatchCache = in.WatchCache
+	out.WatchCacheSizes = in.WatchCacheSizes
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
 	out.ServiceAccountSigningKeyFile = in.ServiceAccountSigningKeyFile
 	out.ServiceAccountIssuer = in.ServiceAccountIssuer
@@ -5463,7 +5464,8 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha3_KubeAPIServerConfig(in *ko
 	out.EtcdQuorumRead = in.EtcdQuorumRead
 	out.RequestTimeout = in.RequestTimeout
 	out.MinRequestTimeout = in.MinRequestTimeout
-	out.TargetRamMB = in.TargetRamMB
+	out.WatchCache = in.WatchCache
+	out.WatchCacheSizes = in.WatchCacheSizes
 	out.ServiceAccountKeyFile = in.ServiceAccountKeyFile
 	out.ServiceAccountSigningKeyFile = in.ServiceAccountSigningKeyFile
 	out.ServiceAccountIssuer = in.ServiceAccountIssuer

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3299,6 +3299,16 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.WatchCache != nil {
+		in, out := &in.WatchCache, &out.WatchCache
+		*out = new(bool)
+		**out = **in
+	}
+	if in.WatchCacheSizes != nil {
+		in, out := &in.WatchCacheSizes, &out.WatchCacheSizes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ServiceAccountKeyFile != nil {
 		in, out := &in.ServiceAccountKeyFile, &out.ServiceAccountKeyFile
 		*out = make([]string, len(*in))

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3402,6 +3402,16 @@ func (in *KubeAPIServerConfig) DeepCopyInto(out *KubeAPIServerConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.WatchCache != nil {
+		in, out := &in.WatchCache, &out.WatchCache
+		*out = new(bool)
+		**out = **in
+	}
+	if in.WatchCacheSizes != nil {
+		in, out := &in.WatchCacheSizes, &out.WatchCacheSizes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ServiceAccountKeyFile != nil {
 		in, out := &in.ServiceAccountKeyFile, &out.ServiceAccountKeyFile
 		*out = make([]string, len(*in))


### PR DESCRIPTION
Cherry pick of #16918 on release-1.30.

#16918: Remove targetRamMb option, which was removed in kubernetes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```