### PR TITLE
Automated cherry pick of #17277: chore(networking): upgrade amazon vpc cni to 1.19.3

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: f7c29b8c7ecc81826fbb05c53bc443f4e387a0e1dd375b9dbdd71de95674a479
+    manifestHash: 01f858a114224a9b057f7bc49d1efe3e4f7e9cce20433eb5a236568c07d32beb
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.0
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -543,7 +543,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.19.2
+          value: v1.19.3
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -556,7 +556,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.3
         livenessProbe:
           exec:
             command:
@@ -613,7 +613,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.6
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.2.0
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -639,7 +639,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.3
         name: aws-vpc-cni-init
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -185,7 +185,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: f7c29b8c7ecc81826fbb05c53bc443f4e387a0e1dd375b9dbdd71de95674a479
+    manifestHash: 01f858a114224a9b057f7bc49d1efe3e4f7e9cce20433eb5a236568c07d32beb
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.0
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -543,7 +543,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.19.2
+          value: v1.19.3
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -556,7 +556,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.3
         livenessProbe:
           exec:
             command:
@@ -613,7 +613,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.6
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.2.0
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -639,7 +639,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.3
         name: aws-vpc-cni-init
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -186,7 +186,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: f7c29b8c7ecc81826fbb05c53bc443f4e387a0e1dd375b9dbdd71de95674a479
+    manifestHash: 01f858a114224a9b057f7bc49d1efe3e4f7e9cce20433eb5a236568c07d32beb
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.0
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -543,7 +543,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.19.2
+          value: v1.19.3
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -556,7 +556,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.3
         livenessProbe:
           exec:
             command:
@@ -613,7 +613,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.6
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.2.0
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -639,7 +639,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.3
         name: aws-vpc-cni-init
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -178,7 +178,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: d0da1a35c40afb854d38096ddb3c4f5b6feefef979eb46937a7b984fe00a221c
+    manifestHash: 21c03f6286047d01dc3f580caa32c3f555c3053775327b7b8df83eff4ee8f753
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.0
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -543,7 +543,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.19.2
+          value: v1.19.3
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -227,7 +227,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: b23994ffa73213979b206b3917c3de9146ac8b1709b7d94d1d287b7f00a2c3b9
+    manifestHash: 9af85cb340fe0bc0006486875f7f4b0c309550f38104b131ad64a4996369d9bb
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.0
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -543,7 +543,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.19.2
+          value: v1.19.3
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -556,7 +556,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: many-addons.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.3
         livenessProbe:
           exec:
             command:
@@ -613,7 +613,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.6
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.2.0
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -639,7 +639,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.3
         name: aws-vpc-cni-init
         resources:
           requests:

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,4 +1,4 @@
-# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.19.2/config/master/aws-k8s-cni.yaml
+# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.19.3/config/master/aws-k8s-cni.yaml
 ---
 # Source: aws-vpc-cni/crds/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -301,7 +301,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.3"
 ---
 # Source: aws-vpc-cni/templates/configmap.yaml
 apiVersion: v1
@@ -313,7 +313,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.3"
 data:
   enable-windows-ipam: "false"
   enable-network-policy-controller: "false"
@@ -332,7 +332,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.19.0"
+    app.kubernetes.io/version: "v1.19.3"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -385,7 +385,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -405,7 +405,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.19.2"
+    app.kubernetes.io/version: "v1.19.3"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -426,7 +426,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.2" }}"
+        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.3" }}"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -451,7 +451,7 @@ spec:
 {{ end }}
       containers:
         - name: aws-node
-          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.2" }}"
+          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.3" }}"
           ports:
             - containerPort: 61678
               name: metrics
@@ -521,7 +521,7 @@ spec:
             # - name: NETWORK_POLICY_ENFORCING_MODE
             #   value: "standard"
             - name: VPC_CNI_VERSION
-              value: "v1.19.2"
+              value: "v1.19.3"
             # - name: WARM_ENI_TARGET
             #   value: "1"
             # - name: WARM_PREFIX_TARGET
@@ -558,7 +558,7 @@ spec:
           - mountPath: /run/xtables.lock
             name: xtables-lock
         - name: aws-eks-nodeagent
-          image: "{{- or .Networking.AmazonVPC.NetworkPolicyAgentImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.6" }}"
+          image: "{{- or .Networking.AmazonVPC.NetworkPolicyAgentImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.2.0" }}"
           env:
             - name: MY_NODE_NAME
               valueFrom:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e20b7ce8c38cbb474ba6869f076add0a1e10d57ac63acaa82d53c44f126db2a5
+    manifestHash: f368578084c2e0bcab27b616c0e9e14bf1eb45d11156ea16066b380681e345f3
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.0
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -545,7 +545,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.19.2
+          value: v1.19.3
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -558,7 +558,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.3
         livenessProbe:
           exec:
             command:
@@ -615,7 +615,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.6
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.2.0
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -641,7 +641,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.3
         name: aws-vpc-cni-init
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e20b7ce8c38cbb474ba6869f076add0a1e10d57ac63acaa82d53c44f126db2a5
+    manifestHash: f368578084c2e0bcab27b616c0e9e14bf1eb45d11156ea16066b380681e345f3
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: amazon-vpc-cni
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.0
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -456,7 +456,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.19.2
+    app.kubernetes.io/version: v1.19.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -545,7 +545,7 @@ spec:
         - name: WARM_PREFIX_TARGET
           value: "1"
         - name: VPC_CNI_VERSION
-          value: v1.19.2
+          value: v1.19.3
         - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
@@ -558,7 +558,7 @@ spec:
               fieldPath: metadata.name
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.19.3
         livenessProbe:
           exec:
             command:
@@ -615,7 +615,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.6
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.2.0
         name: aws-eks-nodeagent
         resources:
           requests:
@@ -641,7 +641,7 @@ spec:
           value: "false"
         - name: ENABLE_IPv6
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.2
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.19.3
         name: aws-vpc-cni-init
         resources:
           requests:


### PR DESCRIPTION
Cherry pick of #17277 on release-1.31.

#17277: chore(networking): upgrade amazon vpc cni to 1.19.3

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```