### PR TITLE
Automated cherry pick of #17336: fix(cilium): operator prometheus port

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -83,7 +83,7 @@ data:
   # NOTE that this will open the port on ALL nodes where Cilium pods are
   # scheduled.
   prometheus-serve-addr: ":{{ .AgentPrometheusPort }}"
-  operator-prometheus-serve-addr: ":6942"
+  operator-prometheus-serve-addr: ":9963"
   enable-metrics: "true"
   {{ end }}
 


### PR DESCRIPTION
Cherry pick of #17336 on release-1.32.

#17336: fix(cilium): operator prometheus port

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```