### PR TITLE
chore(upup): bump aws-cni to 1.18.6

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: a60a3c1fc05a99c395f58df484510bc606cddb3b7131f71da76d2ca85c882384
+    manifestHash: ecf65b1b55dd4a867a6498bb565b774853286453e32d6514ee7d8ab4e5b697ab
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -541,7 +541,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.18.5
+          value: v1.18.6
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -554,7 +554,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.6
         livenessProbe:
           exec:
             command:
@@ -611,7 +611,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.4
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -637,7 +637,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.6
         name: aws-vpc-cni-init
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: a60a3c1fc05a99c395f58df484510bc606cddb3b7131f71da76d2ca85c882384
+    manifestHash: ecf65b1b55dd4a867a6498bb565b774853286453e32d6514ee7d8ab4e5b697ab
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -541,7 +541,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.18.5
+          value: v1.18.6
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -554,7 +554,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.6
         livenessProbe:
           exec:
             command:
@@ -611,7 +611,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.4
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -637,7 +637,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.6
         name: aws-vpc-cni-init
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -186,7 +186,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: a60a3c1fc05a99c395f58df484510bc606cddb3b7131f71da76d2ca85c882384
+    manifestHash: ecf65b1b55dd4a867a6498bb565b774853286453e32d6514ee7d8ab4e5b697ab
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -541,7 +541,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.18.5
+          value: v1.18.6
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -554,7 +554,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.6
         livenessProbe:
           exec:
             command:
@@ -611,7 +611,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.4
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -637,7 +637,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.6
         name: aws-vpc-cni-init
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: ee77d3d72012e12d7a6de39684564a252fcae05edc4ad0cdc5b81fdf43b5424b
+    manifestHash: f5a437508506974e0bf3d82525a12611804d318b480e236ce3493aafcb5a67f6
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -541,7 +541,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.18.5
+          value: v1.18.6
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -227,7 +227,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: ee9b99f490ec4f3bca1d8dc4bb14de9549621eddeb647a33655fcdebd18ff363
+    manifestHash: c6e10f9f0805a127ae6da3f8566725d6415d63f38cc73774e8e8471d390be761
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -541,7 +541,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.18.5
+          value: v1.18.6
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -554,7 +554,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: many-addons.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.6
         livenessProbe:
           exec:
             command:
@@ -611,7 +611,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.4
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -637,7 +637,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.6
         name: aws-vpc-cni-init
         resources:
           requests:

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,4 +1,4 @@
-# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.18.5/config/master/aws-k8s-cni.yaml
+# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.18.6/config/master/aws-k8s-cni.yaml
 ---
 # Source: aws-vpc-cni/crds/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -301,7 +301,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.18.5"
+    app.kubernetes.io/version: "v1.18.6"
 ---
 # Source: aws-vpc-cni/templates/configmap.yaml
 apiVersion: v1
@@ -313,7 +313,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.18.5"
+    app.kubernetes.io/version: "v1.18.6"
 data:
   enable-windows-ipam: "false"
   enable-network-policy-controller: "false"
@@ -332,7 +332,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.18.5"
+    app.kubernetes.io/version: "v1.18.6"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -385,7 +385,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.18.5"
+    app.kubernetes.io/version: "v1.18.6"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -405,7 +405,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.18.5"
+    app.kubernetes.io/version: "v1.18.6"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -426,7 +426,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5" }}"
+        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.6" }}"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -451,7 +451,7 @@ spec:
 {{ end }}
       containers:
         - name: aws-node
-          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5" }}"
+          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.6" }}"
           ports:
             - containerPort: 61678
               name: metrics
@@ -521,7 +521,7 @@ spec:
             # - name: NETWORK_POLICY_ENFORCING_MODE
             #   value: "standard"
             - name: VPC_CNI_VERSION
-              value: "v1.18.5"
+              value: "v1.18.6"
             # - name: WARM_ENI_TARGET
             #   value: "1"
             # - name: WARM_PREFIX_TARGET
@@ -558,7 +558,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: "{{- or .Networking.AmazonVPC.NetworkPolicyAgentImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3" }}"
+          image: "{{- or .Networking.AmazonVPC.NetworkPolicyAgentImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.4" }}"
           env:
             - name: MY_NODE_NAME
               valueFrom:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3eb56f832b8994963d7cadfba8cb580838945c943b3d7852fab2720fca9e27e8
+    manifestHash: 4406f84e1d2ea774c4fe28c46e39508ac923c961f3f2528f17df3b2f62604624
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -543,7 +543,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.18.5
+          value: v1.18.6
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -556,7 +556,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.6
         livenessProbe:
           exec:
             command:
@@ -613,7 +613,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.4
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -639,7 +639,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.6
         name: aws-vpc-cni-init
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3eb56f832b8994963d7cadfba8cb580838945c943b3d7852fab2720fca9e27e8
+    manifestHash: 4406f84e1d2ea774c4fe28c46e39508ac923c961f3f2528f17df3b2f62604624
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.18.5
+    app.kubernetes.io/version: v1.18.6
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -543,7 +543,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.18.5
+          value: v1.18.6
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -556,7 +556,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.18.6
         livenessProbe:
           exec:
             command:
@@ -613,7 +613,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.3
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.4
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -639,7 +639,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.5
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.18.6
         name: aws-vpc-cni-init
         resources:
           requests:


### PR DESCRIPTION
<!--
Thanks for contributing to kubernetes/kops!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines:

 https://git.k8s.io/kops/CONTRIBUTING.md

2. Also, you'll probably want to checkout our development documentation:

https://git.k8s.io/kops/docs/development

3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

4. Finally, make sure all verifications and tests pass by running:
```
 make pr
```
-->

**What this PR does / why we need it**:

Bump AWS CNI to latest patch version

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.18.6