### PR TITLE
Recognize fedora 41 and debian 13

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"path"
 	"reflect"
-	"slices"
 	"strings"
 	"sync"
 
@@ -328,10 +327,7 @@ func (_ *Package) RenderLocal(t *local.LocalTarget, a, e, changes *Package) erro
 			env = append(env, "DEBIAN_FRONTEND=noninteractive")
 		} else if d.IsRHELFamily() {
 
-			if slices.Contains([]distributions.Distribution{
-				distributions.DistributionRhel8, distributions.DistributionRocky8,
-				distributions.DistributionRhel9, distributions.DistributionRocky9,
-			}, d) {
+			if d.HasDNF() {
 				args = []string{"/usr/bin/dnf", "install", "-y", "--setopt=install_weak_deps=False"}
 			} else {
 				args = []string{"/usr/bin/yum", "install", "-y"}

--- a/util/pkg/distributions/identify.go
+++ b/util/pkg/distributions/identify.go
@@ -58,6 +58,8 @@ func FindDistribution(rootfs string) (Distribution, error) {
 		return DistributionDebian11, nil
 	case "debian-12":
 		return DistributionDebian12, nil
+	case "fedora-41":
+		return DistributionFedora41, nil
 	case "ubuntu-20.04":
 		return DistributionUbuntu2004, nil
 	case "ubuntu-22.04":
@@ -88,5 +90,5 @@ func FindDistribution(rootfs string) (Distribution, error) {
 
 	// Some distros are not supported
 	klog.V(2).Infof("Contents of /etc/os-release:\n%s", osReleaseBytes)
-	return Distribution{}, fmt.Errorf("unsupported distro: %s", distro)
+	return Distribution{}, fmt.Errorf("unsupported distro %q", distro)
 }

--- a/util/pkg/distributions/identify_test.go
+++ b/util/pkg/distributions/identify_test.go
@@ -41,17 +41,17 @@ func TestFindDistribution(t *testing.T) {
 		},
 		{
 			rootfs:   "centos7",
-			err:      fmt.Errorf("unsupported distro: centos-7"),
+			err:      fmt.Errorf("unsupported distro %q", "centos-7"),
 			expected: Distribution{},
 		},
 		{
 			rootfs:   "centos8",
-			err:      fmt.Errorf("unsupported distro: centos-8"),
+			err:      fmt.Errorf("unsupported distro %q", "centos-8"),
 			expected: Distribution{},
 		},
 		{
 			rootfs:   "coreos",
-			err:      fmt.Errorf("unsupported distro: coreos-2247.7.0"),
+			err:      fmt.Errorf("unsupported distro %q", "coreos-2247.7.0"),
 			expected: Distribution{},
 		},
 		{
@@ -61,12 +61,12 @@ func TestFindDistribution(t *testing.T) {
 		},
 		{
 			rootfs:   "debian8",
-			err:      fmt.Errorf("unsupported distro: debian-8"),
+			err:      fmt.Errorf("unsupported distro %q", "debian-8"),
 			expected: Distribution{},
 		},
 		{
 			rootfs:   "debian9",
-			err:      fmt.Errorf("unsupported distro: debian-9"),
+			err:      fmt.Errorf("unsupported distro %q", "debian-9"),
 			expected: Distribution{},
 		},
 		{
@@ -91,7 +91,7 @@ func TestFindDistribution(t *testing.T) {
 		},
 		{
 			rootfs:   "rhel7",
-			err:      fmt.Errorf("unsupported distro: rhel-7.8"),
+			err:      fmt.Errorf("unsupported distro %q", "rhel-7.8"),
 			expected: Distribution{},
 		},
 		{
@@ -116,7 +116,7 @@ func TestFindDistribution(t *testing.T) {
 		},
 		{
 			rootfs:   "ubuntu1604",
-			err:      fmt.Errorf("unsupported distro: ubuntu-16.04"),
+			err:      fmt.Errorf("unsupported distro %q", "ubuntu-16.04"),
 			expected: Distribution{},
 		},
 		{


### PR DESCRIPTION
Also simplify the dnf-detection logic; it looks like all our rpm distros now use dnf.
