### PR TITLE
Automated cherry pick of #17184: Update Go to v1.23.4

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_32'
 steps:
 # Push the images
-- name: 'docker.io/library/golang:1.22.7-bookworm'
+- name: 'docker.io/library/golang:1.23.4-bookworm'
   id: images
   entrypoint: make
   env:
@@ -21,7 +21,7 @@ steps:
   - dns-controller-push
   - kube-apiserver-healthcheck-push
 # Push the artifacts
-- name: 'docker.io/library/golang:1.22.7-bookworm'
+- name: 'docker.io/library/golang:1.23.4-bookworm'
   id: artifacts
   entrypoint: make
   env:
@@ -36,7 +36,7 @@ steps:
   args:
   - gcs-upload-and-tag
 # Build cloudbuild artifacts (for attestation)
-- name: 'docker.io/library/golang:1.22.7-bookworm'
+- name: 'docker.io/library/golang:1.23.4-bookworm'
   id: cloudbuild-artifacts
   entrypoint: make
   env:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module k8s.io/kops
 
 // This should be kept in sync with cloudbuild.yaml and the other go.mod files
-go 1.22.7
+go 1.23.4
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/hack
 
-go 1.22.7
+go 1.23.4
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/tests/e2e
 
-go 1.22.7
+go 1.23.4
 
 replace k8s.io/kops => ../../.
 

--- a/tools/otel/traceserver/go.mod
+++ b/tools/otel/traceserver/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kops/tools/otel/traceserver
 
-go 1.22.7
+go 1.23.4
 
 require (
 	go.opentelemetry.io/proto/otlp v1.3.1


### PR DESCRIPTION
Cherry pick of #17184 on release-1.30.

#17184: Update Go to v1.23.4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```