### PR TITLE
Automated cherry pick of #17144: Normalize the hardcoded images used for warmpool pre-pulling

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -144,7 +144,7 @@ func (a *AssetBuilder) RemapManifest(data []byte) ([]byte, error) {
 }
 
 // RemapImage normalizes a containers location if a user sets the AssetsLocation ContainerRegistry location.
-func (a *AssetBuilder) RemapImage(image string) (string, error) {
+func (a *AssetBuilder) RemapImage(image string) string {
 	asset := &ImageAsset{
 		DownloadLocation:  image,
 		CanonicalLocation: image,
@@ -225,20 +225,20 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 	a.ImageAssets = append(a.ImageAssets, asset)
 
 	if !featureflag.ImageDigest.Enabled() || os.Getenv("KOPS_BASE_URL") != "" {
-		return image, nil
+		return image
 	}
 
 	if strings.Contains(image, "@") {
-		return image, nil
+		return image
 	}
 
 	digest, err := crane.Digest(image, crane.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		klog.Warningf("failed to digest image %q: %s", image, err)
-		return image, nil
+		return image
 	}
 
-	return image + "@" + digest, nil
+	return image + "@" + digest
 }
 
 // RemapFile returns a remapped URL for the file, if AssetsLocation is defined.

--- a/pkg/assets/builder_test.go
+++ b/pkg/assets/builder_test.go
@@ -42,11 +42,7 @@ func TestValidate_RemapImage_ContainerProxy_AppliesToDockerHub(t *testing.T) {
 
 	builder.AssetsLocation.ContainerProxy = &proxyURL
 
-	remapped, err := builder.RemapImage(image)
-	if err != nil {
-		t.Error("Error remapping image", err)
-	}
-
+	remapped := builder.RemapImage(image)
 	if remapped != expected {
 		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
 	}
@@ -61,11 +57,7 @@ func TestValidate_RemapImage_ContainerProxy_AppliesToSimplifiedDockerHub(t *test
 
 	builder.AssetsLocation.ContainerProxy = &proxyURL
 
-	remapped, err := builder.RemapImage(image)
-	if err != nil {
-		t.Error("Error remapping image", err)
-	}
-
+	remapped := builder.RemapImage(image)
 	if remapped != expected {
 		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
 	}
@@ -80,11 +72,7 @@ func TestValidate_RemapImage_ContainerProxy_AppliesToSimplifiedKubernetesURL(t *
 
 	builder.AssetsLocation.ContainerProxy = &proxyURL
 
-	remapped, err := builder.RemapImage(image)
-	if err != nil {
-		t.Error("Error remapping image", err)
-	}
-
+	remapped := builder.RemapImage(image)
 	if remapped != expected {
 		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
 	}
@@ -99,11 +87,7 @@ func TestValidate_RemapImage_ContainerProxy_AppliesToLegacyKubernetesURL(t *test
 
 	builder.AssetsLocation.ContainerProxy = &proxyURL
 
-	remapped, err := builder.RemapImage(image)
-	if err != nil {
-		t.Error("Error remapping image", err)
-	}
-
+	remapped := builder.RemapImage(image)
 	if remapped != expected {
 		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
 	}
@@ -118,11 +102,7 @@ func TestValidate_RemapImage_ContainerProxy_AppliesToImagesWithTags(t *testing.T
 
 	builder.AssetsLocation.ContainerProxy = &proxyURL
 
-	remapped, err := builder.RemapImage(image)
-	if err != nil {
-		t.Error("Error remapping image", err)
-	}
-
+	remapped := builder.RemapImage(image)
 	if remapped != expected {
 		t.Errorf("Error remapping image (Expecting: %s, got %s)", expected, remapped)
 	}
@@ -140,11 +120,7 @@ func TestValidate_RemapImage_ContainerRegistry_MappingMultipleTimesConverges(t *
 	remapped := image
 	iterations := make([]map[int]int, 2)
 	for i := range iterations {
-		remapped, err := builder.RemapImage(remapped)
-		if err != nil {
-			t.Errorf("Error remapping image (iteration %d): %s", i, err)
-		}
-
+		remapped := builder.RemapImage(remapped)
 		if remapped != expected {
 			t.Errorf("Error remapping image (Expecting: %s, got %s, iteration: %d)", expected, remapped, i)
 		}

--- a/pkg/kubemanifest/images.go
+++ b/pkg/kubemanifest/images.go
@@ -17,13 +17,12 @@ limitations under the License.
 package kubemanifest
 
 import (
-	"fmt"
 	"strings"
 
 	"k8s.io/klog/v2"
 )
 
-type ImageRemapFunction func(image string) (string, error)
+type ImageRemapFunction func(image string) string
 
 func (m *Object) RemapImages(mapper ImageRemapFunction) error {
 	visitor := &imageRemapVisitor{
@@ -57,10 +56,7 @@ func (m *imageRemapVisitor) VisitString(path []string, v string, mutator func(st
 
 	image := v
 	klog.V(4).Infof("Consider image for re-mapping: %q", image)
-	remapped, err := m.mapper(v)
-	if err != nil {
-		return fmt.Errorf("error remapping image %q: %v", image, err)
-	}
+	remapped := m.mapper(v)
 	if remapped != image {
 		mutator(remapped)
 	}

--- a/pkg/model/components/context.go
+++ b/pkg/model/components/context.go
@@ -150,11 +150,7 @@ func Image(component string, clusterSpec *kops.ClusterSpec, assetsBuilder *asset
 	if !kopsmodel.IsBaseURL(clusterSpec.KubernetesVersion) {
 		image := "registry.k8s.io/" + imageName + ":" + "v" + kubernetesVersion.String()
 
-		image, err := assetsBuilder.RemapImage(image)
-		if err != nil {
-			return "", fmt.Errorf("unable to remap container %q: %v", image, err)
-		}
-		return image, nil
+		return assetsBuilder.RemapImage(image), nil
 	}
 
 	// The simple name is valid when pulling.  But if we

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -314,11 +314,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 		// Remap image via AssetBuilder
 		for i := range pod.Spec.InitContainers {
 			initContainer := &pod.Spec.InitContainers[i]
-			remapped, err := b.AssetBuilder.RemapImage(initContainer.Image)
-			if err != nil {
-				return nil, fmt.Errorf("unable to remap init container image %q: %w", container.Image, err)
-			}
-			initContainer.Image = remapped
+			initContainer.Image = b.AssetBuilder.RemapImage(initContainer.Image)
 		}
 	}
 
@@ -334,11 +330,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 		}
 
 		// Remap image via AssetBuilder
-		remapped, err := b.AssetBuilder.RemapImage(container.Image)
-		if err != nil {
-			return nil, fmt.Errorf("unable to remap container image %q: %w", container.Image, err)
-		}
-		container.Image = remapped
+		container.Image = b.AssetBuilder.RemapImage(container.Image)
 	}
 
 	var clientHost string

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -138,13 +138,7 @@ func (b *KubeApiserverBuilder) buildHealthcheckSidecar() (*corev1.Pod, error) {
 	}
 
 	// Remap image via AssetBuilder
-	{
-		remapped, err := b.AssetBuilder.RemapImage(container.Image)
-		if err != nil {
-			return nil, fmt.Errorf("unable to remap container image %q: %v", container.Image, err)
-		}
-		container.Image = remapped
-	}
+	container.Image = b.AssetBuilder.RemapImage(container.Image)
 
 	return pod, nil
 }

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -167,11 +167,7 @@ func (b *KubeletOptionsBuilder) configureKubelet(cluster *kops.Cluster, kubelet 
 	// Prevent image GC from pruning the pause image
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2040-kubelet-cri#pinned-images
 	image := "registry.k8s.io/pause:3.9"
-	var err error
-	if image, err = b.AssetBuilder.RemapImage(image); err != nil {
-		return err
-	}
-	kubelet.PodInfraContainerImage = image
+	kubelet.PodInfraContainerImage = b.AssetBuilder.RemapImage(image)
 
 	if kubelet.FeatureGates == nil {
 		kubelet.FeatureGates = make(map[string]string)

--- a/pkg/nodemodel/nodeupconfigbuilder.go
+++ b/pkg/nodemodel/nodeupconfigbuilder.go
@@ -509,7 +509,8 @@ func (n *nodeUpConfigBuilder) buildWarmPoolImages(ig *kops.InstanceGroup) []stri
 	if assetBuilder != nil {
 		for _, image := range assetBuilder.ImageAssets {
 			for _, prefix := range desiredImagePrefixes {
-				if strings.HasPrefix(image.DownloadLocation, prefix) {
+				remappedPrefix := assets.NormalizeImage(assetBuilder, prefix)
+				if strings.HasPrefix(image.DownloadLocation, remappedPrefix) {
 					images[image.DownloadLocation] = true
 				}
 			}


### PR DESCRIPTION
Cherry pick of #17144 on release-1.31.

#17144: Normalize the hardcoded images used for warmpool pre-pulling

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```