### PR TITLE
Split dpkg-query fields with a tab

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -145,7 +145,7 @@ func (e *Package) Find(c *fi.NodeupContext) (*Package, error) {
 }
 
 func (e *Package) findDpkg(c *fi.NodeupContext) (*Package, error) {
-	args := []string{"dpkg-query", "-f", "${db:Status-Abbrev}${Version}\\n", "-W", e.Name}
+	args := []string{"dpkg-query", "-f", "${db:Status-Abbrev}\\t${Version}\\n", "-W", e.Name}
 	human := strings.Join(args, " ")
 
 	klog.V(2).Infof("Listing installed packages: %s", human)
@@ -166,12 +166,12 @@ func (e *Package) findDpkg(c *fi.NodeupContext) (*Package, error) {
 			continue
 		}
 
-		tokens := strings.Split(line, " ")
+		tokens := strings.Split(line, "\t")
 		if len(tokens) != 2 {
 			return nil, fmt.Errorf("error parsing dpkg-query line %q", line)
 		}
-		state := tokens[0]
-		version := tokens[1]
+		state := strings.TrimSpace(tokens[0])
+		version := strings.TrimSpace(tokens[1])
 
 		switch state {
 		case "ii":


### PR DESCRIPTION
ref: https://man7.org/linux/man-pages/man1/dpkg-query.1.html

```
           db:Status-Abbrev
               It contains the abbreviated package status (as three
               characters), such as “ii ” or “iHR” (since dpkg 1.16.2).
               See the --list command description for more details.
```

We were previously splitting on a space which depended on Status-Abbrev only using 1 or 2 of its 3 character width. When Status-Abbrev has 3 non-whitespace characters the parsing fails. Now we use tab delimiters and trim off any whitespace after splitting.

This is the first step towards fixing the failing GCE presubmit. Based on [these logs](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kops/17270/pull-kops-e2e-k8s-gce-cilium/1892382171776159744/artifacts/34.118.249.58/journal.log):

```
nodeup[5467]: I0220 01:46:51.146325    5467 executor.go:214] Executing task "Package/chrony": Package: chrony
nodeup[5467]: I0220 01:46:51.146424    5467 package.go:151] Listing installed packages: dpkg-query -f ${db:Status-Abbrev}${Version}\n -W chrony
nodeup[5467]: W0220 01:46:51.153117    5467 executor.go:141] error running task "Package/chrony" (0s remaining to succeed): error parsing dpkg-query line "iHR4.5-1ubuntu4"
```

The package reports a status of `iHR` which indicates Half-installed and Reinst-required. Based on the journal logs, chronyd is already installed in the image, and nodeup attempts to reinstall/upgrade it and doesn't report any error in doing so. Perhaps the config file needs to change but I would be surprised if that results in the package as requiring reinstallation.

`nodeup[1257]: I0220 01:35:25.221313    1257 changes.go:81] Field changed "Contents" actual="# Welcome to the chrony configuration file. See chrony.conf(5) for more\n# information about usable directives.\n\n# Use servers from the NTP Pool Project. Approved by Ubuntu Technical Board\n# on 2011-02-08 (LP: #104525). See http://www.pool.ntp.org/join.html... (truncated)" expected="# Built by kOps - do NOT edit\n\npool time.google.com prefer iburst\ndriftfile /var/lib/chrony/drift\nleapsectz right/UTC\nlogdir /var/log/chrony\nmakestep 1.0 3\nmaxupdateskew 100.0\nrtcsync\n"`