### PR TITLE
feat(docs): add toggle for light/dark mode support

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,8 +21,28 @@ theme:
     logo: 'material/cloud-outline'
   favicon: 'img/logo-notext.svg'
   palette:
-    primary: 'teal'
-    accent: 'green'
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: 'teal'
+      accent: 'green'
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Match OS theme (Automatic)
+
 plugins:
   - search
   - macros:


### PR DESCRIPTION
<!--
Thanks for contributing to kubernetes/kops!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines:

 https://git.k8s.io/kops/CONTRIBUTING.md

2. Also, you'll probably want to checkout our development documentation:

https://git.k8s.io/kops/docs/development

3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

4. Finally, make sure all verifications and tests pass by running:
```
 make pr
```
-->

**What this PR does / why we need it**:
This adds a long-overdue toggle for dark mode support in our docs website. The website will automatically align with the OS theme (light/dark), but it's possible to toggle dark mode on/off by using the switch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
Followed mkdocs insturctions [here](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette-toggle)

Netlify Preview deploy [here](https://deploy-preview-16951--kubernetes-kops.netlify.app/)

And also screenshots below.

**Light Mode Screenshot (Same as before)**:
![image](https://github.com/user-attachments/assets/a835a194-1470-4468-a0ad-b74d33d1dfc4)


**Dark Mode Screenshot**:
![image](https://github.com/user-attachments/assets/07951178-f8f8-4f4b-bf86-e3262b2863ea)

