### PR TITLE
tests: run kops toolbox dump in bare-metal e2e

### DIFF
--- a/docs/cli/kops_toolbox_dump.md
+++ b/docs/cli/kops_toolbox_dump.md
@@ -23,6 +23,7 @@ kops toolbox dump [CLUSTER] [flags]
 ### Options
 
 ```
+      --cloud-resources      Include cloud resources in the dump (default true)
       --dir string           Target directory; if specified will collect logs and other information.
   -h, --help                 help for dump
       --k8s-resources        Include k8s resources in the dump

--- a/tests/e2e/scenarios/bare-metal/dump-artifacts
+++ b/tests/e2e/scenarios/bare-metal/dump-artifacts
@@ -71,3 +71,12 @@ for ns in kube-system; do
     kubectl logs -n ${ns} ${pod} > ${ARTIFACTS}/logs/${ns}/${pod}.log || true
   done
 done
+
+# Use `kops toolbox dump` to dump a lot of useful information
+mkdir -p ${ARTIFACTS}/dump
+${KOPS} toolbox dump \
+  --dir ${ARTIFACTS}/dump \
+  --k8s-resources \
+  --private-key ${REPO_ROOT}/.build/.ssh/id_ed25519 \
+  --ssh-user root \
+  --name metal.k8s.local

--- a/tests/e2e/scenarios/bare-metal/dump-artifacts
+++ b/tests/e2e/scenarios/bare-metal/dump-artifacts
@@ -73,10 +73,12 @@ for ns in kube-system; do
 done
 
 # Use `kops toolbox dump` to dump a lot of useful information
+# We pass --cloud-resources=false because dumping cloud resources is not implemented on metal
 mkdir -p ${ARTIFACTS}/dump
 ${KOPS} toolbox dump \
   --dir ${ARTIFACTS}/dump \
   --k8s-resources \
+  --cloud-resources=false \
   --private-key ${REPO_ROOT}/.build/.ssh/id_ed25519 \
   --ssh-user root \
   --name metal.k8s.local

--- a/tests/e2e/scenarios/bare-metal/run-test
+++ b/tests/e2e/scenarios/bare-metal/run-test
@@ -28,7 +28,7 @@ BINDIR=${WORKDIR}/bin
 mkdir -p "${BINDIR}"
 go build -o ${BINDIR}/kops ./cmd/kops
 
-KOPS=${BINDIR}/kops
+export KOPS=${BINDIR}/kops
 
 function cleanup() {
   echo "running dump-artifacts"


### PR DESCRIPTION
This lets us share the diagnostic-dumping code.

We don't want to recreate the dumping apparatus
