### PR TITLE
Only set NTH ManagedASGTag label if it doesn't already exist

### DIFF
--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -161,7 +161,10 @@ func (b *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (ma
 		// Apply NTH Labels
 		nth := b.Cluster.Spec.CloudProvider.AWS.NodeTerminationHandler
 		if nth.IsQueueMode() {
-			labels[fi.ValueOf(nth.ManagedASGTag)] = ""
+			k := fi.ValueOf(nth.ManagedASGTag)
+			if _, ok := labels[k]; !ok && k != "" {
+				labels[k] = ""
+			}
 		}
 	}
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -235,7 +235,7 @@ spec:
     enableSpotInterruptionDraining: true
     enabled: true
     excludeFromLoadBalancers: true
-    managedASGTag: aws-node-termination-handler/managed
+    managedASGTag: kubernetes.io/cluster/complex.example.com
     memoryRequest: 64Mi
     podTerminationGracePeriod: -1
     prometheusEnable: false

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 93627ba43aa9bca83bd85005d328f2b42c28a9cf0cad1c03375fa4e33d59a877
+    manifestHash: 565c78752a2216a5bef8c63aff4fe1435e054689f565f587b375c593b346a411
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -176,7 +176,7 @@ spec:
         - name: CHECK_TAG_BEFORE_DRAINING
           value: "true"
         - name: MANAGED_TAG
-          value: aws-node-termination-handler/managed
+          value: kubernetes.io/cluster/complex.example.com
         - name: USE_PROVIDER_ID
           value: "true"
         - name: DRY_RUN

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -67,6 +67,8 @@ spec:
   kubernetesVersion: v1.30.0
   masterPublicName: api.complex.example.com
   networkCIDR: 172.20.0.0/16
+  nodeTerminationHandler:
+    managedASGTag: kubernetes.io/cluster/complex.example.com
   additionalNetworkCIDRs:
   - 10.1.0.0/16
   - 10.2.0.0/16

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -67,6 +67,8 @@ spec:
   kubernetesVersion: v1.30.0
   masterPublicName: api.complex.example.com
   networkCIDR: 172.20.0.0/16
+  nodeTerminationHandler:
+    managedASGTag: kubernetes.io/cluster/complex.example.com
   additionalNetworkCIDRs:
   - 10.1.0.0/16
   - 10.2.0.0/16

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -178,7 +178,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com"
   tag {
     key                 = "kubernetes.io/cluster/complex.example.com"
     propagate_at_launch = true
-    value               = ""
+    value               = "owned"
   }
   target_group_arns   = [aws_lb_target_group.tcp-complex-example-com-vpjolq.id, aws_lb_target_group.tls-complex-example-com-5nursn.id]
   vpc_zone_identifier = [aws_subnet.us-test-1a-complex-example-com.id]
@@ -236,7 +236,7 @@ resource "aws_autoscaling_group" "nodes-complex-example-com" {
   tag {
     key                 = "kubernetes.io/cluster/complex.example.com"
     propagate_at_launch = true
-    value               = ""
+    value               = "owned"
   }
   vpc_zone_identifier = [aws_subnet.us-test-1a-complex-example-com.id]
 }
@@ -490,7 +490,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
       "k8s.io/role/control-plane"                                                                             = "1"
       "k8s.io/role/master"                                                                                    = "1"
       "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
-      "kubernetes.io/cluster/complex.example.com"                                                             = ""
+      "kubernetes.io/cluster/complex.example.com"                                                             = "owned"
     }
   }
   tag_specifications {
@@ -506,7 +506,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
       "k8s.io/role/control-plane"                                                                             = "1"
       "k8s.io/role/master"                                                                                    = "1"
       "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
-      "kubernetes.io/cluster/complex.example.com"                                                             = ""
+      "kubernetes.io/cluster/complex.example.com"                                                             = "owned"
     }
   }
   tags = {
@@ -520,7 +520,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
     "k8s.io/role/control-plane"                                                                             = "1"
     "k8s.io/role/master"                                                                                    = "1"
     "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
-    "kubernetes.io/cluster/complex.example.com"                                                             = ""
+    "kubernetes.io/cluster/complex.example.com"                                                             = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data")
 }
@@ -584,7 +584,7 @@ resource "aws_launch_template" "nodes-complex-example-com" {
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
       "k8s.io/role/node"                                                           = "1"
       "kops.k8s.io/instancegroup"                                                  = "nodes"
-      "kubernetes.io/cluster/complex.example.com"                                  = ""
+      "kubernetes.io/cluster/complex.example.com"                                  = "owned"
     }
   }
   tag_specifications {
@@ -597,7 +597,7 @@ resource "aws_launch_template" "nodes-complex-example-com" {
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
       "k8s.io/role/node"                                                           = "1"
       "kops.k8s.io/instancegroup"                                                  = "nodes"
-      "kubernetes.io/cluster/complex.example.com"                                  = ""
+      "kubernetes.io/cluster/complex.example.com"                                  = "owned"
     }
   }
   tags = {
@@ -608,7 +608,7 @@ resource "aws_launch_template" "nodes-complex-example-com" {
     "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
     "k8s.io/role/node"                                                           = "1"
     "kops.k8s.io/instancegroup"                                                  = "nodes"
-    "kubernetes.io/cluster/complex.example.com"                                  = ""
+    "kubernetes.io/cluster/complex.example.com"                                  = "owned"
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.complex.example.com_user_data")
 }

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -141,11 +141,6 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com"
     value               = "John Doe"
   }
   tag {
-    key                 = "aws-node-termination-handler/managed"
-    propagate_at_launch = true
-    value               = ""
-  }
-  tag {
     key                 = "foo/bar"
     propagate_at_launch = true
     value               = "fib+baz"
@@ -183,7 +178,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com"
   tag {
     key                 = "kubernetes.io/cluster/complex.example.com"
     propagate_at_launch = true
-    value               = "owned"
+    value               = ""
   }
   target_group_arns   = [aws_lb_target_group.tcp-complex-example-com-vpjolq.id, aws_lb_target_group.tls-complex-example-com-5nursn.id]
   vpc_zone_identifier = [aws_subnet.us-test-1a-complex-example-com.id]
@@ -219,11 +214,6 @@ resource "aws_autoscaling_group" "nodes-complex-example-com" {
     value               = "John Doe"
   }
   tag {
-    key                 = "aws-node-termination-handler/managed"
-    propagate_at_launch = true
-    value               = ""
-  }
-  tag {
     key                 = "foo/bar"
     propagate_at_launch = true
     value               = "fib+baz"
@@ -246,7 +236,7 @@ resource "aws_autoscaling_group" "nodes-complex-example-com" {
   tag {
     key                 = "kubernetes.io/cluster/complex.example.com"
     propagate_at_launch = true
-    value               = "owned"
+    value               = ""
   }
   vpc_zone_identifier = [aws_subnet.us-test-1a-complex-example-com.id]
 }
@@ -493,7 +483,6 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
       "KubernetesCluster"                                                                                     = "complex.example.com"
       "Name"                                                                                                  = "master-us-test-1a.masters.complex.example.com"
       "Owner"                                                                                                 = "John Doe"
-      "aws-node-termination-handler/managed"                                                                  = ""
       "foo/bar"                                                                                               = "fib+baz"
       "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
@@ -501,7 +490,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
       "k8s.io/role/control-plane"                                                                             = "1"
       "k8s.io/role/master"                                                                                    = "1"
       "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
-      "kubernetes.io/cluster/complex.example.com"                                                             = "owned"
+      "kubernetes.io/cluster/complex.example.com"                                                             = ""
     }
   }
   tag_specifications {
@@ -510,7 +499,6 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
       "KubernetesCluster"                                                                                     = "complex.example.com"
       "Name"                                                                                                  = "master-us-test-1a.masters.complex.example.com"
       "Owner"                                                                                                 = "John Doe"
-      "aws-node-termination-handler/managed"                                                                  = ""
       "foo/bar"                                                                                               = "fib+baz"
       "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
@@ -518,14 +506,13 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
       "k8s.io/role/control-plane"                                                                             = "1"
       "k8s.io/role/master"                                                                                    = "1"
       "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
-      "kubernetes.io/cluster/complex.example.com"                                                             = "owned"
+      "kubernetes.io/cluster/complex.example.com"                                                             = ""
     }
   }
   tags = {
     "KubernetesCluster"                                                                                     = "complex.example.com"
     "Name"                                                                                                  = "master-us-test-1a.masters.complex.example.com"
     "Owner"                                                                                                 = "John Doe"
-    "aws-node-termination-handler/managed"                                                                  = ""
     "foo/bar"                                                                                               = "fib+baz"
     "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
     "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
@@ -533,7 +520,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
     "k8s.io/role/control-plane"                                                                             = "1"
     "k8s.io/role/master"                                                                                    = "1"
     "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
-    "kubernetes.io/cluster/complex.example.com"                                                             = "owned"
+    "kubernetes.io/cluster/complex.example.com"                                                             = ""
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data")
 }
@@ -593,12 +580,11 @@ resource "aws_launch_template" "nodes-complex-example-com" {
       "KubernetesCluster"                                                          = "complex.example.com"
       "Name"                                                                       = "nodes.complex.example.com"
       "Owner"                                                                      = "John Doe"
-      "aws-node-termination-handler/managed"                                       = ""
       "foo/bar"                                                                    = "fib+baz"
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
       "k8s.io/role/node"                                                           = "1"
       "kops.k8s.io/instancegroup"                                                  = "nodes"
-      "kubernetes.io/cluster/complex.example.com"                                  = "owned"
+      "kubernetes.io/cluster/complex.example.com"                                  = ""
     }
   }
   tag_specifications {
@@ -607,24 +593,22 @@ resource "aws_launch_template" "nodes-complex-example-com" {
       "KubernetesCluster"                                                          = "complex.example.com"
       "Name"                                                                       = "nodes.complex.example.com"
       "Owner"                                                                      = "John Doe"
-      "aws-node-termination-handler/managed"                                       = ""
       "foo/bar"                                                                    = "fib+baz"
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
       "k8s.io/role/node"                                                           = "1"
       "kops.k8s.io/instancegroup"                                                  = "nodes"
-      "kubernetes.io/cluster/complex.example.com"                                  = "owned"
+      "kubernetes.io/cluster/complex.example.com"                                  = ""
     }
   }
   tags = {
     "KubernetesCluster"                                                          = "complex.example.com"
     "Name"                                                                       = "nodes.complex.example.com"
     "Owner"                                                                      = "John Doe"
-    "aws-node-termination-handler/managed"                                       = ""
     "foo/bar"                                                                    = "fib+baz"
     "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
     "k8s.io/role/node"                                                           = "1"
     "kops.k8s.io/instancegroup"                                                  = "nodes"
-    "kubernetes.io/cluster/complex.example.com"                                  = "owned"
+    "kubernetes.io/cluster/complex.example.com"                                  = ""
   }
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.complex.example.com_user_data")
 }


### PR DESCRIPTION
Reported on slack.

If a cluster has ManagedASGTag set to an existing label, it is overwritten with an empty value. For the `kubernetes.io/cluster/$cluster` tag, this can cause problems during cluster deletion.

NTH doesn't actually care about the value of the tag:

https://github.com/aws/aws-node-termination-handler/blob/a0c0aa1bd14780b0d5ca7ce70cd92eed746ff64d/pkg/monitor/sqsevent/sqs-monitor.go#L427-L431

So if the tag is already set then we should preserve its existing value.
