### PR TITLE
Better dumping via private IP when bastion is not set

### DIFF
--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -209,6 +209,9 @@ func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, 
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		}
 
+		klog.Infof("will SSH using username %q", sshConfig.User)
+		klog.Infof("ssh auth methods %v", sshConfig.Auth)
+
 		keyRing := agent.NewKeyring()
 		defer func(keyRing agent.Agent) {
 			_ = keyRing.RemoveAll()


### PR DESCRIPTION
Previously this would always fail in a confusing way,
regardless of whether we had connectivity,
because we tried to connect to an empty-string host.

Now we are more explicit about the error,
and will at least try to connect directly.