### PR TITLE
Automated cherry pick of #16765: Allocate more resources to cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@
 timeout: 1800s
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'N1_HIGHCPU_32'
 steps:
 # Push the images
 - name: 'docker.io/library/golang:1.22.7-bookworm'


### PR DESCRIPTION
Cherry pick of #16765 on release-1.30.

#16765: Allocate more resources to cloudbuild

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```