### PR TITLE
Remove reconcile flag from `kops update`

### DIFF
--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -190,8 +190,6 @@ func NewCmdUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&options.Prune, "prune", options.Prune, "Delete old revisions of cloud resources that were needed during an upgrade")
 	cmd.Flags().BoolVar(&options.IgnoreKubeletVersionSkew, "ignore-kubelet-version-skew", options.IgnoreKubeletVersionSkew, "Setting this to true will force updating the kubernetes version on all instance groups, regardles of which control plane version is running")
 
-	cmd.Flags().BoolVar(&options.Reconcile, "reconcile", options.Reconcile, "Reconcile the cluster by rolling the control plane and nodes sequentially")
-
 	return cmd
 }
 
@@ -219,10 +217,6 @@ func RunCoreUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer, c
 }
 
 func RunUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *UpdateClusterOptions) (*UpdateClusterResults, error) {
-	if c.Reconcile {
-		return nil, RunReconcileCluster(ctx, f, out, &c.CoreUpdateClusterOptions)
-	}
-
 	results := &UpdateClusterResults{}
 
 	isDryrun := false

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -37,7 +37,6 @@ kops update cluster [CLUSTER] [flags]
       --out string                     Path to write any local output
       --phase string                   Subset of tasks to run: cluster, network, security
       --prune                          Delete old revisions of cloud resources that were needed during an upgrade
-      --reconcile                      Reconcile the cluster by rolling the control plane and nodes sequentially
       --ssh-public-key string          SSH public key to use (deprecated: use kops create secret instead)
       --target target                  Target - "direct", "terraform" (default direct)
       --user string                    Existing user in kubeconfig file to use.  Implies --create-kube-config


### PR DESCRIPTION
We have `kops reconcile`, and it's confusing having both.

We didn't ship the --reconcile flag in any released version.
