### PR TITLE
Automated cherry pick of #17321: tests: verify that we can marshal tasks to json

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"os"
@@ -1251,10 +1252,19 @@ func (i *integrationTest) runTest(t *testing.T, ctx context.Context, h *testutil
 		options.ClusterName = i.clusterName
 		options.LifecycleOverrides = i.lifecycleOverrides
 
-		_, err := RunUpdateCluster(ctx, factory, &stdout, options)
+		updateClusterResults, err := RunUpdateCluster(ctx, factory, &stdout, options)
 		if err != nil {
 			t.Fatalf("error running update cluster %q: %v", i.clusterName, err)
 		}
+
+		// Verify that we can print all the tasks
+		// Catches bugs like https://github.com/kubernetes/kops/issues/17316
+		for key, task := range updateClusterResults.TaskMap {
+			if _, err := json.Marshal(task); err != nil {
+				t.Errorf("unable to marshal task %q of type %T to json: %v", key, task, err)
+			}
+		}
+
 	}
 
 	// Compare main files

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -82,12 +82,12 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 
 		// @step: now lets build the autoscaling group task
 		if ig.Spec.Manager != "Karpenter" {
-			tsk, err := b.buildAutoScalingGroupTask(c, name, ig)
+			asg, err := b.buildAutoScalingGroupTask(c, name, ig)
 			if err != nil {
 				return err
 			}
-			tsk.LaunchTemplate = task
-			c.AddTask(tsk)
+			asg.LaunchTemplate = task
+			c.AddTask(asg)
 
 			warmPool := b.Cluster.Spec.CloudProvider.AWS.WarmPool.ResolveDefaults(ig)
 
@@ -103,9 +103,9 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.CloudupModelBuilderContext) e
 				if warmPool.MaxSize != nil {
 					warmPoolTask.MaxSize = fi.PtrTo(int32(aws.ToInt64(warmPool.MaxSize)))
 				}
-				tsk.WarmPool = warmPoolTask
+				asg.WarmPool = warmPoolTask
 			} else {
-				tsk.WarmPool = nil
+				asg.WarmPool = nil
 			}
 			c.AddTask(warmPoolTask)
 

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -100,8 +100,10 @@ type AutoscalingGroup struct {
 	TargetGroups []*TargetGroup
 	// CapacityRebalance makes ASG proactively replace spot instances when ASG receives a rebalance recommendation
 	CapacityRebalance *bool
-	// WarmPool is the WarmPool config for the ASG
-	WarmPool *WarmPool
+
+	// WarmPool is the WarmPool config for the ASG.
+	// It is marked to be ignored in JSON marshalling to avoid a circular dependency.
+	WarmPool *WarmPool `json:"-"`
 
 	deletions []fi.CloudupDeletion
 }

--- a/upup/pkg/fi/cloudup/awstasks/warmpool.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool.go
@@ -41,6 +41,7 @@ type WarmPool struct {
 	// MinSize is the smallest number of nodes in the warm pool.
 	MinSize int32
 
+	// AutoscalingGroup is the AutoscalingGroup on which we configure this warmpool.
 	AutoscalingGroup *AutoscalingGroup
 }
 


### PR DESCRIPTION
Cherry pick of #17321 on release-1.30.

#17321: tests: verify that we can marshal tasks to json

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```