### PR TITLE
fix kindnet permissions

### DIFF
--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: 94a6df20bdbaafa96a21757cce17c3423a82e9fff86308de418cdbb0b272bb41
+    manifestHash: b6731b412e046c9ae24d1a845169a3ed153ab57f544c88cf37497d2b56efd406
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -19,6 +19,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/proxy
+  - nodes/configz
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.32
     manifest: networking.kindnet/k8s-1.32.yaml
-    manifestHash: 7acb14096bbfa57eeddf70108830a2904d227671b7140af7de5f0adf1a2e98dc
+    manifestHash: 6cd95c3169eee904a4b1e9605f49aee25903b0bca938f830bfe9b3d1981918e8
     name: networking.kindnet
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_privatekindnet.example.com-addons-networking.kindnet-k8s-1.32_content
@@ -19,6 +19,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/proxy
+  - nodes/configz
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/upup/models/cloudup/resources/addons/networking.kindnet/k8s-1.32.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kindnet/k8s-1.32.yaml.template
@@ -13,6 +13,13 @@ rules:
       - watch
       - patch
   - apiGroups:
+      - ""
+    resources:
+      - nodes/proxy
+      - nodes/configz
+    verbs:
+      - get
+  - apiGroups:
      - ""
     resources:
       - configmaps


### PR DESCRIPTION
kindnet needs to read the node configuration to obtain the dns nameserver and configuration, so it can implement the dnscache restricting the traffic to the in-cluster dns traffic only and avoid any possible disruption on the network

Fixes: https://github.com/aojea/kindnet/issues/159

/assign @hakman 