### PR TITLE
make sure use correct endpoint for China cluster

### DIFF
--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -575,8 +575,14 @@ func (p *S3Path) GetHTTPsUrl(dualstack bool) (string, error) {
 	var url string
 	if dualstack {
 		url = fmt.Sprintf("https://s3.dualstack.%s.amazonaws.com/%s/%s", bucketDetails.region, bucketDetails.name, p.Key())
+		if strings.Contains(bucketDetails.region, "cn-") {
+			url = fmt.Sprintf("https://s3.dualstack.%s.amazonaws.com.cn/%s/%s", bucketDetails.region, bucketDetails.name, p.Key())
+		}
 	} else {
 		url = fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", bucketDetails.name, bucketDetails.region, p.Key())
+		if strings.Contains(bucketDetails.region, "cn-") {
+			url = fmt.Sprintf("https://%s.s3.%s.amazonaws.com.cn/%s", bucketDetails.name, bucketDetails.region, p.Key())
+		}
 	}
 	return strings.TrimSuffix(url, "/"), nil
 }
@@ -773,7 +779,6 @@ func (p *S3Path) RenderTerraform(w *terraformWriter.TerraformWriter, name string
 		}
 		return w.RenderResource("aws_s3_object", name, tf)
 	}
-
 }
 
 // AWSErrorCode returns the aws error code, if it is an smity.APIError, otherwise ""


### PR DESCRIPTION
My boyfriend was working with Kops and ran into an issue where the URI generator wasn’t behaving as expected in the China cluster. Turns out, the problem was with the endpoint (used for setting up IRSA) in China—it had an extra .cn at the end of the string. After digging into it, I found the fix! 😎
For reference: [AWS China Endpoints Documentation](https://docs.amazonaws.cn/en_us/aws/latest/userguide/endpoints-Beijing.html)