### PR TITLE
chore: add context to rolling update functions

### DIFF
--- a/cmd/kops/delete_instance.go
+++ b/cmd/kops/delete_instance.go
@@ -219,7 +219,6 @@ func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, opti
 	d := &instancegroups.RollingUpdateCluster{
 		Clientset:         clientSet,
 		Cluster:           cluster,
-		Ctx:               ctx,
 		MasterInterval:    0,
 		NodeInterval:      0,
 		BastionInterval:   0,
@@ -248,7 +247,7 @@ func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, opti
 	}
 	d.ClusterValidator = clusterValidator
 
-	return d.UpdateSingleInstance(cloudMember, options.Surge)
+	return d.UpdateSingleInstance(ctx, cloudMember, options.Surge)
 }
 
 func getNodes(ctx context.Context, cluster *kopsapi.Cluster, verbose bool) (kubernetes.Interface, string, []v1.Node, error) {

--- a/cmd/kops/rolling-update_cluster.go
+++ b/cmd/kops/rolling-update_cluster.go
@@ -348,7 +348,6 @@ func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer
 
 	d := &instancegroups.RollingUpdateCluster{
 		Clientset:         clientset,
-		Ctx:               ctx,
 		Cluster:           cluster,
 		MasterInterval:    options.ControlPlaneInterval,
 		NodeInterval:      options.NodeInterval,
@@ -456,7 +455,7 @@ func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer
 	}
 	d.ClusterValidator = clusterValidator
 
-	return d.RollingUpdate(groups, list)
+	return d.RollingUpdate(ctx, groups, list)
 }
 
 func completeInstanceGroup(f commandutils.Factory, selectedInstanceGroups *[]string, selectedInstanceGroupRoles *[]string) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/instancegroups/instancegroups_test.go
+++ b/pkg/instancegroups/instancegroups_test.go
@@ -60,7 +60,7 @@ func TestWarmPoolOnlyRoll(t *testing.T) {
 	instance.State = cloudinstances.WarmPool
 
 	{
-		err := c.rollingUpdateInstanceGroup(group, 0*time.Second)
+		err := c.rollingUpdateInstanceGroup(ctx, group, 0*time.Second)
 		if err != nil {
 			t.Fatalf("could not roll instance group: %v", err)
 		}

--- a/pkg/instancegroups/rollingupdate_os_test.go
+++ b/pkg/instancegroups/rollingupdate_os_test.go
@@ -83,7 +83,6 @@ func getTestSetupOS(t *testing.T, ctx context.Context) (*RollingUpdateCluster, *
 		ValidateTickDuration:    1 * time.Millisecond,
 		ValidateSuccessDuration: 5 * time.Millisecond,
 		ValidateCount:           2,
-		Ctx:                     ctx,
 		Cluster:                 cluster,
 		Clientset:               clientset,
 	}
@@ -106,7 +105,7 @@ func TestRollingUpdateDisabledSurgeOS(t *testing.T) {
 	c, cloud := getTestSetupOS(t, ctx)
 
 	groups, igList := getGroupsAllNeedUpdateOS(t, c)
-	err := c.RollingUpdate(groups, igList)
+	err := c.RollingUpdate(ctx, groups, igList)
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCountOS(t, cloud, "node-1", 3)
@@ -117,6 +116,8 @@ func TestRollingUpdateDisabledSurgeOS(t *testing.T) {
 
 func makeGroupOS(t *testing.T, groups map[string]*cloudinstances.CloudInstanceGroup, igList *kopsapi.InstanceGroupList,
 	c *RollingUpdateCluster, subnet string, role kopsapi.InstanceGroupRole, count int, needUpdate int) {
+	ctx := context.TODO()
+
 	cloud := c.Cloud.(*openstack.MockCloud)
 	igif := c.Clientset.InstanceGroupsFor(c.Cluster)
 	fakeClient := c.K8sClient.(*fake.Clientset)
@@ -136,7 +137,7 @@ func makeGroupOS(t *testing.T, groups map[string]*cloudinstances.CloudInstanceGr
 
 	igList.Items = append(igList.Items, newIg)
 
-	ig, err := igif.Create(c.Ctx, &newIg, v1meta.CreateOptions{})
+	ig, err := igif.Create(ctx, &newIg, v1meta.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create ig %v: %v", subnet, err)
 	}

--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -65,7 +65,6 @@ func getTestSetup() (*RollingUpdateCluster, *awsup.MockAWSCloud) {
 	cluster.Name = "test.k8s.local"
 
 	c := &RollingUpdateCluster{
-		Ctx:                     context.Background(),
 		Cluster:                 cluster,
 		Cloud:                   mockcloud,
 		MasterInterval:          1 * time.Millisecond,
@@ -213,7 +212,7 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 	c, cloud := getTestSetup()
 
 	groups := getGroupsAllNeedUpdate(c.K8sClient, cloud)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	cordoned := ""
@@ -269,7 +268,7 @@ func TestRollingUpdateAllNeedUpdateCloudonly(t *testing.T) {
 	c.ClusterValidator = &assertNotCalledClusterValidator{T: t}
 
 	groups := getGroupsAllNeedUpdate(c.K8sClient, cloud)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assert.Empty(t, c.K8sClient.(*fake.Clientset).Actions())
@@ -288,7 +287,7 @@ func TestRollingUpdateAllNeedUpdateNoFailOnValidate(t *testing.T) {
 	c.ClusterValidator = &failingClusterValidator{}
 
 	groups := getGroupsAllNeedUpdate(c.K8sClient, cloud)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(ctx, &autoscaling.DescribeAutoScalingGroupsInput{})
@@ -298,10 +297,11 @@ func TestRollingUpdateAllNeedUpdateNoFailOnValidate(t *testing.T) {
 }
 
 func TestRollingUpdateNoneNeedUpdate(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 	groups := getGroups(c.K8sClient, cloud)
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assert.Empty(t, c.K8sClient.(*fake.Clientset).Actions())
@@ -319,7 +319,7 @@ func TestRollingUpdateNoneNeedUpdateWithForce(t *testing.T) {
 
 	c.Force = true
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(ctx, &autoscaling.DescribeAutoScalingGroupsInput{})
@@ -329,11 +329,12 @@ func TestRollingUpdateNoneNeedUpdateWithForce(t *testing.T) {
 }
 
 func TestRollingUpdateEmptyGroup(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -343,12 +344,13 @@ func TestRollingUpdateEmptyGroup(t *testing.T) {
 }
 
 func TestRollingUpdateUnknownRole(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 	groups := getGroups(c.K8sClient, cloud)
 
 	groups["node-1"].InstanceGroup.Spec.Role = "Unknown"
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -358,12 +360,13 @@ func TestRollingUpdateUnknownRole(t *testing.T) {
 }
 
 func TestRollingUpdateAllNeedUpdateFailsValidation(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	c.ClusterValidator = &failingClusterValidator{}
 
 	groups := getGroupsAllNeedUpdate(c.K8sClient, cloud)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -373,12 +376,13 @@ func TestRollingUpdateAllNeedUpdateFailsValidation(t *testing.T) {
 }
 
 func TestRollingUpdateAllNeedUpdateErrorsValidation(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	c.ClusterValidator = &erroringClusterValidator{}
 
 	groups := getGroupsAllNeedUpdate(c.K8sClient, cloud)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -388,26 +392,28 @@ func TestRollingUpdateAllNeedUpdateErrorsValidation(t *testing.T) {
 }
 
 func TestRollingUpdateNodes1NeedsUpdateFailsValidation(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	c.ClusterValidator = &failingClusterValidator{}
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 3, 3)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
 }
 
 func TestRollingUpdateNodes1NeedsUpdateErrorsValidation(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	c.ClusterValidator = &erroringClusterValidator{}
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 3, 3)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -444,6 +450,7 @@ func (v *failAfterOneNodeClusterValidator) Validate() (*validation.ValidationClu
 }
 
 func TestRollingUpdateClusterFailsValidationAfterOneMaster(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	c.ClusterValidator = &failAfterOneNodeClusterValidator{
@@ -453,7 +460,7 @@ func TestRollingUpdateClusterFailsValidationAfterOneMaster(t *testing.T) {
 	}
 
 	groups := getGroupsAllNeedUpdate(c.K8sClient, cloud)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -463,6 +470,7 @@ func TestRollingUpdateClusterFailsValidationAfterOneMaster(t *testing.T) {
 }
 
 func TestRollingUpdateClusterErrorsValidationAfterOneMaster(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	c.ClusterValidator = &failAfterOneNodeClusterValidator{
@@ -472,7 +480,7 @@ func TestRollingUpdateClusterErrorsValidationAfterOneMaster(t *testing.T) {
 	}
 
 	groups := getGroupsAllNeedUpdate(c.K8sClient, cloud)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -482,6 +490,7 @@ func TestRollingUpdateClusterErrorsValidationAfterOneMaster(t *testing.T) {
 }
 
 func TestRollingUpdateNonRelatedInstanceGroupFailure(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
@@ -494,7 +503,7 @@ func TestRollingUpdateNonRelatedInstanceGroupFailure(t *testing.T) {
 		InstanceGroup: groups["node-2"].InstanceGroup,
 	}
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 0)
@@ -504,6 +513,7 @@ func TestRollingUpdateNonRelatedInstanceGroupFailure(t *testing.T) {
 }
 
 func TestRollingUpdateRelatedInstanceGroupFailure(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
@@ -516,7 +526,7 @@ func TestRollingUpdateRelatedInstanceGroupFailure(t *testing.T) {
 		InstanceGroup: groups["node-1"].InstanceGroup,
 	}
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -526,6 +536,7 @@ func TestRollingUpdateRelatedInstanceGroupFailure(t *testing.T) {
 }
 
 func TestRollingUpdateMasterGroupFailure(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
@@ -538,7 +549,7 @@ func TestRollingUpdateMasterGroupFailure(t *testing.T) {
 		InstanceGroup: groups["master-1"].InstanceGroup,
 	}
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -548,6 +559,7 @@ func TestRollingUpdateMasterGroupFailure(t *testing.T) {
 }
 
 func TestRollingUpdateValidationErrorInstanceGroupNil(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
@@ -560,7 +572,7 @@ func TestRollingUpdateValidationErrorInstanceGroupNil(t *testing.T) {
 		InstanceGroup: nil,
 	}
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -570,6 +582,7 @@ func TestRollingUpdateValidationErrorInstanceGroupNil(t *testing.T) {
 }
 
 func TestRollingUpdateValidationErrorInstanceGroupExitableError(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
@@ -583,7 +596,7 @@ func TestRollingUpdateValidationErrorInstanceGroupExitableError(t *testing.T) {
 		InstanceGroup: groups["node-2"].InstanceGroup,
 	}
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 0)
@@ -591,10 +604,10 @@ func TestRollingUpdateValidationErrorInstanceGroupExitableError(t *testing.T) {
 	assertGroupInstanceCount(t, cloud, "node-3", 3)
 	assertGroupInstanceCount(t, cloud, "master-1", 2)
 	assertGroupInstanceCount(t, cloud, "bastion-1", 1)
-
 }
 
 func TestRollingUpdateClusterFailsValidationAfterOneNode(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	c.ClusterValidator = &failAfterOneNodeClusterValidator{
@@ -605,13 +618,14 @@ func TestRollingUpdateClusterFailsValidationAfterOneNode(t *testing.T) {
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 3, 3)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 2)
 }
 
 func TestRollingUpdateClusterErrorsValidationAfterOneNode(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	c.ClusterValidator = &failAfterOneNodeClusterValidator{
@@ -622,7 +636,7 @@ func TestRollingUpdateClusterErrorsValidationAfterOneNode(t *testing.T) {
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 3, 3)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.Error(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 2)
@@ -665,6 +679,7 @@ func (v *flappingClusterValidator) Validate() (*validation.ValidationCluster, er
 }
 
 func TestRollingUpdateFlappingValidation(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	// This should only take a few milliseconds,
@@ -678,7 +693,7 @@ func TestRollingUpdateFlappingValidation(t *testing.T) {
 	}
 
 	groups := getGroupsAllNeedUpdate(c.K8sClient, cloud)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 0)
@@ -708,6 +723,7 @@ func (v *failThreeTimesClusterValidator) Validate() (*validation.ValidationClust
 }
 
 func TestRollingUpdateValidatesAfterBastion(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	// This should only take a few milliseconds,
@@ -718,7 +734,7 @@ func TestRollingUpdateValidatesAfterBastion(t *testing.T) {
 	c.ClusterValidator = &failThreeTimesClusterValidator{}
 
 	groups := getGroupsAllNeedUpdate(c.K8sClient, cloud)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 0)
@@ -825,11 +841,12 @@ func assertGroupNeedUpdate(t *testing.T, groups map[string]*cloudinstances.Cloud
 }
 
 func TestRollingUpdateTaintAllButOneNeedUpdate(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 3, 2)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	cordoned := ""
@@ -870,6 +887,7 @@ func TestRollingUpdateTaintAllButOneNeedUpdate(t *testing.T) {
 }
 
 func TestRollingUpdateMaxSurgeIgnoredForMaster(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	two := intstr.FromInt(2)
@@ -879,7 +897,7 @@ func TestRollingUpdateMaxSurgeIgnoredForMaster(t *testing.T) {
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "master-1", kopsapi.InstanceGroupRoleControlPlane, 3, 2)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	cordoned := ""
@@ -922,6 +940,7 @@ func TestRollingUpdateMaxSurgeIgnoredForMaster(t *testing.T) {
 }
 
 func TestRollingUpdateDisabled(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 	c.CloudOnly = true
 
@@ -930,7 +949,7 @@ func TestRollingUpdateDisabled(t *testing.T) {
 	}
 
 	groups := getGroupsAllNeedUpdate(c.K8sClient, cloud)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -958,6 +977,7 @@ func (m *disabledSurgeTest) DetachInstances(ctx context.Context, input *autoscal
 }
 
 func TestRollingUpdateDisabledSurge(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	disabledSurgeTest := &disabledSurgeTest{
@@ -974,7 +994,7 @@ func TestRollingUpdateDisabledSurge(t *testing.T) {
 	}
 
 	groups := getGroupsAllNeedUpdate(c.K8sClient, cloud)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 3)
@@ -1169,6 +1189,7 @@ func newConcurrentTest(t *testing.T, cloud *awsup.MockAWSCloud, numSurge int, al
 }
 
 func TestRollingUpdateMaxUnavailableAllNeedUpdate(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	concurrentTest := newConcurrentTest(t, cloud, 0, true)
@@ -1184,7 +1205,7 @@ func TestRollingUpdateMaxUnavailableAllNeedUpdate(t *testing.T) {
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 7, 7)
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 0)
@@ -1192,6 +1213,7 @@ func TestRollingUpdateMaxUnavailableAllNeedUpdate(t *testing.T) {
 }
 
 func TestRollingUpdateMaxUnavailableAllButOneNeedUpdate(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	concurrentTest := newConcurrentTest(t, cloud, 0, false)
@@ -1206,7 +1228,7 @@ func TestRollingUpdateMaxUnavailableAllButOneNeedUpdate(t *testing.T) {
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 7, 6)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 1)
@@ -1214,6 +1236,7 @@ func TestRollingUpdateMaxUnavailableAllButOneNeedUpdate(t *testing.T) {
 }
 
 func TestRollingUpdateMaxUnavailableAllNeedUpdateMaster(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	concurrentTest := newConcurrentTest(t, cloud, 0, true)
@@ -1229,7 +1252,7 @@ func TestRollingUpdateMaxUnavailableAllNeedUpdateMaster(t *testing.T) {
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "master-1", kopsapi.InstanceGroupRoleControlPlane, 7, 7)
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "master-1", 0)
@@ -1266,6 +1289,7 @@ func (e *ec2IgnoreTags) CreateTags(ctx context.Context, params *ec2.CreateTagsIn
 }
 
 func TestRollingUpdateMaxSurgeAllNeedUpdate(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	concurrentTest := newConcurrentTest(t, cloud, 2, true)
@@ -1285,7 +1309,7 @@ func TestRollingUpdateMaxSurgeAllNeedUpdate(t *testing.T) {
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 6, 6)
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 0)
@@ -1293,6 +1317,7 @@ func TestRollingUpdateMaxSurgeAllNeedUpdate(t *testing.T) {
 }
 
 func TestRollingUpdateMaxSurgeAllButOneNeedUpdate(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	concurrentTest := newConcurrentTest(t, cloud, 2, false)
@@ -1311,7 +1336,7 @@ func TestRollingUpdateMaxSurgeAllButOneNeedUpdate(t *testing.T) {
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 7, 6)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 1)
@@ -1329,6 +1354,7 @@ func (c *countDetach) DetachInstances(ctx context.Context, input *autoscaling.De
 }
 
 func TestRollingUpdateMaxSurgeGreaterThanNeedUpdate(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	countDetach := &countDetach{AutoScalingAPI: cloud.MockAutoscaling}
@@ -1342,7 +1368,7 @@ func TestRollingUpdateMaxSurgeGreaterThanNeedUpdate(t *testing.T) {
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 3, 2)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 1)
@@ -1358,6 +1384,7 @@ func (m *failDetachAutoscaling) DetachInstances(ctx context.Context, input *auto
 }
 
 func TestRollingUpdateDetachFails(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	cloud.MockAutoscaling = &failDetachAutoscaling{AutoScalingAPI: cloud.MockAutoscaling}
@@ -1370,7 +1397,7 @@ func TestRollingUpdateDetachFails(t *testing.T) {
 
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 3, 2)
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 1)
@@ -1474,6 +1501,7 @@ func (m *alreadyDetachedTestAutoscaling) DetachInstances(ctx context.Context, in
 }
 
 func TestRollingUpdateMaxSurgeAllNeedUpdateOneAlreadyDetached(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	alreadyDetachedTest := &alreadyDetachedTest{
@@ -1500,7 +1528,7 @@ func TestRollingUpdateMaxSurgeAllNeedUpdateOneAlreadyDetached(t *testing.T) {
 	makeGroup(groups, c.K8sClient, cloud, "node-1", kopsapi.InstanceGroupRoleNode, 4, 4)
 	alreadyDetachedTest.detached[groups["node-1"].NeedUpdate[3].ID] = true
 	groups["node-1"].NeedUpdate[3].Status = cloudinstances.CloudInstanceStatusDetached
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 0)
@@ -1508,6 +1536,7 @@ func TestRollingUpdateMaxSurgeAllNeedUpdateOneAlreadyDetached(t *testing.T) {
 }
 
 func TestRollingUpdateMaxSurgeAllNeedUpdateMaxAlreadyDetached(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 
 	// Should behave the same as TestRollingUpdateMaxUnavailableAllNeedUpdate
@@ -1532,7 +1561,7 @@ func TestRollingUpdateMaxSurgeAllNeedUpdateMaxAlreadyDetached(t *testing.T) {
 	groups["node-1"].NeedUpdate[6].Status = cloudinstances.CloudInstanceStatusNeedsUpdate
 	// TODO verify those are the last two instances terminated
 
-	err := c.RollingUpdate(groups, &kopsapi.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kopsapi.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 
 	assertGroupInstanceCount(t, cloud, "node-1", 0)
@@ -1555,7 +1584,7 @@ func assertTaint(t *testing.T, action testingclient.PatchAction) {
 }
 
 func assertGroupInstanceCount(t *testing.T, cloud awsup.AWSCloud, groupName string, expected int) {
-	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(context.Background(), &autoscaling.DescribeAutoScalingGroupsInput{
+	asgGroups, _ := cloud.Autoscaling().DescribeAutoScalingGroups(context.TODO(), &autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []string{groupName},
 	})
 	for _, group := range asgGroups.AutoScalingGroups {

--- a/pkg/instancegroups/rollingupdate_warmpool_test.go
+++ b/pkg/instancegroups/rollingupdate_warmpool_test.go
@@ -35,6 +35,7 @@ import (
 // Here we have three nodes that are up to date, while three warm nodes need updating.
 // Only the initial cluster validation should be run
 func TestRollingUpdateOnlyWarmPoolNodes(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 	k8sClient := c.K8sClient
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
@@ -45,12 +46,13 @@ func TestRollingUpdateOnlyWarmPoolNodes(t *testing.T) {
 
 	assert.Equal(t, 3, len(groups["node-1"].NeedUpdate), "number of nodes needing update")
 
-	err := c.RollingUpdate(groups, &kops.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kops.InstanceGroupList{})
 	assert.NoError(t, err, "rolling update")
 	assert.Equal(t, 1, validator.numValidations, "number of validations")
 }
 
 func TestRollingWarmPoolBeforeJoinedNodes(t *testing.T) {
+	ctx := context.TODO()
 	c, cloud := getTestSetup()
 	k8sClient := c.K8sClient
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
@@ -62,7 +64,7 @@ func TestRollingWarmPoolBeforeJoinedNodes(t *testing.T) {
 	}
 	cloud.MockEC2 = warmPoolBeforeJoinedNodesTest
 
-	err := c.RollingUpdate(groups, &kops.InstanceGroupList{})
+	err := c.RollingUpdate(ctx, groups, &kops.InstanceGroupList{})
 
 	assert.NoError(t, err, "rolling update")
 


### PR DESCRIPTION
Move it out of the struct, and into the function parameters.

This is more go idiomatic.
