### PR TITLE
ServiceTrafficDistribution cannot be switched off for kubernetes master (for scalability tests)

### DIFF
--- a/tests/e2e/scenarios/scalability/run-test.sh
+++ b/tests/e2e/scenarios/scalability/run-test.sh
@@ -101,14 +101,12 @@ create_args+=("--set spec.kubeAPIServer.maxMutatingRequestsInflight=400")
 create_args+=("--set spec.kubeAPIServer.enableProfiling=true")
 create_args+=("--set spec.kubeAPIServer.enableContentionProfiling=true")
 create_args+=("--set spec.kubeAPIServer.logLevel=2")
-create_args+=("--set spec.kubeAPIServer.featureGates=ServiceTrafficDistribution=false")
 # this is required for Prometheus server to scrape metrics endpoint on APIServer
 create_args+=("--set spec.kubeAPIServer.anonymousAuth=true")
 # this is required for kindnet to use nftables
 create_args+=("--set spec.kubeProxy.proxyMode=${KUBE_PROXY_MODE:-iptables}")
 # this is required for prometheus to scrape kube-proxy metrics endpoint
 create_args+=("--set spec.kubeProxy.metricsBindAddress=0.0.0.0:10249")
-create_args+=("--set spec.kubeProxy.featureGates=ServiceTrafficDistribution=false")
 create_args+=("--node-count=${KUBE_NODE_COUNT:-100}")
 # TODO: track failures of tests (HostPort & OIDC) when using `--dns=none`
 create_args+=("--dns=none")


### PR DESCRIPTION
Feature gate is GA now: https://github.com/kubernetes/kubernetes/pull/130673

- https://testgrid.k8s.io/amazon-ec2-release#ec2-master-small-scale-performance&width=20
- https://testgrid.k8s.io/amazon-ec2-release#ec2-master-scale-performance&width=20

```
❯
❯ (find . -name kube-apiserver.log && find . -name kube-proxy.log)
./1902072946013245440/artifacts/18.116.47.23/kube-apiserver.log
./1902072946013245440/artifacts/3.142.225.232/kube-apiserver.log
./1902072946013245440/artifacts/18.191.224.177/kube-apiserver.log
./1902072946013245440/artifacts/18.116.47.23/kube-proxy.log
./1902072946013245440/artifacts/3.142.225.232/kube-proxy.log
./1902072946013245440/artifacts/18.191.224.177/kube-proxy.log
❯ grep ServiceTrafficDistribution ./1902072946013245440/artifacts/18.116.47.23/kube-apiserver.log | head -1
E0318 19:14:31.778687      12 run.go:72] "command failed" err="cannot set feature gate ServiceTrafficDistribution to false, feature is locked to true"
❯ grep ServiceTrafficDistribution ./1902072946013245440/artifacts/18.116.47.23/kube-proxy.log | head -1
E0318 19:14:31.623058      12 run.go:72] "command failed" err="failed complete: cannot set feature gate ServiceTrafficDistribution to false, feature is locked to true"
```