### PR TITLE
Kindnet requires cluster to provide ipam via the node.spec.podcidr

### DIFF
--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -111,7 +111,7 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o *kops.Cluster) erro
 	networking := &clusterSpec.Networking
 	if networking.Kubenet != nil {
 		kcm.ConfigureCloudRoutes = fi.PtrTo(true)
-	} else if gce.UsesIPAliases(o) {
+	} else if networking.GCP != nil {
 		kcm.ConfigureCloudRoutes = fi.PtrTo(false)
 		if kcm.CloudProvider == "external" {
 			// kcm should not allocate node cidrs with the CloudAllocator if we're using the external CCM

--- a/pkg/resources/gce/dump.go
+++ b/pkg/resources/gce/dump.go
@@ -79,7 +79,8 @@ func DumpManagedInstance(op *resources.DumpOperation, r *resources.Resource) err
 
 	op.Dump.Instances = append(op.Dump.Instances, i)
 
-	op.Dump.Resources = append(op.Dump.Resources, instanceDetails)
+	// Unclear if we should include the instance details in the dump - assume YAGNI until someone needs it
+	// dump.Resources = append(dump.Resources, instanceDetails)
 
 	return nil
 }

--- a/pkg/resources/gce/dump.go
+++ b/pkg/resources/gce/dump.go
@@ -79,8 +79,7 @@ func DumpManagedInstance(op *resources.DumpOperation, r *resources.Resource) err
 
 	op.Dump.Instances = append(op.Dump.Instances, i)
 
-	// Unclear if we should include the instance details in the dump - assume YAGNI until someone needs it
-	// dump.Resources = append(dump.Resources, instanceDetails)
+	op.Dump.Resources = append(op.Dump.Resources, instanceDetails)
 
 	return nil
 }

--- a/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_master-us-test-1a.masters.privatekindnet.example.com_user_data
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_master-us-test-1a.masters.privatekindnet.example.com_user_data
@@ -130,7 +130,7 @@ ClusterName: privatekindnet.example.com
 ConfigBase: memfs://clusters.example.com/privatekindnet.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: ControlPlane
-NodeupConfigHash: lgPxiqJbDn1WQqD2BR2dzZRFvgBtedQIcphqjfGgam0=
+NodeupConfigHash: jTF3I7at/1p0jwCMDz9kTq2uKvqMG+UEhKlJd1X96+8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
@@ -101,7 +101,7 @@ spec:
     serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   kubeControllerManager:
-    allocateNodeCIDRs: false
+    allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s
     cloudProvider: external
     clusterCIDR: 100.96.0.0/11

--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -233,7 +233,7 @@ CAs:
 ClusterName: privatekindnet.example.com
 ControlPlaneConfig:
   KubeControllerManager:
-    allocateNodeCIDRs: false
+    allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s
     cloudProvider: external
     clusterCIDR: 100.96.0.0/11


### PR DESCRIPTION
Different cloud providers provide the basic ipam functionality on the node.spec.podcidr via different components.

Typically this was done on the kube-controller-manager, but since the removal of the in-tree cloud provider code in Kubernetes, the GCP only ipam mode called CloudAllocator is not available, so it is provided by the cloud-controller-manager.

The commit in 27e8624cffec1ba643bb29d37ae1aa3e024d3527 made a GCP only check to apply to all cloud providers, hence disabling the ipamm functionality in the KCM, and as a consequence the kindnet jobs that depend on that started failing

https://testgrid.k8s.io/kops-distro-u2404#kops-aws-cni-kindnet

Revert that PR and keep the dumping functionality that is unrelated to the IPAM functionality