### PR TITLE
chore(channels): bump k8s and ubuntu jammy ami versions in alpha channel

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -66,11 +66,11 @@ spec:
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0 <1.27.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241113
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241120
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.27.0 <1.31.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20241113
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20241120
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.27.0 <1.31.0"
@@ -186,11 +186,11 @@ spec:
   - range: ">=1.30.0-alpha.1"
     recommendedVersion: "1.29.0-beta.1"
     #requiredVersion: 1.30.0
-    kubernetesVersion: 1.30.6
+    kubernetesVersion: 1.30.7
   - range: ">=1.29.0-alpha.1"
     recommendedVersion: "1.29.0-beta.1"
     #requiredVersion: 1.29.0
-    kubernetesVersion: 1.29.10
+    kubernetesVersion: 1.29.11
   - range: ">=1.28.0-alpha.1"
     recommendedVersion: "1.28.4"
     #requiredVersion: 1.28.0


### PR DESCRIPTION
<!--
Thanks for contributing to kubernetes/kops!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines:

 https://git.k8s.io/kops/CONTRIBUTING.md

2. Also, you'll probably want to checkout our development documentation:

https://git.k8s.io/kops/docs/development

3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests

4. Finally, make sure all verifications and tests pass by running:
```
 make pr
```
-->

**What this PR does / why we need it**:
Bumps alpha channel versions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
- https://github.com/kubernetes/kubernetes/releases/tag/v1.29.11
- https://github.com/kubernetes/kubernetes/releases/tag/v1.30.7
