### PR TITLE
Support 1.33 pre-releases with --cloud-provider flag removal validation

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -187,7 +187,7 @@ func ValidateCluster(c *kops.Cluster, strict bool, vfsContext *vfs.VFSContext) f
 				}
 			}
 			if c.Spec.KubeAPIServer != nil && (strict || c.Spec.KubeAPIServer.CloudProvider != "") {
-				if k8sVersion != nil && k8sVersion.LT(semver.MustParse("1.33.0")) {
+				if k8sVersion != nil && k8sVersion.LT(semver.MustParse("1.33.0-alpha.3")) {
 					if c.Spec.KubeAPIServer.CloudProvider != "external" && k8sCloudProvider != c.Spec.KubeAPIServer.CloudProvider {
 						allErrs = append(allErrs, field.Forbidden(fieldSpec.Child("kubeAPIServer", "cloudProvider"), "Did not match cluster cloudProvider"))
 					}


### PR DESCRIPTION
Upgrade jobs to latest k/k are failing because the validation was still being enforced for k8s 1.33.0-beta.1:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/17319/pull-kops-e2e-aws-upgrade-k130-ko130-to-klatest-kolatest-many-addons/1908282150768087040

This updates the logic to skip pre-releases that included the flag removal (https://github.com/kubernetes/kubernetes/commit/2382c0125b3c8a55e9963fd3e663a3c1c25819a2)