### PR TITLE
Skip test `Services should implement NodePort and HealthCheckNodePort…

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -83,12 +83,9 @@ func (t *Tester) setSkipRegexFlag() error {
 			// This seems to be specific to the kube-proxy replacement
 			// < 33 so we look at this again
 			skipRegex += "|Services.should.support.externalTrafficPolicy.Local.for.type.NodePort"
-
-			if cluster.Spec.LegacyCloudProvider == "gce" {
-				// https://github.com/kubernetes/kubernetes/issues/129221
-				// < 33 so we look at this again
-				skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"
-			}
+			// https://github.com/kubernetes/kubernetes/issues/129221
+			// < 33 so we look at this again
+			skipRegex += "|Services.should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes"
 		}
 
 		if isPre28 {


### PR DESCRIPTION
`Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes` started failing for AWS also since Dec 11.
https://testgrid.k8s.io/kops-network-plugins#kops-aws-cni-cilium

Ref: https://github.com/kubernetes/kubernetes/issues/129221