### PR TITLE
Automated cherry pick of #17171: Adding VolumeType for Azure for etcdMembers

### DIFF
--- a/upup/pkg/fi/cloudup/azuretasks/disk.go
+++ b/upup/pkg/fi/cloudup/azuretasks/disk.go
@@ -35,6 +35,7 @@ type Disk struct {
 	ResourceGroup *ResourceGroup
 	SizeGB        *int32
 	Tags          map[string]*string
+	VolumeType    *compute.DiskStorageAccountTypes
 	Zones         []*string
 }
 
@@ -76,6 +77,9 @@ func (d *Disk) Find(c *fi.CloudupContext) (*Disk, error) {
 		SizeGB: found.Properties.DiskSizeGB,
 		Tags:   found.Tags,
 		Zones:  found.Zones,
+	}
+	if found.SKU != nil && found.SKU.Name != nil {
+		disk.VolumeType = found.SKU.Name
 	}
 	if found.Properties != nil {
 		disk.SizeGB = found.Properties.DiskSizeGB
@@ -129,7 +133,7 @@ func (*Disk) RenderAzure(t *azure.AzureAPITarget, a, e, changes *Disk) error {
 			DiskSizeGB: e.SizeGB,
 		},
 		SKU: &compute.DiskSKU{
-			Name: to.Ptr(compute.DiskStorageAccountTypesStandardSSDLRS),
+			Name: e.VolumeType,
 		},
 		Tags:  e.Tags,
 		Zones: e.Zones,

--- a/upup/pkg/fi/cloudup/azuretasks/disk_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/disk_test.go
@@ -29,8 +29,9 @@ import (
 )
 
 const (
-	testTagKey   = "key"
-	testTagValue = "value"
+	testTagKey     = "key"
+	testTagValue   = "value"
+	testVolumeType = "StandardSSD_LRS"
 )
 
 func newTestDisk() *Disk {
@@ -40,7 +41,8 @@ func newTestDisk() *Disk {
 		ResourceGroup: &ResourceGroup{
 			Name: to.Ptr("rg"),
 		},
-		SizeGB: to.Ptr[int32](32),
+		SizeGB:     to.Ptr[int32](32),
+		VolumeType: to.Ptr(compute.DiskStorageAccountTypesStandardSSDLRS),
 		Tags: map[string]*string{
 			testTagKey: to.Ptr(testTagValue),
 		},


### PR DESCRIPTION
Cherry pick of #17171 on release-1.31.

#17171: Adding VolumeType for Azure for etcdMembers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```