### PR TITLE
Automated cherry pick of #17170: Update Cilium to v1.16.5

### DIFF
--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.16.3"
+		c.Version = "v1.16.5"
 	}
 
 	if c.EnableEndpointHealthChecking == nil {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -227,7 +227,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.16.3
+      version: v1.16.5
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 3dec2f27921f9e61bd722d058ec85a68e459d1fe3f09055ef9d8b03acf1a55dd
+    manifestHash: ec67d5e19b40dc4ec1c07fe956904c93630ef98a1f93cfd9c6eb9004c8e050ea
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -582,7 +582,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -700,7 +700,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -719,7 +719,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -746,7 +746,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -770,7 +770,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -805,7 +805,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -830,7 +830,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -993,7 +993,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.3
+        image: quay.io/cilium/operator:v1.16.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -153,7 +153,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal-warmpool.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: hDw7GDccItBvn+jlc6WzJY9fsp/mwxeXHtMTGK8EWnY=
+NodeupConfigHash: CrKN+2s86J9XP6beZL08+/dOp8xaeEYWKVhWt2hLo68=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -219,7 +219,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.3
+      version: v1.16.5
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: bc7f7e8765ce60f4a51faa622445f05312d6f6ff5c2cdae2bbc2b7fdaabf35fa
+    manifestHash: 79c3afa98cfb90c97da58bbc799657538111c520785c9191ceabcacd65890cd3
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -583,7 +583,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -701,7 +701,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -720,7 +720,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -747,7 +747,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -771,7 +771,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -806,7 +806,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -831,7 +831,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -994,7 +994,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.3
+        image: quay.io/cilium/operator:v1.16.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
@@ -64,7 +64,7 @@ containerdConfig:
 usesLegacyGossip: false
 usesNoneDNS: false
 warmPoolImages:
-- quay.io/cilium/cilium:v1.16.3
-- quay.io/cilium/operator:v1.16.3
+- quay.io/cilium/cilium:v1.16.5
+- quay.io/cilium/operator:v1.16.5
 - registry.k8s.io/kube-proxy:v1.26.0
 - registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.12

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
@@ -200,7 +200,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.3
+      version: v1.16.5
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://tests/scw-minimal.k8s.local/secrets

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: b09e39b605118cc04f98b48d24b0fa6c88487b04a0108574a61692c222f68e1b
+    manifestHash: b8ff520e1fab86258a9119be0ce2e56d2975f8658db16d6fb74ebd5a62daa24d
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
@@ -583,7 +583,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -701,7 +701,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -720,7 +720,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -747,7 +747,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -771,7 +771,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -806,7 +806,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -831,7 +831,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -994,7 +994,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.3
+        image: quay.io/cilium/operator:v1.16.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -221,7 +221,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.16.3
+      version: v1.16.5
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: f7612a95ce7e6eb6c7f4aff40ef362372345b45c4697b46ef78f5518d279e566
+    manifestHash: adccc130fb74a2aaf5784d76e54f1798aff3fd51e4e1aea1ed3a567d37d79a5f
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -585,7 +585,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -728,7 +728,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -747,7 +747,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -774,7 +774,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -798,7 +798,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -833,7 +833,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -858,7 +858,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1021,7 +1021,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.3
+        image: quay.io/cilium/operator:v1.16.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -229,7 +229,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.3
+      version: v1.16.5
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 36722e061be4bc322c060c5b28ebe41678b94361e32327bf652b53ef316972f0
+    manifestHash: bb8ab0eb9b524b3d24f1c4d6ce49f16897cf7160d4e8551b2100833d592a5fca
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -586,7 +586,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -704,7 +704,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -723,7 +723,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -750,7 +750,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -774,7 +774,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -809,7 +809,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -834,7 +834,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1001,7 +1001,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.3
+        image: quay.io/cilium/operator:v1.16.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -226,7 +226,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.3
+      version: v1.16.5
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -155,7 +155,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: ac9d01d0a3554b4774f2fd65840adaaae75b8512fcba39a487b80741e99de7c1
+    manifestHash: a634b1417a8cda30b27d6167bad863baccffcd5944662aa73f2afee23c3f6d0d
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -837,7 +837,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -966,7 +966,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -985,7 +985,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -1012,7 +1012,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -1036,7 +1036,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -1071,7 +1071,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -1096,7 +1096,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1273,7 +1273,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.3
+        image: quay.io/cilium/operator:v1.16.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1377,7 +1377,7 @@ spec:
         - serve
         command:
         - hubble-relay
-        image: quay.io/cilium/hubble-relay:v1.16.3
+        image: quay.io/cilium/hubble-relay:v1.16.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 12

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -233,7 +233,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.16.3
+      version: v1.16.5
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 8c601006d81de04e5d79a68f6bb155eb0ef45ca3d53305dbc2c0a1d458092426
+    manifestHash: bc3bc87fdbfa9e1721539e67523eb0803e59acc35f5a98189e915bcfc0e4a12f
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -595,7 +595,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -744,7 +744,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -763,7 +763,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -790,7 +790,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -814,7 +814,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -849,7 +849,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -874,7 +874,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.3
+        image: quay.io/cilium/cilium:v1.16.5
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1048,7 +1048,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.3
+        image: quay.io/cilium/operator:v1.16.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 45bddd141fefbbd61619eb858684854c1a4a92239f00098495ff97fe97201aef
+    manifestHash: 75f56f20d00fdfff26d59fcf430cba0679639a4625ce0907de47509f1a8de67a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -113,7 +113,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 45bddd141fefbbd61619eb858684854c1a4a92239f00098495ff97fe97201aef
+    manifestHash: 75f56f20d00fdfff26d59fcf430cba0679639a4625ce0907de47509f1a8de67a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -170,7 +170,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 45bddd141fefbbd61619eb858684854c1a4a92239f00098495ff97fe97201aef
+    manifestHash: 75f56f20d00fdfff26d59fcf430cba0679639a4625ce0907de47509f1a8de67a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #17170 on release-1.31.

#17170: Update Cilium to v1.16.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```