### PR TITLE
Automated cherry pick of #17361: feat: Added cni-exclusive setting for cilium

### DIFF
--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -169,7 +169,7 @@ Cilium can make use of the [wireguard protocol for transparent encryption](https
 ```
 
 #### CNI Exclusive
-{{ kops_feature_table(kops_added_default='1.31', k8s_min='1.20') }}
+{{ kops_feature_table(kops_added_default='1.32') }}
 
 If you want to use additional CNI plugins, for example when using service meshes like Istio or Linkerd, It is required to disable the `cni-exclusive` option so that Cilium does not remove the other CNI configuration files.
 

--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -168,6 +168,16 @@ Cilium can make use of the [wireguard protocol for transparent encryption](https
       encryptionType: wireguard
 ```
 
+#### CNI Exclusive
+{{ kops_feature_table(kops_added_default='1.31', k8s_min='1.20') }}
+
+If you want to use additional CNI plugins, for example when using service meshes like Istio or Linkerd, It is required to disable the `cni-exclusive` option so that Cilium does not remove the other CNI configuration files.
+
+```yaml
+  networking:
+    cilium:
+      cniExclusive: false
+```
 
 #### Resources in Cilium
 {{ kops_feature_table(kops_added_default='1.21', k8s_min='1.20') }}

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5343,6 +5343,11 @@ spec:
                       cniBinPath:
                         description: CniBinPath is unused.
                         type: string
+                      cniExclusive:
+                        description: |-
+                          CniExclusive configures whether to remove other CNI configuration files.
+                          Default: true
+                        type: boolean
                       containerRuntime:
                         description: ContainerRuntime is unused.
                         items:

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -511,6 +511,9 @@ type CiliumNetworkingSpec struct {
 	// EnableUnreachableRoutes enables unreachable routes on pod deletion.
 	// Default: false
 	EnableUnreachableRoutes *bool `json:"enableUnreachableRoutes,omitempty"`
+	// CniExclusive configures whether to remove other CNI configuration files.
+	// Default: true
+	CniExclusive *bool `json:"cniExclusive,omitempty"`
 	// Hubble configures the Hubble service on the Cilium agent.
 	Hubble *HubbleSpec `json:"hubble,omitempty"`
 

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -613,6 +613,9 @@ type CiliumNetworkingSpec struct {
 	// EnableUnreachableRoutes enables unreachable routes on pod deletion.
 	// Default: false
 	EnableUnreachableRoutes *bool `json:"enableUnreachableRoutes,omitempty"`
+	// CniExclusive configures whether to remove other CNI configuration files.
+	// Default: true
+	CniExclusive *bool `json:"cniExclusive,omitempty"`
 	// Hubble configures the Hubble service on the Cilium agent.
 	Hubble *HubbleSpec `json:"hubble,omitempty"`
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2079,6 +2079,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.EtcdManaged = in.EtcdManaged
 	out.EnableRemoteNodeIdentity = in.EnableRemoteNodeIdentity
 	out.EnableUnreachableRoutes = in.EnableUnreachableRoutes
+	out.CniExclusive = in.CniExclusive
 	if in.Hubble != nil {
 		in, out := &in.Hubble, &out.Hubble
 		*out = new(kops.HubbleSpec)
@@ -2156,6 +2157,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.EtcdManaged = in.EtcdManaged
 	out.EnableRemoteNodeIdentity = in.EnableRemoteNodeIdentity
 	out.EnableUnreachableRoutes = in.EnableUnreachableRoutes
+	out.CniExclusive = in.CniExclusive
 	if in.Hubble != nil {
 		in, out := &in.Hubble, &out.Hubble
 		*out = new(HubbleSpec)

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -669,6 +669,11 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CniExclusive != nil {
+		in, out := &in.CniExclusive, &out.CniExclusive
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Hubble != nil {
 		in, out := &in.Hubble, &out.Hubble
 		*out = new(HubbleSpec)

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -459,6 +459,9 @@ type CiliumNetworkingSpec struct {
 	// EnableUnreachableRoutes enables unreachable routes on pod deletion.
 	// Default: false
 	EnableUnreachableRoutes *bool `json:"enableUnreachableRoutes,omitempty"`
+	// CniExclusive configures whether to remove other CNI configuration files.
+	// Default: true
+	CniExclusive *bool `json:"cniExclusive,omitempty"`
 	// Hubble configures the Hubble service on the Cilium agent.
 	Hubble *HubbleSpec `json:"hubble,omitempty"`
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2214,6 +2214,7 @@ func autoConvert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.EtcdManaged = in.EtcdManaged
 	out.EnableRemoteNodeIdentity = in.EnableRemoteNodeIdentity
 	out.EnableUnreachableRoutes = in.EnableUnreachableRoutes
+	out.CniExclusive = in.CniExclusive
 	if in.Hubble != nil {
 		in, out := &in.Hubble, &out.Hubble
 		*out = new(kops.HubbleSpec)
@@ -2291,6 +2292,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha3_CiliumNetworkingSpec(in *
 	out.EtcdManaged = in.EtcdManaged
 	out.EnableRemoteNodeIdentity = in.EnableRemoteNodeIdentity
 	out.EnableUnreachableRoutes = in.EnableUnreachableRoutes
+	out.CniExclusive = in.CniExclusive
 	if in.Hubble != nil {
 		in, out := &in.Hubble, &out.Hubble
 		*out = new(HubbleSpec)

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -691,6 +691,11 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CniExclusive != nil {
+		in, out := &in.CniExclusive, &out.CniExclusive
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Hubble != nil {
 		in, out := &in.Hubble, &out.Hubble
 		*out = new(HubbleSpec)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -772,6 +772,11 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CniExclusive != nil {
+		in, out := &in.CniExclusive, &out.CniExclusive
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Hubble != nil {
 		in, out := &in.Hubble, &out.Hubble
 		*out = new(HubbleSpec)

--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -161,6 +161,10 @@ func (b *CiliumOptionsBuilder) BuildOptions(o *kops.Cluster) error {
 		c.EncryptionType = kops.CiliumEncryptionTypeIPSec
 	}
 
+	if c.CniExclusive == nil {
+		c.CniExclusive = fi.PtrTo(true)
+	}
+
 	hubble := c.Hubble
 	if hubble != nil {
 		if hubble.Enabled == nil {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -191,6 +191,7 @@ spec:
       bpfNeighGlobalMax: 524288
       bpfPolicyMapMax: 16384
       clusterName: default
+      cniExclusive: true
       cpuRequest: 25m
       disableCNPStatusUpdates: true
       disableMasquerade: true

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -183,6 +183,7 @@ spec:
       bpfNeighGlobalMax: 524288
       bpfPolicyMapMax: 16384
       clusterName: default
+      cniExclusive: true
       cpuRequest: 25m
       disableCNPStatusUpdates: true
       disableMasquerade: false

--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
@@ -178,6 +178,7 @@ spec:
       bpfNeighGlobalMax: 524288
       bpfPolicyMapMax: 16384
       clusterName: default
+      cniExclusive: true
       cpuRequest: 25m
       disableCNPStatusUpdates: true
       disableMasquerade: false

--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
@@ -185,6 +185,7 @@ spec:
       bpfNeighGlobalMax: 524288
       bpfPolicyMapMax: 16384
       clusterName: default
+      cniExclusive: true
       cpuRequest: 25m
       disableCNPStatusUpdates: true
       disableMasquerade: false

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -189,6 +189,7 @@ spec:
       bpfNeighGlobalMax: 524288
       bpfPolicyMapMax: 16384
       clusterName: default
+      cniExclusive: true
       cpuRequest: 25m
       disableCNPStatusUpdates: true
       disableMasquerade: false

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
@@ -198,6 +198,7 @@ spec:
       bpfPolicyMapMax: 16384
       clusterID: 253
       clusterName: privatecilium.example.com
+      cniExclusive: true
       cpuRequest: 25m
       disableCNPStatusUpdates: true
       disableMasquerade: false

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -195,6 +195,7 @@ spec:
       bpfNeighGlobalMax: 524288
       bpfPolicyMapMax: 16384
       clusterName: default
+      cniExclusive: true
       cpuRequest: 25m
       disableCNPStatusUpdates: true
       disableMasquerade: false

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.15.yaml.template
@@ -319,7 +319,7 @@ data:
 
   # Tell the agent to generate and write a CNI configuration file
   write-cni-conf-when-ready: /host/etc/cni/net.d/05-cilium.conflist
-  cni-exclusive: "true"
+  cni-exclusive: "{{ .CniExclusive }}"
   cni-log-file: "/var/run/cilium/cilium-cni.log"
 
   {{ if WithDefaultBool .Hubble.Enabled false }}


### PR DESCRIPTION
Cherry pick of #17361 on release-1.32.

#17361: feat: Added cni-exclusive setting for cilium

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```