### PR TITLE
Dial down warning level when asset is not found

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -314,7 +314,7 @@ func (a *AssetBuilder) findHash(file *FileAsset) (*hashing.Hash, error) {
 		return knownHash, nil
 	}
 
-	klog.Infof("asset %q is not well-known, downloading hash", file.CanonicalURL)
+	klog.V(2).Infof("asset %q is not well-known, downloading hash", file.CanonicalURL)
 
 	// We now prefer sha256 hashes
 	for backoffSteps := 1; backoffSteps <= 3; backoffSteps++ {


### PR DESCRIPTION
We have to download the hash file for assets that are not well-known,
but this is not an error, and this causes a lot of noise in our logs.
