### PR TITLE
fix(cilium): operator prometheus port

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -83,7 +83,7 @@ data:
   # NOTE that this will open the port on ALL nodes where Cilium pods are
   # scheduled.
   prometheus-serve-addr: ":{{ .AgentPrometheusPort }}"
-  operator-prometheus-serve-addr: ":6942"
+  operator-prometheus-serve-addr: ":9963"
   enable-metrics: "true"
   {{ end }}
 


### PR DESCRIPTION
pr #16800 changed the operator prometheus port to `9963`. However the config actually still has `operator-prometheus-serve-addr: ":6942"` which makes scraping the declared port not possible as the wrong port is discovered.

This pr simply fixes the config.