### PR TITLE
WarmPool should implement CompareWithID

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/warmpool.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool.go
@@ -66,6 +66,13 @@ func (e *WarmPool) GetDependencies(tasks map[string]fi.CloudupTask) []fi.Cloudup
 	return deps
 }
 
+var _ fi.CompareWithID = &WarmPool{}
+
+// CompareWithID returns the ID of the WarmPool task
+func (e *WarmPool) CompareWithID() *string {
+	return e.Name
+}
+
 // Find is used to discover the ASG in the cloud provider.
 func (e *WarmPool) Find(c *fi.CloudupContext) (*WarmPool, error) {
 	ctx := c.Context()


### PR DESCRIPTION
This is as a top-level task and implementing
CompareWithID lets us refer to it from multiple
tasks.
