### PR TITLE
docs: updated etcdctl example

### DIFF
--- a/docs/operations/etcd_administration.md
+++ b/docs/operations/etcd_administration.md
@@ -36,8 +36,8 @@ kubectl exec -it -n kube-system $CONTAINER -- sh
 3\. Run etcdctl
 
 ```bash
-ETCD_VERSION=3.5.1
-ETCDDIR=/opt/etcd-v$ETCD_VERSION-linux-amd64 # Replace with arm64 if you are running an arm control plane
+ETCD_VERSION=3.5.13
+ETCDDIR=/opt/etcd-v$ETCD_VERSION
 CERTDIR=/rootfs/srv/kubernetes/kube-apiserver/
 alias etcdctl="ETCDCTL_API=3 $ETCDDIR/etcdctl --cacert=$CERTDIR/etcd-ca.crt --cert=$CERTDIR/etcd-client.crt --key=$CERTDIR/etcd-client.key --endpoints=https://127.0.0.1:4001"
 ```


### PR DESCRIPTION
On a modern (k8s and kops 1.31.x) cluster, etcd CLI tools are located in:

```
# /opt/etcd-v3.5.13/etcdctl version
etcdctl version: 3.5.13
API version: 3.5
```

so I updated the docs example to point to the right place, so it can be used as-is.