### PR TITLE
Automated cherry pick of #17282: Cleanup logging for reconcile cluster

### DIFF
--- a/cmd/kops/reconcile_cluster.go
+++ b/cmd/kops/reconcile_cluster.go
@@ -166,7 +166,7 @@ func RunReconcileCluster(ctx context.Context, f *util.Factory, out io.Writer, c 
 		}
 	}
 
-	fmt.Fprintf(out, "Doing rolling-update for control plane\n")
+	fmt.Fprintf(out, "Performing rolling-update for control plane\n")
 	{
 		opt := &RollingUpdateOptions{}
 		opt.InitDefaults()
@@ -192,7 +192,7 @@ func RunReconcileCluster(ctx context.Context, f *util.Factory, out io.Writer, c 
 		}
 	}
 
-	fmt.Fprintf(out, "Doing rolling-update for nodes\n")
+	fmt.Fprintf(out, "Performing rolling-update for nodes\n")
 	{
 		opt := &RollingUpdateOptions{}
 		opt.InitDefaults()

--- a/cmd/kops/rolling-update_cluster.go
+++ b/cmd/kops/rolling-update_cluster.go
@@ -285,7 +285,6 @@ func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer
 		countByRole[instanceGroup.Spec.Role] = countByRole[instanceGroup.Spec.Role] + minSize
 	}
 	if countByRole[kopsapi.InstanceGroupRoleAPIServer]+countByRole[kopsapi.InstanceGroupRoleControlPlane] <= 1 {
-		fmt.Fprintf(out, "Detected single-control-plane cluster; won't detach before draining\n")
 		options.DeregisterControlPlaneNodes = false
 	}
 

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -478,7 +478,7 @@ func RunUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Up
 			fmt.Fprintf(sb, "\n")
 		}
 
-		if !firstRun {
+		if !firstRun && !c.Reconcile {
 			// TODO: Detect if rolling-update is needed
 			fmt.Fprintf(sb, "\n")
 			fmt.Fprintf(sb, "Changes may require instances to restart: kops rolling-update cluster\n")

--- a/pkg/instancegroups/rollingupdate.go
+++ b/pkg/instancegroups/rollingupdate.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -230,7 +232,8 @@ func (c *RollingUpdateCluster) RollingUpdate(ctx context.Context, groups map[str
 		}
 	}
 
-	klog.Infof("Rolling update completed for cluster %q!", c.ClusterName)
+	igNames := slices.Sorted(maps.Keys(groups))
+	klog.Infof("Completed rolling update for cluster %q instance groups %v", c.ClusterName, igNames)
 	return errors.NewAggregate(errs)
 }
 


### PR DESCRIPTION
Cherry pick of #17282 on release-1.32.

#17282: Cleanup logging for reconcile cluster

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```