### PR TITLE
Automated cherry pick of #17177: Use the same port for hubble-metrics that is used by cilium

### DIFF
--- a/docs/contributing/ports.md
+++ b/docs/contributing/ports.md
@@ -5,9 +5,8 @@ so we can avoid port collisions.
 
 See also pkg/wellknownports/wellknownports.go
 
-
 | Port | Description                              |
-|------|------------------------------------------|
+| ---- | ---------------------------------------- |
 | 22   | SSH                                      |
 | 443  | Kubernetes API                           |
 | 179  | Calico                                   |
@@ -31,4 +30,4 @@ See also pkg/wellknownports/wellknownports.go
 | 4789 | VXLAN                                    |
 | 6942 | Cilium operator prometheus port          |
 | 9090 | Cilium prometheus port                   |
-| 9091 | Cilium hubble prometheus port            |
+| 9965 | Cilium hubble prometheus port            |

--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -71,7 +71,7 @@ const (
 	CiliumPrometheusPort = 9090
 
 	// CiliumHubblePrometheusPort is the default port where Hubble exposes metrics
-	CiliumHubblePrometheusPort = 9091
+	CiliumHubblePrometheusPort = 9965
 
 	// VxlanUDP is the port used by VXLAN tunneling over UDP
 	VxlanUDP = 8472

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -155,7 +155,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 3fdb869ea26ce50ae6db32e1b997749f18cbb30ebf31468f2c5da2c692681a54
+    manifestHash: 958394ebe214f5422622d174e6a01c1312d325865a515c517363d4406a1882c5
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -78,7 +78,7 @@ data:
   hubble-disable-tls: "false"
   hubble-listen-address: :4244
   hubble-metrics: drop
-  hubble-metrics-server: :9091
+  hubble-metrics-server: :9965
   hubble-socket-path: /var/run/cilium/hubble.sock
   hubble-tls-cert-file: /var/lib/cilium/tls/hubble/tls.crt
   hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/ca.crt
@@ -831,8 +831,8 @@ spec:
           hostPort: 4244
           name: peer-service
           protocol: TCP
-        - containerPort: 9091
-          hostPort: 9091
+        - containerPort: 9965
+          hostPort: 9965
           name: hubble-metrics
           protocol: TCP
         readinessProbe:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -332,7 +332,7 @@ data:
   hubble-tls-key-file: /var/lib/cilium/tls/hubble/tls.key
   hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/ca.crt
   {{ if .Hubble.Metrics }}
-  hubble-metrics-server: ":9091"
+  hubble-metrics-server: ":9965"
   hubble-metrics:
   {{- range .Hubble.Metrics }}
     {{ . }}
@@ -1099,8 +1099,8 @@ spec:
           hostPort: 4244
           protocol: TCP
         {{- if .Hubble.Metrics }}
-        - containerPort: 9091
-          hostPort: 9091
+        - containerPort: 9965
+          hostPort: 9965
           name: hubble-metrics
           protocol: TCP
         {{- end }}


### PR DESCRIPTION
Cherry pick of #17177 on release-1.30.

#17177: Use the same port for hubble-metrics that is used by cilium

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```