### PR TITLE
Revert 1.30 Cherrypick "correct hubble tls file names as ..."

### DIFF
--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -155,7 +155,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 4e4fac09787584805b01dd37d1a349d1f047e94b0f7170a239520a4e152b820f
+    manifestHash: 3fdb869ea26ce50ae6db32e1b997749f18cbb30ebf31468f2c5da2c692681a54
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -80,9 +80,9 @@ data:
   hubble-metrics: drop
   hubble-metrics-server: :9091
   hubble-socket-path: /var/run/cilium/hubble.sock
-  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/server.crt
-  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/client-ca.crt
-  hubble-tls-key-file: /var/lib/cilium/tls/hubble/server.key
+  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/tls.crt
+  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/ca.crt
+  hubble-tls-key-file: /var/lib/cilium/tls/hubble/tls.key
   identity-allocation-mode: crd
   identity-change-grace-period: 5s
   ingress-default-lb-mode: dedicated

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -328,9 +328,9 @@ data:
   # An additional address for Hubble server to listen to (e.g. ":4244").
   hubble-listen-address: ":4244"
   hubble-disable-tls: "false"
-  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/server.crt
-  hubble-tls-key-file: /var/lib/cilium/tls/hubble/server.key
-  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/client-ca.crt
+  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/tls.crt
+  hubble-tls-key-file: /var/lib/cilium/tls/hubble/tls.key
+  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/ca.crt
   {{ if .Hubble.Metrics }}
   hubble-metrics-server: ":9091"
   hubble-metrics:


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/16965

This reverts the cherrypick of https://github.com/kubernetes/kops/pull/16855 in https://github.com/kubernetes/kops/pull/16856