### PR TITLE
Automated cherry pick of #16948: openstack: add external dns support

### DIFF
--- a/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.19.yaml.template
@@ -63,6 +63,10 @@ spec:
           value: "127.0.0.1"
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
+{{ range $name, $value := DNSControllerEnvs }}
+        - name: {{ $name }}
+          value: {{ $value }}
+{{ end }}
         ports:
         - name: http
           protocol: TCP

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -811,6 +811,8 @@ func (tf *TemplateFunctions) ExternalDNSArgv() ([]string, error) {
 	switch cloudProvider {
 	case kops.CloudProviderAWS:
 		argv = append(argv, "--provider=aws")
+	case kops.CloudProviderOpenstack:
+		argv = append(argv, "--provider=designate")
 	case kops.CloudProviderGCE:
 		project := cluster.Spec.CloudProvider.GCE.Project
 		argv = append(argv, "--provider=google")


### PR DESCRIPTION
Cherry pick of #16948 on release-1.30.

#16948: openstack: add external dns support

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```