### PR TITLE
kube-router: bump version v2.1.1 -> v2.5.0

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v2.1.1
+        image: docker.io/cloudnativelabs/kube-router:v2.5.0
         args:
         - --run-router=true
         - --run-firewall=true
@@ -117,7 +117,7 @@ spec:
           readOnly: true
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v2.1.1
+        image: docker.io/cloudnativelabs/kube-router:v2.5.0
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
FYI @hakman 

A long overdue bump to kube-router's image on kops. This comes with a bunch of bug fixes as well as a newer iptables userspace.

I've tested a deployment of this against a new kops cluster and haven't noticed any regressions.