### PR TITLE
Automated cherry pick of #17274: make --admin configurable to rolling-update

### DIFF
--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -59,6 +59,7 @@ kops rolling-update cluster [CLUSTER] [flags]
 ### Options
 
 ```
+      --admin duration                    a cluster admin user credential with the specified lifetime (default 18h0m0s)
       --bastion-interval duration         Time to wait between restarting bastions (default 15s)
       --cloudonly                         Perform rolling update without validating cluster status (will cause downtime)
       --control-plane-interval duration   Time to wait between restarting control plane nodes (default 15s)


### PR DESCRIPTION
Cherry pick of #17274 on release-1.31.

#17274: make --admin configurable to rolling-update

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```