### PR TITLE
Automated cherry pick of #17311: Update Calico to v3.29.2
#17312: Update Cilium to v1.16.7
#17313: Update metrics-server to v0.7.2

### DIFF
--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.16.5"
+		c.Version = "v1.16.7"
 	}
 
 	if c.EnableEndpointHealthChecking == nil {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 5a79936723087694804b3f2dd19917119822494bb92c2ea8f8554729bb293e9f
+    manifestHash: f858a160d2ed56d622fb7d3cbcb589ddbb2aa2b83677a505f46330ba42c81bb7
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -176,7 +176,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.7.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.7.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 5a79936723087694804b3f2dd19917119822494bb92c2ea8f8554729bb293e9f
+    manifestHash: f858a160d2ed56d622fb7d3cbcb589ddbb2aa2b83677a505f46330ba42c81bb7
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -176,7 +176,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.7.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.7.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: f5a15bd72ed37b6a3e36df1bddd77c6440f6b067c3b97f3d216e24d2ed014826
+    manifestHash: 20fc8a62a91b813e570401ad440cc0bc3ebc6423b365b38378d44f1b19e0c69c
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -176,7 +176,7 @@ spec:
         - --kubelet-preferred-address-types=InternalIP
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.7.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.7.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 5a79936723087694804b3f2dd19917119822494bb92c2ea8f8554729bb293e9f
+    manifestHash: f858a160d2ed56d622fb7d3cbcb589ddbb2aa2b83677a505f46330ba42c81bb7
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_many-addons.example.com-addons-metrics-server.addons.k8s.io-k8s-1.11_content
@@ -176,7 +176,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.7.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.7.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.25
     manifest: networking.projectcalico.org/k8s-1.25.yaml
-    manifestHash: 55b59a095cb1c3d87680744115ff0f3b8dd2b4112356d8721fc9a9bf33868d04
+    manifestHash: 0b908c4c6d7093e9cafdde3db1b448088de2de8b42f726869176a7ed43767a80
     name: networking.projectcalico.org
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.25_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.25_content
@@ -6337,7 +6337,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.29.1
+        image: docker.io/calico/node:v3.29.2
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -6417,7 +6417,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.29.1
+        image: docker.io/calico/cni:v3.29.2
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -6431,7 +6431,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.29.1
+        image: docker.io/calico/node:v3.29.2
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:
@@ -6560,7 +6560,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.29.1
+        image: docker.io/calico/kube-controllers:v3.29.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -212,7 +212,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.16.5
+      version: v1.16.7
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: ec67d5e19b40dc4ec1c07fe956904c93630ef98a1f93cfd9c6eb9004c8e050ea
+    manifestHash: 701616c03e4ad157a9db6cf3caa3a82fc8c200b7d0b838d50668603abe69e43a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -582,7 +582,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -700,7 +700,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -719,7 +719,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -746,7 +746,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -770,7 +770,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -805,7 +805,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -830,7 +830,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -993,7 +993,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.5
+        image: quay.io/cilium/operator:v1.16.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -153,7 +153,7 @@ ConfigServer:
   - https://kops-controller.internal.minimal-warmpool.example.com:3988/
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: cx4pXSvDOgr+SqcmYZll2ol8Zr1R2mvPBA6r+1p6SBo=
+NodeupConfigHash: 5uju3TyrpJia7EVXjpE80ZhpgiJ8lkHOSz6oHXR8ekE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -204,7 +204,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.5
+      version: v1.16.7
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 79c3afa98cfb90c97da58bbc799657538111c520785c9191ceabcacd65890cd3
+    manifestHash: 1d069b812e49ee373c8c35c4a7c653e7c7690c8292f34025abd2c33db0064277
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -583,7 +583,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -701,7 +701,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -720,7 +720,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -747,7 +747,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -771,7 +771,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -806,7 +806,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -831,7 +831,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -994,7 +994,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.5
+        image: quay.io/cilium/operator:v1.16.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
@@ -61,7 +61,7 @@ containerdConfig:
 usesLegacyGossip: false
 usesNoneDNS: false
 warmPoolImages:
-- quay.io/cilium/cilium:v1.16.5
-- quay.io/cilium/operator:v1.16.5
+- quay.io/cilium/cilium:v1.16.7
+- quay.io/cilium/operator:v1.16.7
 - registry.k8s.io/kube-proxy:v1.32.0
 - registry.k8s.io/provider-aws/cloud-controller-manager:v1.31.0

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
@@ -200,7 +200,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.5
+      version: v1.16.7
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://tests/scw-minimal.k8s.local/secrets

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: b8ff520e1fab86258a9119be0ce2e56d2975f8658db16d6fb74ebd5a62daa24d
+    manifestHash: cceac64c304516725d40231c9b73cff5e8299856760fb6cea3222f1c21d080f7
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_scw-minimal.k8s.local-addons-networking.cilium.io-k8s-1.16_content
@@ -583,7 +583,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -701,7 +701,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -720,7 +720,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -747,7 +747,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -771,7 +771,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -806,7 +806,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -831,7 +831,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -994,7 +994,7 @@ spec:
           value: api.internal.scw-minimal.k8s.local
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.5
+        image: quay.io/cilium/operator:v1.16.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.25
     manifest: networking.projectcalico.org/k8s-1.25.yaml
-    manifestHash: e41cade1ae0f05c607612802deea3cdfeec1f1d8d7f01becc65f63fb225a5ec8
+    manifestHash: f16968ad43bb21350e5b985ef6137cda40767f6a06509ec9b05e6b1e80b60301
     name: networking.projectcalico.org
     prune:
       kinds:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.25_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.25_content
@@ -6332,7 +6332,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.29.1
+        image: docker.io/calico/node:v3.29.2
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -6406,7 +6406,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.29.1
+        image: docker.io/calico/cni:v3.29.2
         imagePullPolicy: IfNotPresent
         name: upgrade-ipam
         securityContext:
@@ -6441,7 +6441,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.29.1
+        image: docker.io/calico/cni:v3.29.2
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -6455,7 +6455,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.29.1
+        image: docker.io/calico/node:v3.29.2
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:
@@ -6587,7 +6587,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.29.1
+        image: docker.io/calico/kube-controllers:v3.29.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -206,7 +206,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.16.5
+      version: v1.16.7
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: adccc130fb74a2aaf5784d76e54f1798aff3fd51e4e1aea1ed3a567d37d79a5f
+    manifestHash: 210aad01f06c3cc7f91e69931cd81881496c91740622f8a2f1867e1df64e7410
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -585,7 +585,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -728,7 +728,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -747,7 +747,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -774,7 +774,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -798,7 +798,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -833,7 +833,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -858,7 +858,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1021,7 +1021,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.5
+        image: quay.io/cilium/operator:v1.16.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -214,7 +214,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.5
+      version: v1.16.7
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: bb8ab0eb9b524b3d24f1c4d6ce49f16897cf7160d4e8551b2100833d592a5fca
+    manifestHash: d7856bfc2bc1190c333411aa196efab57fd217253de2cd00ba6e9e58318f8894
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -586,7 +586,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -704,7 +704,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -723,7 +723,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -750,7 +750,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -774,7 +774,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -809,7 +809,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -834,7 +834,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1001,7 +1001,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.5
+        image: quay.io/cilium/operator:v1.16.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -226,7 +226,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.16.5
+      version: v1.16.7
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -155,7 +155,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: d517037904591938b5a8f391024ed9c561e54f7adc5bf4bfaf243d2a10a4967a
+    manifestHash: 79db9d85ae81dccb36c7ea45d54ce5a11b8c554fc583976c8edbe2c76ef0b45e
     name: networking.cilium.io
     needsPKI: true
     needsRollingUpdate: all

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -837,7 +837,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -966,7 +966,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -985,7 +985,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -1012,7 +1012,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -1036,7 +1036,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -1071,7 +1071,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -1096,7 +1096,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1273,7 +1273,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.5
+        image: quay.io/cilium/operator:v1.16.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1377,7 +1377,7 @@ spec:
         - serve
         command:
         - hubble-relay
-        image: quay.io/cilium/hubble-relay:v1.16.5
+        image: quay.io/cilium/hubble-relay:v1.16.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 12

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -218,7 +218,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.16.5
+      version: v1.16.7
   nodeTerminationHandler:
     cpuRequest: 50m
     deleteSQSMsgIfNodeNotFound: false

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: bc3bc87fdbfa9e1721539e67523eb0803e59acc35f5a98189e915bcfc0e4a12f
+    manifestHash: 4156a83ceda6287eaa790ad43d7f0acf1dc7d0a12afd30078ad9841e93d6e53c
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -595,7 +595,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -744,7 +744,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: config
         terminationMessagePolicy: FallbackToLogsOnError
@@ -763,7 +763,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -790,7 +790,7 @@ spec:
         env:
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: apply-sysctl-overwrites
         securityContext:
@@ -814,7 +814,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -849,7 +849,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -874,7 +874,7 @@ spec:
           name: cilium-run
       - command:
         - /install-plugin.sh
-        image: quay.io/cilium/cilium:v1.16.5
+        image: quay.io/cilium/cilium:v1.16.7
         imagePullPolicy: IfNotPresent
         name: install-cni-binaries
         resources:
@@ -1048,7 +1048,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.16.5
+        image: quay.io/cilium/operator:v1.16.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -145,7 +145,7 @@ spec:
 {{ if WithDefaultBool .MetricsServer.Insecure true }}
         - --kubelet-insecure-tls
 {{ end }}
-        image: {{ or .MetricsServer.Image "registry.k8s.io/metrics-server/metrics-server:v0.7.1" }}
+        image: {{ or .MetricsServer.Image "registry.k8s.io/metrics-server/metrics-server:v0.7.2" }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.25.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.25.yaml.template
@@ -1,4 +1,4 @@
-# Pulled and modified from: https://raw.githubusercontent.com/projectcalico/calico/v3.29.1/manifests/calico-typha.yaml
+# Pulled and modified from: https://raw.githubusercontent.com/projectcalico/calico/v3.29.2/manifests/calico-typha.yaml
 ---
 {{- if .Networking.Calico.BPFEnabled }}
 # Set these to the IP and port of your API server; In BPF mode, we need to connect directly to the
@@ -6184,7 +6184,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.29.1" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.29.2" }}
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -6213,7 +6213,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.29.1" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.29.2" }}
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -6256,7 +6256,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.29.1" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.29.2" }}
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -6282,7 +6282,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.29.1" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.29.2" }}
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -6620,7 +6620,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.29.1" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.29.2" }}
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.
@@ -6714,7 +6714,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.29.1" }}
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.29.2" }}
         imagePullPolicy: IfNotPresent
         name: calico-typha
         ports:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -99,7 +99,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 75f56f20d00fdfff26d59fcf430cba0679639a4625ce0907de47509f1a8de67a
+    manifestHash: 4a07a56473cdad035456abc6f2dd3515f3437ef4492f8d6f0e397f7951b2f9ad
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -106,7 +106,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 75f56f20d00fdfff26d59fcf430cba0679639a4625ce0907de47509f1a8de67a
+    manifestHash: 4a07a56473cdad035456abc6f2dd3515f3437ef4492f8d6f0e397f7951b2f9ad
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 5a79936723087694804b3f2dd19917119822494bb92c2ea8f8554729bb293e9f
+    manifestHash: f858a160d2ed56d622fb7d3cbcb589ddbb2aa2b83677a505f46330ba42c81bb7
     name: metrics-server.addons.k8s.io
     selector:
       k8s-app: metrics-server

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -176,7 +176,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
-        image: registry.k8s.io/metrics-server/metrics-server:v0.7.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.7.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 1a15a7fb5f16c2df150971afbcf554671713453759fb0aaec2040369138d75b3
+    manifestHash: ce64b6db009e467b9d24a4aa1153e814d5ee903ecff084cd61579320edf55bc7
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -163,7 +163,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.15.yaml
-    manifestHash: 75f56f20d00fdfff26d59fcf430cba0679639a4625ce0907de47509f1a8de67a
+    manifestHash: 4a07a56473cdad035456abc6f2dd3515f3437ef4492f8d6f0e397f7951b2f9ad
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -176,7 +176,7 @@ spec:
         - --kubelet-preferred-address-types=Hostname
         - --tls-cert-file=/srv/tls.crt
         - --tls-private-key-file=/srv/tls.key
-        image: registry.k8s.io/metrics-server/metrics-server:v0.7.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.7.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
Cherry pick of #17311 #17312 #17313 on release-1.32.

#17311: Update Calico to v3.29.2
#17312: Update Cilium to v1.16.7
#17313: Update metrics-server to v0.7.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```