### PR TITLE
Automated cherry pick of #17297: kube-router: bump version v2.1.1 -> v2.5.0

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v2.1.1
+        image: docker.io/cloudnativelabs/kube-router:v2.5.0
         args:
         - --run-router=true
         - --run-firewall=true
@@ -117,7 +117,7 @@ spec:
           readOnly: true
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v2.1.1
+        image: docker.io/cloudnativelabs/kube-router:v2.5.0
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
Cherry pick of #17297 on release-1.32.

#17297: kube-router: bump version v2.1.1 -> v2.5.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```