### PR TITLE
kindnet: use commands instead of args for the container image

### DIFF
--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: 43ba729e334963108d9468ac9fe4ca08f3b99bc2ae19c4f830895438f453d684
+    manifestHash: f986094857bdd8b6b72dc503bb31b5c78a0b811a7872690fd0bfb7ee575e1fb1
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -100,7 +100,7 @@ spec:
         tier: node
     spec:
       containers:
-      - args:
+      - command:
         - /bin/kindnetd
         - --hostname-override=$(NODE_NAME)
         - --v=2

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: 6f423b54cac7857cdd53f1998b399e3a029e675569c7ac6ae7eaf3e0979095f1
+    manifestHash: 0bb1fd2f646124bf3a5e1c41db9ad7f44103f5fbf9e4d8076b1d791e35c58443
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -100,7 +100,7 @@ spec:
         tier: node
     spec:
       containers:
-      - args:
+      - command:
         - /bin/kindnetd
         - --hostname-override=$(NODE_NAME)
         - --v=2

--- a/upup/models/cloudup/resources/addons/networking.kindnet/k8s-1.32.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kindnet/k8s-1.32.yaml.template
@@ -102,7 +102,7 @@ spec:
       containers:
       - name: kindnet-cni
         image: "ghcr.io/aojea/kindnetd:{{ .Networking.Kindnet.Version }}"
-        args:
+        command:
         - /bin/kindnetd
         - --hostname-override=$(NODE_NAME)
         - --v={{ .Networking.Kindnet.LogLevel }}


### PR DESCRIPTION
With the final 1.8.0 release of kindnet (yeah, this time the tag is final 😄 ).
One of the features is that it completely moved the image to distroless https://github.com/aojea/kindnet/releases/tag/v1.8.0

Because of that, current manifest that is using `args:` instead of `command:` fails to run https://testgrid.k8s.io/kops-distro-u2404#kops-aws-cni-kindnet

 
