### PR TITLE
Fix conditional for reconcile command in upgrade tests

### DIFF
--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -121,7 +121,7 @@ else
   "${KOPS_B}" edit cluster "${CLUSTER_NAME}" "--set=cluster.spec.kubernetesVersion=${K8S_VERSION_B}"
 fi
 
-if [[ "${KOPS_VERSION_B}" =~ 1.(20|21|22|23|24|25|26|27|28|29|30). ]]; then
+if [[ "${KOPS_VERSION_B}" =~ 1.(20|21|22|23|24|25|26|27|28|29|30) ]]; then
   # kOps introduced the reconcile command in 1.31
   # TODO: remove this block once we stop testing upgrades to kops <1.31
   "${KOPS_B}" update cluster


### PR DESCRIPTION
Example failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-aws-upgrade-k130-ko130-to-k130-ko130/1891475173542989824

```
 + [[ 1.30 =~ 1.(20|21|22|23|24|25|26|27|28|29|30). ]]
+ /tmp/kops.nYZ7aVdIW reconcile cluster
Error: unknown command "reconcile" for "kops" 
```