### PR TITLE
Remove more unnecessary IMDS request logging

### DIFF
--- a/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
+++ b/dnsprovider/pkg/dnsprovider/providers/aws/route53/route53.go
@@ -52,7 +52,6 @@ func newRoute53() (*Interface, error) {
 	ctx := context.TODO()
 
 	imdsCfg, err := awsconfig.LoadDefaultConfig(ctx,
-		awsconfig.WithClientLogMode(aws.LogRetries),
 		awsconfig.WithRetryer(func() aws.Retryer {
 			return retry.AddWithMaxAttempts(retry.NewStandard(), 5)
 		}),


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kops/issues/16837#issuecomment-2506780983

Here is the call stack leading to the logging statement: 

https://github.com/kubernetes/kops/blob/323dbae1b3a41571c27878b4574b9540860dcf12/vendor/github.com/aws/aws-sdk-go-v2/config/load_options.go#L912-L917

https://github.com/kubernetes/kops/blob/323dbae1b3a41571c27878b4574b9540860dcf12/vendor/github.com/aws/aws-sdk-go-v2/aws/logging.go#L16-L21

https://github.com/kubernetes/kops/blob/323dbae1b3a41571c27878b4574b9540860dcf12/vendor/github.com/aws/aws-sdk-go-v2/aws/logging.go#L36-L39

https://github.com/kubernetes/kops/blob/323dbae1b3a41571c27878b4574b9540860dcf12/vendor/github.com/aws/aws-sdk-go-v2/feature/ec2/imds/request_middleware.go#L112-L115

https://github.com/kubernetes/kops/blob/323dbae1b3a41571c27878b4574b9540860dcf12/vendor/github.com/aws/aws-sdk-go-v2/aws/retry/middleware.go#L402-L405

https://github.com/kubernetes/kops/blob/323dbae1b3a41571c27878b4574b9540860dcf12/vendor/github.com/aws/aws-sdk-go-v2/aws/retry/middleware.go#L74-L79

https://github.com/kubernetes/kops/blob/323dbae1b3a41571c27878b4574b9540860dcf12/vendor/github.com/aws/aws-sdk-go-v2/aws/retry/middleware.go#L204-L205

The empty `/` in the log is because the IMDS client doesn't use the typical service + operation scheme for its requests.

