### PR TITLE
Fix version upgrade kubelet support

### DIFF
--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -29,6 +29,7 @@ kops update cluster [CLUSTER] [flags]
       --allow-kops-downgrade           Allow an older version of kOps to update the cluster than last used
       --create-kube-config             Will control automatically creating the kube config file on your local filesystem (default true)
   -h, --help                           help for cluster
+      --ignore-kubelet-version-skew    Setting this to true will force updating the kubernetes version on all instance groups, regardles of which control plane version is running
       --instance-group strings         Instance groups to update (defaults to all if not specified)
       --instance-group-roles strings   Instance group roles to update (control-plane,apiserver,node,bastion)
       --internal                       Use the cluster's internal DNS name. Implies --create-kube-config

--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -51,6 +51,11 @@ type AssetBuilder struct {
 	// KubernetesVersion is the version of kubernetes we are installing
 	KubernetesVersion semver.Version
 
+	// KubeletSupportedVersion is the max version of kubelet that we are currently allowed to run on worker nodes.
+	// This is used to avoid violating the kubelet supported version skew policy,
+	// (we are not allowed to run a newer kubelet on a worker node than the control plane)
+	KubeletSupportedVersion string
+
 	// StaticManifests records manifests used by nodeup:
 	// * e.g. sidecar manifests for static pods run by kubelet
 	StaticManifests []*StaticManifest

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -224,6 +224,12 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, wellKnownAddre
 		return nil, nil, fmt.Errorf("building instance group model: %w", err)
 	}
 
+	if !hasAPIServer && n.assetBuilder.KubeletSupportedVersion != "" {
+		if err := igModel.ForceKubernetesVersion(n.assetBuilder.KubeletSupportedVersion); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	kubernetesAssets, err := BuildKubernetesFileAssets(igModel, n.assetBuilder)
 	if err != nil {
 		return nil, nil, err

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -137,6 +137,9 @@ type ApplyClusterCmd struct {
 
 	// InstanceGroupFilter is a predicate that restricts which instance groups we will update.
 	InstanceGroupFilter predicates.Predicate[*kops.InstanceGroup]
+
+	// The current oldest version of control plane nodes, defaults to version defined in cluster spec if IgnoreVersionSkew was set
+	ControlPlaneRunningVersion string
 }
 
 // ApplyResults holds information about an ApplyClusterCmd operation.
@@ -239,6 +242,9 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) (*ApplyResults, error) {
 	}
 
 	assetBuilder := assets.NewAssetBuilder(c.Clientset.VFSContext(), c.Cluster.Spec.Assets, c.Cluster.Spec.KubernetesVersion, c.GetAssets)
+	if len(c.ControlPlaneRunningVersion) > 0 && c.ControlPlaneRunningVersion != c.Cluster.Spec.KubernetesVersion {
+		assetBuilder.KubeletSupportedVersion = c.ControlPlaneRunningVersion
+	}
 	err = c.upgradeSpecs(ctx, assetBuilder)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Automatically preserve kubelet supported version skew on worker nodes while control plane is being updated

Fixes: https://github.com/kubernetes/kops/issues/16907
