### PR TITLE
Automated cherry pick of #17179: Re-enable Flannel

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1134,11 +1134,7 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 		}
 		optionTaken = true
 
-		if cluster.IsKubernetesGTE("1.28") {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("flannel"), "Flannel is not supported for Kubernetes >= 1.28"))
-		} else {
-			allErrs = append(allErrs, validateNetworkingFlannel(cluster, v.Flannel, fldPath.Child("flannel"))...)
-		}
+		allErrs = append(allErrs, validateNetworkingFlannel(cluster, v.Flannel, fldPath.Child("flannel"))...)
 	}
 
 	if v.Calico != nil {

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -97,6 +97,19 @@ func (t *Tester) setSkipRegexFlag() error {
 			// Ref: https://github.com/kubernetes/kubernetes/pull/113335
 			skipRegex += "|should.create.a.Pod.with.SCTP.HostPort"
 		}
+
+		if k8sVersion.Minor < 34 {
+			// < 34 so we revisit this in future
+			// This test checks for kube-proxy on port 10249 (`127.0.0.1:10249/proxyMode`)
+			// It appears that the cilium kube-proxy replacement does not implement this.
+			// Ref: https://github.com/kubernetes/kubernetes/issues/126903
+			skipRegex += "|KubeProxy.should.update.metric.for.tracking.accepted.packets.destined.for.localhost.nodeports"
+		}
+	} else if networking.Flannel != nil {
+		if k8sVersion.Minor < 33 {
+			// < 33 so we look at this again
+			skipRegex += "|Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes"
+		}
 	} else if networking.KubeRouter != nil {
 		skipRegex += "|should set TCP CLOSE_WAIT timeout|should check kube-proxy urls"
 	} else if networking.Kubenet != nil {

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.25
     manifest: networking.flannel/k8s-1.25.yaml
-    manifestHash: 0b0d13083ea6ee5196f49234a338d9d96e21684a622d2320bd4d9241f7b2e2d7
+    manifestHash: d1a97af395802323fdf6820591e85bd7916a6fa855464e8c53216e98aa21ef91
     name: networking.flannel
     prune:
       kinds:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-networking.flannel-k8s-1.25_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-networking.flannel-k8s-1.25_content
@@ -5,6 +5,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: networking.flannel
     app.kubernetes.io/managed-by: kops
+    k8s-app: flannel
     pod-security.kubernetes.io/enforce: privileged
     role.kubernetes.io/networking: "1"
   name: kube-flannel
@@ -18,6 +19,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: networking.flannel
     app.kubernetes.io/managed-by: kops
+    k8s-app: flannel
     role.kubernetes.io/networking: "1"
   name: flannel
 rules:
@@ -32,6 +34,7 @@ rules:
   resources:
   - nodes
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -50,6 +53,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: networking.flannel
     app.kubernetes.io/managed-by: kops
+    k8s-app: flannel
     role.kubernetes.io/networking: "1"
   name: flannel
 roleRef:
@@ -70,6 +74,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: networking.flannel
     app.kubernetes.io/managed-by: kops
+    k8s-app: flannel
     role.kubernetes.io/networking: "1"
   name: flannel
   namespace: kube-flannel
@@ -101,6 +106,7 @@ data:
   net-conf.json: |-
     {
       "Network": "100.64.0.0/10",
+      "EnableNFTables": true,
       "Backend": {
         "Type": "vxlan"
       }
@@ -112,6 +118,7 @@ metadata:
     addon.kops.k8s.io/name: networking.flannel
     app: flannel
     app.kubernetes.io/managed-by: kops
+    k8s-app: flannel
     role.kubernetes.io/networking: "1"
     tier: node
   name: kube-flannel-cfg
@@ -127,6 +134,7 @@ metadata:
     addon.kops.k8s.io/name: networking.flannel
     app: flannel
     app.kubernetes.io/managed-by: kops
+    k8s-app: flannel
     role.kubernetes.io/networking: "1"
     tier: node
   name: kube-flannel-ds
@@ -171,12 +179,9 @@ spec:
               fieldPath: metadata.namespace
         - name: EVENT_QUEUE_DEPTH
           value: "5000"
-        image: docker.io/rancher/mirrored-flannelcni-flannel:v0.19.2
+        image: ghcr.io/flannel-io/flannel:v0.26.4
         name: kube-flannel
         resources:
-          limits:
-            cpu: 100m
-            memory: 50Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -201,7 +206,7 @@ spec:
         - /opt/cni/bin/flannel
         command:
         - cp
-        image: docker.io/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.1.0
+        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.6.2-flannel1
         name: install-cni-plugin
         volumeMounts:
         - mountPath: /opt/cni/bin
@@ -212,7 +217,7 @@ spec:
         - /etc/cni/net.d/10-flannel.conflist
         command:
         - cp
-        image: docker.io/rancher/mirrored-flannelcni-flannel:v0.19.2
+        image: ghcr.io/flannel-io/flannel:v0.26.4
         name: install-cni
         volumeMounts:
         - mountPath: /etc/cni/net.d

--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.25.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.25.yaml.template
@@ -1,15 +1,18 @@
-# Pulled and modified from: https://raw.githubusercontent.com/coreos/flannel/v0.19.2/Documentation/kube-flannel.yml
+# Pulled and modified from: https://raw.githubusercontent.com/coreos/flannel/v0.26.4/Documentation/kube-flannel.yml
 ---
 kind: Namespace
 apiVersion: v1
 metadata:
   name: kube-flannel
   labels:
+    k8s-app: flannel
     pod-security.kubernetes.io/enforce: privileged
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  labels:
+    k8s-app: flannel
   name: flannel
 rules:
 - apiGroups:
@@ -23,6 +26,7 @@ rules:
   resources:
   - nodes
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -35,6 +39,8 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  labels:
+    k8s-app: flannel
   name: flannel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,6 +54,8 @@ subjects:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    k8s-app: flannel
   name: flannel
   namespace: kube-flannel
 ---
@@ -58,6 +66,7 @@ metadata:
   namespace: kube-flannel
   labels:
     tier: node
+    k8s-app: flannel
     app: flannel
 data:
   cni-conf.json: |
@@ -83,6 +92,7 @@ data:
   net-conf.json: |
     {
       "Network": "{{ .Networking.NonMasqueradeCIDR }}",
+      "EnableNFTables": true,
       "Backend": {
         "Type": "{{ FlannelBackendType }}"
       }
@@ -96,6 +106,7 @@ metadata:
   labels:
     tier: node
     app: flannel
+    k8s-app: flannel
 spec:
   selector:
     matchLabels:
@@ -124,8 +135,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni-plugin
-       #image: flannelcni/flannel-cni-plugin:v1.1.0 for ppc64le and mips64le (dockerhub limitations may apply)
-        image: docker.io/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.1.0
+        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.6.2-flannel1
         command:
         - cp
         args:
@@ -136,8 +146,7 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
       - name: install-cni
-       #image: flannelcni/flannel:v0.19.2 for ppc64le and mips64le (dockerhub limitations may apply)
-        image: docker.io/rancher/mirrored-flannelcni-flannel:v0.19.2
+        image: ghcr.io/flannel-io/flannel:v0.26.4
         command:
         - cp
         args:
@@ -151,8 +160,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-       #image: flannelcni/flannel:v0.19.2 for ppc64le and mips64le (dockerhub limitations may apply)
-        image: docker.io/rancher/mirrored-flannelcni-flannel:v0.19.2
+        image: ghcr.io/flannel-io/flannel:v0.26.4
         command:
         - /opt/bin/flanneld
         args:
@@ -161,9 +169,6 @@ spec:
         - --iptables-resync={{- or .Networking.Flannel.IptablesResyncSeconds "5" }}
         resources:
           requests:
-            cpu: "100m"
-            memory: "50Mi"
-          limits:
             cpu: "100m"
             memory: "50Mi"
         securityContext:


### PR DESCRIPTION
Cherry pick of #17179 on release-1.30.

#17179: Re-enable Flannel

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```