### PR TITLE
Pin GCP CCM image to v32.2.4

### DIFF
--- a/pkg/model/components/gcpcloudcontrollermanager.go
+++ b/pkg/model/components/gcpcloudcontrollermanager.go
@@ -74,7 +74,7 @@ func (b *GCPCloudControllerManagerOptionsBuilder) BuildOptions(cluster *kops.Clu
 		// TODO: Implement CCM image publishing
 		switch b.ControlPlaneKubernetesVersion().Minor() {
 		default:
-			ccmConfig.Image = "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master"
+			ccmConfig.Image = "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4"
 		}
 	}
 

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -23,7 +23,7 @@ spec:
     clusterName: ha-gce-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 002dac69385a975a8a2c4182981033e05880031c179dd1459ee569076cdce654
+    manifestHash: 8848daa01a1eba5593954e6deed7fa332bd06580f2aeed6299e5a6a164a171da
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterName: minimal-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -126,7 +126,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 3c55d971edba1793b82df1a202b0f429a778f2f4f8294c010d7a4fb7aca70c8b
+    manifestHash: dc8bbce922afb0a0b8ddf5046b0a437855e3ab3da201767529325b7306a0bfac
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_minimal.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
@@ -23,7 +23,7 @@ spec:
     clusterName: minimal-gce-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 563ea6c4b61247cbba3dc624b378a56dfdb2f887a39592f15ba1589b540b6487
+    manifestHash: 2dbb043fedf395b9030d1dc48cd89326cf96de37aebe9019201ace2d3ee9115d
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
@@ -26,7 +26,7 @@ spec:
     clusterName: minimal-gce-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 563ea6c4b61247cbba3dc624b378a56dfdb2f887a39592f15ba1589b540b6487
+    manifestHash: 2dbb043fedf395b9030d1dc48cd89326cf96de37aebe9019201ace2d3ee9115d
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_minimal-gce.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
@@ -27,7 +27,7 @@ spec:
     clusterName: minimal-gce-ilb-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 9be551d87a138c931e1e39fa4445fee18fe5ca495cf6229fb104001abd35fd93
+    manifestHash: 125eca8c38d2f8ce90015ba6d3b6390f7b9e74488ce5d9c73cebcfbd79da0d94
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -27,7 +27,7 @@ spec:
     clusterName: minimal-gce-with-a-very-very-very-very-very-long-name-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 5c1d2b26f8a2d8f8b622381cdc06b34be87be9a5d0dd5764a248b28809621824
+    manifestHash: d14749a8f8a5984e3c8657d10b8bef7f768ba302012fb2f4f384539ed3f44e30
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterName: minimal-gce-with-a-very-very-very-very-very-long-name-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 5c1d2b26f8a2d8f8b622381cdc06b34be87be9a5d0dd5764a248b28809621824
+    manifestHash: d14749a8f8a5984e3c8657d10b8bef7f768ba302012fb2f4f384539ed3f44e30
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
@@ -27,7 +27,7 @@ spec:
     clusterName: minimal-gce-plb-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: ce85b344b9411208fd901c7699027cbffa4d1eb478c81acc44a1133acd01bda8
+    manifestHash: dd4fb1d11df2ddeae3417f179827020f4cb1019247ff2f00c798d938f6350652
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_minimal-gce-plb.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
@@ -23,7 +23,7 @@ spec:
     clusterName: minimal-gce-private-example-com
     controllers:
     - '*'
-    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
     leaderElection:
       leaderElect: true
   cloudProvider: gce

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 15b18fbb8f418b530f48d2a8b9d1318f6f7b5c4df12e5d5179ec21f57842e06c
+    manifestHash: cb05a2e357db1f88553f876cde27710ad9034c7371cd9279337a8b0770fa9456
     name: gcp-cloud-controller.addons.k8s.io
     prune:
       kinds:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-gcp-cloud-controller.addons.k8s.io-k8s-1.23_content
@@ -46,7 +46,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
The GCP CCM Image builds included a breaking change in https://github.com/kubernetes/cloud-provider-gcp/pull/825
until we can update our manifest to account for the change, lets pin to the last stable tag from https://console.cloud.google.com/artifacts/docker/k8s-staging-cloud-provider-gcp/us/gcr.io/cloud-controller-manager?invt=AbuPzg

ref: #17347