### PR TITLE
2024 Scale dev

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -72,7 +72,7 @@ if [[ "${CLOUD_PROVIDER}" == "gce" ]]; then
   create_args+=("--node-volume-size=30")
   create_args+=("--master-volume-size=1000")
   create_args+=("--gce-service-account=default")
-  create_args+=("--image=${INSTANCE_IMAGE:-ubuntu-os-cloud/ubuntu-2204-jammy-v20231213a}")
+  create_args+=("--image=${INSTANCE_IMAGE:-ubuntu-os-cloud/ubuntu-2204-jammy-v20240927}")
 fi
 create_args+=("--networking=${CNI_PLUGIN:-calico}")
 if [[ "${CNI_PLUGIN}" == "amazonvpc" ]]; then


### PR DESCRIPTION
We have plenty of GCP credits to burn between now and the end of the year. 

Restarting https://github.com/kubernetes/kops/pull/16181
Part of https://github.com/kubernetes/enhancements/issues/4224
