### PR TITLE
Automated cherry pick of #17357: add goaway-chance parameter for kube-apiserver

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1921,6 +1921,11 @@ spec:
                     description: FeatureGates is set of key=value pairs that describe
                       feature gates for alpha/experimental features.
                     type: object
+                  goawayChance:
+                    description: GoawayChance is the probability that send a GOAWAY
+                      to HTTP/2 clients. Default to 0, means never send GOAWAY. Max
+                      is 0.02 to prevent break the apiserver.
+                    type: string
                   http2MaxStreamsPerConnection:
                     description: HTTP2MaxStreamsPerConnection sets the limit that
                       the server gives to clients for the maximum number of streams

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -469,6 +469,8 @@ type KubeAPIServerConfig struct {
 	RequestheaderAllowedNames []string `json:"requestheaderAllowedNames,omitempty" flag:"requestheader-allowed-names"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	// GoawayChance is the probability that send a GOAWAY to HTTP/2 clients. Default to 0, means never send GOAWAY. Max is 0.02 to prevent break the apiserver.
+	GoawayChance string `json:"goawayChance,omitempty" flag:"goaway-chance"`
 	// MaxRequestsInflight The maximum number of non-mutating requests in flight at a given time.
 	MaxRequestsInflight int32 `json:"maxRequestsInflight,omitempty" flag:"max-requests-inflight" flag-empty:"0"`
 	// MaxMutatingRequestsInflight The maximum number of mutating requests in flight at a given time. Defaults to 200

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -476,6 +476,8 @@ type KubeAPIServerConfig struct {
 	RequestheaderAllowedNames []string `json:"requestheaderAllowedNames,omitempty" flag:"requestheader-allowed-names"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	// GoawayChance is the probability that send a GOAWAY to HTTP/2 clients. Default to 0, means never send GOAWAY. Max is 0.02 to prevent break the apiserver.
+	GoawayChance string `json:"goawayChance,omitempty" flag:"goaway-chance"`
 	// MaxRequestsInflight The maximum number of non-mutating requests in flight at a given time.
 	MaxRequestsInflight int32 `json:"maxRequestsInflight,omitempty" flag:"max-requests-inflight" flag-empty:"0"`
 	// MaxMutatingRequestsInflight The maximum number of mutating requests in flight at a given time. Defaults to 200

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4947,6 +4947,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.RequestheaderClientCAFile = in.RequestheaderClientCAFile
 	out.RequestheaderAllowedNames = in.RequestheaderAllowedNames
 	out.FeatureGates = in.FeatureGates
+	out.GoawayChance = in.GoawayChance
 	out.MaxRequestsInflight = in.MaxRequestsInflight
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
@@ -5063,6 +5064,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.RequestheaderClientCAFile = in.RequestheaderClientCAFile
 	out.RequestheaderAllowedNames = in.RequestheaderAllowedNames
 	out.FeatureGates = in.FeatureGates
+	out.GoawayChance = in.GoawayChance
 	out.MaxRequestsInflight = in.MaxRequestsInflight
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -467,6 +467,8 @@ type KubeAPIServerConfig struct {
 	RequestheaderAllowedNames []string `json:"requestheaderAllowedNames,omitempty" flag:"requestheader-allowed-names"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	// GoawayChance is the probability that send a GOAWAY to HTTP/2 clients. Default to 0, means never send GOAWAY. Max is 0.02 to prevent break the apiserver.
+	GoawayChance string `json:"goawayChance,omitempty" flag:"goaway-chance"`
 	// MaxRequestsInflight The maximum number of non-mutating requests in flight at a given time.
 	MaxRequestsInflight int32 `json:"maxRequestsInflight,omitempty" flag:"max-requests-inflight" flag-empty:"0"`
 	// MaxMutatingRequestsInflight The maximum number of mutating requests in flight at a given time. Defaults to 200

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5342,6 +5342,7 @@ func autoConvert_v1alpha3_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.RequestheaderClientCAFile = in.RequestheaderClientCAFile
 	out.RequestheaderAllowedNames = in.RequestheaderAllowedNames
 	out.FeatureGates = in.FeatureGates
+	out.GoawayChance = in.GoawayChance
 	out.MaxRequestsInflight = in.MaxRequestsInflight
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection
@@ -5458,6 +5459,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha3_KubeAPIServerConfig(in *ko
 	out.RequestheaderClientCAFile = in.RequestheaderClientCAFile
 	out.RequestheaderAllowedNames = in.RequestheaderAllowedNames
 	out.FeatureGates = in.FeatureGates
+	out.GoawayChance = in.GoawayChance
 	out.MaxRequestsInflight = in.MaxRequestsInflight
 	out.MaxMutatingRequestsInflight = in.MaxMutatingRequestsInflight
 	out.HTTP2MaxStreamsPerConnection = in.HTTP2MaxStreamsPerConnection


### PR DESCRIPTION
Cherry pick of #17357 on release-1.30.

#17357: add goaway-chance parameter for kube-apiserver

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```