### PR TITLE
Remove default CPU limits for aws-iam-authentication and node-problem-detector

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -197,7 +197,6 @@ spec:
                         - type: integer
                         - type: string
                         description: CPULimit CPU limit of AWS IAM Authenticator container.
-                          Default 10m
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       cpuRequest:
@@ -5983,9 +5982,7 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: |-
-                      CPULimit of NodeProblemDetector container.
-                      Default: 10m
+                    description: CPULimit of NodeProblemDetector container.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   cpuRequest:

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -429,7 +429,7 @@ type AWSAuthenticationSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// MemoryLimit memory limit of AWS IAM Authenticator container. Default 20Mi
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
-	// CPULimit CPU limit of AWS IAM Authenticator container. Default 10m
+	// CPULimit CPU limit of AWS IAM Authenticator container.
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
 	// IdentityMappings maps IAM Identities to Kubernetes users/groups
 	IdentityMappings []AWSAuthenticationIdentityMappingSpec `json:"identityMappings,omitempty"`

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -1081,7 +1081,6 @@ type NodeProblemDetectorConfig struct {
 	// Default: 80Mi
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// CPULimit of NodeProblemDetector container.
-	// Default: 10m
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -427,7 +427,7 @@ type AWSAuthenticationSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// MemoryLimit memory limit of AWS IAM Authenticator container. Default 20Mi
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
-	// CPULimit CPU limit of AWS IAM Authenticator container. Default 10m
+	// CPULimit CPU limit of AWS IAM Authenticator container.
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
 	// IdentityMappings maps IAM Identities to Kubernetes users/groups
 	IdentityMappings []AWSAuthenticationIdentityMappingSpec `json:"identityMappings,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -1147,7 +1147,6 @@ type NodeProblemDetectorConfig struct {
 	// Default: 80Mi
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// CPULimit of NodeProblemDetector container.
-	// Default: 10m
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
 }
 

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -395,7 +395,7 @@ type AWSAuthenticationSpec struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// MemoryLimit memory limit of AWS IAM Authenticator container. Default 20Mi
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
-	// CPULimit CPU limit of AWS IAM Authenticator container. Default 10m
+	// CPULimit CPU limit of AWS IAM Authenticator container.
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
 	// IdentityMappings maps IAM Identities to Kubernetes users/groups
 	IdentityMappings []AWSAuthenticationIdentityMappingSpec `json:"identityMappings,omitempty"`

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -1073,7 +1073,6 @@ type NodeProblemDetectorConfig struct {
 	// Default: 80Mi
 	MemoryLimit *resource.Quantity `json:"memoryLimit,omitempty"`
 	// CPULimit of NodeProblemDetector container.
-	// Default: 10m
 	CPULimit *resource.Quantity `json:"cpuLimit,omitempty"`
 }
 

--- a/pkg/model/components/nodeproblemdetector.go
+++ b/pkg/model/components/nodeproblemdetector.go
@@ -51,11 +51,6 @@ func (b *NodeProblemDetectorOptionsBuilder) BuildOptions(o *kops.Cluster) error 
 		npd.MemoryRequest = &defaultMemoryRequest
 	}
 
-	if npd.CPULimit == nil {
-		defaultCPULimit := resource.MustParse("200m")
-		npd.CPULimit = &defaultCPULimit
-	}
-
 	if npd.MemoryLimit == nil {
 		defaultMemoryLimit := resource.MustParse("100Mi")
 		npd.MemoryLimit = &defaultMemoryLimit

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
@@ -174,7 +174,6 @@ spec:
         name: aws-iam-authenticator
         resources:
           limits:
-            cpu: 100m
             memory: 20Mi
           requests:
             cpu: 10m

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 4a72854108b5bf11c547c832153a13abc6b26952723ae7a9a9f8dd7126b8116c
+    manifestHash: 9d0ba9f3934d111d6bb78773dd7176afd7287e0d257d1b096a7f92f4f0f635bb
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -201,7 +201,6 @@ spec:
   networking:
     amazonvpc: {}
   nodeProblemDetector:
-    cpuLimit: 200m
     cpuRequest: 20m
     enabled: true
     image: registry.k8s.io/node-problem-detector/node-problem-detector:v0.8.18

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -163,7 +163,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: node-problem-detector.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 94b31d90ea983e0cb64dc233c11174684a0b0fb18ea9cd7cbc93013881e1a230
+    manifestHash: 2184f20ded053de803f02517754d43cbcf905d42f5f24c14db1d438552cddd60
     name: node-problem-detector.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-node-problem-detector.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-node-problem-detector.addons.k8s.io-k8s-1.17_content
@@ -80,7 +80,6 @@ spec:
         name: node-problem-detector
         resources:
           limits:
-            cpu: 200m
             memory: 100Mi
           requests:
             cpu: 20m

--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -191,7 +191,9 @@ spec:
             cpu: {{ or .Authentication.AWS.CPURequest "10m" }}
           limits:
             memory: {{ or .Authentication.AWS.MemoryLimit "20Mi" }}
-            cpu: {{ or .Authentication.AWS.CPULimit "100m" }}
+            {{- if .Authentication.AWS.CPULimit }}
+            cpu: {{ .Authentication.AWS.CPULimit }}
+            {{- end }}
         livenessProbe:
           httpGet:
             host: 127.0.0.1

--- a/upup/models/cloudup/resources/addons/node-problem-detector.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-problem-detector.addons.k8s.io/k8s-1.17.yaml.template
@@ -62,7 +62,9 @@ spec:
           privileged: true
         resources:
           limits:
+            {{- if .CPULimit }}
             cpu: {{ .CPULimit }}
+            {{- end }}
             memory: {{ .MemoryLimit }}
           requests:
             cpu: {{ .CPURequest }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
@@ -176,7 +176,6 @@ spec:
         name: aws-iam-authenticator
         resources:
           limits:
-            cpu: 100m
             memory: 20Mi
           requests:
             cpu: 10m

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 4debe9956ffc92cd7c8da44e6fcc4c9705d51faa6640be9a59e8d86e0854c7ad
+    manifestHash: ac5ba2e6329d812c6868648642c335f51ecacbff8836b1011868b7604d45d2ca
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
@@ -175,7 +175,6 @@ spec:
         name: aws-iam-authenticator
         resources:
           limits:
-            cpu: 100m
             memory: 20Mi
           requests:
             cpu: 10m

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: c8a71f31e741c1938991952cf16728801dc2e2f1b81f92aef39b0d9c250a3f94
+    manifestHash: 285bcdd9f7937fc1e50c19c27b6c0f4e3ef4ccb1e8ea4d1db8feee887481d457
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"


### PR DESCRIPTION
Remove the default CPU limits defined for the aws-iam-authentication and node-problem-detector DaemonSets.

This makes them behave the same as the other `cpuLimit` parameters for the cluster that also do not have defaults.

As it was previously set up, if an administrator does not want CPU limits defined for these DaemonSets, there was no way to define that via the cluster spec.