### PR TITLE
Skip hostnetwork + hostname tests through 1.33

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -167,8 +167,9 @@ func (t *Tester) setSkipRegexFlag() error {
 	// ref: https://github.com/kubernetes/kops/issues/16349
 	// ref: https://github.com/kubernetes/kubernetes/issues/123255
 	// ref: https://github.com/kubernetes/kubernetes/issues/121018
-	// < 33 so we look at this again
-	if k8sVersion.Minor < 33 {
+	// ref: https://github.com/kubernetes/kubernetes/pull/126896
+	// < 34 so we look at this again
+	if k8sVersion.Minor < 34 {
 		skipRegex += "|Services.should.function.for.service.endpoints.using.hostNetwork"
 	}
 


### PR DESCRIPTION
These tests are still failing in 1.33 because of the hostname inconsistencies in the e2e test's assumptions.

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-gce-cni-cilium-k8s-ci/1895087038508568576

```
{ failed [FAILED] failed dialing endpoint, received unexpected responses... 
Attempt 0
Command curl -g -q -s 'http://100.96.3.253:9080/dial?request=hostname&protocol=http&host=100.68.31.181&port=80&tries=1'
retrieved map[nodes-us-west3-a-x22d.c.k8s-infra-e2e-boskos-109.internal:{}]
expected map[nodes-us-west3-a-fmh4:{} nodes-us-west3-a-gc31:{} nodes-us-west3-a-km0d:{} nodes-us-west3-a-x22d:{}]
In [It] at: k8s.io/kubernetes/test/e2e/network/networking.go:479 @ 02/27/25 12:42:40.728
}
```