### PR TITLE
Temporarily skip failing cilium test to unblock PRs

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -91,6 +91,12 @@ func (t *Tester) setSkipRegexFlag() error {
 			// This seems to be specific to the kube-proxy replacement
 			// < 33 so we look at this again
 			skipRegex += "|Services.should.support.externalTrafficPolicy.Local.for.type.NodePort"
+
+			if cluster.Spec.LegacyCloudProvider == "gce" {
+				// https://github.com/kubernetes/kubernetes/issues/129221
+				// < 33 so we look at this again
+				skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"
+			}
 		}
 
 		if isPre28 {


### PR DESCRIPTION
This job uses the latest stable k/k release, and started failing once 1.32.0 was released:

https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-kops-e2e-k8s-gce-cilium

This test was added in https://github.com/kubernetes/kubernetes/pull/125222. Until we can look into this further and/or progress is made on the linked k/k issue, we can skip the test to unblock other kops PRs.