### PR TITLE
Use Ubuntu 24.04 (Noble) as the default distro for K8s 1.32+

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -69,19 +69,19 @@ spec:
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
       providerID: aws
       architectureID: amd64
-      kubernetesVersion: ">=1.27.0 <1.31.0"
+      kubernetesVersion: ">=1.27.0 <1.32.0"
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20241211
       providerID: aws
       architectureID: arm64
-      kubernetesVersion: ">=1.27.0 <1.31.0"
+      kubernetesVersion: ">=1.27.0 <1.32.0"
     - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
       providerID: aws
       architectureID: amd64
-      kubernetesVersion: ">=1.31.0"
+      kubernetesVersion: ">=1.32.0"
     - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20241206
       providerID: aws
       architectureID: arm64
-      kubernetesVersion: ">=1.31.0"
+      kubernetesVersion: ">=1.32.0"
     - name: cos-cloud/cos-stable-65-10323-99-0
       providerID: gce
       architectureID: amd64
@@ -97,11 +97,11 @@ spec:
     - name: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
       providerID: gce
       architectureID: amd64
-      kubernetesVersion: ">=1.27.0 <1.31.0"
+      kubernetesVersion: ">=1.27.0 <1.32.0"
     - name: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
       providerID: gce
       architectureID: amd64
-      kubernetesVersion: ">=1.31.0"
+      kubernetesVersion: ">=1.32.0"
     - name: Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202406060
       providerID: azure
       architectureID: amd64
@@ -109,11 +109,11 @@ spec:
     - name: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202405140
       providerID: azure
       architectureID: amd64
-      kubernetesVersion: ">=1.27.0 <1.31.0"
+      kubernetesVersion: ">=1.27.0 <1.32.0"
     - name: Canonical:ubuntu-24_04-lts:server-gen1:24.04.202407011
       providerID: azure
       architectureID: amd64
-      kubernetesVersion: ">=1.31.0"
+      kubernetesVersion: ">=1.32.0"
   cluster:
     kubernetesVersion: v1.5.8
     networking:

--- a/channels/stable
+++ b/channels/stable
@@ -69,11 +69,19 @@ spec:
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
       providerID: aws
       architectureID: amd64
-      kubernetesVersion: ">=1.27.0"
+      kubernetesVersion: ">=1.27.0 <1.32.0"
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20241211
       providerID: aws
       architectureID: arm64
-      kubernetesVersion: ">=1.27.0"
+      kubernetesVersion: ">=1.27.0 <1.32.0"
+    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
+      providerID: aws
+      architectureID: amd64
+      kubernetesVersion: ">=1.32.0"
+    - name: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20241206
+      providerID: aws
+      architectureID: arm64
+      kubernetesVersion: ">=1.32.0"
     - name: cos-cloud/cos-stable-65-10323-99-0
       providerID: gce
       architectureID: amd64
@@ -89,7 +97,11 @@ spec:
     - name: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
       providerID: gce
       architectureID: amd64
-      kubernetesVersion: ">=1.27.0"
+      kubernetesVersion: ">=1.27.0 <1.32.0"
+    - name: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
+      providerID: gce
+      architectureID: amd64
+      kubernetesVersion: ">=1.32.0"
     - name: Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202406060
       providerID: azure
       architectureID: amd64
@@ -97,7 +109,11 @@ spec:
     - name: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202405140
       providerID: azure
       architectureID: amd64
-      kubernetesVersion: ">=1.27.0"
+      kubernetesVersion: ">=1.27.0 <1.32.0"
+    - name: Canonical:ubuntu-24_04-lts:server-gen1:24.04.202407011
+      providerID: azure
+      architectureID: amd64
+      kubernetesVersion: ">=1.32.0"
   cluster:
     kubernetesVersion: v1.5.8
     networking:

--- a/tests/integration/create_cluster/cilium-eni/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/cilium-eni/expected-v1alpha2.yaml
@@ -71,7 +71,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -89,7 +89,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex-private/expected-v1alpha2.yaml
@@ -135,7 +135,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -159,7 +159,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -177,7 +177,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -195,7 +195,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -213,7 +213,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 4
   minSize: 4
@@ -232,7 +232,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 3
   minSize: 3
@@ -250,7 +250,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 3
   minSize: 3

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -107,7 +107,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -125,7 +125,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -143,7 +143,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: control-plane-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -161,7 +161,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 4
   minSize: 4
@@ -180,7 +180,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 3
   minSize: 3
@@ -198,7 +198,7 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
   name: nodes-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 3
   minSize: 3

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -105,7 +105,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -123,7 +123,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -141,7 +141,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -159,7 +159,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -177,7 +177,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1c
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -73,7 +73,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: control-plane-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -93,7 +93,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: control-plane-us-test1-b
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -113,7 +113,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: control-plane-us-test1-c
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -133,7 +133,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: nodes-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -153,7 +153,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: nodes-us-test1-b
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -173,7 +173,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: nodes-us-test1-c
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_hetzner/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_hetzner/expected-v1alpha2.yaml
@@ -71,7 +71,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-fsn1-1
 spec:
-  image: ubuntu-22.04
+  image: ubuntu-24.04
   machineType: cx21
   maxSize: 1
   minSize: 1
@@ -89,7 +89,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-fsn1-2
 spec:
-  image: ubuntu-22.04
+  image: ubuntu-24.04
   machineType: cx21
   maxSize: 1
   minSize: 1
@@ -107,7 +107,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-fsn1-3
 spec:
-  image: ubuntu-22.04
+  image: ubuntu-24.04
   machineType: cx21
   maxSize: 1
   minSize: 1
@@ -125,7 +125,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-fsn1
 spec:
-  image: ubuntu-22.04
+  image: ubuntu-24.04
   machineType: cx21
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -79,7 +79,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-1
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -97,7 +97,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-2
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -115,7 +115,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-3
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -133,7 +133,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -95,7 +95,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-1
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -113,7 +113,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-2
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -131,7 +131,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1a-3
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -149,7 +149,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1b-1
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -167,7 +167,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: control-plane-us-test-1b-2
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -185,7 +185,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -203,7 +203,7 @@ metadata:
     kops.k8s.io/cluster: ha.example.com
   name: nodes-us-test-1b
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -72,7 +72,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -90,7 +90,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -108,7 +108,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-1.32/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.32/expected-v1alpha2.yaml
@@ -67,7 +67,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-arm64/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-arm64/expected-v1alpha2.yaml
@@ -67,7 +67,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20241206
   machineType: m6g.xlarge
   maxSize: 1
   minSize: 1
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20241206
   machineType: m6g.xlarge
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-gce-dns-none/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-gce-dns-none/expected-v1alpha2.yaml
@@ -65,7 +65,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-gce/expected-v1alpha2.yaml
@@ -65,7 +65,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-medium
   maxSize: 1
   minSize: 1
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test1-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-irsa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-irsa/expected-v1alpha2.yaml
@@ -71,7 +71,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -89,7 +89,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal_feature-gates/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal_feature-gates/expected-v1alpha2.yaml
@@ -91,7 +91,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -109,7 +109,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal_hetzner/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal_hetzner/expected-v1alpha2.yaml
@@ -63,7 +63,7 @@ metadata:
     kops.k8s.io/cluster: minimal.k8s.local
   name: control-plane-fsn1
 spec:
-  image: ubuntu-22.04
+  image: ubuntu-24.04
   machineType: cx21
   maxSize: 1
   minSize: 1
@@ -81,7 +81,7 @@ metadata:
     kops.k8s.io/cluster: minimal.k8s.local
   name: nodes-fsn1
 spec:
-  image: ubuntu-22.04
+  image: ubuntu-24.04
   machineType: cx21
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -72,7 +72,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -90,7 +90,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -108,7 +108,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -88,7 +88,7 @@ metadata:
     kops.k8s.io/cluster: overrides.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -75,7 +75,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.micro
   maxSize: 1
   minSize: 1
@@ -96,7 +96,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid3
   - sg-exampleid4
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -117,7 +117,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid
   - sg-exampleid2
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-micro
   maxSize: 1
   minSize: 1
@@ -93,7 +93,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid3
   - sg-exampleid4
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-standard-2
   maxSize: 1
   minSize: 1
@@ -116,7 +116,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid
   - sg-exampleid2
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240607
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20240701a
   machineType: e2-medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -74,7 +74,7 @@ metadata:
     kops.k8s.io/cluster: private-subnets.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -92,7 +92,7 @@ metadata:
     kops.k8s.io/cluster: private-subnets.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -69,7 +69,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -69,7 +69,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -87,7 +87,7 @@ metadata:
     kops.k8s.io/cluster: subnet.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -68,7 +68,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: control-plane-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -86,7 +86,7 @@ metadata:
     kops.k8s.io/cluster: vpc.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241211
+  image: 099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241206
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1653,7 +1653,7 @@ func defaultImage(cluster *api.Cluster, channel *api.Channel, architecture archi
 		case api.CloudProviderScaleway:
 			return defaultScalewayImageFocal, nil
 		}
-	} else {
+	} else if kubernetesVersion.LT(semver.MustParse("1.32.0")) {
 		switch cluster.GetCloudProvider() {
 		case api.CloudProviderDO:
 			return defaultDOImageJammy, nil
@@ -1661,6 +1661,17 @@ func defaultImage(cluster *api.Cluster, channel *api.Channel, architecture archi
 			return defaultHetznerImageJammy, nil
 		case api.CloudProviderScaleway:
 			return defaultScalewayImageJammy, nil
+		case api.CloudProviderMetal:
+			return "dummy-metal-image", nil
+		}
+	} else {
+		switch cluster.GetCloudProvider() {
+		case api.CloudProviderDO:
+			return defaultDOImageNoble, nil
+		case api.CloudProviderHetzner:
+			return defaultHetznerImageNoble, nil
+		case api.CloudProviderScaleway:
+			return defaultScalewayImageNoble, nil
 		case api.CloudProviderMetal:
 			return "dummy-metal-image", nil
 		}

--- a/upup/pkg/fi/cloudup/new_cluster_test.go
+++ b/upup/pkg/fi/cloudup/new_cluster_test.go
@@ -508,7 +508,7 @@ func TestDefaultImage(t *testing.T) {
 				},
 			},
 			architecture: architectures.ArchitectureAmd64,
-			expected:     defaultDOImageJammy,
+			expected:     defaultDOImageNoble,
 		},
 		{
 			cluster: &api.Cluster{
@@ -520,7 +520,7 @@ func TestDefaultImage(t *testing.T) {
 				},
 			},
 			architecture: architectures.ArchitectureAmd64,
-			expected:     defaultHetznerImageJammy,
+			expected:     defaultHetznerImageNoble,
 		},
 		{
 			cluster: &api.Cluster{
@@ -532,7 +532,7 @@ func TestDefaultImage(t *testing.T) {
 				},
 			},
 			architecture: architectures.ArchitectureAmd64,
-			expected:     defaultScalewayImageJammy,
+			expected:     defaultScalewayImageNoble,
 		},
 	}
 

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -59,6 +59,9 @@ const (
 	defaultDOImageJammy       = "ubuntu-22-04-x64"
 	defaultHetznerImageJammy  = "ubuntu-22.04"
 	defaultScalewayImageJammy = "ubuntu_jammy"
+	defaultDOImageNoble       = "ubuntu-24-04-x64"
+	defaultHetznerImageNoble  = "ubuntu-24.04"
+	defaultScalewayImageNoble = "ubuntu_noble"
 )
 
 // TODO: this hardcoded list can be replaced with DescribeInstanceTypes' DedicatedHostsSupported field


### PR DESCRIPTION
As discussed during the Jan 10th Office Hours, we are defaulting to Ubuntu 24.04 (Noble) starting with K8s 1.32.

/cc @rifelpet @justinsb @zetaab 