### PR TITLE
Use port 9811 for EBS CSI controller healthcheck

### DIFF
--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_additionalobjects.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a5b98b0e1567802e86a0acdf40915643d41f06db609e2f66a702b0cb3e2deb5f
+    manifestHash: ab4a6f82af9ce89cfc4458d0da29e42b2fbe13b5be0515af0f27dd1256bb7b56
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,7 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 708673cced95a78d0fe1558035c0ecf42831c03909f5a5c87260b9a3152ba812
+    manifestHash: 3b0df2d544873a0453d87b9a197830fba310cb73cbd09f367fad7db6161e9e34
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 29e5d90b768b96358405830bfddefcbeb5021a5f61a9f5d7337a3ca9958c4e43
+    manifestHash: 175814ab70587812d227ab0fa84fea60598ca86bbb1b6b916132dcf9558bdedc
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cas-priority-expander-custom.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 39cef94908b236f6655a56e658a5c8ce7482e02a8f467f12889798838b7d9997
+    manifestHash: 618a57463c43b385b746a8d9cfa66606143d675750baa52e587e442785f3d77d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cas-priority-expander.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 67fe4767a73c3d6991847705e6a4e108b845598a4e866b9c54a43cdd18ea6680
+    manifestHash: 916c40c65c8dd2498d7976c60a90f86812ae553164515bd151ffe4462f9dbe42
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 17fd795c56753c4281d8df073380a638403e4aee10fd68dada5c356bf9488264
+    manifestHash: bfc948340e56cecb10d825d217ee9b614a9fdb37c54d9dde7eef6177fc04dccd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 698ef91047a24ebef2e35f01dc5da5cb8e0c066c956b7bc3da03b8b1b0916d34
+    manifestHash: 69447c3e0d8cfe291773dfa3baeae28731448de5b6b236b0deb9b1144bc4b845
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: b32426417f7de6a078379f6552c9c3a07a196f62a9b5452bafd8d0d476abe14a
+    manifestHash: fc81153cec28c58bb1db488b9f8d683591d660eaff2c7075f018c963e21a4bda
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_containerd.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: b32426417f7de6a078379f6552c9c3a07a196f62a9b5452bafd8d0d476abe14a
+    manifestHash: fc81153cec28c58bb1db488b9f8d683591d660eaff2c7075f018c963e21a4bda
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 4c9851cc0526e3121d831d8bdd93b40a84492b409f39e736baf902cfd49097c7
+    manifestHash: d10948a715a668965ad7e82fdebf5541188b2407493f2d7efb72da48224badb8
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 5b97f53fb8cad34434eb9dd2c7b280c2e7d8e339dfeeaa9e146870bdfc9d9fe5
+    manifestHash: 6174190a8dbb2f3efcb49a4cb99504f5b328d179b1a7970e89d1650fc2b5da86
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 89800bddb7b4cd673ccbb612a77c55ac8e41b5c84717adb634e42372c11384c4
+    manifestHash: e7c3df47bf5ff90f86348c6598fb84ea03bc94719bb0adaa123e72807ee3ac5e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,7 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 708673cced95a78d0fe1558035c0ecf42831c03909f5a5c87260b9a3152ba812
+    manifestHash: 3b0df2d544873a0453d87b9a197830fba310cb73cbd09f367fad7db6161e9e34
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e12a90cfe11908aa8d48fb27562bf6242a3d13c1c7ade14304f43bcba73ceb74
+    manifestHash: 6862502b85afabd105ca745cd708a50aafd455e9e24a5f58d6cb5320d54fcf61
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 3c639d6da7104f5e9f8d7b7eebb2e19b7d5b325447353f4eae05dae57592da7f
+    manifestHash: 8c4a375af16a025bbfa0a8585e2f88f62ac76c4c580a86b001fe678de5be6125
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 980c8d8add4062a91bfe4c3f22af939a7c501c99e7ab6ede5b047fc1ede6178a
+    manifestHash: ac43c73942f638aa93329a3448ace0139d6ca40318addf6e555f3f6cc9bb0e67
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,7 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 708673cced95a78d0fe1558035c0ecf42831c03909f5a5c87260b9a3152ba812
+    manifestHash: 3b0df2d544873a0453d87b9a197830fba310cb73cbd09f367fad7db6161e9e34
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1121,7 +1121,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -193,7 +193,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1eb869764e6c608a046d589638dc389913c5a3428fb4ecdda7626b91550343d2
+    manifestHash: db7ca215ecd9c12f6f746b37865600f8130ef9844faf7bad48ba8e661fd83ee7
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1121,7 +1121,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -200,7 +200,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1eb869764e6c608a046d589638dc389913c5a3428fb4ecdda7626b91550343d2
+    manifestHash: db7ca215ecd9c12f6f746b37865600f8130ef9844faf7bad48ba8e661fd83ee7
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1121,7 +1121,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -201,7 +201,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1eb869764e6c608a046d589638dc389913c5a3428fb4ecdda7626b91550343d2
+    manifestHash: db7ca215ecd9c12f6f746b37865600f8130ef9844faf7bad48ba8e661fd83ee7
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -899,7 +899,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1081,7 +1081,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -193,7 +193,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0cbdc7b57eccbde1cab112d2184c9503e1c955dec3e7fb9d3053f4ebbf385ed9
+    manifestHash: b9cc46ce67bb8b7d3a0524b892ee74363af29d4f3cd81d3dc9c95dcc1c1e32d2
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1083,7 +1083,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -242,7 +242,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9f986096669cb8c9a14f04bb6010506bea9cc81f1816b3549142e19b257e7013
+    manifestHash: 93f2cbab89b3a139165fd128ca4f247bf13bd000e65fe7c876702dd4670ad6b7
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.27/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.28/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_minimal-aws.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: ba71cbde24af4ef7fe7b2a96feb2839112780e3f89586e527c2cc98d54197c65
+    manifestHash: acddf456ba0164b8d109efaade70478d2da76f72966d61ba55113503fede2f93
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_minimal-etcd.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6afb32b6f5ae929c5ec0d47ee7d3d4946d3987918cd648c03147dd08d3dc5933
+    manifestHash: 5fc43105ee9423944095c1da90ccdd3429355d8c4de4326d0ff7124e4ef196a7
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -905,7 +905,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1057,7 +1057,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -168,7 +168,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: de399ffc1c8a0803fd4442d1b4705af05063a459e6dab503cc0798eaa334dcb5
+    manifestHash: 02ffc898b0f441a3757cdbe800f27e6adfdf67c062f1d1dd701e81ccec879a25
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -905,7 +905,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1057,7 +1057,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -121,7 +121,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: de399ffc1c8a0803fd4442d1b4705af05063a459e6dab503cc0798eaa334dcb5
+    manifestHash: 02ffc898b0f441a3757cdbe800f27e6adfdf67c062f1d1dd701e81ccec879a25
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -905,7 +905,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1057,7 +1057,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: de399ffc1c8a0803fd4442d1b4705af05063a459e6dab503cc0798eaa334dcb5
+    manifestHash: 02ffc898b0f441a3757cdbe800f27e6adfdf67c062f1d1dd701e81ccec879a25
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -905,7 +905,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1057,7 +1057,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: de399ffc1c8a0803fd4442d1b4705af05063a459e6dab503cc0798eaa334dcb5
+    manifestHash: 02ffc898b0f441a3757cdbe800f27e6adfdf67c062f1d1dd701e81ccec879a25
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 2c037fd0dfcb4aab796bbbfd935b6cd766d1dd686547dfdd2fc6027669ee6769
+    manifestHash: 32694ed7b6bad6047e5f82e037c71f0d2ef1da116e5f778a150fec0b1fdae044
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 645d0938afbc9bc8cf14fb4ce2565b90eaa524046159d9090b883fc1582e1911
+    manifestHash: d7631bc37a7ff85109c478b3657f4f37ab6973757fa25cc5da34686ee863e956
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 3bf6d5159feb604c7ac48508480b18040762b12db35af0075d2f1bee87807a10
+    manifestHash: e87584bab5b76e6acd04df7897ba77ce3e1a1bca885a3bae5769b3d566afe544
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,7 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.k8s.local

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a3ff813d36b15f0697c8d6454e7e075895c9ac6e3f931f1a819a57a48fd5e3b2
+    manifestHash: 4b03c78c6dd4e2eb383102d7a212de1725971d2fa0d22326ac31feedea01110e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 953f7b54d0da96a955523210aac7151fd102447835de175a9dcc4e8f089e011a
+    manifestHash: 791d8f8f03c1937ad4bcae6574628da5811461ac170ac22da3e915129256022e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 953f7b54d0da96a955523210aac7151fd102447835de175a9dcc4e8f089e011a
+    manifestHash: 791d8f8f03c1937ad4bcae6574628da5811461ac170ac22da3e915129256022e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,7 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.nthimdsprocessor.lon-kfj86l

--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -104,7 +104,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 53653dcc2ad09dbf1199f011770b821b7a0c8d08996b777c8da5fe5db7281252
+    manifestHash: 89d9d1b576ddca58a20420074ddef2671101c266c1dd599a719f1b91751cab5c
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nthimdsprocessor.longclustername.example.com-addons-bootstrap_content
@@ -104,7 +104,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 6e38957d9f0df9e7ed6816d74f32644ba1744c099a9c7982f3489afddc5a4de0
+    manifestHash: 70b99058533de3424acc9ebcd3e0f215730aff3a84e83ffdefecfe9c7bb8ff1a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: cb9d61e31f16c05f718131aa2408c68aef2fa4956feb02c71b2ba7569a27e3d1
+    manifestHash: fe34112d96ebbff0f4d5e9d202bdcddfa34597f8450effba588347b9df7cd969
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0826603ac19bf719905db750280d18aaa28436da3227d92d1f873520622e415c
+    manifestHash: 62ca293e3cd716f4279a08a381774eafd226b153e23760e615bfec381d17a8c9
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -168,7 +168,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9c8a762c8db5c82dd367c5d7de0d90e11216fe86a1d1069171bb7a3423e6c694
+    manifestHash: f1db751f65db1e5cfe3d76d46f646e0e220172e84e4d0f455c68a8d4c1e46b4d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -168,7 +168,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: edcb2f66a69b7da34dffc8a35412ba1106874eb601ab2748cc2dd570af833908
+    manifestHash: 5af73c8411274677331a01fb932e654bd3a0a71338b560a670cf70f6bcc75d2d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 01ab3de240821688dd1532a496334dab16aa483386a38d1fbc8bc48776cfe847
+    manifestHash: de80c082290dfe44e460395ca008e78da25cb18ee75d8877757c5cdb55421de8
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 01ab3de240821688dd1532a496334dab16aa483386a38d1fbc8bc48776cfe847
+    manifestHash: de80c082290dfe44e460395ca008e78da25cb18ee75d8877757c5cdb55421de8
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -171,7 +171,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 01ab3de240821688dd1532a496334dab16aa483386a38d1fbc8bc48776cfe847
+    manifestHash: de80c082290dfe44e460395ca008e78da25cb18ee75d8877757c5cdb55421de8
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 86bf1571fc243e7e79260d743e58a558cd8b0957fdb48446b5783380e9ca27fa
+    manifestHash: 87a215fe67d46da80e2b7879af91b5f87ddf3bba66df7fa691cab52a93832d34
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7d0ccca0efb757cc1c8d68b84a5f44cf5eed10e12bbdf42b01282d7ce5469dc0
+    manifestHash: 459d8da90b163c654ba80ce7801f9c106844104944546f2f5bf92d0b23eead8a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 583aea94faa01c10272612ab369b9219735f2cb574602ad412e18ffbbe88d652
+    manifestHash: 121a89c29264b3e86637992a3bf1978fcf71dc2ba2034dd47210469de094ac34
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -164,7 +164,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 4d52310b3dcd33d3d4352d73aa74fff240dc5e41f1f073a6d776e014d506cd0e
+    manifestHash: f3ee02c9da6a3bcfa419cd8e5813e8a91a3bdc817d9c32057ea606e4dc948ba0
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -155,7 +155,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7f015e0639c893075697428d2a3e8bf0bb62f5260a950e8cc3cd33bc013312ce
+    manifestHash: ef35355c967fec6ada5ace915b4f8dba46d8ec727f714500db212ef386fc9fc7
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1084,7 +1084,7 @@ spec:
           readOnly: true
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         env:
         - name: AWS_ROLE_ARN
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 708673cced95a78d0fe1558035c0ecf42831c03909f5a5c87260b9a3152ba812
+    manifestHash: 3b0df2d544873a0453d87b9a197830fba310cb73cbd09f367fad7db6161e9e34
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 4cdc734018ea4d96008b291c9f8b66b1dfe829a5ea9e8cc74f919b6d9ffa4f69
+    manifestHash: a4c1293fa13cc21464ab2771a0ade73ce26851a70fc6b9dd236018412e13ca03
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: b9438dd3596adb168f5a439f47267f1264eab7a98311a89b18fc6d74525a909d
+    manifestHash: 1c08c5e9b5b550d6d1f3ecd95922ba9bdc58d6fcd1a3a34f7d7799ffb5acca89
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -905,7 +905,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1057,7 +1057,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: de399ffc1c8a0803fd4442d1b4705af05063a459e6dab503cc0798eaa334dcb5
+    manifestHash: 02ffc898b0f441a3757cdbe800f27e6adfdf67c062f1d1dd701e81ccec879a25
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 2957291e9d3919cb7b29396979eb46cbcf857f6e24aa5b38951fa82d3cdcad4d
+    manifestHash: 724c31fcb29937168fdd2c49227862f123dbc35948fdb2f56d8850d732ce1bb1
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -901,7 +901,7 @@ spec:
           timeoutSeconds: 3
         name: ebs-plugin
         ports:
-        - containerPort: 9809
+        - containerPort: 9811
           name: healthz
           protocol: TCP
         - containerPort: 3301
@@ -1053,7 +1053,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
         imagePullPolicy: IfNotPresent
         name: liveness-probe

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bb202a8404fe78c6ef294b7e7f83a634588927ed1ad640d23c4798eece1cb974
+    manifestHash: 22e3d94070e9b480315c0163479741d8c6b55005252539f486d2dceb1a284c8e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -741,7 +741,7 @@ spec:
           mountPath: /var/lib/csi/sockets/pluginproxy/
         ports:
         - name: healthz
-          containerPort: 9809
+          containerPort: 9811
           protocol: TCP
         - name: metrics
           containerPort: 3301
@@ -932,7 +932,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --csi-address=/csi/csi.sock
-        - --http-endpoint=0.0.0.0:9809
+        - --http-endpoint=0.0.0.0:9811
         volumeMounts:
         - name: socket-dir
           mountPath: /csi

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
+    manifestHash: 67176b6289a3c37979877436fe221b2420889b6bc0e63506013ea297a64215ed
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
+    manifestHash: 67176b6289a3c37979877436fe221b2420889b6bc0e63506013ea297a64215ed
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
+    manifestHash: 67176b6289a3c37979877436fe221b2420889b6bc0e63506013ea297a64215ed
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
+    manifestHash: 67176b6289a3c37979877436fe221b2420889b6bc0e63506013ea297a64215ed
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
+    manifestHash: 67176b6289a3c37979877436fe221b2420889b6bc0e63506013ea297a64215ed
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -114,7 +114,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
+    manifestHash: 67176b6289a3c37979877436fe221b2420889b6bc0e63506013ea297a64215ed
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
+    manifestHash: 67176b6289a3c37979877436fe221b2420889b6bc0e63506013ea297a64215ed
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -128,7 +128,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
+    manifestHash: 67176b6289a3c37979877436fe221b2420889b6bc0e63506013ea297a64215ed
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
+    manifestHash: 67176b6289a3c37979877436fe221b2420889b6bc0e63506013ea297a64215ed
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: d66a2070ecc72f8b94394d8ce7dc6f7165ec57ab65d8b82146391478e4ea02e3
+    manifestHash: 4523b7420e3052613c98e961299af12e014c2c87542c6aefaf4849d53cb3471e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 585002a966cf0bf4342a1dcc5faf909d1694fcb500fad30634f0ae0c7a3c9464
+    manifestHash: 67176b6289a3c37979877436fe221b2420889b6bc0e63506013ea297a64215ed
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io


### PR DESCRIPTION
Fixes this: https://github.com/kubernetes/kops/pull/16909#issuecomment-2503707815

I used 9811 because 9810 is in use by the AWS FSx and file-cache CSI drivers: https://github.com/search?type=code&q=9810+language%3Ayaml++org%3Akubernetes-sigs