### PR TITLE
feat(cilium): adding EnableLocalRedirectPolicy parameter

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5424,6 +5424,13 @@ spec:
                           EnableL7Proxy enables L7 proxy for L7 policy enforcement.
                           Default: true
                         type: boolean
+                      enableLocalRedirectPolicy:
+                        description: |-
+                          EnableLocalRedirectPolicy that enables pod traffic destined to an IP address and port/protocol
+                          tuple or Kubernetes service to be redirected locally to backend pod(s) within a node, using eBPF.
+                          https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/
+                          Default: false
+                        type: boolean
                       enableNodePort:
                         description: |-
                           EnableNodePort replaces kube-proxy with Cilium's BPF implementation.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -370,6 +370,11 @@ type CiliumNetworkingSpec struct {
 	// EnableL7Proxy enables L7 proxy for L7 policy enforcement.
 	// Default: true
 	EnableL7Proxy *bool `json:"enableL7Proxy,omitempty"`
+	// EnableLocalRedirectPolicy that enables pod traffic destined to an IP address and port/protocol
+	// tuple or Kubernetes service to be redirected locally to backend pod(s) within a node, using eBPF.
+	// https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/
+	// Default: false
+	EnableLocalRedirectPolicy *bool `json:"enableLocalRedirectPolicy,omitempty"`
 	// EnableBPFMasquerade enables masquerading packets from endpoints leaving the host with BPF instead of iptables.
 	// Default: false
 	EnableBPFMasquerade *bool `json:"enableBPFMasquerade,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -372,6 +372,11 @@ type CiliumNetworkingSpec struct {
 	// EnableL7Proxy enables L7 proxy for L7 policy enforcement.
 	// Default: true
 	EnableL7Proxy *bool `json:"enableL7Proxy,omitempty"`
+	// EnableLocalRedirectPolicy that enables pod traffic destined to an IP address and port/protocol
+	// tuple or Kubernetes service to be redirected locally to backend pod(s) within a node, using eBPF.
+	// https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/
+	// Default: false
+	EnableLocalRedirectPolicy *bool `json:"enableLocalRedirectPolicy,omitempty"`
 	// EnableBPFMasquerade enables masquerading packets from endpoints leaving the host with BPF instead of iptables.
 	// Default: false
 	EnableBPFMasquerade *bool `json:"enableBPFMasquerade,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1987,6 +1987,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	// INFO: in.DisableK8sServices opted out of conversion generation
 	out.EnablePolicy = in.EnablePolicy
 	out.EnableL7Proxy = in.EnableL7Proxy
+	out.EnableLocalRedirectPolicy = in.EnableLocalRedirectPolicy
 	out.EnableBPFMasquerade = in.EnableBPFMasquerade
 	out.EnableEndpointHealthChecking = in.EnableEndpointHealthChecking
 	// INFO: in.EnableTracing opted out of conversion generation
@@ -2098,6 +2099,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.DisableEndpointCRD = in.DisableEndpointCRD
 	out.EnablePolicy = in.EnablePolicy
 	out.EnableL7Proxy = in.EnableL7Proxy
+	out.EnableLocalRedirectPolicy = in.EnableLocalRedirectPolicy
 	out.EnableBPFMasquerade = in.EnableBPFMasquerade
 	out.EnableEndpointHealthChecking = in.EnableEndpointHealthChecking
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -603,6 +603,11 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableLocalRedirectPolicy != nil {
+		in, out := &in.EnableLocalRedirectPolicy, &out.EnableLocalRedirectPolicy
+		*out = new(bool)
+		**out = **in
+	}
 	if in.EnableBPFMasquerade != nil {
 		in, out := &in.EnableBPFMasquerade, &out.EnableBPFMasquerade
 		*out = new(bool)

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -333,6 +333,11 @@ type CiliumNetworkingSpec struct {
 	// EnableL7Proxy enables L7 proxy for L7 policy enforcement.
 	// Default: true
 	EnableL7Proxy *bool `json:"enableL7Proxy,omitempty"`
+	// EnableLocalRedirectPolicy that enables pod traffic destined to an IP address and port/protocol
+	// tuple or Kubernetes service to be redirected locally to backend pod(s) within a node, using eBPF.
+	// https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/
+	// Default: false
+	EnableLocalRedirectPolicy *bool `json:"enableLocalRedirectPolicy,omitempty"`
 	// EnableBPFMasquerade enables masquerading packets from endpoints leaving the host with BPF instead of iptables.
 	// Default: false
 	EnableBPFMasquerade *bool `json:"enableBPFMasquerade,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2157,6 +2157,7 @@ func autoConvert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.DisableEndpointCRD = in.DisableEndpointCRD
 	out.EnablePolicy = in.EnablePolicy
 	out.EnableL7Proxy = in.EnableL7Proxy
+	out.EnableLocalRedirectPolicy = in.EnableLocalRedirectPolicy
 	out.EnableBPFMasquerade = in.EnableBPFMasquerade
 	out.EnableEndpointHealthChecking = in.EnableEndpointHealthChecking
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
@@ -2233,6 +2234,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha3_CiliumNetworkingSpec(in *
 	out.DisableEndpointCRD = in.DisableEndpointCRD
 	out.EnablePolicy = in.EnablePolicy
 	out.EnableL7Proxy = in.EnableL7Proxy
+	out.EnableLocalRedirectPolicy = in.EnableLocalRedirectPolicy
 	out.EnableBPFMasquerade = in.EnableBPFMasquerade
 	out.EnableEndpointHealthChecking = in.EnableEndpointHealthChecking
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -642,6 +642,11 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableLocalRedirectPolicy != nil {
+		in, out := &in.EnableLocalRedirectPolicy, &out.EnableLocalRedirectPolicy
+		*out = new(bool)
+		**out = **in
+	}
 	if in.EnableBPFMasquerade != nil {
 		in, out := &in.EnableBPFMasquerade, &out.EnableBPFMasquerade
 		*out = new(bool)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -723,6 +723,11 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableLocalRedirectPolicy != nil {
+		in, out := &in.EnableLocalRedirectPolicy, &out.EnableLocalRedirectPolicy
+		*out = new(bool)
+		**out = **in
+	}
 	if in.EnableBPFMasquerade != nil {
 		in, out := &in.EnableBPFMasquerade, &out.EnableBPFMasquerade
 		*out = new(bool)

--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -139,6 +139,10 @@ func (b *CiliumOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 		c.EnableL7Proxy = fi.PtrTo(true)
 	}
 
+	if c.EnableLocalRedirectPolicy == nil {
+		c.EnableLocalRedirectPolicy = fi.PtrTo(false)
+	}
+
 	if c.DisableCNPStatusUpdates == nil {
 		c.DisableCNPStatusUpdates = fi.PtrTo(true)
 	}

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -212,6 +212,7 @@ spec:
       enableBPFMasquerade: false
       enableEndpointHealthChecking: true
       enableL7Proxy: true
+      enableLocalRedirectPolicy: false
       enableRemoteNodeIdentity: true
       enableUnreachableRoutes: false
       hubble:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 0c83f79dd943a154662cf1734b14afd5b3f57f945e26f5805ea263fc9cd7c733
+    manifestHash: 3dec2f27921f9e61bd722d058ec85a68e459d1fe3f09055ef9d8b03acf1a55dd
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -51,6 +51,7 @@ data:
   enable-ipv6: "true"
   enable-ipv6-masquerade: "false"
   enable-l7-proxy: "true"
+  enable-local-redirect-policy: "false"
   enable-node-port: "false"
   enable-remote-node-identity: "true"
   enable-service-topology: "false"

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -204,6 +204,7 @@ spec:
       enableBPFMasquerade: false
       enableEndpointHealthChecking: true
       enableL7Proxy: true
+      enableLocalRedirectPolicy: false
       enableRemoteNodeIdentity: true
       enableUnreachableRoutes: false
       hubble:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: e20102c57059c105762a9e526913d54064345c7a6f462bb194481df9491b9e09
+    manifestHash: bc7f7e8765ce60f4a51faa622445f05312d6f6ff5c2cdae2bbc2b7fdaabf35fa
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -51,6 +51,7 @@ data:
   enable-ipv6: "false"
   enable-ipv6-masquerade: "false"
   enable-l7-proxy: "true"
+  enable-local-redirect-policy: "false"
   enable-node-port: "false"
   enable-remote-node-identity: "true"
   enable-service-topology: "false"

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
@@ -184,6 +184,7 @@ spec:
       enableBPFMasquerade: false
       enableEndpointHealthChecking: true
       enableL7Proxy: true
+      enableLocalRedirectPolicy: false
       enableNodePort: true
       enableRemoteNodeIdentity: true
       enableUnreachableRoutes: false

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 54bfa4260f0111b78afdae9dd0cded3f0cbb815b3f3104cbfbf71347edd96a4a
+    manifestHash: b09e39b605118cc04f98b48d24b0fa6c88487b04a0108574a61692c222f68e1b
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
@@ -51,6 +51,7 @@ data:
   enable-ipv6: "false"
   enable-ipv6-masquerade: "false"
   enable-l7-proxy: "true"
+  enable-local-redirect-policy: "false"
   enable-node-port: "true"
   enable-remote-node-identity: "true"
   enable-service-topology: "false"

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -206,6 +206,7 @@ spec:
       enableBPFMasquerade: true
       enableEndpointHealthChecking: true
       enableL7Proxy: true
+      enableLocalRedirectPolicy: false
       enableRemoteNodeIdentity: true
       enableUnreachableRoutes: false
       hubble:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: cee3b0b1d69ab6822b004ccada95ae75a9964e5edab73b7b9ad7cec349e7313b
+    manifestHash: f7612a95ce7e6eb6c7f4aff40ef362372345b45c4697b46ef78f5518d279e566
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -53,6 +53,7 @@ data:
   enable-ipv6: "false"
   enable-ipv6-masquerade: "false"
   enable-l7-proxy: "true"
+  enable-local-redirect-policy: "false"
   enable-node-port: "false"
   enable-remote-node-identity: "true"
   enable-service-topology: "false"

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -210,6 +210,7 @@ spec:
       enableBPFMasquerade: false
       enableEndpointHealthChecking: true
       enableL7Proxy: true
+      enableLocalRedirectPolicy: false
       enableRemoteNodeIdentity: true
       enableUnreachableRoutes: false
       hubble:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: e406ff605e0421c49f3fe01fa04f07928c341bc79a7d5fe71305a035d5f1d076
+    manifestHash: 36722e061be4bc322c060c5b28ebe41678b94361e32327bf652b53ef316972f0
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -51,6 +51,7 @@ data:
   enable-ipv6: "false"
   enable-ipv6-masquerade: "false"
   enable-l7-proxy: "true"
+  enable-local-redirect-policy: "false"
   enable-node-port: "false"
   enable-remote-node-identity: "true"
   enable-service-topology: "false"

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -204,6 +204,7 @@ spec:
       enableBPFMasquerade: false
       enableEndpointHealthChecking: true
       enableL7Proxy: true
+      enableLocalRedirectPolicy: false
       enableRemoteNodeIdentity: true
       enableUnreachableRoutes: false
       hubble:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -155,7 +155,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 9c423eebef5ac27defdcdff9c7024b33861adcbd62928c6a0c8a3db4b897cb69
+    manifestHash: ac9d01d0a3554b4774f2fd65840adaaae75b8512fcba39a487b80741e99de7c1
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -69,6 +69,7 @@ data:
   enable-ipv6: "false"
   enable-ipv6-masquerade: "false"
   enable-l7-proxy: "true"
+  enable-local-redirect-policy: "false"
   enable-node-port: "false"
   enable-remote-node-identity: "true"
   enable-service-topology: "false"

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -216,6 +216,7 @@ spec:
       enableBPFMasquerade: true
       enableEndpointHealthChecking: true
       enableL7Proxy: true
+      enableLocalRedirectPolicy: false
       enableNodePort: true
       enableRemoteNodeIdentity: true
       enableUnreachableRoutes: false

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 59dd2dba26c98808b12efde637d423130af3020d865de67b56bd9066c87c765f
+    manifestHash: 8c601006d81de04e5d79a68f6bb155eb0ef45ca3d53305dbc2c0a1d458092426
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -53,6 +53,7 @@ data:
   enable-ipv6: "false"
   enable-ipv6-masquerade: "false"
   enable-l7-proxy: "true"
+  enable-local-redirect-policy: "false"
   enable-node-port: "true"
   enable-remote-node-identity: "true"
   enable-service-topology: "false"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -279,6 +279,10 @@ data:
   # enable-l7-proxy enables L7 proxy for L7 policy enforcement. (default true)
   enable-l7-proxy: "{{ .EnableL7Proxy }}"
 
+  # enable-local-redirect-policy EnableLocalRedirectPolicy that enables pod traffic destined to an IP address and port/protocol
+  # tuple or Kubernetes service to be redirected locally to backend pod(s) within a node, using eBPF. (default false)
+  enable-local-redirect-policy: "{{ .EnableLocalRedirectPolicy }}"
+
   cgroup-root: /run/cilium/cgroupv2
 
   disable-cnp-status-updates: "{{ .DisableCNPStatusUpdates }}"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: e36f5ab6a807e2ab12f741978b535f59927bf9618d3239ca9ed65af010838468
+    manifestHash: 45bddd141fefbbd61619eb858684854c1a4a92239f00098495ff97fe97201aef
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: e36f5ab6a807e2ab12f741978b535f59927bf9618d3239ca9ed65af010838468
+    manifestHash: 45bddd141fefbbd61619eb858684854c1a4a92239f00098495ff97fe97201aef
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: e36f5ab6a807e2ab12f741978b535f59927bf9618d3239ca9ed65af010838468
+    manifestHash: 45bddd141fefbbd61619eb858684854c1a4a92239f00098495ff97fe97201aef
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
## Context

This PR adds the EnableLocalRedirectPolicy parameter to the Cilium spec in kOps, allowing optional activation of the Local Redirect Policy.