### PR TITLE
Reduce number of nodes in manyaddons tests

### DIFF
--- a/tests/e2e/templates/many-addons.yaml.tmpl
+++ b/tests/e2e/templates/many-addons.yaml.tmpl
@@ -96,8 +96,8 @@ spec:
   associatePublicIp: true
   image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20240927
   machineType: t3.medium
-  maxSize: 4
-  minSize: 4
+  maxSize: 2
+  minSize: 2
   role: Node
   subnets:
   - {{$zone}}


### PR DESCRIPTION
Many of the manyaddons tests are flaky:

https://testgrid.k8s.io/kops-upgrades-many-addons

Mid rotation some nodes fail to join for some reason:

```
I1104 20:04:03.890143   14885 instancegroups.go:567] Cluster did not pass validation, will retry in "30s": InstanceGroup "nodes-us-west-2a" did not have enough nodes 1 vs 4.
I1104 20:04:36.517763   14885 instancegroups.go:567] Cluster did not pass validation, will retry in "30s": InstanceGroup "nodes-us-west-2a" did not have enough nodes 1 vs 4. 
```

I'll revisit https://github.com/kubernetes/kops/pull/16354 to improve our visibility here, but first we can try reducing the number of nodes. The not-manyaddons upgrade tests use 4 nodes total, and most of the extra Deployments in the cluster have very minimal resource requests, so we'll try reducing from 12 to 6 nodes total.