### PR TITLE
e2e: name artifacts after the tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,5 +36,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: tests-e2e-scenarios-bare-metal
           path: /tmp/artifacts/


### PR DESCRIPTION
These artifacts are not scoped to the job, so we should give them unambiguous names.
