### PR TITLE
bump kindnet default version to 1.8.2

### DIFF
--- a/pkg/model/components/kindnet.go
+++ b/pkg/model/components/kindnet.go
@@ -37,7 +37,7 @@ func (b *KindnetOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.8.0"
+		c.Version = "v1.8.2"
 	}
 
 	if c.Masquerade == nil {

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
@@ -185,7 +185,7 @@ spec:
       logLevel: 2
       masquerade:
         enabled: false
-      version: v1.8.0
+      version: v1.8.2
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: f986094857bdd8b6b72dc503bb31b5c78a0b811a7872690fd0bfb7ee575e1fb1
+    manifestHash: 94a6df20bdbaafa96a21757cce17c3423a82e9fff86308de418cdbb0b272bb41
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -121,7 +121,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: ghcr.io/aojea/kindnetd:v1.8.0
+        image: ghcr.io/aojea/kindnetd:v1.8.2
         name: kindnet-cni
         resources:
           requests:
@@ -140,7 +140,7 @@ spec:
         - sh
         - -c
         - cat /opt/cni/bin/cni-kindnet > /cni/cni-kindnet ; chmod +x /cni/cni-kindnet
-        image: ghcr.io/aojea/kindnetd:v1.8.0
+        image: ghcr.io/aojea/kindnetd:v1.8.2
         name: install-cni-bin
         volumeMounts:
         - mountPath: /cni

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
@@ -193,7 +193,7 @@ spec:
         - 172.20.0.0/16
         - 100.96.0.0/11
         - 100.64.0.0/13
-      version: v1.8.0
+      version: v1.8.2
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: 0bb1fd2f646124bf3a5e1c41db9ad7f44103f5fbf9e4d8076b1d791e35c58443
+    manifestHash: 7acb14096bbfa57eeddf70108830a2904d227671b7140af7de5f0adf1a2e98dc
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -122,7 +122,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: ghcr.io/aojea/kindnetd:v1.8.0
+        image: ghcr.io/aojea/kindnetd:v1.8.2
         name: kindnet-cni
         resources:
           requests:
@@ -141,7 +141,7 @@ spec:
         - sh
         - -c
         - cat /opt/cni/bin/cni-kindnet > /cni/cni-kindnet ; chmod +x /cni/cni-kindnet
-        image: ghcr.io/aojea/kindnetd:v1.8.0
+        image: ghcr.io/aojea/kindnetd:v1.8.2
         name: install-cni-bin
         volumeMounts:
         - mountPath: /cni


### PR DESCRIPTION
Some bugfixes https://github.com/aojea/kindnet/releases/tag/v1.8.1
and some other more https://github.com/aojea/kindnet/releases/tag/v1.8.2
